### PR TITLE
fix: hide cozy to cozy sharing behind a flag

### DIFF
--- a/src/sharing/ShareModal.jsx
+++ b/src/sharing/ShareModal.jsx
@@ -32,41 +32,54 @@ export class ShareModal extends Component {
     } = this.props
     // TODO: temporary
     const loaded = contacts.fetchStatus === 'loaded'
+
+    const enableEmailSharing = window.location.search
+      .toLowerCase()
+      .includes('sharingiscaring')
+
+    const tabs = [
+      <Tab name="link">{t(`${documentType}.share.shareByLink.title`)}</Tab>
+    ]
+    const tabPanels = [
+      <TabPanel name="link">
+        <ShareByLink
+          document={this.props.document}
+          documentType={documentType}
+          checked={!!sharing.sharingLink}
+          link={sharing.sharingLink}
+          onEnable={shareByLink}
+          onDisable={revokeLink}
+        />
+      </TabPanel>
+    ]
+
+    if (enableEmailSharing) {
+      tabs.push(
+        <Tab name="email">{t(`${documentType}.share.shareByEmail.title`)}</Tab>
+      )
+      tabPanels.push(
+        <TabPanel name="email">
+          {loaded && (
+            <ShareByEmail
+              document={this.props.document}
+              documentType={documentType}
+              recipients={sharing.recipients}
+              contacts={contacts.data}
+              sharingDesc={sharingDesc}
+              onShare={share}
+              onUnshare={unshare}
+            />
+          )}
+        </TabPanel>
+      )
+    }
+
     return (
       <Modal title={t(`${documentType}.share.title`)} secondaryAction={onClose}>
-        <Tabs initialActiveTab="email">
-          <TabList className={styles['pho-share-modal-tabs']}>
-            <Tab name="email">
-              {t(`${documentType}.share.shareByEmail.title`)}
-            </Tab>
-            <Tab name="link">
-              {t(`${documentType}.share.shareByLink.title`)}
-            </Tab>
-          </TabList>
+        <Tabs initialActiveTab="link">
+          <TabList className={styles['pho-share-modal-tabs']}>{tabs}</TabList>
           <TabPanels className={styles['pho-share-modal-content']}>
-            <TabPanel name="email">
-              {loaded && (
-                <ShareByEmail
-                  document={this.props.document}
-                  documentType={documentType}
-                  recipients={sharing.recipients}
-                  contacts={contacts.data}
-                  sharingDesc={sharingDesc}
-                  onShare={share}
-                  onUnshare={unshare}
-                />
-              )}
-            </TabPanel>
-            <TabPanel name="link">
-              <ShareByLink
-                document={this.props.document}
-                documentType={documentType}
-                checked={!!sharing.sharingLink}
-                link={sharing.sharingLink}
-                onEnable={shareByLink}
-                onDisable={revokeLink}
-              />
-            </TabPanel>
+            {tabPanels}
           </TabPanels>
         </Tabs>
       </Modal>


### PR DESCRIPTION
- Only shows the share by email tab if the URL contains the magic `sharingiscaring` word
- Make the link sharing the default tab