### PR TITLE
feat: Add Support for editor's name

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,6 +4,7 @@
   "icon": "app-icon.svg",
   "description": "File manager for Cozy v3",
   "source": "https://github.com/cozy/cozy-drive.git@build",
+  "editor": "Cozy",
   "developer": {
     "name": "Cozy",
     "url": "https://cozy.io"

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -35,14 +35,11 @@ export const initClient = (url, onRegister = null, device = 'Device') => {
 }
 
 export const initBar = () => {
-  const root = document.querySelector('[role=application]')
-  const data = root.dataset
-
   cozy.bar.init({
-    appName: data.cozyAppName,
-    appEditor: data.cozyAppEditor,
-    iconPath: data.cozyIconPath,
-    lang: data.cozyLocale,
+    appName: 'Cozy Drive',
+    appEditor: 'Cozy',
+    iconPath: require('../../../vendor/assets/app-icon.svg'),
+    lang: 'en',
     replaceTitleOnMobile: true
   })
 }

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -35,10 +35,14 @@ export const initClient = (url, onRegister = null, device = 'Device') => {
 }
 
 export const initBar = () => {
+  const root = document.querySelector('[role=application]')
+  const data = root.dataset
+
   cozy.bar.init({
-    appName: 'Cozy Drive',
-    iconPath: require('../../../vendor/assets/app-icon.svg'),
-    lang: 'en',
+    appName: data.cozyAppName,
+    appEditor: data.cozyAppEditor,
+    iconPath: data.cozyIconPath,
+    lang: data.cozyLocale,
     replaceTitleOnMobile: true
   })
 }

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -23,5 +23,6 @@
   data-cozy-domain="{{.Domain}}"
   data-cozy-locale="{{.Locale}}"
   data-cozy-app-name="{{.AppName}}"
+  data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-icon-path="{{.IconPath}}"
 >

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   cozy.bar.init({
     appName: data.cozyAppName,
+    appEditor: data.cozyAppEditor,
     iconPath: data.cozyIconPath,
     lang: data.cozyLocale,
     replaceTitleOnMobile: true


### PR DESCRIPTION
Adding Editor's name to the manifest so the stack can use it and make sure this data is shared so the cozy-bar can use it.

tl;dr: It displays the "Cozy" before the "Drive" in the Cozy-bar

Related PR: https://github.com/cozy/cozy-bar/pull/37
