### PR TITLE
fix: always return promise in menu click handler

### DIFF
--- a/src/drive/components/FileActionMenu.jsx
+++ b/src/drive/components/FileActionMenu.jsx
@@ -79,7 +79,7 @@ const Menu = props => {
         return (
           <Component
             className={styles[`fil-action-${actionName}`]}
-            onClick={() => actions[actionName].action(files)}
+            onClick={() => Promise.resolve(actions[actionName].action(files))}
             files={files}
           >
             {t(`SelectionBar.${actionName}`)}


### PR DESCRIPTION
Addressing [this](https://sentry.cozycloud.cc/sentry/cozy-drive-v3/issues/388/) error in sentry.

The [MenuItem](https://github.com/cozy/cozy-drive/blob/master/src/drive/components/FileActionMenu.jsx#L26) component just assumes that `onClick` is going to return a promise, but there was no guarantee for that. For example, [showing the sharing modal](https://github.com/cozy/cozy-drive/blob/master/src/drive/ducks/files/Container.jsx#L89) doesn't.

Now whatever the click handler returns, it gets wrapped in a promise.