### PR TITLE
feat: enable piwik tracking on mobile

### DIFF
--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -7,7 +7,7 @@ import { getDeviceName } from '../lib/device'
 import { openFolder } from '../../../src/actions'
 import { REGISTRATION_ABORT, onRegistered } from '../lib/registration'
 import { logException, logInfo, configure as configureReporter } from '../lib/reporter'
-import { startTracker, resetTracker } from '../lib/tracker'
+import { startTracker, stopTracker } from '../lib/tracker'
 import { pingOnceADay } from './timestamp'
 import { revokeClient as reduxRevokeClient } from './authorization'
 
@@ -34,7 +34,7 @@ export const setAnalytics = (analytics, source = 'settings') => (dispatch, getSt
     // start the piwik tracker
     startTracker(state.mobile.settings.serverUrl)
   } else if (analytics === false) {
-    resetTracker()
+    stopTracker()
   }
 }
 export const setBackupImages = backupImages => ({ type: BACKUP_IMAGES, backupImages })

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -7,6 +7,7 @@ import { getDeviceName } from '../lib/device'
 import { openFolder } from '../../../src/actions'
 import { REGISTRATION_ABORT, onRegistered } from '../lib/registration'
 import { logException, logInfo, configure as configureReporter } from '../lib/reporter'
+import { startTracker, resetTracker } from '../lib/tracker'
 import { pingOnceADay } from './timestamp'
 import { revokeClient as reduxRevokeClient } from './authorization'
 
@@ -30,6 +31,10 @@ export const setAnalytics = (analytics, source = 'settings') => (dispatch, getSt
     const value = state.mobile.settings.backupImages
     logInfo(`${source}: backup images is ${value ? 'enabled' : 'disabled'}`)
     dispatch(pingOnceADay(state.mobile.timestamp, analytics))
+    // start the piwik tracker
+    startTracker(state.mobile.settings.serverUrl)
+  } else if (analytics === false) {
+    resetTracker()
   }
 }
 export const setBackupImages = backupImages => ({ type: BACKUP_IMAGES, backupImages })

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -2,14 +2,14 @@
 import { getLang } from './init'
 import { LocalStorage as Storage } from 'cozy-client-js'
 
-export const cozyAppName = 'Drive'
+export const softwareID = 'io.cozy.drive.mobile'
 export const clientRevokedMsg = 'Client has been revoked'
 const getStorage = () => new Storage()
 const getClientName = device => `Cozy Drive (${device})`
 
 const getClientParams = (device) => ({
   redirectURI: 'http://localhost',
-  softwareID: 'io.cozy.drive.mobile',
+  softwareID: softwareID,
   clientName: getClientName(device),
   softwareVersion: __APP_VERSION__,
   clientKind: 'mobile',
@@ -39,7 +39,7 @@ export const initClient = (url, onRegister = null, device = 'Device') => {
 
 export const initBar = () => {
   cozy.bar.init({
-    appName: cozyAppName,
+    appName: 'Drive',
     appEditor: 'Cozy',
     iconPath: require('../../../vendor/assets/app-icon.svg'),
     lang: getLang(),

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -2,6 +2,7 @@
 import { getLang } from './init'
 import { LocalStorage as Storage } from 'cozy-client-js'
 
+export const cozyAppName = 'Drive'
 export const clientRevokedMsg = 'Client has been revoked'
 const getStorage = () => new Storage()
 const getClientName = device => `Cozy Drive (${device})`
@@ -38,7 +39,7 @@ export const initClient = (url, onRegister = null, device = 'Device') => {
 
 export const initBar = () => {
   cozy.bar.init({
-    appName: 'Drive',
+    appName: cozyAppName,
     appEditor: 'Cozy',
     iconPath: require('../../../vendor/assets/app-icon.svg'),
     lang: getLang(),

--- a/mobile/src/lib/store.js
+++ b/mobile/src/lib/store.js
@@ -2,6 +2,8 @@ import { createStore, applyMiddleware } from 'redux'
 import RavenMiddleWare from 'redux-raven-middleware'
 import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
+import eventTrackerMiddleware from '../../../src/middlewares/EventTracker'
+import { createTrackerMiddleware } from '../../../src/lib/tracker'
 
 import filesApp from '../reducers'
 import { ANALYTICS_URL, getConfig as getAnalyticsConfiguration } from './reporter'
@@ -9,6 +11,7 @@ import { saveState } from './localStorage'
 
 const loggerMiddleware = createLogger()
 const ravenMiddleWare = RavenMiddleWare(ANALYTICS_URL, getAnalyticsConfiguration())
+const trackerMiddleware = createTrackerMiddleware()
 
 export const configureStore = (persistedState) => {
   const store = createStore(
@@ -17,7 +20,9 @@ export const configureStore = (persistedState) => {
     applyMiddleware(
       ravenMiddleWare,
       thunkMiddleware,
-      loggerMiddleware
+      loggerMiddleware,
+      eventTrackerMiddleware,
+      trackerMiddleware
     )
   )
 

--- a/mobile/src/lib/tracker.js
+++ b/mobile/src/lib/tracker.js
@@ -1,0 +1,31 @@
+/* global __PIWIK_TRACKER_URL__ __PIWIK_SITEID__ */
+import { getTracker, configureTracker } from '../../../src/lib/tracker'
+import { cozyAppName } from './cozy-helper'
+
+// We'll need access to the app's router history at some point
+let appHistory
+
+export const useHistoryForTracker = (history) => {
+  appHistory = history
+}
+
+export const startTracker = (cozyServerUrl = '') => {
+  // start the tracker, inject the script
+  const trackerInstance = getTracker(__PIWIK_TRACKER_URL__, __PIWIK_SITEID__, false, true)
+
+  // configure the options that aren't in webpack variables
+  let url = new URL(cozyServerUrl)
+
+  configureTracker({
+    userId: url.hostname || cozyServerUrl,
+    app: cozyAppName
+  })
+
+  // connect to the router history if possible
+  if (appHistory) {
+    trackerInstance.connectToHistory(appHistory)
+    trackerInstance.track(appHistory.getCurrentLocation()) // force tracking the current page
+  }
+}
+
+export { resetTracker } from '../../../src/lib/tracker'

--- a/mobile/src/lib/tracker.js
+++ b/mobile/src/lib/tracker.js
@@ -1,6 +1,8 @@
 /* global __PIWIK_TRACKER_URL__ __PIWIK_SITEID__ */
-import { getTracker, configureTracker } from '../../../src/lib/tracker'
+import { getTracker, configureTracker, resetTracker } from '../../../src/lib/tracker'
 import { cozyAppName } from './cozy-helper'
+
+const mobileHeartBeatDelay = 30 // how many seconds between each hreatbeat ping to the server
 
 // We'll need access to the app's router history at some point
 let appHistory
@@ -18,7 +20,8 @@ export const startTracker = (cozyServerUrl = '') => {
 
   configureTracker({
     userId: url.hostname || cozyServerUrl,
-    app: cozyAppName
+    app: cozyAppName,
+    heartbeat: mobileHeartBeatDelay
   })
 
   // connect to the router history if possible
@@ -28,4 +31,27 @@ export const startTracker = (cozyServerUrl = '') => {
   }
 }
 
-export { resetTracker } from '../../../src/lib/tracker'
+export const stopTracker = () => {
+  resetTracker()
+  stopHeartBeat()
+}
+
+export const startHeartBeat = () => {
+  const trackerInstance = getTracker()
+
+  if (trackerInstance) {
+    try {
+      trackerInstance.push(['enableHeartBeatTimer', mobileHeartBeatDelay])
+    } catch (err) {}
+  }
+}
+
+export const stopHeartBeat = () => {
+  const trackerInstance = getTracker()
+
+  if (trackerInstance) {
+    try {
+      trackerInstance.push(['disableHeartBeatTimer']) // undocumented, see https://github.com/piwik/piwik/blob/3.x-dev/js/piwik.js#L6544
+    } catch (err) {}
+  }
+}

--- a/mobile/src/lib/tracker.js
+++ b/mobile/src/lib/tracker.js
@@ -1,6 +1,6 @@
 /* global __PIWIK_TRACKER_URL__ __PIWIK_SITEID__ */
 import { getTracker, configureTracker, resetTracker } from '../../../src/lib/tracker'
-import { cozyAppName } from './cozy-helper'
+import { softwareID } from './cozy-helper'
 
 const mobileHeartBeatDelay = 30 // how many seconds between each hreatbeat ping to the server
 
@@ -20,7 +20,7 @@ export const startTracker = (cozyServerUrl = '') => {
 
   configureTracker({
     userId: url.hostname || cozyServerUrl,
-    app: cozyAppName,
+    app: softwareID,
     heartbeat: mobileHeartBeatDelay
   })
 

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -15,6 +15,7 @@ import { loadState } from './lib/localStorage'
 import { configureStore } from './lib/store'
 import { initServices, getLang } from './lib/init'
 import { startBackgroundService } from './lib/background'
+import { startTracker, useHistoryForTracker } from './lib/tracker'
 import { resetClient } from './lib/cozy-helper'
 import { pingOnceADay } from './actions/timestamp'
 import { backupImages } from './actions/mediaBackup'
@@ -53,6 +54,9 @@ const renderAppWithPersistedState = persistedState => {
     store.dispatch(backupImages())
     if (navigator && navigator.splashscreen) navigator.splashscreen.hide()
   }, false)
+
+  useHistoryForTracker(hashHistory)
+  if (store.getState().mobile.settings.analytics) startTracker(store.getState().mobile.settings.serverUrl)
 
   const context = window.context
   const root = document.querySelector('[role=application]')

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -15,7 +15,7 @@ import { loadState } from './lib/localStorage'
 import { configureStore } from './lib/store'
 import { initServices, getLang } from './lib/init'
 import { startBackgroundService } from './lib/background'
-import { startTracker, useHistoryForTracker } from './lib/tracker'
+import { startTracker, useHistoryForTracker, startHeartBeat, stopHeartBeat } from './lib/tracker'
 import { resetClient } from './lib/cozy-helper'
 import { pingOnceADay } from './actions/timestamp'
 import { backupImages } from './actions/mediaBackup'
@@ -45,8 +45,13 @@ const renderAppWithPersistedState = persistedState => {
     }
   }
 
+  document.addEventListener('pause', () => {
+    if (store.getState().mobile.settings.analytics) stopHeartBeat()
+  }, false)
+
   document.addEventListener('resume', () => {
     pingOnceADayWithState()
+    if (store.getState().mobile.settings.analytics) startHeartBeat()
   }, false)
 
   document.addEventListener('deviceready', () => {

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -63,7 +63,7 @@ export const getTracker = (trackerUrl, siteId, automaticallyConfigure = true, in
 *                         {string} options.userId
 *                         {number} options.appDimensionId
 *                         {string} options.app
-*                         {boolean} options.heartbeat
+*                         {number} options.heartbeat
 */
 export const configureTracker = (options = {}) => {
   // early out in case the tracker is not available
@@ -86,15 +86,16 @@ export const configureTracker = (options = {}) => {
   }
 
   // merge default options with what has been provided
-  options = Object.assign({
+  options = {
     userId: userId,
     appDimensionId: __PIWIK_DIMENSION_ID_APP__,
     app: appName,
-    heartbeat: true
-  }, options)
+    heartbeat: 15,
+    ...options
+  }
 
   // apply them
-  if (options.heartbeat) trackerInstance.push(['enableHeartBeatTimer'])
+  if (parseInt(options.heartbeat) > 0) trackerInstance.push(['enableHeartBeatTimer', parseInt(options.heartbeat)])
   trackerInstance.push(['setUserId', options.userId])
   trackerInstance.push(['setCustomDimension', options.appDimensionId, options.app])
 }


### PR DESCRIPTION
As discussed, I've updated the tracker lib so that it can be used to inject the piwik script instead of relying on it to be already there.

On the mobile side of things, i've added a file in lib that can active and deactivate the tracking, and I've added the middlewares. the activate function is called once on start up, and when the setting is changed.