### PR TITLE
fix: misuse of empty labels

### DIFF
--- a/src/components/Error/Empty-photos.jsx
+++ b/src/components/Error/Empty-photos.jsx
@@ -3,18 +3,13 @@ import styles from './empty-photos'
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 
-export const Empty = ({ t }) => {
+const Empty = ({ t, emptyType }) => {
   return (
     <div className={styles['pho-empty']}>
-      <h2>{t(`Empty.albums_title`)}</h2>
-      <p>{t(`Empty.albums_text`)}</p>
+      <h2>{t(`Empty.${emptyType}_title`)}</h2>
+      <p>{t(`Empty.${emptyType}_text`)}</p>
     </div>
   )
 }
 
-const TranslatedEmpty = translate()(Empty)
-
-export const withEmpty = (isEmpty, BaseComponent) => props =>
-  isEmpty(props) ? <TranslatedEmpty /> : <BaseComponent {...props} />
-
-export default TranslatedEmpty
+export default translate()(Empty)

--- a/src/photos/components/AlbumsList.jsx
+++ b/src/photos/components/AlbumsList.jsx
@@ -2,7 +2,7 @@ import styles from '../styles/albumsList'
 
 import React from 'react'
 
-import { withEmpty } from 'components/Error/Empty-photos'
+import Empty from 'components/Error/Empty-photos'
 import AlbumItem from '../containers/AlbumItem'
 
 const FALLBACK_CREATION_DATE = null
@@ -14,18 +14,23 @@ const sortByCreationDate = (a, b) => {
   )
 }
 
-const DumbAlbumsList = props => (
-  <div role="contentinfo">
-    <div className={styles['pho-album-list']}>
-      {props.albums
-        .sort(sortByCreationDate)
-        .map(a => (
-          <AlbumItem album={a} key={a.id} onServerError={props.onServerError} />
-        ))}
+const AlbumsList = props =>
+  props.albums.length === 0 ? (
+    <Empty emptyType="albums" />
+  ) : (
+    <div role="contentinfo">
+      <div className={styles['pho-album-list']}>
+        {props.albums
+          .sort(sortByCreationDate)
+          .map(a => (
+            <AlbumItem
+              album={a}
+              key={a.id}
+              onServerError={props.onServerError}
+            />
+          ))}
+      </div>
     </div>
-  </div>
-)
-
-const AlbumsList = withEmpty(props => props.albums.length === 0, DumbAlbumsList)
+  )
 
 export default AlbumsList

--- a/src/photos/components/SelectAlbumsForm.jsx
+++ b/src/photos/components/SelectAlbumsForm.jsx
@@ -4,33 +4,31 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { withError } from 'components/Error/ErrorComponent'
-import { withEmpty } from 'components/Error/Empty-photos'
+import Empty from 'components/Error/Empty-photos'
 
 import AlbumItem from '../containers/AlbumItem'
 
-const DumbAlbumsList = props => (
-  <div
-    className={classNames(
-      styles['pho-album-list'],
-      styles['pho-album-list--thumbnails'],
-      styles['pho-album-list--selectable']
-    )}
-  >
-    {props.albums.data.map(a => (
-      <AlbumItem
-        album={a}
-        key={a.id}
-        onServerError={props.onServerError}
-        onClick={props.onSubmitSelectedAlbum}
-      />
-    ))}
-  </div>
-)
-
-const AlbumsList = withEmpty(
-  props => props.albums.data.length === 0,
-  DumbAlbumsList
-)
+const AlbumsList = props =>
+  props.albums.data.length === 0 ? (
+    <Empty emptyType="albums" />
+  ) : (
+    <div
+      className={classNames(
+        styles['pho-album-list'],
+        styles['pho-album-list--thumbnails'],
+        styles['pho-album-list--selectable']
+      )}
+    >
+      {props.albums.data.map(a => (
+        <AlbumItem
+          album={a}
+          key={a.id}
+          onServerError={props.onServerError}
+          onClick={props.onSubmitSelectedAlbum}
+        />
+      ))}
+    </div>
+  )
 
 const DumbAlbumsView = props => (
   <div>

--- a/src/photos/locales/en.json
+++ b/src/photos/locales/en.json
@@ -7,25 +7,35 @@
     "btn-client": "Get Cozy for desktop",
     "btn-client-web": "Get Cozy",
     "btn-client-mobile": "Get Cozy Drive on your mobile!",
-    "banner-txt-client": "Tip: your pictures, bills, ID documents, all accessible anytime, from any of your device with Cozy Drive installed on your computer",
+    "banner-txt-client":
+      "Tip: your pictures, bills, ID documents, all accessible anytime, from any of your device with Cozy Drive installed on your computer",
     "banner-btn-client": "Download now",
     "link-client": "https://docs.cozy.io/en/download/"
   },
   "Empty": {
     "timeline_photos_title": "You don't have any photos yet.",
-    "timeline_photos_text":  "Click the \"Upload\" button to add photos.",
+    "timeline_photos_text": "Click the \"Upload\" button to add photos.",
     "albums_title": "You don't have any album yet.",
-    "albums_text": "Start by clicking \"New album\" to create your first album.",
-    "album_photos_title": "There is not photo in this album yet.",
-    "album_photos_text": "Start by clicking \"Add photos to album\" to add some."
+    "albums_text":
+      "Start by clicking \"New album\" to create your first album.",
+    "album_photos_title": "There is no photo in this album yet.",
+    "album_photos_text":
+      "Start by clicking \"Add photos to album\" to add some.",
+    "shared_album_photos_title": "There is no photo in this album yet.",
+    "shared_album_photos_text": "Come back later"
   },
   "Error": {
-    "albums_title": "An error occurred while retrieving the albums list. Please try again later.",
-    "album_photos_title": "An error occurred while retrieving the album's photos list. Please try again later.",
-    "timeline_photos_title": "An error occurred while retrieving the photos list. Please try again later.",
-    "public_album_error_title": "An error occurred while retrieving the photos list. Please try again later.",
+    "albums_title":
+      "An error occurred while retrieving the albums list. Please try again later.",
+    "album_photos_title":
+      "An error occurred while retrieving the album's photos list. Please try again later.",
+    "timeline_photos_title":
+      "An error occurred while retrieving the photos list. Please try again later.",
+    "public_album_error_title":
+      "An error occurred while retrieving the photos list. Please try again later.",
     "public_album_unshared_title": "Sorry, this link is no longer available.",
-    "public_album_unshared_text": "One lost, ten found... or just check out with the owner for help. This file might not be lost.",
+    "public_album_unshared_text":
+      "One lost, ten found... or just check out with the owner for help. This file might not be lost.",
     "refresh": "Refresh now",
     "generic": "An error occurred, please try again.",
     "album_rename_abort": "The album name can not be empty."
@@ -94,10 +104,13 @@
     "album_item_shared_rw": "Shared (read/write)",
     "add_photos": {
       "title": "Add to album",
-      "success": "Album %{name} has been updated with %{smart_count} photo. |||| Album %{name} has been updated with %{smart_count} photos.",
+      "success":
+        "Album %{name} has been updated with %{smart_count} photo. |||| Album %{name} has been updated with %{smart_count} photos.",
       "error": {
-        "generic": "An error occurred when updating the album, please try again.",
-        "reference": "Some photos has not been added to the album. Please check and try again.",
+        "generic":
+          "An error occurred when updating the album, please try again.",
+        "reference":
+          "Some photos has not been added to the album. Please check and try again.",
         "response": {
           "Forbidden": "Application does not have permission to update albums."
         }
@@ -117,7 +130,8 @@
       "shareByLink": {
         "title": "By public link",
         "subtitle": "Share by link",
-        "desc": "Anyone with the provided link can see and download your photos."
+        "desc":
+          "Anyone with the provided link can see and download your photos."
       },
       "shareByEmail": {
         "title": "By email",
@@ -147,7 +161,8 @@
       "close": "Close",
       "gettingLink": "Getting your link...",
       "error": {
-        "generic": "An error occurred when creating the album share link, please try again."
+        "generic":
+          "An error occurred when creating the album share link, please try again."
       }
     },
     "create": {
@@ -163,10 +178,13 @@
         "create_label": "Create a new album",
         "create_button": "Create"
       },
-      "success": "Album %{name} has been created with %{smart_count} photo. |||| Album %{name} has been created with %{smart_count} photos.",
+      "success":
+        "Album %{name} has been created with %{smart_count} photo. |||| Album %{name} has been created with %{smart_count} photos.",
       "error": {
-        "generic": "An error occurred when creating the album, please try again.",
-        "already_exists": "The album %{name} already exists, please pick another one.",
+        "generic":
+          "An error occurred when creating the album, please try again.",
+        "already_exists":
+          "The album %{name} already exists, please pick another one.",
         "name_missing": "You have to give a name to your album."
       }
     },
@@ -178,13 +196,15 @@
     "remove_photos": {
       "success": "The photo has been removed from album %{album_name}",
       "error": {
-        "generic": "An error occured while removing the photo, please try again."
+        "generic":
+          "An error occured while removing the photo, please try again."
       }
     },
     "remove_album": {
       "success": "Album %{name} was deleted.",
       "error": {
-        "generic": "An error occured while removing the album, please try again."
+        "generic":
+          "An error occured while removing the album, please try again."
       }
     },
     "quit_album": {
@@ -197,7 +217,7 @@
   "Viewer": {
     "close": "Close",
     "actions": {
-      "download" : "Download"
+      "download": "Download"
     }
   },
   "destroyconfirmation": {
@@ -217,17 +237,22 @@
   "timeline": {
     "DeleteConfirm": {
       "title": "Delete this element? |||| Delete these elements?",
-      "trash": "It will be moved to the Trash. |||| They will be moved to the Trash.",
-      "restore": "You can still restore it whenever you want. |||| You can still restore them whenever you want.",
-      "shared": "If you have shared it, people won't be able to access it. |||| If you have shared them, people won't be able to access them.",
-      "related": "Some of the photos within the selection are related to an album. They will be removed from it if you proceed to trash them.",
+      "trash":
+        "It will be moved to the Trash. |||| They will be moved to the Trash.",
+      "restore":
+        "You can still restore it whenever you want. |||| You can still restore them whenever you want.",
+      "shared":
+        "If you have shared it, people won't be able to access it. |||| If you have shared them, people won't be able to access them.",
+      "related":
+        "Some of the photos within the selection are related to an album. They will be removed from it if you proceed to trash them.",
       "cancel": "Cancel",
       "delete": "Remove"
     }
   },
   "UploadQueue": {
     "path": "/Photos/Uploaded from Cozy Photos",
-    "header": "Uploading %{smart_count} photo to Cozy Photos |||| Uploading %{smart_count} photos to Cozy Photos",
+    "header":
+      "Uploading %{smart_count} photo to Cozy Photos |||| Uploading %{smart_count} photos to Cozy Photos",
     "header_mobile": "%{done} of %{total} uploading…",
     "header_done": "Uploaded %{done} out of %{total} successfully",
     "close": "close",
@@ -235,7 +260,8 @@
       "pending": "Pending"
     },
     "alert": {
-      "success": "%{smart_count} photo uploaded with success. |||| %{smart_count} photos uploaded with success.",
+      "success":
+        "%{smart_count} photo uploaded with success. |||| %{smart_count} photos uploaded with success.",
       "success_conflicts":
         "%{smart_count} photo uploaded with %{conflictNumber} conflict(s). |||| %{smart_count} photos uploaded with %{conflictNumber} conflict(s).",
       "errors": "Errors occurred during the photos upload."

--- a/targets/photos/web/public/App.jsx
+++ b/targets/photos/web/public/App.jsx
@@ -152,6 +152,7 @@ class App extends Component {
           </div>
         </div>
         <PhotoBoard
+          photosContext="shared_album"
           lists={[{ photos: data }]}
           selected={selected}
           showSelection={selected.length !== 0}


### PR DESCRIPTION
I misread the information when I worked on https://github.com/cozy/cozy-drive/pull/482

Here is a revert and a fix for empty shared album:

- revert: use `photosContext`
- fix: add 2 i18n keys for this specific case
- remove: the HOC was too noisy for this component, I removed it

_Note: I think one should rethink the abstraction of the _Empty_ component (The _Error_ one is similarly affected). What is an `<Empty />` component responsible for? It displays one big picture, one h2 title and one paragraph with details. As for now, it receives a single prop called `emptyType`, that means this component is responsible for steering the rendering towards the correct _«type»_ (what is a type? that is too mysterious), but he does not steer anything toward anywhere. We should change that._