### PR TITLE
chore: downgrade list library items

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -90,5 +90,5 @@
     <plugin name="io.cozy.jsbackgroundservice" spec="https://github.com/cozy/cordova-jsbackgroundservice#v1.2.0" />
     <plugin name="cordova-plugin-contacts" spec="2.3.1" />
     <plugin name="cordova-plugin-apprate" spec="~1.3.0" />
-    <plugin name="io.cozy.plugins.listlibraryitems" spec="https://github.com/cozy/cordova-plugin-list-library-items#v1.0.2" />
+    <plugin name="io.cozy.plugins.listlibraryitems" spec="https://github.com/cozy/cordova-plugin-list-library-items#v1.0.1" />
 </widget>


### PR DESCRIPTION
Version `1.0.2` forced all URLs into `https` instead of `http`, which is a problem for development envs, but also for instances that don't have a certificate (not sure if that's a thing in real life though). So I'd like to reverse it. What do you think?