### PR TITLE
Fast search

### DIFF
--- a/config/webpack.target.browser.js
+++ b/config/webpack.target.browser.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const fs = require('fs')
-const { DefinePlugin } = require('webpack')
+const { DefinePlugin, ProvidePlugin } = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = function(production, app) {
@@ -22,6 +22,10 @@ module.exports = function(production, app) {
       minify: {
         collapseWhitespace: true
       }
+    }),
+    new ProvidePlugin({
+      PouchDB: 'pouchdb',
+      pouchdbFind: 'pouchdb-find'
     })
   ]
 

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -12,6 +12,8 @@ class SuggestionProvider extends React.Component {
       const { query } = event.data
       this.provideSuggestions(query, intent)
     })
+
+    this.context.client.startReplicationFrom(() => {}) // the sync functions take a redux-style `dispatch` function as a callback, but we don't handle the replication status at the moment
   }
 
   async provideSuggestions(query, intent) {

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -1,4 +1,3 @@
-/* global cozy */
 import React from 'react'
 import FuzzyPathSearch from '../FuzzyPathSearch'
 
@@ -40,23 +39,11 @@ class SuggestionProvider extends React.Component {
   // fetches pretty much all the files and preloads FuzzyPathSearch
   async indexFiles() {
     return new Promise(async resolve => {
-      const index = await cozy.client.data.defineIndex('io.cozy.files', ['_id'])
-
-      let files = []
-      const limit = 100
-      const pageLimit = 500 // that's 50 000 files max
-      let page = 0
-      let response
-      do {
-        response = await cozy.client.data.query(index, {
-          selector: { _id: { $gt: null } },
-          limit: limit,
-          skip: page * limit,
-          wholeResponse: true
-        })
-        files = files.concat(response.docs)
-        ++page
-      } while (response.next && page < pageLimit)
+      const allDocs = await this.context.client.fetchCollection(
+        'files',
+        'io.cozy.files'
+      )
+      const files = allDocs.data
 
       const folders = files.filter(file => file.type === 'directory')
 

--- a/src/lib/cozy-client/CozyClient.js
+++ b/src/lib/cozy-client/CozyClient.js
@@ -48,6 +48,14 @@ export default class CozyClient {
     return this.facade.startSync(dispatch)
   }
 
+  startReplicationTo(dispatch) {
+    return this.facade.startReplicationTo(dispatch)
+  }
+
+  startReplicationFrom(dispatch) {
+    return this.facade.startReplicationFrom(dispatch)
+  }
+
   getAdapter(doctype) {
     return this.facade.getAdapter(doctype)
   }

--- a/src/lib/cozy-client/DataAccessFacade.js
+++ b/src/lib/cozy-client/DataAccessFacade.js
@@ -1,6 +1,10 @@
 /* global cozy, PouchDB */
 import CozyStackAdapter from './adapters/CozyStackAdapter'
-import PouchdbAdapter from './adapters/PouchdbAdapter'
+import PouchdbAdapter, {
+  SYNC_BIDIRECTIONAL,
+  SYNC_TO,
+  SYNC_FROM
+} from './adapters/PouchdbAdapter'
 
 // const isOnline = () =>
 //   typeof navigator !== 'undefined' ? navigator.onLine : true
@@ -34,7 +38,15 @@ export default class DataAccessFacade {
   }
 
   startSync(dispatch) {
-    return this.pouchAdapter.sync(dispatch)
+    return this.pouchAdapter.sync(dispatch, SYNC_BIDIRECTIONAL)
+  }
+
+  startReplicationTo(dispatch) {
+    return this.pouchAdapter.sync(dispatch, SYNC_TO)
+  }
+
+  startReplicationFrom(dispatch) {
+    return this.pouchAdapter.sync(dispatch, SYNC_FROM)
   }
 }
 

--- a/targets/drive/web/main.jsx
+++ b/targets/drive/web/main.jsx
@@ -27,8 +27,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset
 
+  const protocol = window.location ? window.location.protocol : 'https:'
+  const cozyUrl = `${protocol}//${data.cozyDomain}`
+
   const client = new CozyClient({
-    cozyURL: `//${data.cozyDomain}`,
+    cozyURL: cozyUrl,
     token: data.cozyToken
   })
 

--- a/targets/drive/web/services.jsx
+++ b/targets/drive/web/services.jsx
@@ -1,5 +1,4 @@
  /* global __DEVELOPMENT__ */
-/* global cozy */
 
 import 'babel-polyfill'
 
@@ -7,6 +6,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import IntentHandler from 'drive/ducks/services'
 import { I18n } from 'cozy-ui/react/I18n'
+import { CozyClient, CozyProvider } from 'cozy-client'
 
 if (__DEVELOPMENT__) {
   // Enables React dev tools for Preact
@@ -35,13 +35,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const data = root.dataset
   const { intent } = getQueryParameter()
 
-  cozy.client.init({
-    cozyURL: '//' + data.cozyDomain,
+  const client = new CozyClient({
+    cozyURL: `//${data.cozyDomain}`,
     token: data.cozyToken
   })
 
   render((
     <I18n lang={data.cozyLocale} dictRequire={(lang) => require(`drive/locales/${lang}`)}>
-      <IntentHandler intentId={intent} />
+      <CozyProvider client={client}>
+        <IntentHandler intentId={intent} />
+      </CozyProvider>
     </I18n>), root)
 })

--- a/targets/drive/web/services.jsx
+++ b/targets/drive/web/services.jsx
@@ -37,7 +37,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const client = new CozyClient({
     cozyURL: `//${data.cozyDomain}`,
-    token: data.cozyToken
+    token: data.cozyToken,
+    offline: { doctypes: ['io.cozy.files'] }
   })
 
   render((


### PR DESCRIPTION
So the search now uses Cozy Client. I've made the following changes to the client:

- Make sure the cozy url has a protocol.
- Since the doctype `io.cozy.files` can't be written *to*, we only want to replicate *from* the cozy instance. I've added methods that allow to do one way syncs. 