### PR TITLE
chore: update ios to latest engine

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -35,7 +35,7 @@
         <splash density="port-xxhdpi" src="res/screens/android/screen-xxhdpi-portrait.png" />
         <splash density="port-xxxhdpi" src="res/screens/android/screen-xxxhdpi-portrait.png" />
     </platform>
-    <engine name="ios" spec="4.3.1" />
+    <engine name="ios" spec="4.5.1" />
     <platform name="ios">
         <preference name="StatusBarOverlaysWebView" value="false" />
         <preference name="StatusBarStyle" value="default" />
@@ -61,6 +61,7 @@
         <icon height="76" src="res/icons/ios/icon-76.png" width="76" />
         <icon height="152" src="res/icons/ios/icon-76-2x.png" width="152" />
         <icon height="167" src="res/icons/ios/icon-83.5-2x.png" width="167" />
+        <icon height="1024" src="store/icons/icon-1024.jpg" width="1024" />
         <splash height="1136" src="res/screens/ios/screen-iphone-568h-2x.png" width="640" />
         <splash height="480" src="res/screens/ios/screen-iphone-portrait.png" width="320" />
         <splash height="960" src="res/screens/ios/screen-iphone-portrait-2x.png" width="640" />


### PR DESCRIPTION
The latest versions of iOS require a new icon to be generated, the latest ios engine version takes care of that.