### PR TITLE
feat: Add press action on file list :point_up_2:

### DIFF
--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -43,10 +43,13 @@ class File extends Component {
     this.gesturesHandler.get('doubletap').recognizeWith('singletap').requireFailure('onpress')
     this.gesturesHandler.get('singletap').requireFailure('doubletap').requireFailure('onpress')
     this.gesturesHandler.on('onpress singletap doubletap', (ev) => {
-      if (ev.type === 'onpress' || (this.props.selectionModeActive && ev.type === 'singletap')) {
-        this.toggle(ev.srcEvent)
-      } else {
-        this.open(ev.srcEvent, this.props.attributes)
+      const enableTouchEvents = ev => ['INPUT', 'BUTTON', 'LABEL'].indexOf(ev.target.nodeName) === -1
+      if (enableTouchEvents(ev)) {
+        if (ev.type === 'onpress' || (this.props.selectionModeActive && ev.type === 'singletap')) {
+          this.toggle(ev.srcEvent)
+        } else {
+          this.open(ev.srcEvent, this.props.attributes)
+        }
       }
     })
   }


### PR DESCRIPTION
This feature add 3 gestures on file list:

- [x] [tap](https://github.com/cozy/cozy-drive/pull/250/files#diff-7e3f754a65a763e426e5b54107d0702aR41): to open or to select an item
- [x] [doubletap](https://github.com/cozy/cozy-drive/pull/250/files#diff-7e3f754a65a763e426e5b54107d0702aR40): to open an item
- [x] [press](https://github.com/cozy/cozy-drive/pull/250/files#diff-7e3f754a65a763e426e5b54107d0702aR42): to select an item

It's disable on [label](https://github.com/cozy/cozy-drive/pull/250/files#diff-7e3f754a65a763e426e5b54107d0702aR94) checkbox and [button](https://github.com/cozy/cozy-drive/pull/250/files#diff-7e3f754a65a763e426e5b54107d0702aR113) action. 