### PR TITLE
fix: decide on download type at runtime

### DIFF
--- a/src/lib/cozy-client/slices/sharings.js
+++ b/src/lib/cozy-client/slices/sharings.js
@@ -465,9 +465,7 @@ const getAppUrlForDoctype = (state, doctype) => {
 
 const buildSharingLink = (state, id, doctype, sharecode) => {
   const appUrl = getAppUrlForDoctype(state, doctype)
-  return `${appUrl}public?sharecode=${sharecode}&id=${id}${
-    doctype === 'file' ? '&directdownload' : ''
-  }`
+  return `${appUrl}public?sharecode=${sharecode}&id=${id}`
 }
 
 // helpers

--- a/targets/drive/web/public/main.jsx
+++ b/targets/drive/web/public/main.jsx
@@ -25,7 +25,7 @@ const getQueryParameter = () =>
     .map(varval => varval.split('='))
     .reduce(arrToObj, {})
 
-function init() {
+async function init() {
   const lang = document.documentElement.getAttribute('lang') || 'en'
   const root = document.querySelector('[role=application]')
   const data = root.dataset
@@ -39,7 +39,23 @@ function init() {
     token: sharecode
   })
 
-  if (directdownload) {
+  let useDirectDownload
+
+  if (directdownload !== undefined) useDirectDownload = true
+  else {
+    try {
+      const response = await client.fetchDocument('io.cozy.files', id)
+      const { data = [] } = response
+      const isFile = data.length > 0 && data[0].type === 'file'
+      useDirectDownload = isFile
+    }
+    catch (e) {
+      console.warn(e)
+      useDirectDownload = false
+    }
+  }
+
+  if (useDirectDownload) {
     cozy.client.files
       .getDownloadLinkById(id)
       .then(link => {


### PR DESCRIPTION
This PR may cause problems for our next release. The commit we're merging into prod here is already on master so theoretically it's all ok but I'm not super confident.