### PR TITLE
fix: removed cozy-helper import

### DIFF
--- a/src/targets/mobile/containers/RatingModal.jsx
+++ b/src/targets/mobile/containers/RatingModal.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 import { connect } from 'react-redux'
 import withPersistentState from '../lib/withPersistentState'
-import { softwareID, softwareName } from '../lib/cozy-helper'
+import { SOFTWARE_ID, SOFTWARE_NAME } from '../lib/constants'
 
 import styles from '../styles/rating'
 
@@ -36,8 +36,8 @@ class RatingModal extends Component {
           yes: t('mobile.rating.rate.yes'),
           no: t('mobile.rating.rate.no'),
           later: t('mobile.rating.rate.later'),
-          softwareID,
-          softwareName
+          softwareID: SOFTWARE_ID,
+          softwareName: SOFTWARE_NAME
         })
 
         if (buttonIndex === BUTTON_INDEX_LATER) {

--- a/src/targets/mobile/lib/constants.js
+++ b/src/targets/mobile/lib/constants.js
@@ -1,0 +1,2 @@
+export const SOFTWARE_ID = 'io.cozy.drive.mobile'
+export const SOFTWARE_NAME = 'Cozy Drive'

--- a/src/targets/mobile/lib/cozy-helper.js
+++ b/src/targets/mobile/lib/cozy-helper.js
@@ -1,16 +1,15 @@
 /* global cozy, document, __APP_VERSION__, __ALLOW_HTTP__ */
 import { getLang } from './init'
 import { LocalStorage as Storage } from 'cozy-client-js'
+import { SOFTWARE_NAME, SOFTWARE_ID } from './constants'
 
-export const softwareID = 'io.cozy.drive.mobile'
-export const softwareName = 'Cozy Drive'
 export const clientRevokedMsg = 'Client has been revoked'
 const getStorage = () => new Storage()
-const getClientName = device => `${softwareName} (${device})`
+const getClientName = device => `${SOFTWARE_NAME} (${device})`
 
 const getClientParams = (device) => ({
   redirectURI: 'http://localhost',
-  softwareID: softwareID,
+  softwareID: SOFTWARE_ID,
   clientName: getClientName(device),
   softwareVersion: __APP_VERSION__,
   clientKind: 'mobile',

--- a/src/targets/mobile/lib/tracker.js
+++ b/src/targets/mobile/lib/tracker.js
@@ -1,6 +1,6 @@
 /* global __PIWIK_TRACKER_URL__ __PIWIK_SITEID_MOBILE__ */
 import { getTracker, configureTracker, resetTracker } from 'cozy-ui/react/helpers/tracker'
-import { softwareID } from './cozy-helper'
+import { SOFTWARE_ID } from './constants'
 
 const mobileHeartBeatDelay = 30 // how many seconds between each hreatbeat ping to the server
 
@@ -20,7 +20,7 @@ export const startTracker = (cozyServerUrl = '') => {
 
   configureTracker({
     userId: url.hostname || cozyServerUrl,
-    app: softwareID,
+    app: SOFTWARE_ID,
     heartbeat: mobileHeartBeatDelay
   })
 


### PR DESCRIPTION
- the rating modal was importing constants from `cozy-helper`
- this caused `cozy-helper` and it's dependencies to get included in the build files, even the browser-build
- one of these dependencies is the sentry `reporter.js`, which was missing a global variable at runtime and that's how I noticed the problem

So I'm proposing to move the constants to a separate file where they can be imported from without side-effects.