### PR TITLE
feat: new route to display files

### DIFF
--- a/src/drive/components/AppRoute.jsx
+++ b/src/drive/components/AppRoute.jsx
@@ -15,11 +15,11 @@ const AppRoute = (
   <Route component={Layout}>
     <Route component={FileExplorer}>
       <Redirect from="/" to="files" />
-      <Route path="files(/:folderId)" component={Folder} />
+      <Route path="folder(/:folderId)" component={Folder} />
       <Route path="recent" component={Recent} />
       <Route path="trash(/:folderId)" component={Trash} />
-      <Route path="show(/:fileId)" component={FileOpener} />
-      <Redirect from="*" to="files" />
+      <Route path="file(/:fileId)" component={FileOpener} />
+      <Redirect from="*" to="folder" />
     </Route>
   </Route>
 )

--- a/src/drive/components/AppRoute.jsx
+++ b/src/drive/components/AppRoute.jsx
@@ -19,6 +19,7 @@ const AppRoute = (
       <Route path="recent" component={Recent} />
       <Route path="trash(/:folderId)" component={Trash} />
       <Route path="show(/:fileId)" component={FileOpener} />
+      <Redirect from="*" to="files" />
     </Route>
   </Route>
 )

--- a/src/drive/components/AppRoute.jsx
+++ b/src/drive/components/AppRoute.jsx
@@ -6,7 +6,8 @@ import FileExplorer from '../containers/FileExplorer'
 
 import {
   FolderContainer as Folder,
-  RecentContainer as Recent
+  RecentContainer as Recent,
+  FileOpener
 } from '../ducks/files'
 import { Container as Trash } from '../ducks/trash'
 
@@ -17,6 +18,7 @@ const AppRoute = (
       <Route path="files(/:folderId)" component={Folder} />
       <Route path="recent" component={Recent} />
       <Route path="trash(/:folderId)" component={Trash} />
+      <Route path="show(/:fileId)" component={FileOpener} />
     </Route>
   </Route>
 )

--- a/src/drive/containers/Nav.jsx
+++ b/src/drive/containers/Nav.jsx
@@ -67,7 +67,7 @@ const Nav = ({ t, location, openFiles, openRecent, openTrash }) => {
       <ul className={styles['coz-nav']}>
         <li className={styles['coz-nav-item']}>
           <ActiveLink
-            to="/files"
+            to="/folder"
             onClick={openFiles}
             className={classNames(
               styles['coz-nav-link'],

--- a/src/drive/ducks/files/FileOpener.js
+++ b/src/drive/ducks/files/FileOpener.js
@@ -44,7 +44,7 @@ class FileOpener extends Component {
     )
 
     // Go to the parent folder
-    router.push(`/files/${parent.data.id}`)
+    router.push(`/folder/${parent.data.id}`)
   }
 
   render() {

--- a/src/drive/ducks/files/FileOpener.js
+++ b/src/drive/ducks/files/FileOpener.js
@@ -1,0 +1,64 @@
+/* global cozy */
+
+import { getFileDownloadUrl } from '../../actions'
+import { Spinner, Modal } from 'cozy-ui/react'
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import styles from './styles'
+
+const withAlert = Wrapped =>
+  connect(null, dispatch => ({
+    alert: data => dispatch({ type: 'ALERT', alert: data })
+  }))(Wrapped)
+
+export default withAlert(
+  class extends Component {
+    state = { url: null, loading: false, closing: false }
+
+    componentWillMount() {
+      this.openFile()
+    }
+
+    async openFile() {
+      const { router, params: { fileId } } = this.props
+      try {
+        const url = await getFileDownloadUrl(fileId)
+        this.setState({ url })
+      } catch (e) {
+        router.push('/')
+        alert({
+          message: 'alert.could_not_open_file'
+        })
+      } finally {
+        this.setState({ loading: false })
+      }
+    }
+
+    handleClose = async () => {
+      this.setState({ closing: true })
+      const { router, params: { fileId } } = this.props
+      const { relationships: { parent } } = await cozy.client.files.statById(
+        fileId
+      )
+
+      // Go to the parent folder
+      router.push(`/files/${parent.data.id}`)
+    }
+
+    render() {
+      const { closing, loading, url } = this.state
+      return (
+        <div className={styles.fileOpener}>
+          {loading || closing ? (
+            <Spinner size="xxlarge" loadingType="message" middle="true" />
+          ) : null}
+          {url && !closing ? (
+            <Modal overflowHidden withCross secondaryAction={this.handleClose}>
+              <iframe frameBorder="0" src={url} />
+            </Modal>
+          ) : null}
+        </div>
+      )
+    }
+  }
+)

--- a/src/drive/ducks/files/FileOpener.js
+++ b/src/drive/ducks/files/FileOpener.js
@@ -1,9 +1,12 @@
 /* global cozy */
 
-import { getFileDownloadUrl } from '../../actions'
-import { Spinner, Modal } from 'cozy-ui/react'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import { flowRight as compose } from 'lodash'
+
+import { Spinner, Modal, translate } from 'cozy-ui/react'
+
+import { getFileDownloadUrl } from '../../actions'
 import styles from './styles'
 
 const withAlert = Wrapped =>
@@ -11,54 +14,62 @@ const withAlert = Wrapped =>
     alert: data => dispatch({ type: 'ALERT', alert: data })
   }))(Wrapped)
 
-export default withAlert(
-  class extends Component {
-    state = { url: null, loading: false, closing: false }
+class FileOpener extends Component {
+  state = { url: null, loading: false, closing: false }
 
-    componentWillMount() {
-      this.openFile()
-    }
+  componentWillMount() {
+    this.openFile()
+  }
 
-    async openFile() {
-      const { router, params: { fileId } } = this.props
-      try {
-        const url = await getFileDownloadUrl(fileId)
-        this.setState({ url })
-      } catch (e) {
-        router.push('/')
-        alert({
-          message: 'alert.could_not_open_file'
-        })
-      } finally {
-        this.setState({ loading: false })
-      }
-    }
-
-    handleClose = async () => {
-      this.setState({ closing: true })
-      const { router, params: { fileId } } = this.props
-      const { relationships: { parent } } = await cozy.client.files.statById(
-        fileId
-      )
-
-      // Go to the parent folder
-      router.push(`/files/${parent.data.id}`)
-    }
-
-    render() {
-      const { closing, loading, url } = this.state
-      return (
-        <div className={styles.fileOpener}>
-          {loading || closing ? (
-            <Spinner size="xxlarge" loadingType="message" middle="true" />
-          ) : null}
-          {url && !closing ? (
-            <Modal overflowHidden withCross secondaryAction={this.handleClose}>
-              <iframe frameBorder="0" src={url} />
-            </Modal>
-          ) : null}
-        </div>
-      )
+  async openFile() {
+    const { router, params: { fileId }, alert } = this.props
+    try {
+      const url = await getFileDownloadUrl(fileId)
+      this.setState({ url })
+    } catch (e) {
+      router.push('/')
+      alert({
+        message: 'alert.could_not_open_file'
+      })
+    } finally {
+      this.setState({ loading: false })
     }
   }
-)
+
+  handleClose = async () => {
+    this.setState({ closing: true })
+    const { router, params: { fileId } } = this.props
+    const { relationships: { parent } } = await cozy.client.files.statById(
+      fileId
+    )
+
+    // Go to the parent folder
+    router.push(`/files/${parent.data.id}`)
+  }
+
+  render() {
+    const { t } = this.props
+    const { closing, loading, url } = this.state
+    return (
+      <div className={styles.fileOpener}>
+        {loading || closing ? (
+          <Spinner size="xxlarge" loadingType="message" middle="true" />
+        ) : null}
+        {url && !closing ? (
+          <Modal overflowHidden withCross secondaryAction={this.handleClose}>
+            <p className={styles['fileOpener__fallback']}>
+              {t('Files.viewer-fallback')}
+            </p>
+            <iframe
+              className={styles['fileOpener__iframe']}
+              frameBorder="0"
+              src={url}
+            />
+          </Modal>
+        ) : null}
+      </div>
+    )
+  }
+}
+
+export default compose(withAlert, translate())(FileOpener)

--- a/src/drive/ducks/files/index.jsx
+++ b/src/drive/ducks/files/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Container from './Container'
+export { default as FileOpener } from './FileOpener'
 
 export const FolderContainer = props => (
   <Container isTrashContext={false} canUpload canCreateFolder {...props} />

--- a/src/drive/ducks/files/styles.styl
+++ b/src/drive/ducks/files/styles.styl
@@ -1,4 +1,28 @@
-.fileOpener iframe {
+.fileOpener__iframe
     width 80vw
     height 80vw
-}
+    position relative // new stacking context to be above fallback
+
+
+.fileOpener__fallback
+    // vertical-align center
+    position absolute
+    top 0
+    bottom 0
+    height 3rem // sufficient to hold all the text
+    margin auto
+
+    text-align center
+
+    // display after 2s (wait for iframe to load)
+    animation display-after-1s ease 0s
+    animation-delay 2s
+    animation-fill-mode both
+    width 100%
+
+@keyframes display-after-1s
+    0%
+        color transparent
+    100%
+        color inherit
+

--- a/src/drive/ducks/files/styles.styl
+++ b/src/drive/ducks/files/styles.styl
@@ -1,0 +1,4 @@
+.fileOpener iframe {
+    width 80vw
+    height 80vw
+}

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -77,7 +77,7 @@ class SuggestionProvider extends React.Component {
             id: file._id,
             name: file.name,
             path,
-            url: window.location.origin + '/#/files/' + dirId
+            url: window.location.origin + '/#/folder/' + dirId
           }
         })
 

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -83,7 +83,8 @@
       "error": {
         "generic": "An error occurred when creating the file share link, please try again."
       }
-    }
+    },
+    "viewer-fallback": "If the file has started downloading, you can close this."
   },
   "table": {
     "head_name": "Name",

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -170,6 +170,7 @@
     "public_unshared_text": "One lost, ten found... or just check out with the owner for help. This file might not be lost."
   },
   "alert": {
+    "could_not_open_file": "The file could not be opened",
     "try_again": "An error has occurred, please try again in a moment.",
     "restore_file_success": "The selection has been successfully restored.",
     "trash_file_success": "The selection has been moved to the Trash.",

--- a/src/drive/reducers/view.js
+++ b/src/drive/reducers/view.js
@@ -197,14 +197,14 @@ export const getFilePath = ({ view }, file) => {
 
 export const getFolderIdFromRoute = (location, params) => {
   if (params.folderId) return params.folderId
-  if (location.pathname.match(/^\/files/)) return ROOT_DIR_ID
+  if (location.pathname.match(/^\/folder/)) return ROOT_DIR_ID
   if (location.pathname.match(/^\/trash/)) return TRASH_DIR_ID
 }
 
 export const getFolderUrl = (folderId, location) => {
-  if (folderId === ROOT_DIR_ID) return '/files'
+  if (folderId === ROOT_DIR_ID) return '/folder'
   if (folderId === TRASH_DIR_ID) return '/trash'
-  const url = location.pathname.match(/^\/files/) ? '/files/' : '/trash/'
+  const url = location.pathname.match(/^\/folder/) ? '/folder/' : '/trash/'
   return url + folderId
 }
 


### PR DESCRIPTION
Adds a new route `/show/:fileId` that shows a modal with the given file in an iframe. It is useful for the bank mobile application since the mobile intents do not work yet.

* When the user closes the modal, the displayed folder is the parent folder of the file.
* Some mobiles do not display the PDF in an iframe and instead try to download the file. Since we cannot know whether the iframe is displaying or downloading the file, a fallback message is shown 2s after the modal is shown "You can close this if you have downloaded the file".

On a mobile whose modal is not displaying the file : 

<img width=50% src=https://user-images.githubusercontent.com/465582/31506868-fb28b628-af78-11e7-8538-fce55c45d78d.png />

On a mobile displaying the file

<img width=50% src=https://user-images.githubusercontent.com/465582/31506894-0e92de8c-af79-11e7-8010-03ea20da0652.png />

This PR is a first step, we should have later on a proper viewer (maybe PDF.js) to display PDFs on all mobiles.
