### PR TITLE
fix: window.open bug in safari

### DIFF
--- a/src/targets/public/main.jsx
+++ b/src/targets/public/main.jsx
@@ -41,7 +41,7 @@ function init () {
 
   if (directdownload) {
     cozy.client.files.getDownloadLinkById(id).then(
-      link => window.open(`${cozy.client._url}${link}`, '_SELF')
+      link => { window.location = `${cozy.client._url}${link}` }
     ).catch(e => {
       cozy.bar.init({
         appName: data.cozyAppName,


### PR DESCRIPTION
Looks like Safari doesn't like the `_SELF` parameter for `window.open`.

(Tagging in @enguerran just for information)