### PR TITLE
fix: remove unused errorType

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build:photos": "npm run build:photos:browser",
     "build:photos:browser":
       "npm run internal:build -- --env.app=photos --env.target=browser --env.production",
-    "clean:browser": "rm -rf build/*",
     "clean:drive:browser": "rm -rf build/drive/*",
     "clean:photos:browser": "rm -rf build/photos/*",
     "clean:mobile": "rm -rf targets/*/mobile/www/*",
@@ -28,8 +27,8 @@
     "prebuild:photos:browser": "npm run clean:photos:browser",
     "prebuild:drive:mobile": "npm run clean:mobile",
     "pretest": "npm run lint",
-    "prewatch:drive:browser": "npm run clean:browser",
-    "prewatch:photos:browser": "npm run clean:browser",
+    "prewatch:drive:browser": "npm run clean:drive:browser",
+    "prewatch:photos:browser": "npm run clean:photos:browser",
     "prewatch:drive:mobile": "npm run clean:mobile",
     "lint": "npm-run-all --parallel 'lint:*'",
     "lint:styles": "stylint src/drive/styles --config ./.stylintrc",

--- a/src/components/Error/Empty-drive.jsx
+++ b/src/components/Error/Empty-drive.jsx
@@ -1,4 +1,4 @@
-import styles from '../styles/empty'
+import styles from './empty-drive'
 
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'

--- a/src/components/Error/Empty-photos.jsx
+++ b/src/components/Error/Empty-photos.jsx
@@ -1,4 +1,4 @@
-import styles from '../styles/emptyAndError'
+import styles from './empty-photos'
 
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
@@ -6,8 +6,8 @@ import { translate } from 'cozy-ui/react/I18n'
 export const Empty = ({ t }) => {
   return (
     <div className={styles['pho-empty']}>
-      <h2>{t(`Empty.album_title`)}</h2>
-      <p>{t(`Empty.album_text`)}</p>
+      <h2>{t(`Empty.albums_title`)}</h2>
+      <p>{t(`Empty.albums_text`)}</p>
     </div>
   )
 }

--- a/src/components/Error/ErrorComponent.jsx
+++ b/src/components/Error/ErrorComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import classNames from 'classnames'
 
-import styles from '../styles/emptyAndError'
+import styles from './empty-photos'
 
 export const ErrorComponent = ({ t, errorType }) => {
   return (

--- a/src/components/Error/ErrorShare-drive.jsx
+++ b/src/components/Error/ErrorShare-drive.jsx
@@ -1,13 +1,13 @@
-import styles from '../styles/emptyAndError'
+import styles from './empty-drive'
 
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 
 export const ErrorShare = ({ t, errorType }) => {
   return (
-    <div className={styles['pho-errorShare']}>
-      <h2>{t(`Error.${errorType}_title`)}</h2>
-      <p>{t(`Error.${errorType}_text`)}</p>
+    <div className={styles['fil-errorShare']}>
+      <h2>{t(`error.${errorType}_title`)}</h2>
+      <p>{t(`error.${errorType}_text`)}</p>
     </div>
   )
 }

--- a/src/components/Error/ErrorShare-photos.jsx
+++ b/src/components/Error/ErrorShare-photos.jsx
@@ -1,13 +1,13 @@
-import styles from '../styles/empty'
+import styles from './empty-photos'
 
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 
 export const ErrorShare = ({ t, errorType }) => {
   return (
-    <div className={styles['fil-errorShare']}>
-      <h2>{t(`error.${errorType}_title`)}</h2>
-      <p>{t(`error.${errorType}_text`)}</p>
+    <div className={styles['pho-errorShare']}>
+      <h2>{t(`Error.${errorType}_title`)}</h2>
+      <p>{t(`Error.${errorType}_text`)}</p>
     </div>
   )
 }

--- a/src/components/Error/Oops.jsx
+++ b/src/components/Error/Oops.jsx
@@ -1,4 +1,4 @@
-import styles from '../styles/oops'
+import styles from './oops'
 
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'

--- a/src/components/Error/empty-drive.styl
+++ b/src/components/Error/empty-drive.styl
@@ -38,12 +38,12 @@ $empty
 .fil-empty
     @extends $empty
     &:before
-        background  embedurl('../assets/icons/icon-type-folder.svg') center center / cover no-repeat
+        background  embedurl('../../drive/assets/icons/icon-type-folder.svg') center center / cover no-repeat
 
 .fil-trash-empty
     @extends $empty
     &:before
-        background  embedurl('../assets/icons/icon-trash-big.svg') center center / cover no-repeat
+        background  embedurl('../../drive/assets/icons/icon-trash-big.svg') center center / cover no-repeat
         height      10rem
 
         @media (max-width: (1023/basefont)rem)
@@ -52,4 +52,4 @@ $empty
 .fil-errorShare
     @extends $empty
     &:before
-        background  embedurl('../assets/icons/icon-cloud-wrong.svg') center center / contain no-repeat
+        background  embedurl('../../drive/assets/icons/icon-cloud-wrong.svg') center center / contain no-repeat

--- a/src/components/Error/empty-photos.styl
+++ b/src/components/Error/empty-photos.styl
@@ -42,14 +42,14 @@ $empty
 .pho-error
     @extends $empty
     &:before
-        background  embedurl('../assets/icons/icon-image-broken.svg') center center / cover no-repeat
+        background  embedurl('../../photos/assets/icons/icon-image-broken.svg') center center / cover no-repeat
 
 .pho-errorShare
     @extends $empty
     &:before
-        background  embedurl('../assets/icons/icon-cloud-wrong.svg') center center / contain no-repeat
+        background  embedurl('../../photos/assets/icons/icon-cloud-wrong.svg') center center / contain no-repeat
 
 .pho-empty
     @extends $empty
     &:before
-        background  embedurl('../assets/icons/icon-main-app.svg') center center / cover no-repeat
+        background  embedurl('../../photos/assets/icons/icon-main-app.svg') center center / cover no-repeat

--- a/src/components/Error/oops.styl
+++ b/src/components/Error/oops.styl
@@ -1,0 +1,8 @@
+@require 'cozy-ui'
+@require './empty-drive'
+
+.fil-oops
+    @extends $empty
+
+    &:before
+        background  embedurl("../../drive/assets/icons/icon-folder-broken.svg") center center / cover no-repeat

--- a/src/drive/components/FolderContent.jsx
+++ b/src/drive/components/FolderContent.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Spinner from 'cozy-ui/react/Spinner'
-import Oops from './Oops'
-import Empty, { EmptyTrash } from './Empty'
+import Oops from 'components/Error/Oops'
+import Empty, { EmptyTrash } from 'components/Error/Empty-drive'
 import FileList from './FileList'
 
 const EmptyContent = props => {

--- a/src/drive/components/LightFolderView.jsx
+++ b/src/drive/components/LightFolderView.jsx
@@ -7,7 +7,7 @@ import FolderContent from './FolderContent'
 import FileListHeader from './FileListHeader'
 import Topbar from './Topbar'
 import Breadcrumb from '../containers/Breadcrumb'
-import ErrorShare from './ErrorShare'
+import ErrorShare from 'components/Error/ErrorShare-drive'
 
 import DownloadButton from './DownloadButton'
 import Menu, { Item } from 'components/Menu'

--- a/src/drive/styles/oops.styl
+++ b/src/drive/styles/oops.styl
@@ -1,8 +1,0 @@
-@require 'cozy-ui'
-@require './empty'
-
-.fil-oops
-    @extends $empty
-
-    &:before
-        background  embedurl("../assets/icons/icon-folder-broken.svg") center center / cover no-repeat

--- a/src/photos/components/AlbumsList.jsx
+++ b/src/photos/components/AlbumsList.jsx
@@ -2,7 +2,7 @@ import styles from '../styles/albumsList'
 
 import React from 'react'
 
-import { withEmpty } from '../components/Empty'
+import { withEmpty } from 'components/Error/Empty-photos'
 import AlbumItem from '../containers/AlbumItem'
 
 const FALLBACK_CREATION_DATE = null

--- a/src/photos/components/AlbumsList.jsx
+++ b/src/photos/components/AlbumsList.jsx
@@ -26,10 +26,6 @@ const DumbAlbumsList = props => (
   </div>
 )
 
-const AlbumsList = withEmpty(
-  props => props.albums.length === 0,
-  'albums',
-  DumbAlbumsList
-)
+const AlbumsList = withEmpty(props => props.albums.length === 0, DumbAlbumsList)
 
 export default AlbumsList

--- a/src/photos/components/Empty.jsx
+++ b/src/photos/components/Empty.jsx
@@ -3,22 +3,18 @@ import styles from '../styles/emptyAndError'
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 
-export const Empty = ({ t, emptyType }) => {
+export const Empty = ({ t }) => {
   return (
     <div className={styles['pho-empty']}>
-      <h2>{t(`Empty.${emptyType}_title`)}</h2>
-      <p>{t(`Empty.${emptyType}_text`)}</p>
+      <h2>{t(`Empty.album_title`)}</h2>
+      <p>{t(`Empty.album_text`)}</p>
     </div>
   )
 }
 
 const TranslatedEmpty = translate()(Empty)
 
-export const withEmpty = (isEmpty, type, BaseComponent) => props =>
-  isEmpty(props) ? (
-    <TranslatedEmpty emptyType={type} />
-  ) : (
-    <BaseComponent {...props} />
-  )
+export const withEmpty = (isEmpty, BaseComponent) => props =>
+  isEmpty(props) ? <TranslatedEmpty /> : <BaseComponent {...props} />
 
 export default TranslatedEmpty

--- a/src/photos/components/PhotoBoard.jsx
+++ b/src/photos/components/PhotoBoard.jsx
@@ -5,9 +5,9 @@ import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer'
 import { translate } from 'cozy-ui/react/I18n'
 
 import PhotoList from './PhotoList'
-import Empty from './Empty'
+import Empty from 'components/Error/Empty-photos'
 import Loading from './Loading'
-import ErrorComponent from './ErrorComponent'
+import ErrorComponent from 'components/Error/ErrorComponent'
 import classNames from 'classnames'
 
 const Spinner = () => <div className={styles['pho-list-spinner']} />

--- a/src/photos/components/SelectAlbumsForm.jsx
+++ b/src/photos/components/SelectAlbumsForm.jsx
@@ -3,8 +3,8 @@ import styles from '../styles/albumsList'
 import React from 'react'
 import classNames from 'classnames'
 
-import { withError } from '../components/ErrorComponent'
-import { withEmpty } from '../components/Empty'
+import { withError } from 'components/Error/ErrorComponent'
+import { withEmpty } from 'components/Error/Empty-photos'
 
 import AlbumItem from '../containers/AlbumItem'
 

--- a/src/photos/components/SelectAlbumsForm.jsx
+++ b/src/photos/components/SelectAlbumsForm.jsx
@@ -29,7 +29,6 @@ const DumbAlbumsList = props => (
 
 const AlbumsList = withEmpty(
   props => props.albums.data.length === 0,
-  'albums',
   DumbAlbumsList
 )
 

--- a/src/photos/containers/AlbumsView.jsx
+++ b/src/photos/containers/AlbumsView.jsx
@@ -6,7 +6,7 @@ import { AlbumsToolbar, fetchAlbums, fetchSharedAlbums } from '../ducks/albums'
 
 import AlbumsList from '../components/AlbumsList'
 import Loading from '../components/Loading'
-import ErrorComponent from '../components/ErrorComponent'
+import ErrorComponent from 'components/Error/ErrorComponent'
 import Topbar from '../components/Topbar'
 
 const Content = ({ list }) => {

--- a/targets/drive/web/public/main.jsx
+++ b/targets/drive/web/public/main.jsx
@@ -9,7 +9,7 @@ import configureStore from 'drive/store/configureStore'
 import PublicLayout from 'drive/components/PublicLayout'
 
 import LightFolderView from 'drive/components/LightFolderView'
-import ErrorShare from 'drive/components/ErrorShare'
+import ErrorShare from 'components/Error/ErrorShare-drive'
 
 document.addEventListener('DOMContentLoaded', init)
 
@@ -18,15 +18,14 @@ const arrToObj = (obj = {}, [key, val = true]) => {
   return obj
 }
 
-const getQueryParameter = () => window
-  .location
-  .search
-  .substring(1)
-  .split('&')
-  .map(varval => varval.split('='))
-  .reduce(arrToObj, {})
+const getQueryParameter = () =>
+  window.location.search
+    .substring(1)
+    .split('&')
+    .map(varval => varval.split('='))
+    .reduce(arrToObj, {})
 
-function init () {
+function init() {
   const lang = document.documentElement.getAttribute('lang') || 'en'
   const root = document.querySelector('[role=application]')
   const data = root.dataset
@@ -40,23 +39,29 @@ function init () {
   }
 
   if (directdownload) {
-    cozy.client.files.getDownloadLinkById(id).then(
-      link => { window.location = `${cozy.client._url}${link}` }
-    ).catch(e => {
-      cozy.bar.init({
-        appName: data.cozyAppName,
-        appEditor: data.cozyAppEditor,
-        iconPath: data.cozyIconPath,
-        lang: data.cozyLocale,
-        replaceTitleOnMobile: true
+    cozy.client.files
+      .getDownloadLinkById(id)
+      .then(link => {
+        window.location = `${cozy.client._url}${link}`
       })
-      render(
-        <I18n lang={lang} dictRequire={(lang) => require(`drive/locales/${lang}`)}>
-          <ErrorShare errorType={`public_unshared`} />
-        </I18n>,
-        root
-      )
-    })
+      .catch(e => {
+        cozy.bar.init({
+          appName: data.cozyAppName,
+          appEditor: data.cozyAppEditor,
+          iconPath: data.cozyIconPath,
+          lang: data.cozyLocale,
+          replaceTitleOnMobile: true
+        })
+        render(
+          <I18n
+            lang={lang}
+            dictRequire={lang => require(`drive/locales/${lang}`)}
+          >
+            <ErrorShare errorType={`public_unshared`} />
+          </I18n>,
+          root
+        )
+      })
   } else {
     if (__DEVELOPMENT__) {
       // Enables React dev tools for Preact
@@ -68,7 +73,12 @@ function init () {
     }
     const store = configureStore()
 
-    if (data.cozyAppName && data.cozyAppEditor && data.cozyIconPath && data.cozyLocale) {
+    if (
+      data.cozyAppName &&
+      data.cozyAppEditor &&
+      data.cozyIconPath &&
+      data.cozyLocale
+    ) {
       cozy.bar.init({
         appName: data.cozyAppName,
         appEditor: data.cozyAppEditor,
@@ -79,13 +89,13 @@ function init () {
     }
 
     render(
-      <I18n lang={lang} dictRequire={(lang) => require(`drive/locales/${lang}`)}>
+      <I18n lang={lang} dictRequire={lang => require(`drive/locales/${lang}`)}>
         <Provider store={store}>
           <Router history={hashHistory}>
             <Route component={PublicLayout}>
-              <Route path='files(/:folderId)' component={LightFolderView} />
+              <Route path="files(/:folderId)" component={LightFolderView} />
             </Route>
-            <Redirect from='/*' to={`files/${id}`} />
+            <Redirect from="/*" to={`files/${id}`} />
           </Router>
         </Provider>
       </I18n>,

--- a/targets/photos/web/public/App.jsx
+++ b/targets/photos/web/public/App.jsx
@@ -3,8 +3,8 @@ import { cozyConnect } from 'cozy-client'
 
 import PhotoBoard from 'photos/components/PhotoBoard'
 import Loading from 'photos/components/Loading'
-import ErrorComponent from 'photos/components/ErrorComponent'
-import ErrorShare from 'photos/components/ErrorShare'
+import ErrorComponent from 'components/Error/ErrorComponent'
+import ErrorShare from 'components/Error/ErrorShare-photos'
 import { MoreButton } from 'components/Button'
 import Menu, { Item } from 'components/Menu'
 


### PR DESCRIPTION
As I would like to fix a [label bug](https://trello.com/c/IzDE90L5/550-pho-%F0%9F%90%9B-libell%C3%A9s-non-traduits-sur-l%C3%A9cran-de-partage-public-dalbums), I discover duplication.

For now, I moved all related files into one global folder.
But I hope we could refactor components' and style's code into more simple one.