### PR TITLE
Fix stuff

### DIFF
--- a/src/drive/actions/index.js
+++ b/src/drive/actions/index.js
@@ -38,7 +38,6 @@ export const OPEN_FILE_E_NO_APP = 'OPEN_FILE_E_NO_APP'
 export const getOpenedFolderId = state => state.view.openedFolderId
 
 export const extractFileAttributes = f => Object.assign({}, f.attributes, { id: f._id, links: f.links, relationships: f.relationships })
-const toServer = f => Object.assign({}, { attributes: f }, { _id: f.id })
 
 const HTTP_CODE_CONFLICT = 409
 const ALERT_LEVEL_ERROR = 'error'
@@ -148,7 +147,7 @@ export const fetchMoreFiles = (folderId, skip, limit) => {
   }
 }
 
-export const openFileInNewTab = (folder, file) => {
+export const openFileInNewTab = (file) => {
   return async dispatch => {
     if (file.availableOffline) {
       openOfflineFile(file)
@@ -162,8 +161,7 @@ export const openFileInNewTab = (folder, file) => {
     } else {
       const newTab = window.open('about:blank', '_blank') // must be done before the async calls, otherwise pop-up blockers are trigered
 
-      const filePath = await cozy.client.files.getFilePath(file, toServer(folder))
-      const href = await cozy.client.files.getDownloadLinkByPath(filePath)
+      const href = await cozy.client.files.getDownloadLinkById(file.id)
       if (isCordova()) {
         newTab.executeScript({ code: `window.location.href = '${cozy.client._url}${href}'` })
       } else {

--- a/src/drive/actions/index.js
+++ b/src/drive/actions/index.js
@@ -110,9 +110,9 @@ export const fetchRecentFiles = () => {
     })
 
     try {
-      const index = await cozy.client.data.defineIndex('io.cozy.files', ['updated_at', 'size'])
+      const index = await cozy.client.data.defineIndex('io.cozy.files', ['updated_at', 'size', 'trashed'])
       const files = await cozy.client.data.query(index, {
-        selector: {updated_at: {'$gt': null}},
+        selector: {updated_at: {'$gt': null}, trashed: false},
         sort: [{'updated_at': 'desc'}],
         limit: 50
       })

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -142,7 +142,7 @@ class File extends Component {
         </div>
         <FileNameCell attributes={attributes} isRenaming={isRenaming} opening={opening} />
         <div className={classNames(styles['fil-content-cell'], styles['fil-content-date'])}>
-          <time datetime=''>{ f(attributes.created_at, t('table.row_update_format')) }</time>
+          <time datetime=''>{ f(attributes.updated_at || attributes.created_at, t('table.row_update_format')) }</time>
         </div>
         <div className={classNames(styles['fil-content-cell'], styles['fil-content-size'])}>
           {isDirectory(attributes)

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -114,7 +114,7 @@ class File extends Component {
         this.props.router.push(getFolderUrl(attributes.id, this.props.location))
       })
     } else {
-      this.props.onFileOpen(this.props.displayedFolder, { ...attributes, availableOffline: this.props.isAvailableOffline })
+      this.props.onFileOpen({ ...attributes, availableOffline: this.props.isAvailableOffline })
     }
   }
 

--- a/src/drive/components/LightFolderView.jsx
+++ b/src/drive/components/LightFolderView.jsx
@@ -102,8 +102,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(fetchMoreFiles(folderId, skip, limit)),
   onFolderOpen: folderId =>
     dispatch(openFolder(folderId)),
-  onFileOpen: (parentFolder, file) =>
-    dispatch(openFileInNewTab(parentFolder, file)),
+  onFileOpen: (file) =>
+    dispatch(openFileInNewTab(file)),
   onDownload: files => dispatch(downloadFiles(files))
 })
 

--- a/src/drive/containers/FileExplorer.jsx
+++ b/src/drive/containers/FileExplorer.jsx
@@ -86,8 +86,8 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(fetchMoreFiles(folderId, skip, limit)),
   onFolderOpen: folderId =>
     dispatch(openFolder(folderId)),
-  onFileOpen: (parentFolder, file) =>
-    dispatch(openFileInNewTab(parentFolder, file)),
+  onFileOpen: (file) =>
+    dispatch(openFileInNewTab(file)),
   onFileToggle: (file, selected) =>
     dispatch(toggleItemSelection(file, selected))
 })

--- a/src/drive/ducks/trash/Container.jsx
+++ b/src/drive/ducks/trash/Container.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { translate } from 'cozy-ui/react/I18n'
 import confirm from '../../lib/confirm'
+import { isAvailableOffline } from '../files/availableOffline'
 
 import FolderView from '../../components/FolderView'
 import DestroyConfirm from './components/DestroyConfirm'
@@ -12,7 +13,8 @@ import { restoreFiles, destroyFiles } from './actions'
 const mapStateToProps = (state, ownProps) => ({
   isTrashContext: true,
   canUpload: false,
-  Toolbar
+  Toolbar,
+  isAvailableOffline: isAvailableOffline(state)
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({


### PR DESCRIPTION
You should probably review the commits individually.

This PR fixes several things:

- removes trashed files from the "recent" view
- fixes opening files in the recent view, incidentally making the related functions simpler
- fixes the trash view by adding the `isAvailableOffline` prop
- displays the files last update timestamp instead of the creation date, which is what the column was supposed to be anyway