### PR TITLE
fix: handle setup :fries:

### DIFF
--- a/mobile/src/components/MobileAppRoute.jsx
+++ b/mobile/src/components/MobileAppRoute.jsx
@@ -4,6 +4,8 @@ import { Route } from 'react-router'
 import AppRoute from '../../../src/components/AppRoute'
 import App from '../../../src/components/App'
 
+import { initBar } from '../lib/cozy-helper'
+
 import OnBoarding from '../containers/OnBoarding'
 import Settings from '../containers/Settings'
 import RevokableWrapper from '../containers/RevokableWrapper'
@@ -16,7 +18,7 @@ const MobileAppRoute = requireSetup => (
         <Route path='settings' name='mobile.settings' component={Settings} />}
       </Route>
     </Route>
-    <Route path='onboarding' component={OnBoarding} />
+    <Route path='onboarding' component={OnBoarding} onLeave={() => initBar()} />
   </Route>
 )
 

--- a/mobile/src/lib/init.js
+++ b/mobile/src/lib/init.js
@@ -1,7 +1,23 @@
 import { configureReporter } from './reporter'
-import { initClient } from './cozy-helper'
+import { initClient, initBar, isClientRegistered } from './cozy-helper'
+import { revokeClient } from '../actions/authorization'
+import { startReplication } from '../actions/settings'
 
-export const initService = (store) => {
+export const initServices = (store) => {
   configureReporter(store.getState)
   initClient(store.getState().mobile.settings.serverUrl)
+
+  const client = store.getState().settings.client
+  if (client) {
+    isClientRegistered(client)
+      .then((clientIsRegistered) => {
+        if (clientIsRegistered) {
+          startReplication(store.dispatch, store.getState) // don't like to pass `store.dispatch` and `store.getState` as parameters, big coupling
+          initBar()
+        } else {
+          console.warn('Your device is no more connected to your server')
+          store.dispatch(revokeClient())
+        }
+      })
+  }
 }


### PR DESCRIPTION
[react-router](https://github.com/ReactTraining/react-router/blob/v3/docs/API.md#onenternextstate-replace-callback) let us register a function called each time a route is going to enter.

That is the way we drive user to the onboarding or to the application main page.

This is not a way to *initialize* the application.

So I moved the initialization into a function called once the JS file is loaded and evaluated.

And I renamed the `requireSetup` function with a more explicit name.

I would like to initialized the [cozy-bar](https://github.com/cozy/cozy-bar) at two places:
- when the application is opened in classical condition (user already onboarded)
- when the onboarding is finished

Because we don't want to initialized the cozy-bar each time the *normal route* is called (`#/files`).

*Note: I fixed a bug on initialization when user is not registered (because the device was revoked) [introduced earlier](https://github.com/cozy/cozy-drive/pull/214/commits/63a5670815f298ad076c47fad56541e8541a2eef#diff-a8d74123e70b3c36093d784c4d702199R26)*