### PR TITLE
fix: app routes

### DIFF
--- a/src/drive/components/AppRoute.jsx
+++ b/src/drive/components/AppRoute.jsx
@@ -14,13 +14,12 @@ import { Container as Trash } from '../ducks/trash'
 const AppRoute = (
   <Route component={Layout}>
     <Route component={FileExplorer}>
-      <Redirect from="/" to="files" />
+      <Redirect from="/" to="folder" />
       <Route path="folder(/:folderId)" component={Folder} />
       <Route path="recent" component={Recent} />
       <Route path="trash(/:folderId)" component={Trash} />
-      <Route path="file(/:fileId)" component={FileOpener} />
-      <Redirect from="*" to="folder" />
     </Route>
+    <Route path="file/:fileId" component={FileOpener} />
   </Route>
 )
 


### PR DESCRIPTION
I think we missed something while reviewing #423.

Putting the [`file/fileid` route](https://github.com/cozy/cozy-drive/pull/423/files#diff-c1bd35ae3774ffe22abae27a6577346eR21) inside the [`FileExplorer`](https://github.com/cozy/cozy-drive/pull/423/files#diff-c1bd35ae3774ffe22abae27a6577346eR16), it [triggers a redux dispatch](https://github.com/cozy/cozy-drive/blob/master/src/drive/containers/FileExplorer.jsx#L53) with faulty parameters — when it shouldn't dispatch at all.

I also think the line `<Redirect from="/" to="files" />` is obsolete, there's no view named `files`. `<Redirect from="*" to="folder" />` is a newer version of that, but we can merge them together, I believe?