### PR TITLE
fix: public view

### DIFF
--- a/src/components/ButtonClient.jsx
+++ b/src/components/ButtonClient.jsx
@@ -12,9 +12,4 @@ const DumbButtonClientDesktop = ({ t }) => (
   <ButtonClient icon={t('nav.link-client')} className={styles['coz-btn-client']} text={t('nav.btn-client')} />
 )
 
-const DumbButtonClientWeb = ({ t }) => (
-  <ButtonClient icon={t('nav.link-client-web')} className={styles['coz-btn-client']} text={t('nav.btn-client-web')} />
-)
-
 export const ButtonClientDesktop = translate()(DumbButtonClientDesktop)
-export const ButtonClientWeb = translate()(DumbButtonClientWeb)

--- a/src/components/LightFolderView.jsx
+++ b/src/components/LightFolderView.jsx
@@ -29,7 +29,7 @@ class DumbFolderView extends React.Component {
     return (
       <Main>
         <Topbar>
-          <Breadcrumb />
+          <Breadcrumb isPublic />
         </Topbar>
         <div role='contentinfo'>
           <div className={styles['fil-content-table']}>

--- a/src/components/PublicLayout.jsx
+++ b/src/components/PublicLayout.jsx
@@ -1,20 +1,11 @@
 import React from 'react'
 import classNames from 'classnames'
 import { Alerter } from 'cozy-ui/react/Alerter'
-import { ButtonClientWeb as ButtonClient } from '../components/ButtonClient'
 
 import styles from '../styles/layout'
-import sidebarStyles from '../styles/sidebar'
-import navStyles from '../styles/nav'
 
 const PublicLayout = ({ children }) => (
   <div class={classNames(styles['fil-wrapper'], styles['coz-sticky'])}>
-    <aside class={sidebarStyles['fil-sidebar']}>
-      <nav>
-        <ul class={navStyles['coz-nav']} />
-      </nav>
-      <ButtonClient />
-    </aside>
     <Alerter />
     {children}
   </div>

--- a/src/containers/Breadcrumb.jsx
+++ b/src/containers/Breadcrumb.jsx
@@ -38,7 +38,7 @@ class Breadcrumb extends Component {
   }
 
   handleClick = (e, folderId, animate) => {
-    const { router, location, goToFolder } = this.props
+    const { router, location, goToFolder, getFolderUrl } = this.props
     e.preventDefault()
     if (animate) {
       this.toggleOpening()
@@ -138,7 +138,8 @@ class Breadcrumb extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  path: getFolderPath(state, ownProps.location)
+  path: getFolderPath(state, ownProps.location, ownProps.isPublic),
+  getFolderUrl
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/reducers/view.js
+++ b/src/reducers/view.js
@@ -196,10 +196,10 @@ export const getFolderUrl = (folderId, location) => {
 }
 
 // reconstruct the whole path to the current folder (first element is the root, the last is the current folder)
-export const getFolderPath = ({ view }, location) => {
+export const getFolderPath = ({ view }, location, isPublic) => {
   const { displayedFolder } = view
   const path = []
-  const isBrowsingTrash = location.pathname.match(/^\/trash/)
+  const isBrowsingTrash = /^\/trash/.test(location.pathname)
   // dring the first fetch, displayedFolder is null, and we don't want to display anything
   if (displayedFolder) {
     path.push(displayedFolder)
@@ -208,11 +208,14 @@ export const getFolderPath = ({ view }, location) => {
     if (parent && parent.id && !(isBrowsingTrash && parent.id === ROOT_DIR_ID)) {
       path.unshift(parent)
       // has the parent a parent too?
-      if (parent.dir_id && !(isBrowsingTrash && parent.dir_id === ROOT_DIR_ID)) {
+      if (parent.dir_id && !(isBrowsingTrash && parent.dir_id === ROOT_DIR_ID) && !isPublic) {
         // since we don't *actually* have any information about the parent's parent, we have to fake it
         path.unshift({ id: parent.dir_id })
       }
     }
+  }
+  if (isPublic) {
+    return path
   }
   // finally, we need to make sure we have the root level folder, which can be either the root, or the trash folder. While we're at it, we also rename the folders when we need to.
   const hasRootFolder = path[0] && (path[0].id === ROOT_DIR_ID || path[0].id === TRASH_DIR_ID)

--- a/src/styles/table.styl
+++ b/src/styles/table.styl
@@ -35,7 +35,6 @@
     align-items     center
     flex            0 0 auto
     width           100%
-    max-width       'calc(100vw - %s)' % em(220px)
     border-bottom   1px solid grey-09
 
     &:hover


### PR DESCRIPTION
This PR aims to fix two things for public view:

1. [sidebar and layout](#)
1. [breadcrumb](#)

# sidebar and layout

I remove the sidebar because it was added only to remove a glitch in the layout.

The glitch was coming from a CSS rule `max-width 'calc(100vw - %s)' % em(220px)` (stylus syntax).
According to @GoOz2 this rule stand for a safari bug.
I did test my commit in safari with browsertstack 10.1 on Sierra, below a screenshot:

![](http://i.imgur.com/UQ5HKip.png)

# breadcrumb

A long discourse or an illustration? Or both! (click to enlarge)

![](http://i.imgur.com/FsgckSQ.png)

Hope it is good for you
