### PR TITLE
Update the client's last sync date on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   "dependencies": {
     "classnames": "^2.2.0",
     "cozy-bar": "4.1.4",
-    "cozy-client-js": "0.3.18",
+    "cozy-client-js": "0.3.19",
     "cozy-ui": "3.0.0-beta46",
     "date-fns": "^1.22.0",
     "diacritics": "^1.3.0",

--- a/src/drive/mobile/actions/mediaBackup.js
+++ b/src/drive/mobile/actions/mediaBackup.js
@@ -92,6 +92,7 @@ export const startMediaBackup = (dir, force = false) => async (
     }
   }
 
+  cozy.client.settings.updateLastSync()
   dispatch(endMediaUpload())
 }
 

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -15,6 +15,7 @@ export const startReplication = async (
     }
 
     const docsWritten = await startRepeatedReplication()
+    cozy.client.settings.updateLastSync()
     if (docsWritten !== 0) refreshFolder()
   } catch (err) {
     if (

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -1,58 +1,54 @@
 /* global cozy */
 import { clientRevokedMsg } from './cozy-helper'
 
-export const startReplication = (
-  firstReplication,
+export const startReplication = async (
+  hasFinishedFirstReplication,
   firstReplicationFinished,
   refreshFolder,
   revokeClient
 ) => {
-  if (firstReplication) {
-    startRepeatedReplication(refreshFolder, revokeClient)
-  } else {
-    startFirstReplication(firstReplicationFinished, refreshFolder, revokeClient)
+  try {
+    if (!hasFinishedFirstReplication) {
+      await startFirstReplication()
+      console.log('End of first replication')
+      firstReplicationFinished()
+    }
+
+    const docsWritten = await startRepeatedReplication()
+    if (docsWritten !== 0) refreshFolder()
+  } catch (err) {
+    if (
+      err.message === clientRevokedMsg ||
+      err.error === 'code=400, message=Invalid JWT token'
+    ) {
+      console.warn('The device is not connected to your server anymore')
+      revokeClient()
+    } else if (err.message === 'ETIMEDOUT') {
+      console.log('replcation timed out')
+    } else {
+      console.warn(err)
+    }
   }
 }
 
-const startRepeatedReplication = (refreshFolder, revokeClient) => {
-  const options = {
-    onError: onError(revokeClient),
-    onComplete: result => {
-      if (result.docs_written !== 0) {
-        refreshFolder()
+const startRepeatedReplication = () => {
+  return new Promise((resolve, reject) => {
+    const options = {
+      onError: reject,
+      onComplete: result => {
+        resolve(result.docs_written)
       }
     }
-  }
-  cozy.client.offline.startRepeatedReplication('io.cozy.files', 15, options)
-}
-
-const startFirstReplication = (
-  firstReplicationFinished,
-  refreshFolder,
-  revokeClient
-) => {
-  const options = {
-    onError: onError(revokeClient),
-    onComplete: () => {
-      firstReplicationFinished()
-      startRepeatedReplication(refreshFolder, revokeClient)
-    }
-  }
-  cozy.client.offline.replicateFromCozy('io.cozy.files', options).then(() => {
-    console.log('End of Replication')
+    cozy.client.offline.startRepeatedReplication('io.cozy.files', 15, options)
   })
 }
 
-export const onError = revokeClient => err => {
-  if (
-    err.message === clientRevokedMsg ||
-    err.error === 'code=400, message=Invalid JWT token'
-  ) {
-    console.warn('Your device is no more connected to your server')
-    revokeClient()
-  } else if (err.message === 'ETIMEDOUT') {
-    console.log('timeout')
-  } else {
-    console.warn(err)
-  }
+const startFirstReplication = () => {
+  return new Promise((resolve, reject) => {
+    const options = {
+      onError: reject,
+      onComplete: resolve
+    }
+    cozy.client.offline.replicateFromCozy('io.cozy.files', options)
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,9 +1722,9 @@ cozy-bar@4.1.4:
     preact "^8.1.0"
     preact-compat "^3.16.0"
 
-cozy-client-js@0.3.18:
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.18.tgz#754ed71c6f5804d63b402cc78b842de12eccbb9b"
+cozy-client-js@0.3.19:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.19.tgz#c20361a8bc6b23eb4d092360040e8765ef5e59a3"
 
 cozy-ui@3.0.0-beta46:
   version "3.0.0-beta46"


### PR DESCRIPTION
I did some refactoring in 1b04b6bcacd77923c410a4b5b82cbdc70a86929a first — stopping the success / error callbacks to go all the way down the function chain. They probably shouldn't even be  in the replication lib at all, but that will be for another day.

The 2 other commits are just calling the new route.