### PR TITLE
fix: Selection Bar UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "classnames": "^2.2.0",
     "cozy-bar": "3.0.0-beta15",
     "cozy-client-js": "0.2.0",
-    "cozy-ui": "3.0.0-beta18",
+    "cozy-ui": "3.0.0-beta20",
     "date-fns": "^1.22.0",
     "filesize": "^3.3.0",
     "hammerjs": "^2.0.8",

--- a/src/components/FolderView.jsx
+++ b/src/components/FolderView.jsx
@@ -93,6 +93,7 @@ class FolderView extends Component {
             <SelectionBar
               selected={selected}
               actions={actions.selection}
+              mobile={actions.mobile}
               onClose={hideSelectionBar}
               onMoreClick={showActionMenu}
             />}

--- a/src/components/SelectionBar.jsx
+++ b/src/components/SelectionBar.jsx
@@ -1,10 +1,11 @@
+/* global __TARGET__ */
 import styles from '../styles/selectionbar'
 
 import React from 'react'
 import { translate } from '../lib/I18n'
 import classNames from 'classnames'
 
-const SelectionBar = ({ t, selected, actions, onClose, onMoreClick }) => {
+const SelectionBar = ({ t, selected, actions, mobile, onClose, onMoreClick }) => {
   const selectedCount = selected.length
   const actionNames = Object.keys(actions)
   return (
@@ -23,6 +24,15 @@ const SelectionBar = ({ t, selected, actions, onClose, onMoreClick }) => {
           {t('selectionbar.' + actionName)}
         </button>
       ))}
+      {(__TARGET__ === 'mobile' || true) && Object.keys(mobile).map(actionName => (
+        <button
+          className={styles['coz-action-' + actionName.toLowerCase()]}
+          disabled={selectedCount !== 1}
+          onClick={() => mobile[actionName](selected[0])}
+        >
+          {t('selectionbar.' + actionName)}
+        </button>)
+      )}
       {actionNames.length > 4 &&
         <button
           className={classNames('coz-btn', 'coz-btn--extra-white')}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,7 +50,8 @@
     "moveto": "Move",
     "rename": "Rename",
     "restore": "Restore",
-    "close": "Close"
+    "close": "Close",
+    "openWith": "Open with"
   },
   "deleteconfirmation": {
     "title": "Delete this element? |||| Delete these elements?",

--- a/src/styles/selectionbar.styl
+++ b/src/styles/selectionbar.styl
@@ -3,7 +3,3 @@
 
 [role=application]
   @extend $selectionbar
-
-.coz-action-trash
-.coz-action-destroy
-    background embedurl('../assets/icons/ui/icon-delete.svg') em(24px) center no-repeat

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,9 +1449,9 @@ cozy-client-js@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.2.0.tgz#489be51c129a87df4a44609642ec9344c82597bc"
 
-cozy-ui@3.0.0-beta18:
-  version "3.0.0-beta18"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-3.0.0-beta18.tgz#8f0bd6733975c229959226c7118ef4d34fc51e27"
+cozy-ui@3.0.0-beta20:
+  version "3.0.0-beta20"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-3.0.0-beta20.tgz#1ecf336883eec9d758788a86df4021a1bcd34151"
   dependencies:
     classnames "^2.2.5"
     md5 "^2.2.0"


### PR DESCRIPTION
As asked in [this card](https://trello.com/c/oppcRVha/217-3-fil-21-cosmetique-selection-bar), here are some cosmetic changes:

- [x] use cozy-ui for trash icon
- [x] add `open with` in the selection bar

See the bad screenshot below

![](https://trello-attachments.s3.amazonaws.com/57da4e2f6e46493a77d0ba5a/58e297e067a7de67a638dcfc/d770fd456b2d1e50647435d2547f52c1/overlay-selectionbar.png)