### PR TITLE
fix: incorrect flow in breadcrumb state management

### DIFF
--- a/src/containers/Breadcrumb.jsx
+++ b/src/containers/Breadcrumb.jsx
@@ -27,6 +27,16 @@ const Breadcrumb = ({ t, router, location, path, opening, deployed, toggleOpenin
     if (!folder.name) folder.name = '…'
   })
 
+  const onClick = folderId => e => {
+    e.preventDefault()
+    toggleOpening()
+    if (deployed) toggleDeploy()
+    goToFolder(folderId).then(() => {
+      toggleOpening()
+      router.push(getFolderUrl(folderId, location))
+    })
+  }
+
   return (
     <div
       className={classNames(styles['fil-path-backdrop'], {[styles['deployed']]: deployed})}
@@ -36,15 +46,7 @@ const Breadcrumb = ({ t, router, location, path, opening, deployed, toggleOpenin
         <Link
           to={getFolderUrl(path[path.length - 2].id, location)}
           className={styles['fil-path-previous']}
-          onClick={e => {
-            e.preventDefault()
-            toggleOpening()
-            if (deployed) toggleDeploy()
-            goToFolder(path[path.length - 2].id).then(() => {
-              toggleOpening()
-              router.push(getFolderUrl(path[path.length - 2].id, location))
-            })
-          }}
+          onClick={onClick(path[path.length - 2].id)}
         />
       }
       <h2 className={styles['fil-path-title']}>
@@ -54,15 +56,7 @@ const Breadcrumb = ({ t, router, location, path, opening, deployed, toggleOpenin
             return <Link
               to={getFolderUrl(folder.id, location)}
               className={styles['fil-path-link']}
-              onClick={e => {
-                e.preventDefault()
-                toggleOpening()
-                if (deployed) toggleDeploy()
-                goToFolder(folder.id).then(() => {
-                  toggleOpening()
-                  router.push(getFolderUrl(folder.id, location))
-                })
-              }}
+              onClick={onClick(folder.id)}
             >
               <a>
                 { folder.name }

--- a/src/containers/Breadcrumb.jsx
+++ b/src/containers/Breadcrumb.jsx
@@ -33,6 +33,7 @@ const Breadcrumb = ({ t, router, location, path, opening, deployed, toggleOpenin
     if (deployed) toggleDeploy()
     goToFolder(folderId).then(() => {
       toggleOpening()
+      toggleDeploy()
       router.push(getFolderUrl(folderId, location))
     })
   }


### PR DESCRIPTION
The breadcrumb uses a state called `deployed` to display the hierarchical menu and to add a backdrop as an overlay.

This state is toggled when actioning the menu items.

First, I refactored the duplicate code.
Second, I added a `toggleDeploy()` call in the asynchronous call.

*Note: I don't like the animation flow when clicking on the back button. But it is not related to the FIL-24 bug statement.*