### PR TITLE
Keep class name coherent with file name

### DIFF
--- a/src/components/IntentHandler.jsx
+++ b/src/components/IntentHandler.jsx
@@ -4,7 +4,7 @@ import utilStyles from '../styles/utils'
 import React from 'react'
 import Loading from './Loading'
 
-class FileViewer extends React.Component {
+class IntentHandler extends React.Component {
   getInitialState () {
     return {
       loading: true
@@ -52,4 +52,4 @@ class FileViewer extends React.Component {
   }
 }
 
-export default FileViewer
+export default IntentHandler

--- a/src/components/IntentHandler.jsx
+++ b/src/components/IntentHandler.jsx
@@ -36,7 +36,7 @@ class IntentHandler extends React.Component {
       }
     } catch (error) {
       this.setState({ error, loading: false })
-      if (service && intent.attributes.action === 'GET_URL') {
+      if (service && intent && intent.attributes.action === 'GET_URL') {
         service.terminate({ error: error.message })
       }
     }

--- a/src/components/IntentHandler.jsx
+++ b/src/components/IntentHandler.jsx
@@ -36,9 +36,8 @@ class IntentHandler extends React.Component {
       }
     } catch (error) {
       this.setState({ error, loading: false })
-
       if (service && intent.attributes.action === 'GET_URL') {
-        service.terminate({ error })
+        service.terminate({ error: error.message })
       }
     }
   }


### PR DESCRIPTION
1. Rename class to have the same name as the file
2. Only sends the `message` part of the error through the inter-window channel