### PR TITLE
fix: disable folder renaming

### DIFF
--- a/src/ducks/files/Container.jsx
+++ b/src/ducks/files/Container.jsx
@@ -49,7 +49,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       },
       rename: {
         action: selected => dispatch(startRenamingAsync(selected[0])),
-        displayCondition: (selections) => selections.length === 1
+        displayCondition: (selections) => selections.length === 1 && isFile(selections[0])
       }
     }
   })


### PR DESCRIPTION
Temporarily disabled folder renaming to prevent the bug on cozy-desktop. 
I'm merging this PR right away, just looping everybody in FYI.