### PR TITLE
fix: FirstUploadModal not displayed

### DIFF
--- a/src/drive/mobile/containers/FirstUploadModal.jsx
+++ b/src/drive/mobile/containers/FirstUploadModal.jsx
@@ -54,13 +54,12 @@ const OnlyOnceFirstUploadModal = withPersistentState(
 const mapStateToProps = state => {
   const {
     uploading = false,
-    currentUpload = { messageData: { total_upload: 0 } }
+    currentUpload = { messageData: { total: 0 } }
   } = state.mobile.mediaBackup
   const { messageData } = currentUpload
   return {
     uploading:
-      uploading &&
-      messageData['total_upload'] >= MINIMUM_LONG_UPLOAD_FILES_COUNT
+      uploading && messageData['total'] >= MINIMUM_LONG_UPLOAD_FILES_COUNT
   }
 }
 


### PR DESCRIPTION
In https://github.com/cozy/cozy-drive/pull/455 we renamed variables without modifying this call. Maybe we could use selectors here. But for now, let's fix the bug.

- https://github.com/cozy/cozy-drive/pull/455/files#diff-d173561dcc55260e5a4050bb22efe48eL32
- https://github.com/cozy/cozy-drive/pull/455/files#diff-d173561dcc55260e5a4050bb22efe48eL33