### PR TITLE
fix: remove img in media backup progress

### DIFF
--- a/src/drive/mobile/containers/MediaBackupProgression.jsx
+++ b/src/drive/mobile/containers/MediaBackupProgression.jsx
@@ -29,9 +29,7 @@ const UploadProgression = ({ t, current, total, media }) => {
   return (
     <div className={styles['coz-upload-status']}>
       <Progress percent={percent(current, total)} />
-      <div className={styles['coz-progress-pic']}>
-        {media.filePath && <img src={media.filePath} />}
-      </div>
+      <div className={styles['coz-progress-pic']} />
       <div className={styles['coz-upload-status-content']}>
         {t('mobile.settings.media_backup.media_upload', {
           smart_count: total - current


### PR DESCRIPTION
Because we faced some _lags_ in loading Android files.
See https://trello.com/c/7uFiqx4D/526-3-dri-%F0%9F%93%B1-am%C3%A9liorer-le-retour-visuel-lors-de-la-sauvegarde-de-photo