### PR TITLE
fix: extract file attributes after upload

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -122,7 +122,7 @@ export const openFileInNewTab = (folder, file) => {
 export const uploadedFile = (file) => {
   return {
     type: UPLOAD_FILE_SUCCESS,
-    file: file
+    file: extractFileAttributes(file)
   }
 }
 


### PR DESCRIPTION
This fixes the issues with the selection right after an upload, because without the function call `_id` wasn't converted to `id`.