### PR TITLE
feat: indicator for paused file sync

### DIFF
--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -291,7 +291,8 @@
             "If the option is enabled, your device will only backup photos when it's on WIFI in order to save your package."
         },
         "media_upload": "%{remaining} remaining pictures",
-        "media_uptodate": "Media backup is up-to-date"
+        "media_uptodate": "Media backup is up-to-date",
+        "media_wifi": "Please connect to a WIFI"
       },
       "support": {
         "title": "Support",

--- a/src/drive/mobile/containers/UploadProgression.jsx
+++ b/src/drive/mobile/containers/UploadProgression.jsx
@@ -54,6 +54,19 @@ const UploadUptodate = ({ t }) => (
   </div>
 )
 
+const UploadAbortedWifi = ({ t }) => (
+  <div
+    className={classnames(
+      styles['coz-upload-status'],
+      styles['coz-upload-status--waiting']
+    )}
+  >
+    <div className={styles['coz-upload-status-content']}>
+      {t('mobile.settings.media_backup.media_wifi')}
+    </div>
+  </div>
+)
+
 const mapStateToProps = state =>
   state.mobile.mediaBackup.currentUpload
     ? {
@@ -61,13 +74,18 @@ const mapStateToProps = state =>
         current: state.mobile.mediaBackup.currentUpload.messageData.current,
         total: state.mobile.mediaBackup.currentUpload.messageData.total
       }
-    : { media: undefined, current: undefined, total: undefined }
+    : {
+        media: undefined,
+        current: undefined,
+        total: undefined,
+        aborted: state.mobile.mediaBackup.abortedMediaBackup
+      }
 
-const UploadStatus = props =>
-  props.media && props.current && props.total ? (
-    <UploadProgression {...props} />
-  ) : (
-    <UploadUptodate {...props} />
-  )
+const UploadStatus = props => {
+  if (props.media && props.current && props.total)
+    return <UploadProgression {...props} />
+  else if (props.aborted) return <UploadAbortedWifi {...props} />
+  else return <UploadUptodate {...props} />
+}
 
 export default connect(mapStateToProps)(translate()(UploadStatus))

--- a/src/drive/mobile/lib/network.js
+++ b/src/drive/mobile/lib/network.js
@@ -17,16 +17,10 @@ export const watchNetworkState = onConnectionChange => {
 const hasCordovaPlugin = () =>
   window.navigator.connection !== undefined && window.Connection !== undefined
 
-export const getConnectionType = () =>
+const getConnectionType = () =>
   hasCordovaPlugin() ? navigator.connection.type : WIFI
 
-const isWifi = connection => connection === WIFI
-
-// TODO: rename this function
-// There is no reason for a function in a `network.js` file
-// to be called something about `backup`...
-export const backupAllowed = wifiOnly =>
-  isWifi(getConnectionType()) || !wifiOnly
+export const isWifi = () => getConnectionType() === WIFI
 
 export const isOnline = () =>
   hasCordovaPlugin() ? navigator.connection !== NONE : navigator.onLine

--- a/src/drive/mobile/styles/uploadprogression.styl
+++ b/src/drive/mobile/styles/uploadprogression.styl
@@ -49,3 +49,7 @@
 .coz-upload-status--success
     padding-left em(61px)
     background embedurl('../assets/icons/icon-upload-OK.svg') 1rem center no-repeat
+
+.coz-upload-status--waiting
+    padding-left em(61px)
+    background embedurl('../assets/icons/icon-upload-waiting.svg') 1rem center no-repeat


### PR DESCRIPTION
Every time we skip a round of backup, I add a flag in redux so we can inform the user.

I am not very happy with this, but I don't see a way to do this properly *and* in a reasonable time-frame. I think ideally, we should completely reshape this part of the state: include informations such as "list f photos that need to be saved", avoid having properties that are sometimes present and sometimes not, and probably more. But I'm open to suggestions!