### PR TITLE
fix: uploads on android

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -91,5 +91,5 @@
     <plugin name="io.cozy.jsbackgroundservice" spec="https://github.com/cozy/cordova-jsbackgroundservice#v1.2.0" />
     <plugin name="cordova-plugin-contacts" spec="2.3.1" />
     <plugin name="cordova-plugin-apprate" spec="~1.3.0" />
-    <plugin name="io.cozy.plugins.listlibraryitems" spec="https://github.com/cozy/cordova-plugin-list-library-items#v1.0.6" />
+    <plugin name="io.cozy.plugins.listlibraryitems" spec="https://github.com/cozy/cordova-plugin-list-library-items#v1.0.7" />
 </widget>


### PR DESCRIPTION
There's a problem in our upload code for android and I can't find a proper fix for it, so instead I'm fixing it here.

Essentially, uploading a file that already exists will produce an error in Android, but that particular error (`Broken pipe`) could also happen for other reasons. 
My proposal is to check if a file exists before trying to upload it. It's a lot of overhead during the first run, but it's the best I have.