### PR TITLE
fix: add redirect to conserve backward compatibility

### DIFF
--- a/src/drive/components/AppRoute.jsx
+++ b/src/drive/components/AppRoute.jsx
@@ -13,6 +13,7 @@ import { Container as Trash } from '../ducks/trash'
 
 const AppRoute = (
   <Route component={Layout}>
+    <Redirect from="/files/:folderId" to="/folder/:folderId" />
     <Route component={FileExplorer}>
       <Redirect from="/" to="folder" />
       <Route path="folder(/:folderId)" component={Folder} />


### PR DESCRIPTION
For applications that use Drive ability to open folder (Collect when you want to open the drive where your bills are stored), it is necessary to have backward compatibility.