### PR TITLE
fix: cozy url with protocol for services

### DIFF
--- a/targets/drive/web/services.jsx
+++ b/targets/drive/web/services.jsx
@@ -33,10 +33,14 @@ const getQueryParameter = () => window
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset
+
+  const protocol = window.location ? window.location.protocol : 'https:'
+  const cozyUrl = `${protocol}//${data.cozyDomain}`
+
   const { intent } = getQueryParameter()
 
   const client = new CozyClient({
-    cozyURL: `//${data.cozyDomain}`,
+    cozyURL: cozyUrl,
     token: data.cozyToken,
     offline: { doctypes: ['io.cozy.files'] }
   })


### PR DESCRIPTION
On the service page too, we need a URL with protocol in order for pouch to work.