### PR TITLE
feat: display an icon in the search bar results

### DIFF
--- a/config/webpack.config.pictures.js
+++ b/config/webpack.config.pictures.js
@@ -17,7 +17,7 @@ module.exports = function(production) {
           exclude: /(sprites|icons)/,
           loader: 'file-loader',
           options: {
-            path: 'img',
+            outputPath: 'img',
             name: `[name]${production ? '.[hash]' : ''}.[ext]`
           }
         }

--- a/config/webpack.config.pictures.js
+++ b/config/webpack.config.pictures.js
@@ -7,9 +7,9 @@ module.exports = function(production) {
         {
           test: /\.svg$/,
           include: /(sprites|icons)/,
-          loader: 'svg-sprite-loader',
+          loader: 'file-loader',
           options: {
-            name: '[name]_[hash]'
+            name: `[name]${production ? '.[hash]' : ''}.[ext]`
           }
         },
         {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "eslint-plugin-react": "^7.3.0",
     "eslint-plugin-standard": "^3.0.1",
     "extract-text-webpack-plugin": "^3.0.0",
-    "file-loader": "^0.9.0",
+    "file-loader": "^1.1.5",
     "git-directory-deploy": "^1.5.0",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -31,7 +31,8 @@ class SuggestionProvider extends React.Component {
           title: result.name,
           subtitle: result.path,
           term: result.name,
-          onSelect: 'open:' + result.url
+          onSelect: 'open:' + result.url,
+          icon: result.icon
         }))
       },
       intent.attributes.client
@@ -66,7 +67,8 @@ class SuggestionProvider extends React.Component {
             id: file._id,
             name: file.name,
             path,
-            url: window.location.origin + '/#/folder/' + dirId
+            url: window.location.origin + '/#/folder/' + dirId,
+            icon: getIconUrl(file.mime)
           }
         })
 
@@ -75,6 +77,33 @@ class SuggestionProvider extends React.Component {
       resolve()
     })
   }
+}
+
+const iconsContext = require.context(
+  '../../../assets/icons/',
+  false,
+  /icon-type-.*.svg$/
+)
+const icons = iconsContext.keys().reduce((acc, item) => {
+  acc[item.replace(/\.\/icon-type-(.*)\.svg/, '$1')] = iconsContext(item)
+  return acc
+}, {})
+
+const mapMimeIcon = {
+  'image/jpeg': 'image',
+  'image/png': 'image',
+  'application/pdf': 'pdf'
+}
+
+function getIconUrl(mimetype) {
+  const keyIcon =
+    mapMimeIcon[mimetype] ||
+    console.warn(
+      `No icon found, you may need to add a mapping for ${mimetype}`
+    ) ||
+    'files'
+
+  return `${window.location.origin}/${icons[keyIcon]}`
 }
 
 export default SuggestionProvider

--- a/yarn.lock
+++ b/yarn.lock
@@ -3306,11 +3306,12 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.9.0.tgz#1d2daddd424ce6d1b07cfe3f79731bed3617ab42"
+file-loader@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.5.tgz#91c25b6b6fbe56dae99f10a425fd64933b5c9daa"
   dependencies:
-    loader-utils "~0.2.5"
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -5282,7 +5283,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.9, loader-utils@~0.2.5:
+loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.9:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:


### PR DESCRIPTION
I changed the procedure:
1. load every `icon-type` file with [file-loader](https://github.com/webpack-contrib/file-loader)
1. build a mapping object : `name => icon-file-name`
1. map the mime-type to an icon file
1. warn in the console no mapping found
1. build an url
1. pass the url to the searchBar's `renderSuggestion` function

# 1. load every `icon-type`

```js
const iconsContext = require.context(
  '../../../assets/icons/',
  false,
  /icon-type-.*.svg$/
)
```

# 2. build an object

```js
const icons = iconsContext.keys().reduce(
  (acc, item) => ({
    ...acc,
    [item.replace(/\.\/icon-type-(.*)\.svg/, '$1')]: iconsContext(item)
  }),
  {}
)
```

# 3. map `mime-type => icon-file`

```js
const mapMimeIcon = {
  'image/jpeg': 'image',
  'image/png': 'image',
  'application/pdf': 'pdf'
}
```

# 4. warn if mapping's missing

_and add a default icon_

```js
const keyIcon =
  mapMimeIcon[mimetype] ||
  console.warn(
    `No icon found, you may need to add a mapping for ${mimetype}`
  ) ||
  'files'
```

# 5. and 6. are easy to understand

# Screenshot

_example with pdf mapping missing_

![](https://i.imgur.com/oeAcKcx.png)