### PR TITLE
fix: thumbnail in progression status

### DIFF
--- a/src/drive/mobile/styles/uploadprogression.styl
+++ b/src/drive/mobile/styles/uploadprogression.styl
@@ -35,7 +35,7 @@
         left 50%
         max-width 3rem
         max-height 3rem
-        transform translate(-50%)
+        transform translateX(-50%) translateY(-50%)
 
 .coz-upload-status-content
     flex auto


### PR DESCRIPTION
Before:
![localhost_8084_ galaxy s5 6](https://user-images.githubusercontent.com/701648/32777986-9a052fb4-c938-11e7-9ad4-949110bc68f0.png)

After:
![localhost_8084_ galaxy s5 5](https://user-images.githubusercontent.com/701648/32777999-9ed0b266-c938-11e7-8750-8bd9749f116b.png)
