### PR TITLE
Not an actual PR : OPEN intent

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -22,6 +22,13 @@
       "public": false
     }
   },
+  "intents": [
+    {
+      "action": "OPEN",
+      "type": ["io.cozy.files"],
+      "href": "/open"
+    }
+  ],
   "version": "3.0.0",
   "licence": "AGPL-3.0",
   "permissions": {


### PR DESCRIPTION
⚠️ This is not an actual PR, it's just here so we can discuss the issue and decide what approach is best ⚠️ 

I have this use case where I want to display a PDF uploaded in files in another app. My app knows the file's `_id`, but has no permissions on it (and shouldn't have them). So this is a use case for [intents](https://github.com/cozy/cozy-stack/blob/master/docs/intents.md).

Here's how I would do this: allow Cozy Drive to handle `OPEN io.cozy.files` intents -- this is the *service*. The service would be on a completely separate route using separate scripts. It would generate a temporary link for the file, and open that link in an iframe.

If the browser knows how to handle that file type, the file will be displayed; otherwise it will be downloaded. Later, if we want to support more file types, we can replace the iframe with an actual file viewer but keep the route and compatibility intact.

Does this sound reasonable? Would there be any issues on mobile (I don't think so)?  
The mobile app would never actually use this route, so I think it has no impact on it, but maybe I'm missing something?