### PR TITLE
fix: fix chrome mobile on windows view and perhaps may more bugs but …

### DIFF
--- a/src/drive/components/FileList.jsx
+++ b/src/drive/components/FileList.jsx
@@ -35,7 +35,7 @@ class FileList extends PureComponent {
         minimumBatchSize={FETCH_LIMIT}
       >
         {({ onRowsRendered, registerChild }) => (
-          <AutoSizer>
+          <AutoSizer disableHeight>
             {({ width, height }) => (
               <List
                 ref={registerChild}


### PR DESCRIPTION
…future will tell

I'm not 100% sure what this option`disableHeight` does or doesn't do but it stops calculating the height of the list's container and so it fixes the visual bug on Chrome mobile on Windows at least. 

Could be the answer to our 'little' layout issue on mobile as well, we'll see.