### PR TITLE
fix: photos slug in manifest.webapp

### DIFF
--- a/targets/photos/manifest.webapp
+++ b/targets/photos/manifest.webapp
@@ -1,6 +1,6 @@
 {
   "name": "Photos",
-  "slug": "cozy-photos-v3",
+  "slug": "photos",
   "icon": "public/app-icon.svg",
   "description": "Photos manager for Cozy v3",
   "category": "cozy",
@@ -34,27 +34,42 @@
     "files": {
       "description": "Required for photo access",
       "type": "io.cozy.files",
-      "methods": ["GET", "POST", "PUT"]
+      "methods": [
+        "GET",
+        "POST",
+        "PUT"
+      ]
     },
     "apps": {
       "description": "Required by the cozy-bar to display the icons of the apps",
       "type": "io.cozy.apps",
-      "verbs": ["GET"]
+      "verbs": [
+        "GET"
+      ]
     },
     "albums": {
       "description": "Required to manage photos albums",
       "type": "io.cozy.photos.albums",
-      "methods": ["GET", "POST", "PUT"]
+      "methods": [
+        "GET",
+        "POST",
+        "PUT"
+      ]
     },
     "contacts": {
       "description": "Required to to share photos with your contacts",
       "type": "io.cozy.contacts",
-      "methods": ["GET", "POST"]
+      "methods": [
+        "GET",
+        "POST"
+      ]
     },
     "settings": {
       "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
       "type": "io.cozy.settings",
-      "verbs": ["GET"]
+      "verbs": [
+        "GET"
+      ]
     }
   }
 }


### PR DESCRIPTION
The slug is incorrect, maybe that is the reason why I cannot publish to the registry.
See https://trello.com/c/Tu30nQwT/557-3-mettre-les-applications-drive-et-photos-dans-lapps-registry#comment-5a16d924189f25e82a2c3af9