### PR TITLE
refactor: Piwik wrapper

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -26,5 +26,6 @@
   data-cozy-locale="{{.Locale}}"
   data-cozy-app-name="{{.AppName}}"
   data-cozy-app-editor="{{.AppEditor}}"
+  data-cozy-tracking="{{.Tracking}}"
   data-cozy-icon-path="{{.IconPath}}"
 >

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -14,9 +14,11 @@
   <meta name="format-detection" content="telephone=no">
   <script src="cordova.js" defer></script>
   <% } else if (__STACK_ASSETS__) { %>
-  <script src="//{{.Domain}}/assets/js/piwik.js" defer></script>
   {{.CozyClientJS}}
   {{.CozyBar}}
+  <% } %>
+  <%  if (__STACK_ASSETS__ || __DEVELOPMENT__) { %>
+  <script src="//{{.Domain}}/assets/js/piwik.js" defer></script>
   <% } %>
 </head>
 <div

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -1,0 +1,109 @@
+/* global __PIWIK_TRACKER_URL__ __PIWIK_SITEID__ __PIWIK_DIMENSION_ID_APP__ */
+/* global cozy */
+
+let trackerInstance = null
+
+// SIngleton class
+export default class Tracker {
+  /**
+   * Tries to detect if tracking should be enabled or not, based on a `cozyTracking` attribute in the root dataset.
+   * @returns {boolean} Undefined if it can't find the information, true/false otherwise.
+   */
+  static shouldEnableTracking () {
+    const root = document.querySelector('[role=application]')
+
+    if (root && root.dataset) {
+      let track = root.dataset.cozyTracking
+
+      if (track === '' || track === 'true') return true
+      else if (track === 'false') return false
+    }
+
+    return undefined;
+  }
+  /**
+   * Returns the instance of the piwik tracker, creating it on thee fly if required. All parameters are optionnal.
+   * @param   {string} trackerUrl                    The URL of the piwik instance, without the php file name
+   * @param   {number} siteId                        The siteId to use for piwik
+   * @param   {boolean} automaticallyConfigure = true Pass false to skip the automatic configuration
+   * @returns {object} An instance of `PiwikReactRouter` on success, null if the creation fails (usually because of adblockers)
+   */
+  static getTracker (trackerUrl, siteId, automaticallyConfigure = true) {
+    if (trackerInstance !== null) return trackerInstance
+
+    try {
+      var PiwikReactRouter = require('piwik-react-router')
+
+      trackerInstance = (Piwik.getTracker(), PiwikReactRouter({
+        url: trackerUrl || __PIWIK_TRACKER_URL__,
+        siteId: siteId || __PIWIK_SITEID__, // site id is required here
+        injectScript: false
+      }))
+
+      // apply the default configuration
+      if (automaticallyConfigure) Tracker.configureTracker()
+
+      return trackerInstance
+    }
+    catch (err) {
+      //this usually happens when there's an ad blocker
+      console.warn(err)
+      trackerInstance = null
+      return null
+    }
+  }
+  /**
+   * Configures the base options for the tracker which will persist during the session.
+   * @param   {object} options A map of options that can be configured.
+   *          {string} options.userId
+   *          {number} options.appDimensionId
+   *          {string} options.app
+   *          {boolean} options.heartbeat
+   */
+  static configureTracker (options = {}) {
+    // early out in case the tracker is not available
+    if (trackerInstance === null) {
+      // maybe we should throw an error here?
+      return
+    }
+
+    // compute the default values for options
+    let userId
+    let appName
+
+    const root = document.querySelector('[role=application]')
+    if (root && root.dataset) {
+      appName = root.dataset.cozyAppName
+      userId = root.dataset.cozyDomain || ''
+
+      let indexOfPort = userId.indexOf(':')
+      if (indexOfPort >= 0) userId = userId.substring(0, indexOfPort)
+    }
+
+    //merge default options with what has been provided
+    options = Object.assign({
+      userId: userId,
+      appDimensionId: __PIWIK_DIMENSION_ID_APP__,
+      app: appName,
+      heartbeat: true
+    }, options)
+
+    //apply them
+    if (options.heartbeat) trackerInstance.push(['enableHeartBeatTimer'])
+    trackerInstance.push(['setUserId', options.userId])
+    trackerInstance.push(['setCustomDimension', options.appDimensionId, options.app])
+  }
+  /**
+   * Returns a new middleware for redux, which will track events if the action has an `trackEvent` field, containing at least `category` and `action` fields.
+   * @returns {function}
+   */
+  static createMiddleware () {
+    return store => next => action => {
+      if (action.trackEvent && action.trackEvent.category && action.trackEvent.action)  {
+        trackerInstance.push(['trackEvent', action.trackEvent.category, action.trackEvent.action, action.trackEvent.name, action.trackEvent.value])
+      }
+
+      return next(action)
+    }
+  }
+}

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -1,5 +1,5 @@
 /* global __PIWIK_TRACKER_URL__ __PIWIK_SITEID__ __PIWIK_DIMENSION_ID_APP__ */
-/* global cozy */
+/* global Piwik */
 
 // Think of these functions as a singleton class with only static methods.
 let trackerInstance = null
@@ -18,7 +18,7 @@ export const shouldEnableTracking = () => {
     else if (track === 'false') return false
   }
 
-  return undefined;
+  return undefined
 }
 
 /**
@@ -44,9 +44,8 @@ export const getTracker = (trackerUrl, siteId, automaticallyConfigure = true) =>
     if (automaticallyConfigure) configureTracker()
 
     return trackerInstance
-  }
-  catch (err) {
-    //this usually happens when there's an ad blocker
+  } catch (err) {
+    // this usually happens when there's an ad blocker
     console.warn(err)
     trackerInstance = null
     return null
@@ -81,7 +80,7 @@ export const configureTracker = (options = {}) => {
     if (indexOfPort >= 0) userId = userId.substring(0, indexOfPort)
   }
 
-  //merge default options with what has been provided
+  // merge default options with what has been provided
   options = Object.assign({
     userId: userId,
     appDimensionId: __PIWIK_DIMENSION_ID_APP__,
@@ -89,7 +88,7 @@ export const configureTracker = (options = {}) => {
     heartbeat: true
   }, options)
 
-  //apply them
+  // apply them
   if (options.heartbeat) trackerInstance.push(['enableHeartBeatTimer'])
   trackerInstance.push(['setUserId', options.userId])
   trackerInstance.push(['setCustomDimension', options.appDimensionId, options.app])
@@ -101,7 +100,7 @@ export const configureTracker = (options = {}) => {
 */
 export const createTrackerMiddleware = () => {
   return store => next => action => {
-    if (trackerInstance && action.trackEvent && action.trackEvent.category && action.trackEvent.action)  {
+    if (trackerInstance && action.trackEvent && action.trackEvent.category && action.trackEvent.action) {
       trackerInstance.push(['trackEvent', action.trackEvent.category, action.trackEvent.action, action.trackEvent.name, action.trackEvent.value])
     }
 

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -1,109 +1,110 @@
 /* global __PIWIK_TRACKER_URL__ __PIWIK_SITEID__ __PIWIK_DIMENSION_ID_APP__ */
 /* global cozy */
 
+// Think of these functions as a singleton class with only static methods.
 let trackerInstance = null
 
-// SIngleton class
-export default class Tracker {
-  /**
-   * Tries to detect if tracking should be enabled or not, based on a `cozyTracking` attribute in the root dataset.
-   * @returns {boolean} Undefined if it can't find the information, true/false otherwise.
-   */
-  static shouldEnableTracking () {
-    const root = document.querySelector('[role=application]')
+/**
+* Tries to detect if tracking should be enabled or not, based on a `cozyTracking` attribute in the root dataset.
+* @returns {boolean} Undefined if it can't find the information, true/false otherwise.
+*/
+export const shouldEnableTracking = () => {
+  const root = document.querySelector('[role=application]')
 
-    if (root && root.dataset) {
-      let track = root.dataset.cozyTracking
+  if (root && root.dataset) {
+    let track = root.dataset.cozyTracking
 
-      if (track === '' || track === 'true') return true
-      else if (track === 'false') return false
-    }
-
-    return undefined;
+    if (track === '' || track === 'true') return true
+    else if (track === 'false') return false
   }
-  /**
-   * Returns the instance of the piwik tracker, creating it on thee fly if required. All parameters are optionnal.
-   * @param   {string} trackerUrl                    The URL of the piwik instance, without the php file name
-   * @param   {number} siteId                        The siteId to use for piwik
-   * @param   {boolean} automaticallyConfigure = true Pass false to skip the automatic configuration
-   * @returns {object} An instance of `PiwikReactRouter` on success, null if the creation fails (usually because of adblockers)
-   */
-  static getTracker (trackerUrl, siteId, automaticallyConfigure = true) {
-    if (trackerInstance !== null) return trackerInstance
 
-    try {
-      var PiwikReactRouter = require('piwik-react-router')
+  return undefined;
+}
 
-      trackerInstance = (Piwik.getTracker(), PiwikReactRouter({
-        url: trackerUrl || __PIWIK_TRACKER_URL__,
-        siteId: siteId || __PIWIK_SITEID__, // site id is required here
-        injectScript: false
-      }))
+/**
+* Returns the instance of the piwik tracker, creating it on thee fly if required. All parameters are optionnal.
+* @param   {string}  trackerUrl             The URL of the piwik instance, without the php file name
+* @param   {number}  siteId                 The siteId to use for piwik
+* @param   {boolean} automaticallyConfigure = true Pass false to skip the automatic configuration
+* @returns {object}  An instance of `PiwikReactRouter` on success, `null` if the creation fails (usually because of adblockers)
+*/
+export const getTracker = (trackerUrl, siteId, automaticallyConfigure = true) => {
+  if (trackerInstance !== null) return trackerInstance
 
-      // apply the default configuration
-      if (automaticallyConfigure) Tracker.configureTracker()
+  try {
+    var PiwikReactRouter = require('piwik-react-router')
 
-      return trackerInstance
-    }
-    catch (err) {
-      //this usually happens when there's an ad blocker
-      console.warn(err)
-      trackerInstance = null
-      return null
-    }
+    trackerInstance = (Piwik.getTracker(), PiwikReactRouter({
+      url: trackerUrl || __PIWIK_TRACKER_URL__,
+      siteId: siteId || __PIWIK_SITEID__, // site id is required here
+      injectScript: false
+    }))
+
+    // apply the default configuration
+    if (automaticallyConfigure) configureTracker()
+
+    return trackerInstance
   }
-  /**
-   * Configures the base options for the tracker which will persist during the session.
-   * @param   {object} options A map of options that can be configured.
-   *          {string} options.userId
-   *          {number} options.appDimensionId
-   *          {string} options.app
-   *          {boolean} options.heartbeat
-   */
-  static configureTracker (options = {}) {
-    // early out in case the tracker is not available
-    if (trackerInstance === null) {
-      // maybe we should throw an error here?
-      return
-    }
-
-    // compute the default values for options
-    let userId
-    let appName
-
-    const root = document.querySelector('[role=application]')
-    if (root && root.dataset) {
-      appName = root.dataset.cozyAppName
-      userId = root.dataset.cozyDomain || ''
-
-      let indexOfPort = userId.indexOf(':')
-      if (indexOfPort >= 0) userId = userId.substring(0, indexOfPort)
-    }
-
-    //merge default options with what has been provided
-    options = Object.assign({
-      userId: userId,
-      appDimensionId: __PIWIK_DIMENSION_ID_APP__,
-      app: appName,
-      heartbeat: true
-    }, options)
-
-    //apply them
-    if (options.heartbeat) trackerInstance.push(['enableHeartBeatTimer'])
-    trackerInstance.push(['setUserId', options.userId])
-    trackerInstance.push(['setCustomDimension', options.appDimensionId, options.app])
+  catch (err) {
+    //this usually happens when there's an ad blocker
+    console.warn(err)
+    trackerInstance = null
+    return null
   }
-  /**
-   * Returns a new middleware for redux, which will track events if the action has an `trackEvent` field, containing at least `category` and `action` fields.
-   * @returns {function}
-   */
-  static createMiddleware () {
-    return store => next => action => {
-      if (action.trackEvent && action.trackEvent.category && action.trackEvent.action)  {
-        trackerInstance.push(['trackEvent', action.trackEvent.category, action.trackEvent.action, action.trackEvent.name, action.trackEvent.value])
-      }
+}
 
-      return next(action)
+/**
+* Configures the base options for the tracker which will persist during the session.
+* @param   {object} options A map of options that can be configured.
+*                         {string} options.userId
+*                         {number} options.appDimensionId
+*                         {string} options.app
+*                         {boolean} options.heartbeat
+*/
+export const configureTracker = (options = {}) => {
+  // early out in case the tracker is not available
+  if (trackerInstance === null) {
+    // maybe we should throw an error here?
+    return
+  }
+
+  // compute the default values for options
+  let userId
+  let appName
+
+  const root = document.querySelector('[role=application]')
+  if (root && root.dataset) {
+    appName = root.dataset.cozyAppName
+    userId = root.dataset.cozyDomain || ''
+
+    let indexOfPort = userId.indexOf(':')
+    if (indexOfPort >= 0) userId = userId.substring(0, indexOfPort)
+  }
+
+  //merge default options with what has been provided
+  options = Object.assign({
+    userId: userId,
+    appDimensionId: __PIWIK_DIMENSION_ID_APP__,
+    app: appName,
+    heartbeat: true
+  }, options)
+
+  //apply them
+  if (options.heartbeat) trackerInstance.push(['enableHeartBeatTimer'])
+  trackerInstance.push(['setUserId', options.userId])
+  trackerInstance.push(['setCustomDimension', options.appDimensionId, options.app])
+}
+
+/**
+* Returns a new middleware for redux, which will track events if the action has an `trackEvent` field, containing at least `category` and `action` fields.
+* @returns {function}
+*/
+export const createTrackerMiddleware = () => {
+  return store => next => action => {
+    if (trackerInstance && action.trackEvent && action.trackEvent.category && action.trackEvent.action)  {
+      trackerInstance.push(['trackEvent', action.trackEvent.category, action.trackEvent.action, action.trackEvent.name, action.trackEvent.value])
     }
+
+    return next(action)
   }
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -58,22 +58,25 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   let history = hashHistory
-  try {
-    var PiwikReactRouter = require('piwik-react-router')
-    const piwikTracker = (Piwik.getTracker(), PiwikReactRouter({
-      url: __PIWIK_TRACKER_URL__,
-      siteId: __PIWIK_SITEID__,
-      injectScript: false
-    }))
-    piwikTracker.push(['enableHeartBeatTimer'])
-    let userId = data.cozyDomain
-    let indexOfPort = userId.indexOf(':')
-    if (indexOfPort >= 0) userId = userId.substring(0, indexOfPort)
-    piwikTracker.push(['setUserId', userId])
-    piwikTracker.push(['setCustomDimension', __PIWIK_DIMENSION_ID_APP__, data.cozyAppName])
 
-    history = piwikTracker.connectToHistory(hashHistory)
-  } catch (err) {}
+  if (data.cozyTracking === 'true' || data.cozyTracking === ''){
+    try {
+      var PiwikReactRouter = require('piwik-react-router')
+      const piwikTracker = (Piwik.getTracker(), PiwikReactRouter({
+        url: __PIWIK_TRACKER_URL__,
+        siteId: __PIWIK_SITEID__,
+        injectScript: false
+      }))
+      piwikTracker.push(['enableHeartBeatTimer'])
+      let userId = data.cozyDomain
+      let indexOfPort = userId.indexOf(':')
+      if (indexOfPort >= 0) userId = userId.substring(0, indexOfPort)
+      piwikTracker.push(['setUserId', userId])
+      piwikTracker.push(['setCustomDimension', __PIWIK_DIMENSION_ID_APP__, data.cozyAppName])
+
+      history = piwikTracker.connectToHistory(hashHistory)
+    } catch (err) {}
+  }
 
   render((
     <I18n context={context} lang={data.cozyLocale}>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,7 +13,7 @@ import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import { Router, hashHistory } from 'react-router'
 import { I18n } from './lib/I18n'
-import Tracker from './lib/tracker'
+import { shouldEnableTracking, getTracker, createTrackerMiddleware } from './lib/tracker'
 import eventTrackerMiddleware from './middlewares/EventTracker'
 
 import filesApp from './reducers'
@@ -51,12 +51,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let history = hashHistory
   let middlewares = [thunkMiddleware, loggerMiddleware]
 
-  if (Tracker.shouldEnableTracking() && Tracker.getTracker()) {
-    let trackerInstance = Tracker.getTracker()
+  if (shouldEnableTracking() && getTracker()) {
+    let trackerInstance = getTracker()
     history = trackerInstance.connectToHistory(hashHistory)
     trackerInstance.track(hashHistory.getCurrentLocation()) // when using a hash history, the initial visit is not tracked by piwik react router
     middlewares.push(eventTrackerMiddleware)
-    middlewares.push(Tracker.createMiddleware())
+    middlewares.push(createTrackerMiddleware())
   }
 
   // Enable Redux dev tools

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -29,18 +29,6 @@ if (__DEVELOPMENT__) {
   window.React = React
 }
 
-// Enable Redux dev tools
-const composeEnhancers = (__DEVELOPMENT__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
-
-const store = createStore(
-  filesApp,
-  composeEnhancers(applyMiddleware(
-    thunkMiddleware,
-    loggerMiddleware,
-    piwikMiddleware
-  ))
-)
-
 document.addEventListener('DOMContentLoaded', () => {
   const context = window.context
   const root = document.querySelector('[role=application]')
@@ -60,8 +48,11 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   let history = hashHistory
+  let middlewares = [thunkMiddleware, loggerMiddleware]
 
-  if (data.cozyTracking === 'true' || data.cozyTracking === ''){
+  const enableTracking = data.cozyTracking === 'true' || data.cozyTracking === ''
+
+  if (enableTracking){
     try {
       var PiwikReactRouter = require('piwik-react-router')
       const piwikTracker = (Piwik.getTracker(), PiwikReactRouter({
@@ -77,8 +68,17 @@ document.addEventListener('DOMContentLoaded', () => {
       piwikTracker.push(['setCustomDimension', __PIWIK_DIMENSION_ID_APP__, data.cozyAppName])
 
       history = piwikTracker.connectToHistory(hashHistory)
+      middlewares.push(piwikMiddleware)
     } catch (err) {}
   }
+
+  // Enable Redux dev tools
+  const composeEnhancers = (__DEVELOPMENT__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
+
+  const store = createStore(
+    filesApp,
+    composeEnhancers(applyMiddleware.apply(this, middlewares))
+  )
 
   render((
     <I18n context={context} lang={data.cozyLocale}>

--- a/src/middlewares/EventTracker.js
+++ b/src/middlewares/EventTracker.js
@@ -1,4 +1,3 @@
-/* global Piwik */
 import {
   PRE_UPLOAD_FILE
 } from '../actions'

--- a/src/middlewares/EventTracker.js
+++ b/src/middlewares/EventTracker.js
@@ -11,12 +11,10 @@ const ACTIONS = {
   UPLOAD: 'upload'
 }
 
-const piwik = store => next => action => {
-  let event = null
-
+const tracker = store => next => action => {
   switch (action.type) {
     case PRE_UPLOAD_FILE:
-      event = {
+      action.trackEvent = {
         category: CATEGORY.INTERACTION,
         action: ACTIONS.UPLOAD,
         name: 'file',
@@ -27,14 +25,7 @@ const piwik = store => next => action => {
       break
   }
 
-  if (event && event.category && event.action) {
-    try {
-      const tracker = Piwik.getTracker()
-      tracker.trackEvent(event.category, event.action, event.name, event.value)
-    } catch (err) { }
-  }
-
   return next(action)
 }
 
-export default piwik
+export default tracker


### PR DESCRIPTION
This is a proposal for a module dedicated to Piwik, which could be externalized to cozy-ui or a separate library.

The module exposes 2 things:
- access to a unique Piwik instance object; this is important because otherwise every instance has to be configured with the user id, the app name, etc.
- a redux middleware (see comments in code for more on that)

The module's function pull default values from our usual setup (global variables and the root element's dataset), so they need little configuration. However all these defaults can be overriden, so the module should work in any setup and all parts are optional. The only dependency is [piwik-react-router](https://github.com/joernroeder/piwik-react-router) and, of course, Piwik.