### PR TITLE
Support for bulk update/delete

### DIFF
--- a/src/lib/cozy-client/CozyClient.js
+++ b/src/lib/cozy-client/CozyClient.js
@@ -1,6 +1,7 @@
 /* global cozy */
 import DataAccessFacade from './DataAccessFacade'
 import { authenticateWithCordova } from './authentication/mobile'
+import { getIndexFields } from './helpers'
 
 const FILES_DOCTYPE = 'io.cozy.files'
 const SHARINGS_DOCTYPE = 'io.cozy.sharings'
@@ -174,7 +175,7 @@ export default class CozyClient {
     if (!this.indexes[name]) {
       this.indexes[name] = await this.getAdapter(doctype).createIndex(
         doctype,
-        this.getIndexFields(options)
+        getIndexFields(options)
       )
     }
     return this.indexes[name]
@@ -188,16 +189,5 @@ export default class CozyClient {
       ])
     }
     return this.indexes[name]
-  }
-
-  getIndexFields(options) {
-    const { selector, sort } = options
-    if (sort) {
-      // We filter possible duplicated fields
-      return [...Object.keys(selector), ...Object.keys(sort)].filter(
-        (f, i, arr) => arr.indexOf(f) === i
-      )
-    }
-    return Object.keys(selector)
   }
 }

--- a/src/lib/cozy-client/CozyClient.js
+++ b/src/lib/cozy-client/CozyClient.js
@@ -100,8 +100,16 @@ export default class CozyClient {
     return this.getAdapter(doc._type).updateDocument(doc)
   }
 
+  updateDocuments(doctype, query, iterator) {
+    return this.getAdapter(doctype).updateDocuments(doctype, query, iterator)
+  }
+
   deleteDocument(doc) {
     return this.getAdapter(doc._type).deleteDocument(doc)
+  }
+
+  deleteDocuments(doctype, query) {
+    return this.getAdapter(doctype).deleteDocuments(doctype, query)
   }
 
   async fetchSharings(doctype) {

--- a/src/lib/cozy-client/CozyClient.js
+++ b/src/lib/cozy-client/CozyClient.js
@@ -100,6 +100,32 @@ export default class CozyClient {
     return this.getAdapter(doc._type).updateDocument(doc)
   }
 
+  /**
+   * Update documents in bulk.
+   *
+   * All documents matching the query will be retrieved before updating.
+   *
+   * @example
+   * ```
+   * await dispatch(
+   *   updateDocuments(
+   *     'io.cozy.bank.transactions',
+   *     {
+   *       selector: { accountId: '1921680010' }
+   *     },
+   *     {
+   *       updateCollections: ['transactions']
+   *     },
+   *     transaction => ({ ...transaction, amount: transaction.amount + 10 })
+   *   )
+   * )
+   * ```
+   *
+   * @param  {String} doctype  - Doctype of the documents that will be updated
+   * @param  {Object} query    - Mango query to select which documents will be updated
+   * @param  {Function} iterator - Function that will update the documents
+   * @return {Promise}
+   */
   updateDocuments(doctype, query, iterator) {
     return this.getAdapter(doctype).updateDocuments(doctype, query, iterator)
   }
@@ -108,6 +134,21 @@ export default class CozyClient {
     return this.getAdapter(doc._type).deleteDocument(doc)
   }
 
+  /**
+   * Delete documents in bulk.
+   *
+   * All documents matching the query will be retrieved before deleting.
+   *
+   * @example
+   * ```
+   * await dispatch(deleteDocuments('io.cozy.bank.operations', {
+   *   selector: { account: account.id }
+   * }, {
+   *   updateCollections: ['transactions']
+   * }))
+   * ```
+   *
+   */
   deleteDocuments(doctype, query) {
     return this.getAdapter(doctype).deleteDocuments(doctype, query)
   }

--- a/src/lib/cozy-client/__tests__/store.spec.js
+++ b/src/lib/cozy-client/__tests__/store.spec.js
@@ -151,5 +151,73 @@ describe('Redux store tests', () => {
       })
     })
 
+    describe('When documents are successfully updated on the server', () => {
+      const fakeResponse = {
+        data: [
+          {
+            id: '33dda00f0eec15bc3b3c59a615001ac7',
+            name: 'Falcon X',
+            _type: 'io.cozy.rockets'
+          },
+          {
+            id: '33dda00f0eec15bc3b3c59a615001ac8',
+            name: 'Falcon Light',
+            _type: 'io.cozy.rockets'
+          }
+        ]
+      }
+
+      it('should update collections listed in the `updateCollections` option', () => {
+        state = dispatchSuccessfulAction(
+          updateDocuments(
+            'io.cozy.rockets',
+            { selector: {} },
+            {
+              updateCollections: ['rockets']
+            }
+          ),
+          fakeResponse,
+          state
+        )
+        collection = getCollection(state, 'rockets')
+        expect(collection.data[0]).toEqual(fakeResponse.data[0])
+      })
+    })
+
+    describe('When documents are successfully deleted on the server', () => {
+      const fakeResponse = {
+        data: [
+          {
+            id: '33dda00f0eec15bc3b3c59a615001ac7',
+            _deleted: true,
+            _type: 'io.cozy.rockets'
+          },
+          {
+            id: '33dda00f0eec15bc3b3c59a615001ac8',
+            _deleted: true,
+            _type: 'io.cozy.rockets'
+          }
+        ]
+      }
+
+      it('should update collections listed in the `updateCollections` option', () => {
+        state = dispatchSuccessfulAction(
+          deleteDocuments(
+            'io.cozy.rockets',
+            { selector: {} },
+            {
+              updateCollections: ['rockets']
+            }
+          ),
+          fakeResponse,
+          state
+        )
+        collection = getCollection(state, 'rockets')
+        expect(collection.ids.length).toBe(1)
+        expect(collection.ids[0]).toBe('33dda00f0eec15bc3b3c59a615001ac9')
+        expect(collection.data.length).toBe(1)
+        expect(collection.data[0].id).toBe('33dda00f0eec15bc3b3c59a615001ac9')
+      })
+    })
   })
 })

--- a/src/lib/cozy-client/__tests__/store.spec.js
+++ b/src/lib/cozy-client/__tests__/store.spec.js
@@ -3,7 +3,10 @@ import {
   reducer as cozyReducer,
   fetchCollection,
   getCollection,
-  createDocument
+  createDocument,
+  updateDocument,
+  updateDocuments,
+  deleteDocuments
 } from '..'
 
 const reducer = combineReducers({ cozy: cozyReducer })
@@ -119,5 +122,34 @@ describe('Redux store tests', () => {
         expect(collection.data[3]).toEqual(fakeResponse.data[0])
       })
     })
+
+    describe('When a document is successfully updated on the server', () => {
+      const fakeResponse = {
+        data: [
+          {
+            id: '33dda00f0eec15bc3b3c59a615001ac7',
+            _type: 'io.cozy.rockets',
+            name: 'Falcon X'
+          }
+        ]
+      }
+
+      it('should update collections listed in the `updateCollections` option', () => {
+        state = dispatchSuccessfulAction(
+          updateDocument(
+            'io.cozy.rockets',
+            { name: 'Saturn V' },
+            {
+              updateCollections: ['rockets']
+            }
+          ),
+          fakeResponse,
+          state
+        )
+        collection = getCollection(state, 'rockets')
+        expect(collection.data[0]).toEqual(fakeResponse.data[0])
+      })
+    })
+
   })
 })

--- a/src/lib/cozy-client/__tests__/utils.spec.js
+++ b/src/lib/cozy-client/__tests__/utils.spec.js
@@ -1,0 +1,37 @@
+import { getIndexFields } from '../helpers'
+
+describe('Utils', function() {
+  describe('getIndexFields', function() {
+    it('should return the fields that should be indexed', function() {
+      const fields = getIndexFields({
+        selector: {
+          _id: { $gt: null },
+          foo: 'bar'
+        }
+      })
+      expect(fields).toEqual(['_id', 'foo'])
+    })
+
+    it('should return the fields that should be indexed (with sort)', function() {
+      const fields = getIndexFields({
+        selector: {
+          _id: { $gt: null },
+          foo: 'bar'
+        },
+        sort: { baz: true }
+      })
+      expect(fields).toEqual(['_id', 'foo', 'baz'])
+    })
+
+    it('should return the fields that should be indexed (with duplicates)', function() {
+      const fields = getIndexFields({
+        selector: {
+          _id: { $gt: null },
+          foo: 'bar'
+        },
+        sort: { baz: true, foo: true }
+      })
+      expect(fields).toEqual(['_id', 'foo', 'baz'])
+    })
+  })
+})

--- a/src/lib/cozy-client/helpers.js
+++ b/src/lib/cozy-client/helpers.js
@@ -1,4 +1,5 @@
 /* global cozy */
+import { removeObjectProperties } from './utils'
 
 const slugify = text =>
   text
@@ -32,4 +33,27 @@ export const downloadFile = async file => {
   const response = await cozy.client.files.downloadById(file.id)
   const blob = await response.blob()
   forceFileDownload(window.URL.createObjectURL(blob), file.name)
+}
+
+/**
+ * Compute fields that should be indexed for a mango
+ * query to work
+ *
+ * @param  {Object} query - Mango query
+ * @return {Array} - Fields that should be indexed for this query to work
+ */
+export const getIndexFields = query => {
+  const { selector, sort } = query
+  if (sort) {
+    // We filter possible duplicated fields
+    return [...Object.keys(selector), ...Object.keys(sort)].filter(
+      (f, i, arr) => arr.indexOf(f) === i
+    )
+  }
+  return Object.keys(selector)
+}
+
+/** Remove special fields */
+export const sanitizeDoc = doc => {
+  return removeObjectProperties(doc, ['_type'])
 }

--- a/src/lib/cozy-client/index.js
+++ b/src/lib/cozy-client/index.js
@@ -17,7 +17,9 @@ export {
   getDocument,
   createDocument,
   updateDocument,
+  updateDocuments,
   deleteDocument,
+  deleteDocuments,
   createFile,
   trashFile,
   CREATE_DOCUMENT

--- a/src/lib/cozy-client/utils.js
+++ b/src/lib/cozy-client/utils.js
@@ -24,3 +24,14 @@ export const removeObjectProperty = (obj, prop) => {
     return result
   }, {})
 }
+
+export const removeObjectProperties = (obj, props) => {
+  const sProps = new Set(props)
+  const res = Object.keys(obj).reduce((result, key) => {
+    if (!sProps.has(key)) {
+      result[key] = obj[key]
+    }
+    return result
+  }, {})
+  return res
+}


### PR DESCRIPTION
Adding support for `_bulk_docs` method from couchdb.

- The stack directly proxies to couchdb via `/data/`.
- Added pouchdb adapter
- Added stack adapter
- Reducer support

Example code : 
```js
  await dispatch(
    updateDocuments(
      'io.cozy.bank.groups',
      {
        selector: { _id: { $gt: null } }
      },
      group => removeAccountFromGroup(group, account),
      {
        updateCollections: ['groups']
      }
    )
  )
  await dispatch(deleteDocuments('io.cozy.bank.operations', {
    selector: { account: account.id }
  }, {
    updateCollections: ['transactions']
  }))
```