### PR TITLE
fix: file action menu icon

### DIFF
--- a/src/styles/actionmenu.styl
+++ b/src/styles/actionmenu.styl
@@ -33,6 +33,8 @@
 .fil-actionmenu-file
     margin-left   em(19px)
     padding-left  em(45px)
+    background-position 0 center
+    background-repeat no-repeat
 
 .fil-action-openWith
     background embedurl("../assets/icons/icon-link-out-16.svg") em(16px) center no-repeat


### PR DESCRIPTION
The mime type classe names I altered the other day were also used in a different module so that one broke. As far as I can tell these are the only two places they were used.