### PR TITLE
fix: destructuring is not ok for strings

### DIFF
--- a/src/components/ShareButton.jsx
+++ b/src/components/ShareButton.jsx
@@ -5,7 +5,7 @@ const ShareButton = ({ label, disabled, onShare, className }) => (
   <button
     role='button'
     disabled={disabled}
-    className={classnames(...className, 'coz-btn', 'coz-btn--secondary', 'coz-btn--share')}
+    className={classnames(className, 'coz-btn', 'coz-btn--secondary', 'coz-btn--share')}
     onClick={() => onShare()}
   >
     {label}


### PR DESCRIPTION
`<ShareButton className='coz-desktop' />` make sense as `className` props in React/Preact paradigm is a `String`.
But destructuring a `String` with the spread operator is not very useful inside the `<ShareButton />` component.
So I remove the destructuring operation, and now, if you want to add more than one css class for the component, you need to set the value to be a `String` or use something like [classnames](https://github.com/JedWatson/classnames) to build a `String`.

Sorry for that.