### PR TITLE
chore: update list library items plugin

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -90,5 +90,5 @@
     <plugin name="io.cozy.jsbackgroundservice" spec="https://github.com/cozy/cordova-jsbackgroundservice#v1.2.0" />
     <plugin name="cordova-plugin-contacts" spec="2.3.1" />
     <plugin name="cordova-plugin-apprate" spec="~1.3.0" />
-    <plugin name="io.cozy.plugins.listlibraryitems" spec="https://github.com/cozy/cordova-plugin-list-library-items#v1.0.2" />
+    <plugin name="io.cozy.plugins.listlibraryitems" spec="https://github.com/cozy/cordova-plugin-list-library-items#v1.0.3" />
 </widget>


### PR DESCRIPTION
Updates the plugin to version 1.0.3, which re-allows HTTP requests and fixes a possible crash when uploads error.