### PR TITLE
fix: use email input type

### DIFF
--- a/src/sharing/components/ShareAutocomplete.jsx
+++ b/src/sharing/components/ShareAutocomplete.jsx
@@ -67,7 +67,8 @@ export default class ShareAutocomplete extends Component {
       }
         inputProps={{
           onChange: this.onChange.bind(this),
-          value: value
+          value: value,
+          type: 'email'
         }}
       />
     )

--- a/src/sharing/components/autosuggest.styl
+++ b/src/sharing/components/autosuggest.styl
@@ -19,6 +19,9 @@
 .suggestionsContainerOpen
     display block
 
+.input
+    width 100%
+
 .suggestionsList
     margin 0
     padding 10px 0


### PR DESCRIPTION
Today I wanted to share a photo album on my phone, and it was annoying to type the email address without the dedicated keyboard.