### PR TITLE
fix: Download directories and single files

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -228,7 +228,7 @@ export const trashFiles = files => {
 export const downloadSelection = selected => {
   const meta = META_DEFAULTS
   return async (dispatch) => {
-    if (selected.length === 1 && isDirectory(selected[0])) {
+    if (selected.length === 1 && !isDirectory(selected[0])) {
       return dispatch(downloadFile(selected[0], meta))
     }
     const paths = selected.map(f => f.path)


### PR DESCRIPTION
This bug was [introduced here](https://github.com/cozy/cozy-drive/commit/f03593ff3c6f561f00ddbac6bc4df058964254c4#diff-4e3037116dbc2bc69a473b7ace3d02abL229), it was just a logic inversion.