### PR TITLE
fix: select the first file scrolled up the page

### DIFF
--- a/src/components/FolderView.jsx
+++ b/src/components/FolderView.jsx
@@ -89,7 +89,9 @@ class FolderView extends Component {
         </Topbar>
         <div role='contentinfo'>
           {__TARGET__ === 'mobile' && <UploadProgression />}
-          {selectionModeActive && <SelectionBar selected={selected} actions={actions.selection} />}
+          <div style={{display: selectionModeActive ? 'inherit' : 'none'}} >
+            <SelectionBar selected={selected} actions={actions.selection} />
+          </div>
           <div className={styles['fil-content-table']}>
             <FileListHeader />
             <div className={styles['fil-content-body']}>


### PR DESCRIPTION
**bug**
On the first file selection, the view scrolled up to the top.
It was due to the `<SelectionBar />` addition in the DOM.

**fix**
We always have the `<SelectionBar />` in the DOM, but when no files are selected, the wrapping `<div />` HTMLElement is `display: none`. As soone as the first file is selected, we don't mutate the DOM but displaying the wrapping `<div />` HTMLElement.