### PR TITLE
feat: Viewer on desktop is now fullscreen

### DIFF
--- a/src/photos/components/Viewer.jsx
+++ b/src/photos/components/Viewer.jsx
@@ -1,5 +1,6 @@
 /* global cozy */
 import styles from '../styles/viewer'
+import classNames from 'classnames'
 
 import React, { Component } from 'react'
 import { withRouter } from 'react-router'
@@ -11,7 +12,7 @@ import ImageLoader from './ImageLoader'
 
 const KEY_CODE_LEFT = 37
 const KEY_CODE_RIGHT = 39
-const TOOLBAR_HIDE_DELAY = 3000
+const ACTIONS_HIDE_DELAY = 3000
 const MIN_SCALE = 1
 const MAX_SCALE = 6
 const MASS = 10       // If a paning gesture is released while the finger is still moving, the photo will keep paning for a little longer (a if you threw the photo). MASS determines how much the photo will keep paning (the higher the number, the more it will keep going)
@@ -38,13 +39,13 @@ export class Viewer extends Component {
         x: 0,
         y: 0
       },
-      hideToolbar: false
+      hideActions: false
     }
 
     this.navigateToPhoto = this.navigateToPhoto.bind(this)
     this.handleImageLoaded = this.handleImageLoaded.bind(this)
 
-    this.hideToolbarTimeout = null
+    this.hideActionsTimeout = null
   }
 
   componentWillReceiveProps (nextProps) {
@@ -136,9 +137,9 @@ export class Viewer extends Component {
       }, this.applyMomentum.bind(this))
     })
 
-    this.gesturesHandler.on('tap', this.toggleToolbar.bind(this))
+    this.gesturesHandler.on('tap', this.toggleActions.bind(this))
 
-    this.hideToolbarAfterDelay()
+    this.hideActionsAfterDelay()
   }
 
   /**
@@ -186,7 +187,7 @@ export class Viewer extends Component {
    * Things to do when a gesture starts:
    * - saves the current scale and offset, which will be used as base values for calculations
    * - kill any remaining momentum from previous gestures
-   * - hide the toolbar
+   * - hide the actions
    */
   prepareForGesture () {
     this.setState(state => ({
@@ -199,13 +200,13 @@ export class Viewer extends Component {
         x: 0,
         y: 0
       },
-      hideToolbar: true
+      hideActions: true
     }))
   }
 
   componentDidUpdate (prevProps, prevState) {
-    // if the toolbar was hidden but is now displayed, start a countdown to hide it again
-    if (prevState.hideToolbar && !this.state.hideToolbar) this.hideToolbarAfterDelay()
+    // if the viewer's actions were hidden but are now displayed, start a countdown to hide them again
+    if (prevState.hideActions && !this.state.hideActions) this.hideActionsAfterDelay()
   }
 
   componentWillUnmount () {
@@ -231,7 +232,7 @@ export class Viewer extends Component {
 
     this.setState({
       isImageLoading: true,
-      hideToolbar: true,
+      hideActions: true,
       scale: 1,
       offsetX: 0,
       offsetY: 0
@@ -246,28 +247,28 @@ export class Viewer extends Component {
     this.setState({ isImageLoading: false })
   }
 
-  toggleToolbar () {
-    this.setState(state => ({...state, hideToolbar: !state.hideToolbar}))
+  toggleActions () {
+    this.setState(state => ({...state, hideActions: !state.hideActions}))
   }
 
-  hideToolbarAfterDelay () {
-    clearTimeout(this.hideToolbarTimeout)
-    this.hideToolbarTimeout = setTimeout(() => {
-      this.setState({ hideToolbar: true })
-    }, TOOLBAR_HIDE_DELAY)
+  hideActionsAfterDelay () {
+    clearTimeout(this.hideActionsTimeout)
+    this.hideActionsTimeout = setTimeout(() => {
+      this.setState({ hideActions: true })
+    }, ACTIONS_HIDE_DELAY)
   }
 
   render () {
-    const { isImageLoading, previousID, nextID, currentPhoto, singlePhoto, hideToolbar, scale, offsetX, offsetY } = this.state
+    const { isImageLoading, previousID, nextID, currentPhoto, singlePhoto, hideActions, scale, offsetX, offsetY } = this.state
     const style = {
       transform: `scale(${scale}) translate(${offsetX}px, ${offsetY}px)`,
       display: isImageLoading ? 'none' : 'initial'
     }
     return (
       <div className={styles['pho-viewer-wrapper']} role='viewer' ref={viewer => { this.viewer = viewer }}>
-        <ViewerToolbar hidden={hideToolbar} currentPhoto={currentPhoto} />
+        <ViewerToolbar hidden={hideActions} currentPhoto={currentPhoto} />
         <div className={styles['pho-viewer-content']}>
-          {!singlePhoto && <a role='button' className={styles['pho-viewer-nav-previous']} onClick={() => this.navigateToPhoto(previousID)} />}
+          {!singlePhoto && <a role='button' className={classNames(styles['pho-viewer-nav-previous'], {[styles['pho-viewer-nav-previous--hidden']]: hideActions})} onClick={() => this.navigateToPhoto(previousID)} />}
           <div className={styles['pho-viewer-photo']}>
             {currentPhoto &&
               <ImageLoader
@@ -282,7 +283,7 @@ export class Viewer extends Component {
               <Loading noMargin color='white' />
             }
           </div>
-          {!singlePhoto && <a role='button' className={styles['pho-viewer-nav-next']} onClick={() => this.navigateToPhoto(nextID)} />}
+          {!singlePhoto && <a role='button' className={classNames(styles['pho-viewer-nav-next'], {[styles['pho-viewer-nav-next--hidden']]: hideActions})} onClick={() => this.navigateToPhoto(nextID)} />}
         </div>
       </div>
     )

--- a/src/photos/components/Viewer.jsx
+++ b/src/photos/components/Viewer.jsx
@@ -139,6 +139,8 @@ export class Viewer extends Component {
 
     this.gesturesHandler.on('tap', this.toggleActions.bind(this))
 
+    document.addEventListener('mousemove', this.showActions.bind(this))
+
     this.hideActionsAfterDelay()
   }
 
@@ -249,6 +251,10 @@ export class Viewer extends Component {
 
   toggleActions () {
     this.setState(state => ({...state, hideActions: !state.hideActions}))
+  }
+
+  showActions () {
+    this.setState(state => ({...state, hideActions: false}))
   }
 
   hideActionsAfterDelay () {

--- a/src/photos/components/Viewer.jsx
+++ b/src/photos/components/Viewer.jsx
@@ -207,13 +207,11 @@ export class Viewer extends Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    // if the viewer's actions were hidden but are now displayed, start a countdown to hide them again
     if (prevState.hideActions && !this.state.hideActions) this.hideActionsAfterDelay()
   }
 
   componentWillUnmount () {
     document.removeEventListener('keydown', this.onKeyDownCallback, false)
-    // this.gesturesHandler.destroy()
   }
 
   onKeyDown (e) {

--- a/src/photos/components/ViewerToolbar.jsx
+++ b/src/photos/components/ViewerToolbar.jsx
@@ -16,7 +16,7 @@ export const ViewerToolbar = ({ t, router, hidden, currentPhoto }) => {
     })
   }
   return (
-    <div className={classNames(styles['pho-viewer-toolbar'], {[styles['--hidden']]: hidden})} role='viewer-toolbar'>
+    <div className={classNames(styles['pho-viewer-toolbar'], {[styles['pho-viewer-toolbar--hidden']]: hidden})} role='viewer-toolbar'>
       <div className={classNames(styles['coz-selectionbar'], styles['pho-viewer-toolbar-actions'])}>
         <button
           className={styles['coz-action-download']}

--- a/src/photos/styles/viewer.styl
+++ b/src/photos/styles/viewer.styl
@@ -16,12 +16,6 @@
     overflow        hidden
     color           white
 
-    &::after
-        content     ''
-        flex-shrink 0
-        height      em(90px)
-
-
 .pho-viewer-content
     display         flex
     flex-direction  row
@@ -30,22 +24,32 @@
 
 
 .pho-viewer-nav-previous, .pho-viewer-nav-next
-    flex-shrink         0
-    width               em(75px)
-    background-position center
-    background-repeat   no-repeat
-    cursor              pointer
+    position             fixed
+    z-index              101
+    top                  em(90px)
+    bottom               0
+    width                em(75px)
+    background-position  center
+    background-repeat    no-repeat
+    cursor               pointer
+    background-color     alpha(grey-08, .33)
+    transition           .4s opacity ease-out
 
     &:hover,
     &:focus
-        background-color alpha(black, .25)
+        background-color alpha(black, .5)
+
+    &--hidden
+        opacity 0
+        pointer-events none
 
 .pho-viewer-nav-next
-    background-image embedurl('../assets/icons/icon-arrow-right.svg')
+    background-image  embedurl('../assets/icons/icon-arrow-right.svg')
+    right             0
 
 .pho-viewer-nav-previous
-    background-image embedurl('../assets/icons/icon-arrow-left.svg')
-
+    background-image  embedurl('../assets/icons/icon-arrow-left.svg')
+    left              0
 
 .pho-viewer-photo
     position        relative
@@ -63,10 +67,6 @@
 
 
 @media (max-width: (1023/basefont)rem)
-    .pho-viewer-wrapper
-        &::after
-            display none
-
     .pho-viewer-nav-previous, .pho-viewer-nav-next
         display none
 

--- a/src/photos/styles/viewer.styl
+++ b/src/photos/styles/viewer.styl
@@ -7,7 +7,7 @@
     right           0
     top             0
     bottom          0
-    z-index         100
+    z-index         $modal-index
     display         flex
     flex-direction  column
     background      grey-08
@@ -25,7 +25,7 @@
 
 .pho-viewer-nav-previous, .pho-viewer-nav-next
     position             fixed
-    z-index              101
+    z-index              $modal-index + 1
     top                  em(90px)
     bottom               0
     width                em(75px)

--- a/src/photos/styles/viewerToolbar.styl
+++ b/src/photos/styles/viewerToolbar.styl
@@ -5,7 +5,7 @@
 
 .pho-viewer-toolbar
     position    fixed
-    z-index     101
+    z-index     $modal-index + 1
     display     flex
     flex-shrink 0
     width       100%
@@ -30,7 +30,6 @@
 
 .pho-viewer-toolbar-close
     position         fixed
-    z-index          1
     top              0
     right            0
     display          flex

--- a/src/photos/styles/viewerToolbar.styl
+++ b/src/photos/styles/viewerToolbar.styl
@@ -4,12 +4,18 @@
     @extend $selectionbar
 
 .pho-viewer-toolbar
+    position    fixed
     z-index     101
     display     flex
     flex-shrink 0
-    width       100vw
+    width       100%
     height      em(90px)
+    background-color    alpha(grey-08, .33)
+    transition .4s opacity ease-out
 
+    &--hidden
+        opacity 0
+        pointer-events none
 
 .pho-viewer-toolbar-actions
     position          static
@@ -61,23 +67,14 @@
 
 @media (max-width: (1023/basefont)rem)
     .pho-viewer-toolbar
-        position            fixed
-        height              em(48px)
-        background-color    alpha(grey-08, .33)
-        transition .4s opacity ease-out
+        height  em(48px)
 
         &::before
             width em(48px)
 
-        &.--hidden
-            opacity 0
-
     .pho-viewer-toolbar-close
         width   em(48px)
         height  em(48px)
-
-    .pho-viewer-toolbar-close-text
-        display none
 
     .pho-viewer-toolbar-close-cross
         margin auto


### PR DESCRIPTION
Toolbar and next/prev buttons also appears on click just like on mobile.

Also renamed some vars to be more clear.

See video here: 
~~https://www.dropbox.com/s/2xlt7fbv7j14c7u/viewer2.0.mp4?dl=0~~
﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿https://www.dropbox.com/s/pwj7wbolgsyey8k/viewer2.1.mp4?dl=0