### PR TITLE
fix: unable to start on plane mode

### DIFF
--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -29,7 +29,8 @@ export const initClient = (url, onRegister = null, device = 'Device') => {
     console.log(`Cozy Client initializes a connection with ${url}`)
     cozy.client.init({
       cozyURL: url,
-      oauth: getAuth(onRegister, device)
+      oauth: getAuth(onRegister, device),
+      offline: {doctypes: ['io.cozy.files']}
     })
   }
 }


### PR DESCRIPTION
Even if it looked a good idea to remove https://github.com/cozy/cozy-drive/pull/157/files#diff-f96699990a60f265f8d3b7bd25d3e9a6L26 earlier.

It is mandatory while https://github.com/cozy/cozy-client-js/blob/master/src/index.js#L177 is not refactored.

Without that, the mobile application does not start when the phone is on plane mode.