### PR TITLE
fix: cordova displays app in portrait orientation

### DIFF
--- a/mobile/config.xml
+++ b/mobile/config.xml
@@ -13,6 +13,7 @@
     <allow-intent href="geo:*" />
     <hook src="scripts/update-config-version.sh" type="before_build" />
     <engine name="android" spec="6.1.2" />
+    <preference name="Orientation" value="portrait" />
     <platform name="android">
         <preference name="StatusBarBackgroundColor" value="#D6D8DA" />
         <allow-intent href="market:*" />


### PR DESCRIPTION
I don't think landscape mode is very accurate for this kind of application.
I rather to forbid it by adding this configuration preference in cordova's `config.xml`.