### PR TITLE
chore: add sentry native and cocoapods

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "android:drive:publish": "(cd targets/drive/mobile && fastlane supply)",
     "ios:drive:run": "(cd targets/drive/mobile && cordova run ios --device)",
     "ios:drive:run:emulator": "(cd targets/drive/mobile && cordova run ios --emulator)",
-    "ios:drive:publish": "npm run build:drive:mobile && (cd targets/drive/mobile && fastlane ios pushtest)"
+    "ios:drive:publish": "npm run build:drive:mobile && (cd targets/drive/mobile/platforms/ios && pod install) && (cd targets/drive/mobile && fastlane ios pushtest)"
   },
   "repository": {
     "type": "git",

--- a/targets/drive/mobile/README.md
+++ b/targets/drive/mobile/README.md
@@ -9,7 +9,8 @@
 - Node v6 (on macOS: `brew install node@6 && brew link node@6`)
 - ImageMagick (on macOS: `brew install imagemagick`)
 - Android SDK >= 25.0.0 to deploy on android
-- Xcode 8.1 >= to deploy on ios
+- Xcode 8.1 >= to deploy on iOS
+- CocoaPods to deploy on iOS (https://cocoapods.org/)
 - Cordova v6 CLI (`npm install cordova@6 -g`)
 
 

--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -74,6 +74,7 @@
         <splash height="1536" src="res/screens/ios/screen-ipad-landscape-2x.png" width="2048" />
         <splash height="2048" src="res/screens/ios/screen-ipad-landscape-ipadpro.png" width="2732" />
         <splash height="2732" src="res/screens/ios/screen-ipad-portrait-ipadpro.png" width="2048" />
+        <pod name="Sentry" />
     </platform>
     <plugin name="cordova-plugin-splashscreen" spec="https://github.com/cozy/cordova-plugin-splashscreen" />
     <preference name="ShowSplashScreenSpinner" value="false" />
@@ -92,4 +93,7 @@
     <plugin name="cordova-plugin-contacts" spec="2.3.1" />
     <plugin name="cordova-plugin-apprate" spec="~1.3.0" />
     <plugin name="io.cozy.plugins.listlibraryitems" spec="https://github.com/cozy/cordova-plugin-list-library-items#v1.0.3" />
+    <plugin name="cordova-plugin-sentry" spec="https://github.com/mailmangroup/cordova-plugin-sentry" />
+    <preference name="DSNSTRING" value="https://9259817fbb44484b8b7a0a817d968ae4:171a3bcb3095448484aa3e709ea47e9b@sentry.cozycloud.cc/6" />
+    <plugin name="cordova-plugin-cocoapod-support" spec="~1.3.0" />
 </widget>


### PR DESCRIPTION
This PR adds sentry to our native apps, meaning that exception occuring in android and IOS should be reported in our Sentry. The plugin is automatically started so there's nothing else to do.

On iOS, it requires to install the official sentry cocoapod package. Since we don't keep these files in version control, I've added a plugin that takes care of regenerating them.

Fair warning: this is a bit experimental. If we don't get any useful information out of it, we'll revert this PR. Sadly we need to actually publish a version of the app with it in order to really test it.