### PR TITLE
feat: add path to recent files 

### DIFF
--- a/src/drive/actions/index.js
+++ b/src/drive/actions/index.js
@@ -128,15 +128,29 @@ export const fetchRecentFiles = () => {
 
     try {
       const index = await cozy.client.data.defineIndex('io.cozy.files', [
+        '_id',
         'updated_at',
         'size',
         'trashed'
       ])
       const files = await cozy.client.data.query(index, {
-        selector: { updated_at: { $gt: null }, trashed: false },
+        selector: {
+          updated_at: { $gt: null },
+          trashed: false
+        },
         sort: [{ updated_at: 'desc' }],
         limit: 50
       })
+
+      const dirIds = files.map(f => f.dir_id)
+
+      const folders = await cozy.client.data.query(index, {
+        selector: {
+          _id: { $in: dirIds }
+        }
+      })
+
+      console.log(folders)
 
       return dispatch({
         type: FETCH_RECENT_SUCCESS,

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -2,7 +2,7 @@
 import React, { Component } from 'react'
 import classNames from 'classnames'
 import filesize from 'filesize'
-import { withRouter } from 'react-router'
+import { withRouter, Link } from 'react-router'
 import Hammer from 'hammerjs'
 
 import styles from '../styles/table'
@@ -52,11 +52,11 @@ export const getClassFromMime = attrs => {
   return styles['fil-file-' + className]
 }
 
-const getClassDiv = element => {
-  if (element.nodeName === 'DIV') {
-    return element.className
+const getParentOfType = (type, element) => {
+  if (element.nodeName.toLowerCase() === type.toLowerCase()) {
+    return element
   }
-  return getClassDiv(element.parentNode)
+  return getParentOfType(element.parentNode)
 }
 
 const enableTouchEvents = ev => {
@@ -67,7 +67,18 @@ const enableTouchEvents = ev => {
 
   // remove event when it's checkbox (it's already trigger, but Hammer don't respect stopPropagation)
   if (
-    getClassDiv(ev.target).indexOf(styles['fil-content-file-select']) !== -1
+    getParentOfType('div', ev.target).className.indexOf(
+      styles['fil-content-file-select']
+    ) !== -1
+  ) {
+    return false
+  }
+
+  // remove events when they are on the file's path, because it's a different behavior
+  if (
+    getParentOfType('a', ev.target).className.indexOf(
+      styles['fil-file-path']
+    ) !== -1
   ) {
     return false
   }
@@ -252,9 +263,12 @@ const FileNameCell = ({ attributes, isRenaming, opening, withFilePath }) => {
             {opening === true && <Spinner />}
           </div>
           {withFilePath && (
-            <div className={styles['fil-file-path']}>
+            <Link
+              to={`/folder/${attributes.dir_id}`}
+              className={styles['fil-file-path']}
+            >
               <span>{attributes.path}</span>
-            </div>
+            </Link>
           )}
         </div>
       )}

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -251,9 +251,7 @@ const FileNameCell = ({ attributes, isRenaming, opening }) => {
             {opening === true && <Spinner />}
           </div>
           <div className={styles['fil-file-path']}>
-            <span>
-              Path/to/you/prefered/files/that/you/love/so/much/forever/and/ever/fuck/yeah/madafucking/youpla/boom/le/roi/du/pain/d/epice/tavu/tmtc/OKLM/swagg
-            </span>
+            <span>{attributes.path}</span>
           </div>
         </div>
       )}

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -124,8 +124,8 @@ class File extends Component {
     }
   }
 
-  render(
-    {
+  render() {
+    const {
       t,
       f,
       style,
@@ -137,9 +137,8 @@ class File extends Component {
       withSelectionCheckbox,
       withFilePath,
       isAvailableOffline
-    },
-    { opening }
-  ) {
+    } = this.props
+    const { opening } = this.state
     return (
       <div
         ref={fil => {

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -135,6 +135,7 @@ class File extends Component {
       onShowActionMenu,
       isRenaming,
       withSelectionCheckbox,
+      withFilePath,
       isAvailableOffline
     },
     { opening }
@@ -169,6 +170,7 @@ class File extends Component {
           attributes={attributes}
           isRenaming={isRenaming}
           opening={opening}
+          withFilePath={withFilePath}
         />
         <div
           className={classNames(
@@ -224,7 +226,7 @@ const AvailableOfflineBadge = props => (
   </div>
 )
 
-const FileNameCell = ({ attributes, isRenaming, opening }) => {
+const FileNameCell = ({ attributes, isRenaming, opening, withFilePath }) => {
   const classes = classNames(
     styles['fil-content-cell'],
     styles['fil-content-file'],
@@ -250,9 +252,11 @@ const FileNameCell = ({ attributes, isRenaming, opening }) => {
             )}
             {opening === true && <Spinner />}
           </div>
-          <div className={styles['fil-file-path']}>
-            <span>{attributes.path}</span>
-          </div>
+          {withFilePath && (
+            <div className={styles['fil-file-path']}>
+              <span>{attributes.path}</span>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -242,12 +242,19 @@ const FileNameCell = ({ attributes, isRenaming, opening }) => {
       {isRenaming ? (
         <RenameInput />
       ) : (
-        <div>
-          {filename}
-          {extension && (
-            <span className={styles['fil-content-ext']}>{extension}</span>
-          )}
-          {opening === true && <Spinner />}
+        <div className={styles['fil-file']}>
+          <div className={styles['fil-file-filename']}>
+            {filename}
+            {extension && (
+              <span className={styles['fil-content-ext']}>{extension}</span>
+            )}
+            {opening === true && <Spinner />}
+          </div>
+          <div className={styles['fil-file-path']}>
+            <span>
+              Path/to/you/prefered/files/that/you/love/so/much/forever/and/ever/fuck/yeah/madafucking/youpla/boom/le/roi/du/pain/d/epice/tavu/tmtc/OKLM/swagg
+            </span>
+          </div>
         </div>
       )}
     </div>

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -52,11 +52,11 @@ export const getClassFromMime = attrs => {
   return styles['fil-file-' + className]
 }
 
-const getParentOfType = (type, element) => {
-  if (element.nodeName.toLowerCase() === type.toLowerCase()) {
+const getParentDiv = element => {
+  if (element.nodeName.toLowerCase() === 'div') {
     return element
   }
-  return getParentOfType(element.parentNode)
+  return getParentDiv(element.parentNode)
 }
 
 const enableTouchEvents = ev => {
@@ -67,7 +67,7 @@ const enableTouchEvents = ev => {
 
   // remove event when it's checkbox (it's already trigger, but Hammer don't respect stopPropagation)
   if (
-    getParentOfType('div', ev.target).className.indexOf(
+    getParentDiv(ev.target).className.indexOf(
       styles['fil-content-file-select']
     ) !== -1
   ) {
@@ -75,11 +75,7 @@ const enableTouchEvents = ev => {
   }
 
   // remove events when they are on the file's path, because it's a different behavior
-  if (
-    getParentOfType('a', ev.target).className.indexOf(
-      styles['fil-file-path']
-    ) !== -1
-  ) {
+  if (ev.target.className.indexOf(styles['fil-file-path']) >= 0) {
     return false
   }
 

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -267,7 +267,7 @@ const FileNameCell = ({ attributes, isRenaming, opening, withFilePath }) => {
               to={`/folder/${attributes.dir_id}`}
               className={styles['fil-file-path']}
             >
-              <span>{attributes.path}</span>
+              {attributes.path}
             </Link>
           )}
         </div>

--- a/src/drive/components/FileList.jsx
+++ b/src/drive/components/FileList.jsx
@@ -96,7 +96,8 @@ class FileList extends PureComponent {
       onFileOpen,
       onFileToggle,
       showActionMenu,
-      withSelectionCheckbox
+      withSelectionCheckbox,
+      withFilePath
     } = this.props
     const file = this.props.files[index]
     if (!file) {
@@ -120,6 +121,7 @@ class FileList extends PureComponent {
         attributes={file}
         selectionModeActive={selectionModeActive}
         withSelectionCheckbox={withSelectionCheckbox}
+        withFilePath={withFilePath}
         isAvailableOffline={isAvailableOffline && isAvailableOffline(file.id)}
       />
     )

--- a/src/drive/ducks/files/Container.jsx
+++ b/src/drive/ducks/files/Container.jsx
@@ -31,9 +31,6 @@ const isAnyFileReferencedByAlbum = files => {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  isTrashContext: ownProps.isTrashContext,
-  canUpload: ownProps.canUpload,
-  canCreateFolder: ownProps.canCreateFolder,
   isRenaming: isRenaming(state),
   renamingFile: getRenamingFile(state),
   Toolbar,

--- a/src/drive/ducks/files/index.jsx
+++ b/src/drive/ducks/files/index.jsx
@@ -10,6 +10,7 @@ export const RecentContainer = props => (
     isTrashContext={false}
     canUpload={false}
     canCreateFolder={false}
+    withFilePath
     {...props}
   />
 )

--- a/src/drive/reducers/view.js
+++ b/src/drive/reducers/view.js
@@ -4,6 +4,7 @@ import {
   OPEN_FOLDER,
   OPEN_FOLDER_SUCCESS,
   OPEN_FOLDER_FAILURE,
+  FETCH_RECENT,
   FETCH_RECENT_SUCCESS,
   FETCH_RECENT_FAILURE,
   FETCH_MORE_FILES_SUCCESS,
@@ -42,6 +43,8 @@ const openedFolderId = (state = null, action) => {
   switch (action.type) {
     case OPEN_FOLDER:
       return action.folderId
+    case FETCH_RECENT:
+      return null
     default:
       return state
   }

--- a/src/drive/styles/table.styl
+++ b/src/drive/styles/table.styl
@@ -127,6 +127,10 @@
 
 mime-types('fil-file-', '../assets/icons/')
 
+.fil-file
+    display flex
+    flex-direction column
+
 .fil-file-preview
     content ''
     position absolute
@@ -138,6 +142,31 @@ mime-types('fil-file-', '../assets/icons/')
     height em(32px)
     background-size cover
     background-position center center
+
+.fil-file-filename
+    flex 1 1 50%
+
+.fil-file-path
+    flex 1 1 1.5em
+    color cool-grey
+    font-size .75em
+    position: relative;
+    overflow: hidden;
+    white-space: nowrap;
+
+    &::before
+        content: '';
+        position: absolute;
+        z-index: 1;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 5px;
+        background: linear-gradient(to right, rgba(255,255,255,1) 0%,rgba(255,255,255,0) 100%);
+    span
+        position: absolute;
+        width: 100%;
+        direction: rtl;
 
 @keyframes placeHolderShimmer
     0%

--- a/src/drive/styles/table.styl
+++ b/src/drive/styles/table.styl
@@ -150,23 +150,15 @@ mime-types('fil-file-', '../assets/icons/')
     flex 1 1 1.5em
     color cool-grey
     font-size .75em
-    position: relative;
-    overflow: hidden;
-    white-space: nowrap;
+    position relative
+    overflow hidden
+    text-overflow ellipsis
+    white-space nowrap
+    text-decoration none
 
-    &::before
-        content: '';
-        position: absolute;
-        z-index: 1;
-        left: 0;
-        top: 0;
-        bottom: 0;
-        width: 5px;
-        background: linear-gradient(to right, rgba(255,255,255,1) 0%,rgba(255,255,255,0) 100%);
-    span
-        position: absolute;
-        width: 100%;
-        direction: rtl;
+    &:hover,
+    &:focus
+        text-decoration underline
 
 @keyframes placeHolderShimmer
     0%


### PR DESCRIPTION
We fetch the recent files with a mango index (to sort them by `updated_at`), but this API doesn't return the file's path as those are not stored in CouchDB. 
I've added a call to the server to fetch the parent folders of all recent files, as *they* have a `path` attribute. @GoOz has updated the `File` component to allow displaying a file's path next to it's name.