### PR TITLE
fix: image ratio on chrome in Viewer

### DIFF
--- a/src/photos/components/Viewer.jsx
+++ b/src/photos/components/Viewer.jsx
@@ -271,24 +271,22 @@ export class Viewer extends Component {
     return (
       <div className={styles['pho-viewer-wrapper']} role='viewer' ref={viewer => { this.viewer = viewer }}>
         <ViewerToolbar hidden={hideActions} currentPhoto={currentPhoto} />
-        <div className={styles['pho-viewer-content']}>
-          {!singlePhoto && <a role='button' className={classNames(styles['pho-viewer-nav-previous'], {[styles['pho-viewer-nav-previous--hidden']]: hideActions})} onClick={() => this.navigateToPhoto(previousID)} />}
-          <div className={styles['pho-viewer-photo']}>
-            {currentPhoto &&
-              <ImageLoader
-                photo={currentPhoto}
-                onLoad={this.handleImageLoaded}
-                src={`${cozy.client._url}${currentPhoto.links.large}`}
-                style={style}
-                ref={photo => { this.photo = React.findDOMNode(photo) }}
-              />
-            }
-            {(!currentPhoto || isImageLoading) &&
-              <Loading noMargin color='white' />
-            }
-          </div>
-          {!singlePhoto && <a role='button' className={classNames(styles['pho-viewer-nav-next'], {[styles['pho-viewer-nav-next--hidden']]: hideActions})} onClick={() => this.navigateToPhoto(nextID)} />}
+        {!singlePhoto && <a role='button' className={classNames(styles['pho-viewer-nav-previous'], {[styles['pho-viewer-nav-previous--hidden']]: hideActions})} onClick={() => this.navigateToPhoto(previousID)} />}
+        <div className={styles['pho-viewer-photo']}>
+          {currentPhoto &&
+            <ImageLoader
+              photo={currentPhoto}
+              onLoad={this.handleImageLoaded}
+              src={`${cozy.client._url}${currentPhoto.links.large}`}
+              style={style}
+              ref={photo => { this.photo = React.findDOMNode(photo) }}
+            />
+          }
+          {(!currentPhoto || isImageLoading) &&
+            <Loading noMargin color='white' />
+          }
         </div>
+        {!singlePhoto && <a role='button' className={classNames(styles['pho-viewer-nav-next'], {[styles['pho-viewer-nav-next--hidden']]: hideActions})} onClick={() => this.navigateToPhoto(nextID)} />}
       </div>
     )
   }

--- a/src/photos/styles/viewer.styl
+++ b/src/photos/styles/viewer.styl
@@ -47,14 +47,14 @@
 .pho-viewer-photo
     position         relative
     display          flex
-    flex             1 1 auto
+    flex             1 1 100%
     max-height       100%
     max-width        100%
     justify-content  center
     align-items      center
+    flex-direction   column
 
     img
-        position    absolute
         display     block
         max-width   100%
         max-height  100%

--- a/src/photos/styles/viewer.styl
+++ b/src/photos/styles/viewer.styl
@@ -16,13 +16,6 @@
     overflow        hidden
     color           white
 
-.pho-viewer-content
-    display         flex
-    flex-direction  row
-    flex-grow       1
-    overflow        hidden
-
-
 .pho-viewer-nav-previous, .pho-viewer-nav-next
     position             fixed
     z-index              $modal-index + 1
@@ -52,18 +45,20 @@
     left              0
 
 .pho-viewer-photo
-    position        relative
-    display         flex
-    flex-grow       1
-    max-height      100%
-    justify-content center
-    align-items     center
+    position         relative
+    display          flex
+    flex             1 1 auto
+    max-height       100%
+    max-width        100%
+    justify-content  center
+    align-items      center
 
     img
-        display    block
-        max-width  100%
-        max-height 100%
-        box-shadow 0 6px 24px 0 rgba(0, 0, 0, 0.5)
+        position    absolute
+        display     block
+        max-width   100%
+        max-height  100%
+        box-shadow  0 6px 24px 0 rgba(0, 0, 0, 0.5)
 
 
 @media (max-width: (1023/basefont)rem)
@@ -71,5 +66,4 @@
         display none
 
     .pho-viewer-photo img
-        max-height 100vh
         box-shadow none


### PR DESCRIPTION
I removed the wrapping div `pho-viewer-content` as it was not really useful and tweaked a little the CSS so it won't deform images in Chrome anymore.

I don't think it will interfere with the zoom feature but still, if you could take a look @y-lohse that would be appreciated. 