### PR TITLE
Feat/better onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "classnames": "^2.2.0",
     "cozy-bar": "4.3.7",
     "cozy-client-js": "0.4.1",
-    "cozy-ui": "4.0.4",
+    "cozy-ui": "4.0.5",
     "date-fns": "^1.22.0",
     "diacritics": "^1.3.0",
     "filesize": "^3.3.0",

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -219,7 +219,8 @@
         "no_account_link": "Don’t have an account? Request one here."
       },
       "server_selection": {
-        "description": "This is the web address you use to access your Cozy.",
+        "description": "Example: claudedouillet.mycozy.cloud",
+        "label": "Enter your Cozy address",
         "cozy_address_placeholder": "tonystark.mycozy.cloud",
         "button": "Next",
         "wrong_address_with_email":

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -219,7 +219,7 @@
         "no_account_link": "Don’t have an account? Request one here."
       },
       "server_selection": {
-        "description": "Example: claudedouillet.mycozy.cloud",
+        "description": "Example: https://claudedouillet.mycozy.cloud",
         "label": "Enter your Cozy address",
         "cozy_address_placeholder": "tonystark.mycozy.cloud",
         "button": "Next",

--- a/src/drive/mobile/containers/onboarding/SelectServer.jsx
+++ b/src/drive/mobile/containers/onboarding/SelectServer.jsx
@@ -7,10 +7,19 @@ import { translate } from 'cozy-ui/react/I18n'
 
 import { registerDevice, setUrl } from '../../actions/settings'
 import styles from '../../styles/onboarding'
+import Spinner from 'cozy-ui/react/Spinner'
 
 export class SelectServer extends Component {
   componentDidMount() {
     this.serverInput.focus()
+  }
+
+  componentDidUpdate() {
+    if (this.props.error) {
+      this.serverInput.focus()
+      this.serverInput.select()
+    }
+    console.log(this.state)
   }
 
   render() {
@@ -22,6 +31,7 @@ export class SelectServer extends Component {
       serverUrl,
       error
     } = this.props
+    const { fetching } = this.state
     return (
       <div className={classNames(styles['wizard'], styles['select-server'])}>
         <header className={styles['wizard-header']}>
@@ -37,7 +47,7 @@ export class SelectServer extends Component {
           >
             <div className={styles['cozy-logo-white']} />
           </div>
-          <label className={styles['label']}>
+          <label className={styles['coz-form-label']}>
             {t('mobile.onboarding.server_selection.label')}
           </label>
           <input
@@ -62,9 +72,10 @@ export class SelectServer extends Component {
             </p>
           )}
           {error && (
-            <p className={styles['description']} style={{ color: 'red' }}>
-              <ReactMarkdown source={t(error)} />
-            </p>
+            <ReactMarkdown
+              className={classNames(styles['description'], styles['error'])}
+              source={t(error)}
+            />
           )}
         </div>
         <footer className={styles['wizard-footer']}>
@@ -75,6 +86,7 @@ export class SelectServer extends Component {
             disabled={error || !serverUrl}
           >
             {t('mobile.onboarding.server_selection.button')}
+            {fetching && <Spinner />}
           </button>
         </footer>
       </div>

--- a/src/drive/mobile/containers/onboarding/SelectServer.jsx
+++ b/src/drive/mobile/containers/onboarding/SelectServer.jsx
@@ -37,6 +37,9 @@ export class SelectServer extends Component {
           >
             <div className={styles['cozy-logo-white']} />
           </div>
+          <label className={styles['label']}>
+            {t('mobile.onboarding.server_selection.label')}
+          </label>
           <input
             type="url"
             className={

--- a/src/drive/mobile/styles/onboarding.styl
+++ b/src/drive/mobile/styles/onboarding.styl
@@ -54,7 +54,8 @@
 
         &.error
             background pomegranate
-pomegranate
+
+    .illustration
         margin .5em auto
         height 14em
         background-size contain
@@ -62,6 +63,8 @@ pomegranate
     .wizard-main
         margin auto
         padding 0 .5em
+        width 100%
+        box-sizing border-box
 
     .title
         margin    .25em auto
@@ -78,6 +81,11 @@ pomegranate
             font-size em(12px)
             font-style italic
 
+        &.info
+            color cool-grey
+            font-size em(12px)
+            font-style italic
+
     .coz-form-label
         text-align left
 
@@ -91,6 +99,7 @@ pomegranate
         &.error
             color pomegranate
             border-color pomegranate
+
 
     .wizard-footer
         display flex

--- a/src/drive/mobile/styles/onboarding.styl
+++ b/src/drive/mobile/styles/onboarding.styl
@@ -20,7 +20,7 @@
             cursor          pointer
             text-transform  uppercase
             text-align      right
-            color           #95999d
+            color           cool-grey
             margin-left     auto
 
         .close-button
@@ -34,7 +34,7 @@
                 border-radius    3px
                 width            2px
                 height           2em
-                background-color #95999d
+                background-color cool-grey
 
             &::after
                 transform rotate(-45deg);
@@ -51,9 +51,8 @@
         box-shadow    0 1px 3px rgba(50, 54, 63, .19), 0 4px 12px rgba(50, 54, 63, .12)
 
         &.error
-            background #f52d2d
-
-    .illustration
+            background pomegranate
+pomegranate
         margin .5em auto
         height 14em
         background-size contain
@@ -72,19 +71,28 @@
         font-size  em(18px)
         max-width  25em
 
+    .label
+        display block
+        text-align left
+
     .input
         width            100%
-        border           none
+        border           1px solid transparent
         padding-left     0
         font-size        em(22px)
         background-color white
 
         &::placeholder
-            color   #32363f
+            color   charcoal-grey
             opacity .5
 
         &.error
-            color #f52d2d
+            color pomegranate
+            border-color pomegranate
+
+        &:focus
+            border-color
+             charcoal-grey
 
     .wizard-footer
         display flex
@@ -95,14 +103,14 @@
             margin          1.5em .5em 0em .5em
             text-align      left
             text-decoration none
-            color           #297ef2
+            color           dodger-blue
 
 .select-server
     .description
         text-align left
 
 .welcome .logo-wrapper, .select-server .logo-wrapper
-    background #297ef2
+    background dodger-blue
 
 
 // ASSETS

--- a/src/drive/mobile/styles/onboarding.styl
+++ b/src/drive/mobile/styles/onboarding.styl
@@ -1,6 +1,8 @@
 @require 'cozy-ui'
 
 .wizard
+    @extend $form
+    @extend $form-text
     display flex
     flex-direction column
     width   85vw
@@ -71,16 +73,16 @@ pomegranate
         font-size  em(18px)
         max-width  25em
 
-    .label
-        display block
+        &.error
+            color pomegranate
+            font-size em(12px)
+            font-style italic
+
+    .coz-form-label
         text-align left
 
     .input
         width            100%
-        border           1px solid transparent
-        padding-left     0
-        font-size        em(22px)
-        background-color white
 
         &::placeholder
             color   charcoal-grey
@@ -89,10 +91,6 @@ pomegranate
         &.error
             color pomegranate
             border-color pomegranate
-
-        &:focus
-            border-color
-             charcoal-grey
 
     .wizard-footer
         display flex
@@ -108,6 +106,9 @@ pomegranate
 .select-server
     .description
         text-align left
+
+    .description p
+        margin 0
 
 .welcome .logo-wrapper, .select-server .logo-wrapper
     background dodger-blue

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,9 +2098,9 @@ cozy-client-js@^0.3.19:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.19.tgz#c20361a8bc6b23eb4d092360040e8765ef5e59a3"
 
-cozy-ui@4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-4.0.4.tgz#8150ee0808ea561722b01831f4b22ae9db79a685"
+cozy-ui@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-4.0.5.tgz#e16cc21bc0a6b2dbf235a62c20500e9efdbd5ab6"
   dependencies:
     classnames "^2.2.5"
     date-fns "^1.28.5"


### PR DESCRIPTION
Few improvements:

- [x] Added a `label` before the Cozy address' `input`.
- [x] More explicite example & errors.
- [x] The whole compliant with Cozy's styleguide.
- [x] ~~Added a "**https://**" prefix in front of the `input` and removed the auto-updated URL value to make the protocol implicit.~~
- [x] Select & focus the field when there's an error.
- [x] Added a spinner while we're fetching the server and its availability.

Basically it looks now like this:
![onboarding](https://i.imgur.com/W9V3Jcr.gif)
