### PR TITLE
feat: add responsive date format

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "classnames": "^2.2.0",
     "cozy-bar": "4.1.4",
     "cozy-client-js": "0.3.19",
-    "cozy-ui": "4.0.3",
+    "cozy-ui": "4.0.4",
     "date-fns": "^1.22.0",
     "diacritics": "^1.3.0",
     "filesize": "^3.3.0",

--- a/src/drive/components/File.jsx
+++ b/src/drive/components/File.jsx
@@ -11,6 +11,7 @@ import RenameInput from '../ducks/files/RenameInput'
 import { isDirectory } from '../ducks/files/files'
 import Spinner from 'cozy-ui/react/Spinner'
 import Preview from '../components/Preview'
+import breakpointsAware from 'cozy-ui/react/helpers/breakpoints'
 
 import { getFolderUrl } from '../reducers'
 
@@ -143,7 +144,8 @@ class File extends Component {
       isRenaming,
       withSelectionCheckbox,
       withFilePath,
-      isAvailableOffline
+      isAvailableOffline,
+      breakpoints: { isExtraLarge }
     } = this.props
     const { opening } = this.state
     return (
@@ -184,10 +186,12 @@ class File extends Component {
             styles['fil-content-date']
           )}
         >
-          <time dateTime="">
+          <time dateTime={attributes.updated_at || attributes.created_at}>
             {f(
               attributes.updated_at || attributes.created_at,
-              t('table.row_update_format')
+              `${isExtraLarge
+                ? t('table.row_update_format_full')
+                : t('table.row_update_format')}`
             )}
           </time>
         </div>
@@ -272,7 +276,7 @@ const FileNameCell = ({ attributes, isRenaming, opening, withFilePath }) => {
   )
 }
 
-export default withRouter(translate()(File))
+export default breakpointsAware()(withRouter(translate()(File)))
 
 export const FilePlaceholder = ({ style }) => (
   <div style={style} className={styles['fil-content-row']}>

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -102,6 +102,7 @@
     "head_size": "Size",
     "head_status": "Status",
     "row_update_format": "MMM D, YYYY",
+    "row_update_format_full": "MMMM D, YYYY",
     "row_read_only": "Share (Read only)",
     "row_read_write": "Share (Read & Write)",
     "row_size_symbols": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,9 +1718,9 @@ cozy-client-js@0.3.19:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.19.tgz#c20361a8bc6b23eb4d092360040e8765ef5e59a3"
 
-cozy-ui@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-4.0.3.tgz#8dcaef8a01d1f372803351a70e7d8b75ff915711"
+cozy-ui@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-4.0.4.tgz#8150ee0808ea561722b01831f4b22ae9db79a685"
   dependencies:
     classnames "^2.2.5"
     date-fns "^1.28.5"


### PR DESCRIPTION
Changes the date format according to the vewport's size. 
1200+ pixels wide means a full written month, otherwise it's an abbreviated one.