### PR TITLE
feat: recent files view

### DIFF
--- a/src/drive/components/AppRoute.jsx
+++ b/src/drive/components/AppRoute.jsx
@@ -3,14 +3,16 @@ import { Route, Redirect } from 'react-router'
 
 import Layout from './Layout'
 import FileExplorer from '../containers/FileExplorer'
-import Files from '../ducks/files/Container'
+
+import { FolderContainer as Folder, RecentContainer as Recent } from '../ducks/files'
 import { Container as Trash } from '../ducks/trash'
 
 const AppRoute = (
   <Route component={Layout}>
     <Route component={FileExplorer}>
       <Redirect from='/' to='files' />
-      <Route path='files(/:folderId)' component={Files} />
+      <Route path='files(/:folderId)' component={Folder} />
+      <Route path='recent' component={Recent} />
       <Route path='trash(/:folderId)' component={Trash} />
     </Route>
   </Route>

--- a/src/drive/components/FolderView.jsx
+++ b/src/drive/components/FolderView.jsx
@@ -39,7 +39,7 @@ class FolderView extends Component {
 
   render () {
     const { isTrashContext, actionMenuActive, selectionModeActive } = this.props
-    const { files, selected, actionable, actions, Toolbar } = this.props
+    const { files, selected, actionable, actions, Toolbar, canUpload, canCreateFolder } = this.props
     const { hideActionMenu, showSelectionBar } = this.props
 
     const { showAddFolder } = this.state
@@ -48,15 +48,15 @@ class FolderView extends Component {
     const fetchPending = this.props.fetchStatus === 'pending'
     const nothingToDo = isTrashContext && files.length === 0
 
-    const toolbarActions = {
-      addFolder: this.toggleAddFolder
-    }
+    const toolbarActions = {}
+    if (canCreateFolder) toolbarActions.addFolder = this.toggleAddFolder
     return (
       <Main>
         <Topbar>
           <Breadcrumb />
           <Toolbar
             actions={toolbarActions}
+            canUpload={canUpload}
             disabled={fetchFailed || fetchPending || selectionModeActive || nothingToDo}
             onSelectItemsClick={showSelectionBar}
           />

--- a/src/drive/containers/Breadcrumb.jsx
+++ b/src/drive/containers/Breadcrumb.jsx
@@ -63,6 +63,13 @@ class Breadcrumb extends Component {
   render () {
     const { t, location, path } = this.props
     const { opening, deployed } = this.state
+
+    if (location.pathname === '/recent') {
+      path.unshift({
+        name: t('breadcrumb.title_recent')
+      })
+    }
+
     if (!path) {
       return null
     }

--- a/src/drive/containers/FileExplorer.jsx
+++ b/src/drive/containers/FileExplorer.jsx
@@ -14,6 +14,7 @@ import {
 import {
   openFolder,
   getOpenedFolderId,
+  fetchRecentFiles,
   fetchMoreFiles,
   openFileInNewTab
 } from '../actions'
@@ -25,6 +26,8 @@ import {
   isActionMenuVisible
 } from '../reducers'
 
+const isRecentFilesView = (props) => props.location.pathname === '/recent'
+
 const urlHasChanged = (props, newProps) =>
   props.location.pathname !== newProps.location.pathname
 
@@ -33,13 +36,18 @@ const isUrlMatchingOpenedFolder = (props, openedFolderId) =>
 
 class FileExplorer extends Component {
   componentWillMount () {
-    this.props.onFolderOpen(
-      getFolderIdFromRoute(this.props.location, this.props.params)
-    )
+    if (isRecentFilesView(this.props)) {
+      this.props.fetchRecentFiles()
+    } else {
+      this.props.onFolderOpen(
+        getFolderIdFromRoute(this.props.location, this.props.params)
+      )
+    }
   }
 
   componentWillReceiveProps (newProps) {
     if (urlHasChanged(this.props, newProps) &&
+        !isRecentFilesView(newProps) &&
       !isUrlMatchingOpenedFolder(newProps, this.props.openedFolderId)) {
       this.props.onFolderOpen(
         getFolderIdFromRoute(newProps.location, newProps.params)
@@ -72,6 +80,8 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(showActionMenu(fileId)),
   hideActionMenu: () =>
     dispatch(hideActionMenu()),
+  fetchRecentFiles: () =>
+    dispatch(fetchRecentFiles()),
   fetchMoreFiles: (folderId, skip, limit) =>
     dispatch(fetchMoreFiles(folderId, skip, limit)),
   onFolderOpen: folderId =>

--- a/src/drive/containers/Nav.jsx
+++ b/src/drive/containers/Nav.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux'
 import { withRouter, Link } from 'react-router'
 
 import Spinner from 'cozy-ui/react/Spinner'
-import { openFiles, openTrash } from '../actions'
+import { openFiles, openTrash, openRecent } from '../actions'
 
 class CustomLink extends Component {
   constructor (props) {
@@ -55,7 +55,7 @@ class CustomLink extends Component {
 
 const ActiveLink = withRouter(CustomLink)
 
-const Nav = ({ t, location, openFiles, openTrash }) => {
+const Nav = ({ t, location, openFiles, openRecent, openTrash }) => {
   return (
     <nav>
       <ul class={styles['coz-nav']}>
@@ -70,6 +70,19 @@ const Nav = ({ t, location, openFiles, openTrash }) => {
             activeClassName={styles['active']}
           >
             { t('nav.item_drive') }
+          </ActiveLink>
+        </li>
+        <li class={styles['coz-nav-item']}>
+          <ActiveLink
+            to='/recent'
+            onClick={openRecent}
+            className={classNames(
+              styles['coz-nav-link'],
+              styles['fil-cat-recent']
+            )}
+            activeClassName={styles['active']}
+          >
+            { t('nav.item_recent') }
           </ActiveLink>
         </li>
         <li class={styles['coz-nav-item']}>
@@ -103,6 +116,7 @@ const Nav = ({ t, location, openFiles, openTrash }) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   openFiles: () => dispatch(openFiles()),
+  openRecent: () => dispatch(openRecent()),
   openTrash: () => dispatch(openTrash())
 })
 

--- a/src/drive/ducks/files/Container.jsx
+++ b/src/drive/ducks/files/Container.jsx
@@ -29,9 +29,24 @@ const isAnyFileReferencedByAlbum = files => {
   return false
 }
 
+// TODO: sadly, as ShareModalConfirm is used with the confirm helper that renders
+// components outside of the main app, we need to provide the i18n context
+// manually for sharing components
+class ShareModalConfirm extends React.Component {
+  getChildContext () {
+    return { t: this.props.t }
+  }
+
+  render () {
+    const { abort } = this.props
+    return <ShareModal onClose={abort} {...this.props} />
+  }
+}
+
 const mapStateToProps = (state, ownProps) => ({
-  isTrashContext: false,
-  canUpload: true,
+  isTrashContext: ownProps.isTrashContext,
+  canUpload: ownProps.canUpload,
+  canCreateFolder: ownProps.canCreateFolder,
   isRenaming: isRenaming(state),
   renamingFile: getRenamingFile(state),
   Toolbar,
@@ -75,20 +90,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     }
   })
 })
-
-// TODO: sadly, as ShareModalConfirm is used with the confirm helper that renders
-// components outside of the main app, we need to provide the i18n context
-// manually for sharing components
-class ShareModalConfirm extends React.Component {
-  getChildContext () {
-    return { t: this.props.t }
-  }
-
-  render () {
-    const { abort } = this.props
-    return <ShareModal onClose={abort} {...this.props} />
-  }
-}
 
 export default translate()(connect(
   mapStateToProps,

--- a/src/drive/ducks/files/Toolbar.jsx
+++ b/src/drive/ducks/files/Toolbar.jsx
@@ -29,16 +29,17 @@ class Toolbar extends React.Component {
   }
 
   render () {
-    const { t, disabled, displayedFolder, actions, onSelectItemsClick, uploadFiles, downloadAll } = this.props
+    const { t, disabled, displayedFolder, actions, onSelectItemsClick, canUpload, uploadFiles, downloadAll } = this.props
     const notRootfolder = displayedFolder && displayedFolder.id !== ROOT_DIR_ID
     return (
       <div className={styles['fil-toolbar-files']} role='toolbar'>
+        { canUpload &&
         <UploadButton
           disabled={disabled}
           onUpload={files => uploadFiles(files, displayedFolder)}
           label={t('toolbar.item_upload')}
           className={classNames('coz-btn', 'coz-btn--regular', 'coz-btn--upload', 'coz-desktop')}
-        />
+        />}
         { notRootfolder && <ShareButton
           disabled={disabled}
           onShare={() => this.setState(toggleShowShareModal)}
@@ -59,21 +60,22 @@ class Toolbar extends React.Component {
               {t('toolbar.share')}
             </a>
           </Item>}
+          { canUpload &&
           <Item>
             <UploadButton
               onUpload={files => uploadFiles(files, displayedFolder)}
               label={t('toolbar.menu_upload')}
               className={styles['fil-action-upload']}
             />
-          </Item>
-          <Item>
+          </Item>}
+          { actions.addFolder && <Item>
             <a
               className={styles['fil-action-newfolder']}
               onClick={actions.addFolder}
             >
               {t('toolbar.menu_new_folder')}
             </a>
-          </Item>
+          </Item>}
           { notRootfolder && <Item>
             <a
               className={styles['fil-action-download']}

--- a/src/drive/ducks/files/index.jsx
+++ b/src/drive/ducks/files/index.jsx
@@ -1,0 +1,4 @@
+import Container from './Container'
+
+export const FolderContainer = (props) => <Container isTrashContext={false} canUpload canCreateFolder {...props} />
+export const RecentContainer = (props) => <Container isTrashContext={false} canUpload={false} canCreateFolder={false} {...props} />


### PR DESCRIPTION
The [main Container for files](https://github.com/cozy/cozy-drive/blob/master/src/drive/ducks/files/Container.jsx) is almost exactly what we needed for the recent files view, minus a few options. I made a small change [here](https://github.com/cozy/cozy-drive/pull/385/files#diff-791ebcf61511f68da1d94d3b8f95ff19R46) that allows it to be configured at [init time](https://github.com/cozy/cozy-drive/pull/385/files#diff-aaf0824cb9f25c2ee0edbac1cc65054bR1).

I made a few changes to the breadcrumb and the toolbar, and I [created a new function](https://github.com/cozy/cozy-drive/pull/385/files#diff-a171b9a4b7e114f23187cf310589afd9R103) to fetch the most recent files and hooked it into redux.

Note: as it is, the code generates a harmless error because of [this](https://github.com/cozy/cozy-client-js/pull/205#issuecomment-327468028). Not blocking, but I need to look into it.