### PR TITLE
fix: empty trash button no longer visible on mobile

### DIFF
--- a/src/drive/ducks/trash/Toolbar.jsx
+++ b/src/drive/ducks/trash/Toolbar.jsx
@@ -17,6 +17,7 @@ const Toolbar = ({ t, disabled, emptyTrash, onSelectItemsClick }) => (
       className={classNames(
         'coz-btn',
         'coz-btn--danger-outline',
+        'coz-desktop',
         styles['fil-btn--delete']
       )}
       onClick={() => emptyTrash()}


### PR DESCRIPTION
Just added a class to hide this button on mobile. Dunno why it wasn't here before.