### PR TITLE
Better confirmation modal when destroying a selection of files

### DIFF
--- a/src/components/FolderView.jsx
+++ b/src/components/FolderView.jsx
@@ -68,13 +68,15 @@ class FolderView extends Component {
 
   render () {
     const { isTrashContext, showActionMenu } = this.props
-    const { selected, actions, Toolbar } = this.props
+    const { files, selected, actions, Toolbar } = this.props
     const { onShowActionMenu } = this.props
 
     const { showAddFolder, selectionMode } = this.state
 
     const selectionModeActive = selected.length !== 0 || selectionMode === true
     const fetchFailed = this.props.fetchStatus === 'failed'
+    const fetchPending = this.props.fetchStatus === 'pending'
+    const nothingToDo = isTrashContext && files.length === 0
 
     const toolbarActions = {
       addFolder: this.toggleAddFolder
@@ -85,7 +87,7 @@ class FolderView extends Component {
           <Breadcrumb />
           <Toolbar
             actions={toolbarActions}
-            disabled={fetchFailed || selectionModeActive}
+            disabled={fetchFailed || fetchPending || selectionModeActive || nothingToDo}
             onSelectItemsClick={this.toggleSelectionMode}
           />
         </div>

--- a/src/ducks/trash/Container.jsx
+++ b/src/ducks/trash/Container.jsx
@@ -4,7 +4,7 @@ import { translate } from '../../lib/I18n'
 import confirm from '../../lib/confirm'
 
 import FolderView from '../../components/FolderView'
-import EmptyTrashConfirm from './components/EmptyTrashConfirm'
+import DestroyConfirm from './components/DestroyConfirm'
 import Toolbar from './Toolbar'
 
 import { restoreFiles, destroyFiles } from './actions'
@@ -20,7 +20,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     selection: {
       restore: () => dispatch(restoreFiles(ownProps.selected)),
       destroy: () =>
-        confirm(<EmptyTrashConfirm t={ownProps.t} />)
+        confirm(<DestroyConfirm t={ownProps.t} fileCount={ownProps.selected.length} />)
           .then(() => dispatch(destroyFiles(ownProps.selected)))
           .catch(() => {})
     }

--- a/src/ducks/trash/Toolbar.jsx
+++ b/src/ducks/trash/Toolbar.jsx
@@ -18,8 +18,9 @@ const Toolbar = ({ t, disabled, emptyTrash, onSelectItemsClick }) => (
         'coz-btn', 'coz-btn--danger-outline', styles['fil-btn--delete']
       )}
       onClick={() => emptyTrash()}
+      disabled={disabled}
     >
-      {t('toolbar.delete_all')}
+      {t('toolbar.empty_trash')}
     </button>
     <MenuButton>
       <button
@@ -36,7 +37,7 @@ const Toolbar = ({ t, disabled, emptyTrash, onSelectItemsClick }) => (
             className={styles['fil-action-delete']}
             onClick={() => emptyTrash()}
           >
-            {t('toolbar.delete_all')}
+            {t('toolbar.empty_trash')}
           </a>
         </Item>
         <hr />

--- a/src/ducks/trash/components/DestroyConfirm.jsx
+++ b/src/ducks/trash/components/DestroyConfirm.jsx
@@ -1,0 +1,25 @@
+import styles from '../../../styles/confirms'
+import classNames from 'classnames'
+
+import React from 'react'
+import Modal from 'cozy-ui/react/Modal'
+
+const DestroyConfirm = ({ t, fileCount, confirm, abort }) => {
+  const confirmationTexts = ['forbidden', 'restore'].map(type => (
+    <p className={classNames(styles['fil-confirm-text'], styles[`icon-${type}`])}>
+      {t(`destroyconfirmation.${type}`, fileCount)}
+    </p>
+  ))
+
+  return (<Modal
+    title={t('destroyconfirmation.title', fileCount)}
+    description={confirmationTexts}
+    secondaryText={t('destroyconfirmation.cancel')}
+    secondaryAction={abort}
+    primaryType='danger'
+    primaryText={t('destroyconfirmation.delete')}
+    primaryAction={confirm}
+   />)
+}
+
+export default DestroyConfirm

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,6 +67,13 @@
     "cancel": "Cancel",
     "delete": "Delete all"
   },
+  "destroyconfirmation": {
+    "title": "Permanently delete?",
+    "forbidden": "You won't be able to access this file anymore. |||| You won't be able to access these files anymore.",
+    "restore": "You won't be able to restore this file if you didn't make a backup. |||| You won't be able to restore these files if you didn't make a backup.",
+    "cancel": "Cancel",
+    "delete": "Delete permanently"
+  },
   "loading": {
     "message": "Loading"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -20,7 +20,7 @@
     "menu_upload": "Upload files",
     "menu_new_folder": "New folder",
     "menu_select": "Select items",
-    "delete_all": "Delete all"
+    "empty_trash": "Empty trash"
   },
   "table": {
     "head_name": "Name",


### PR DESCRIPTION
#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [x] Localized in english and french
