### PR TITLE
feat: add jpeg preview on filelist

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -33,7 +33,7 @@ export const OPEN_FILE_E_NO_APP = 'OPEN_FILE_E_NO_APP'
 
 export const getOpenedFolderId = state => state.view.openedFolderId
 
-export const extractFileAttributes = f => Object.assign({}, f.attributes, { id: f._id })
+export const extractFileAttributes = f => Object.assign({}, f.attributes, { id: f._id, links: f.links })
 const toServer = f => Object.assign({}, { attributes: f }, { _id: f.id })
 
 export const HTTP_CODE_CONFLICT = 409

--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -145,7 +145,7 @@ class File extends Component {
     const { filename, extension } = splitFilename(attributes)
     return (
       <div className={classes}>
-        { attributes.mime === 'image/jpeg' && <Preview thumbnail={`${cozy.client._url}${attributes.links.small}`} /> }
+        { attributes.links && <Preview thumbnail={`${cozy.client._url}${attributes.links.small}`} /> }
         {isRenaming
           ? <RenameInput />
           : <div>

--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -1,3 +1,4 @@
+/* global cozy */
 import React, { Component } from 'react'
 import classNames from 'classnames'
 import filesize from 'filesize'
@@ -9,6 +10,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import RenameInput from '../ducks/files/RenameInput'
 import { isDirectory } from '../ducks/files/files'
 import Spinner from 'cozy-ui/react/Spinner'
+import Preview from '../components/Preview'
 
 import { getFolderUrl } from '../reducers'
 
@@ -143,6 +145,7 @@ class File extends Component {
     const { filename, extension } = splitFilename(attributes)
     return (
       <div className={classes}>
+        { attributes.mime === 'image/jpeg' && <Preview thumbnail={`${cozy.client._url}${attributes.links.small}`} /> }
         {isRenaming
           ? <RenameInput />
           : <div>

--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -143,9 +143,10 @@ class File extends Component {
       { [styles['fil-content-file-openable']]: !isRenaming }
     )
     const { filename, extension } = splitFilename(attributes)
+    const url = cozy.client._url
     return (
       <div className={classes}>
-        { attributes.links && <Preview thumbnail={`${cozy.client._url}${attributes.links.small}`} /> }
+        { attributes.links && <Preview thumbnail={`${url}${attributes.links.small}`} /> }
         {isRenaming
           ? <RenameInput />
           : <div>

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,0 +1,9 @@
+import styles from '../styles/table'
+
+import React from 'react'
+
+const Preview = ({ thumbnail }) => (
+  <div className={styles['fil-file-preview']} style={`background-image: url(${thumbnail});`} />
+)
+
+export default Preview

--- a/src/styles/table.styl
+++ b/src/styles/table.styl
@@ -126,8 +126,8 @@ mime-types('fil-file-', '../assets/icons/')
     left 0
     top 50%
     transform translateY(-50%)
-    width 32px
-    height 32px
+    width em(32px)
+    height em(32px)
     background-size cover
     background-position center center
 

--- a/src/styles/table.styl
+++ b/src/styles/table.styl
@@ -124,8 +124,9 @@ mime-types('fil-file-', '../assets/icons/')
     content ''
     position absolute
     left 0
-    top 50%
-    transform translateY(-50%)
+    top 0
+    bottom 0
+    margin auto 0
     width em(32px)
     height em(32px)
     background-size cover

--- a/src/styles/table.styl
+++ b/src/styles/table.styl
@@ -76,6 +76,7 @@
     padding-left 0
 
 .fil-content-cell.fil-content-file
+    position       relative
     padding-left   em(45px)
     font-size      16px
     line-height    1.3
@@ -118,6 +119,17 @@
     padding 0 0 0 em(8px)
 
 mime-types('fil-file-', '../assets/icons/')
+
+.fil-file-preview
+    content ''
+    position absolute
+    left 0
+    top 50%
+    transform translateY(-50%)
+    width 32px
+    height 32px
+    background-size cover
+    background-position center center
 
 @keyframes placeHolderShimmer
     0%
@@ -183,3 +195,6 @@ mime-types('fil-file-', '../assets/icons/')
 
         .fil-content-file-action
             display none
+
+    .fil-file-preview
+        left em(16px)


### PR DESCRIPTION
So, I don't replace the mime type icon per say, I just add a new div with the preview image as background on top of that type icon.
Easier way to deal with it than replacing and in that case, when an error occurs, no preview is displayed and the icon type remains visible. Same thing for long loading time.

Although, it would be nice to have even smaller preview image from the stack. Even the small image is still way too big for what we're showing which means way too much bits are loaded, unused and unnecessary bits.