### PR TITLE
feat: Add piwik events

### DIFF
--- a/mobile/src/containers/RevokableWrapper.jsx
+++ b/mobile/src/containers/RevokableWrapper.jsx
@@ -9,7 +9,6 @@ import { unrevokeClient } from '../actions/authorization'
 import { registerDevice } from '../actions/settings'
 
 class RevokableWrapper extends Component {
-
   logout () {
     resetClient()
     this.props.unrevokeClient()

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -17,6 +17,7 @@ export const CREATE_FOLDER = 'CREATE_FOLDER'
 export const CREATE_FOLDER_FAILURE_GENERIC = 'CREATE_FOLDER_FAILURE_GENERIC'
 export const CREATE_FOLDER_FAILURE_DUPLICATE = 'CREATE_FOLDER_FAILURE_DUPLICATE'
 export const CREATE_FOLDER_SUCCESS = 'CREATE_FOLDER_SUCCESS'
+export const PRE_UPLOAD_FILE = 'PRE_UPLOAD_FILE'
 export const UPLOAD_FILE = 'UPLOAD_FILE'
 export const UPLOAD_FILE_SUCCESS = 'UPLOAD_FILE_SUCCESS'
 export const TRASH_FILES = 'TRASH_FILES'
@@ -113,6 +114,10 @@ export const openFileInNewTab = (folder, file) => {
 export const uploadFiles = (files, folder) => {
   return async (dispatch, getState) => {
     let currentFileCount = getState().view.fileCount
+    dispatch({
+      type: PRE_UPLOAD_FILE,
+      count: files.length
+    })
     for (const file of files) {
       try {
         dispatch({ type: UPLOAD_FILE })

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,6 +13,7 @@ import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import { Router, hashHistory } from 'react-router'
 import { I18n } from './lib/I18n'
+import piwikMiddleware from './middlewares/piwik'
 
 import filesApp from './reducers'
 import AppRoute from './components/AppRoute'
@@ -35,7 +36,8 @@ const store = createStore(
   filesApp,
   composeEnhancers(applyMiddleware(
     thunkMiddleware,
-    loggerMiddleware
+    loggerMiddleware,
+    piwikMiddleware
   ))
 )
 

--- a/src/middlewares/piwik.js
+++ b/src/middlewares/piwik.js
@@ -22,8 +22,11 @@ const piwik = store => next => action => {
   }
 
   if (event && event.category && event.action) {
-    const tracker = Piwik.getTracker()
-    tracker.trackEvent(event.category, event.action, event.name, event.value)
+    try {
+      const tracker = Piwik.getTracker()
+      tracker.trackEvent(event.category, event.action, event.name, event.value)
+    }
+    catch (err) { }
   }
 
   return next(action)

--- a/src/middlewares/piwik.js
+++ b/src/middlewares/piwik.js
@@ -14,7 +14,7 @@ const ACTIONS = {
 const piwik = store => next => action => {
   let event = null
 
-  switch (action.type){
+  switch (action.type) {
     case PRE_UPLOAD_FILE:
       event = {
         category: CATEGORY.INTERACTION,
@@ -22,17 +22,16 @@ const piwik = store => next => action => {
         name: 'file',
         value: action.count
       }
-      break;
+      break
     default:
-      break;
+      break
   }
 
   if (event && event.category && event.action) {
     try {
       const tracker = Piwik.getTracker()
       tracker.trackEvent(event.category, event.action, event.name, event.value)
-    }
-    catch (err) { }
+    } catch (err) { }
   }
 
   return next(action)

--- a/src/middlewares/piwik.js
+++ b/src/middlewares/piwik.js
@@ -1,20 +1,26 @@
 /* global Piwik */
 import {
-  UPLOAD_FILE
+  PRE_UPLOAD_FILE
 } from '../actions'
 
 const CATEGORY = {
-  BUTTONS: 'buttons'
+  INTERACTION: 'interaction'
+}
+
+const ACTIONS = {
+  UPLOAD: 'upload'
 }
 
 const piwik = store => next => action => {
   let event = null
 
   switch (action.type){
-    case UPLOAD_FILE:
+    case PRE_UPLOAD_FILE:
       event = {
-        category: CATEGORY.BUTTONS,
-        action: 'upload'
+        category: CATEGORY.INTERACTION,
+        action: ACTIONS.UPLOAD,
+        name: 'file',
+        value: action.count
       }
       break;
     default:

--- a/src/middlewares/piwik.js
+++ b/src/middlewares/piwik.js
@@ -1,0 +1,32 @@
+/* global Piwik */
+import {
+  UPLOAD_FILE
+} from '../actions'
+
+const CATEGORY = {
+  BUTTONS: 'buttons'
+}
+
+const piwik = store => next => action => {
+  let event = null
+
+  switch (action.type){
+    case UPLOAD_FILE:
+      event = {
+        category: CATEGORY.BUTTONS,
+        action: 'upload'
+      }
+      break;
+    default:
+      break;
+  }
+
+  if (event && event.category && event.action) {
+    const tracker = Piwik.getTracker()
+    tracker.trackEvent(event.category, event.action, event.name, event.value)
+  }
+
+  return next(action)
+}
+
+export default piwik


### PR DESCRIPTION
I've created a new redux middleware that can be used as a hook to track certain actions in piwik. The upside is that we'll be able to track most actions quite easily; the downside is that sometimes (as is the case here), we're going to need new actions / modify existing one solely for the middleware, not for the store.

Tell me what you think about this approach, and once we've found a good one I'll deploy the same thing to photos.