### PR TITLE
chore: Use the production build of cozy libs

### DIFF
--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -28,8 +28,8 @@ module.exports = function(production, app) {
         PouchDB: 'pouchdb',
         pouchdbFind: 'pouchdb-find',
         pouchdbAdapterCordovaSqlite: 'pouchdb-adapter-cordova-sqlite',
-        'cozy.client': 'cozy-client-js/dist/cozy-client.js',
-        'cozy.bar': 'cozy-bar/dist/cozy-bar.mobile.js'
+        'cozy.client': production ? 'cozy-client-js/dist/cozy-client.min.js' : 'cozy-client-js/dist/cozy-client.js',
+        'cozy.bar': production ? 'cozy-bar/dist/cozy-bar.mobile.min.js' : 'cozy-bar/dist/cozy-bar.mobile.js'
       }),
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, `../targets/${app}/web/index.ejs`),


### PR DESCRIPTION
Sinon pour un build de prod sur mobile on a le build de la cozy-bar en mode non production et du coup on a un warning comme ceci :

<img width="812" alt="capture d ecran 2017-11-29 a 17 52 23" src="https://user-images.githubusercontent.com/1135513/33387774-753cec6a-d52e-11e7-8d25-2d612108dd33.png">
