### PR TITLE
fix: Download app button position on tablet view

### DIFF
--- a/src/styles/buttonclient.styl
+++ b/src/styles/buttonclient.styl
@@ -12,6 +12,10 @@
 .coz-banner-client
     position relative
 
+    @media (min-width: (480/basefont)rem) and (max-width: (1023/basefont)rem)
+        margin-top     em(-30px)
+        margin-bottom  em(30px)
+
     @media (min-width: (1023/basefont)rem)
         display none
 


### PR DESCRIPTION
Download app button for mobile was misplaced on tablet viewport (between 480px and 1024px).

It surely seems like an odd job. 
I could have done it prettier (but with much more lines) but it would have been too much complex fix for just an ad that is never gonna stay for long anyway. I think this is the most pragmatic way.