### PR TITLE
fix: change placeholder's wording

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -121,7 +121,7 @@
       },
       "server_selection": {
         "description": "This is the web address you use to access your Cozy.",
-        "cozy_address_placeholder": "Your Cozy internet address",
+        "cozy_address_placeholder": "tonystark.mycozy.cloud",
         "button": "Next",
         "wrong_address": "This address doesn’t send to a cozy. Please check the address you provide."
       },


### PR DESCRIPTION
As asked in https://trello.com/c/VPVNgirg/287-fil-dans-l-app-mobile-changer-le-placeholder-pour-montrer-une-adresse-web-et-pas-email