### PR TITLE
fix: add i18n to the intent service

### DIFF
--- a/src/services.jsx
+++ b/src/services.jsx
@@ -6,6 +6,7 @@ import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
 import IntentHandler from './components/IntentHandler'
+import { I18n } from 'cozy-ui/react/I18n'
 
 if (__DEVELOPMENT__) {
   // Enables React dev tools for Preact
@@ -39,5 +40,8 @@ document.addEventListener('DOMContentLoaded', () => {
     token: data.cozyToken
   })
 
-  render(<IntentHandler intentId={intent} />, root)
+  render((
+    <I18n lang={data.cozyLocale} dictRequire={(lang) => require(`./locales/${lang}`)}>
+      <IntentHandler intentId={intent} />
+    </I18n>), root)
 })


### PR DESCRIPTION
The intent service did not work anymore since it does not have i18n. This breaks espacially the cozy-edf application