### PR TITLE
chore: update UI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "classnames": "^2.2.0",
     "cozy-bar": "4.5.0",
     "cozy-client-js": "0.4.3",
-    "cozy-ui": "4.1.0",
+    "cozy-ui": "5.0.1",
     "date-fns": "^1.22.0",
     "diacritics": "^1.3.0",
     "filesize": "^3.3.0",

--- a/src/components/Button/index.styl
+++ b/src/components/Button/index.styl
@@ -1,5 +1,20 @@
 @require 'cozy-ui'
 
+.c-btn
+    @extend $button
+
+.c-btn--secondary
+    @extend $button--secondary
+
+.c-btn--more
+    @extend $button--more
+
+.c-btn-extra
+    @extend $button-extra
+
+.u-visuallyhidden
+    @extend $visuallyhidden
+
 @media (max-width: (1023/basefont)rem)
     .dri-btn--more
         display inline-flex

--- a/src/drive/mobile/styles/uploadstatus.styl
+++ b/src/drive/mobile/styles/uploadstatus.styl
@@ -1,13 +1,13 @@
 @require 'cozy-ui'
 
 .coz-alerter
-    @extends $alerts
+    @extend $alerts
 
     .coz-alert
         bottom 3em
 
 
 .btn--full-width
-    @extends .c-btn
-    @extends .c-btn--regular
+    @extend $button
+    @extend $button--regular
     width 100%

--- a/src/drive/styles/nav.styl
+++ b/src/drive/styles/nav.styl
@@ -1,49 +1,43 @@
 @require 'cozy-ui'
 
 .coz-nav
-    @extend .c-nav
+    @extend $nav
 
 .coz-nav-item
-    @extend .c-nav-item
+    @extend $nav-item
 
 .coz-nav-link
-    @extend .c-nav-link
+    @extend $nav-link
     position relative
 
 .fil-cat-files
     background-image: embedurl("../assets/icons/icon-folder.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-folder-active.svg")
 
 .fil-cat-recent
     background-image: embedurl("../assets/icons/icon-clock.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-clock-active.svg")
 
 .fil-cat-shared
     background-image: embedurl("../assets/icons/icon-shared.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-shared-active.svg")
 
 .fil-cat-activity
     background-image: embedurl("../assets/icons/icon-dashboard.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-dashboard-active.svg")
 
 .fil-cat-trash
     background-image: embedurl("../assets/icons/icon-trash.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-trash-active.svg")
 
 .fil-cat-settings
     background-image: embedurl("../assets/icons/icon-settings.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-settings-active.svg")
 
 @media (max-width: (1023/basefont)rem)

--- a/src/drive/styles/table.styl
+++ b/src/drive/styles/table.styl
@@ -1,6 +1,12 @@
 @require 'cozy-ui'
 @import './mimetypes'
 
+.c-btn
+    @extend $button
+
+.c-btn-extra
+    @extend $button-extra
+
 .fil-content-table
     position        relative
     display         flex

--- a/src/drive/styles/toolbar.styl
+++ b/src/drive/styles/toolbar.styl
@@ -1,5 +1,41 @@
 @require 'cozy-ui'
 
+.c-btn
+    @extend $button
+
+.c-btn--regular
+    @extend $button--regular
+
+.c-btn--secondary
+    @extend $button--secondary
+
+.c-btn--danger
+    @extend $button--danger
+
+.c-btn--danger-outline
+    @extend $button--danger-outline
+
+.c-btn--share
+    @extend $button--share
+
+.c-btn--send
+    @extend $button--send
+
+.c-btn--download
+    @extend $button--download
+
+.c-btn--upload
+    @extend $button--upload
+
+.c-btn--delete
+    @extend $button--delete
+
+.u-hide--mob
+    @extend $hide--mob
+
+.u-hide--desk
+    @extend $hide--desk
+
 .fil-toolbar-files
 .fil-toolbar-trash
     margin-left auto

--- a/src/photos/components/UploadButton.jsx
+++ b/src/photos/components/UploadButton.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import classNames from 'classnames'
 
-import button from 'cozy-ui/stylus/components/button'
+import button from '../styles/toolbar'
 
 const styles = {
   parent: {

--- a/src/photos/styles/createAlbumForm.styl
+++ b/src/photos/styles/createAlbumForm.styl
@@ -1,5 +1,11 @@
 @require 'cozy-ui'
 
+.c-btn
+    @extend $button
+
+.c-btn--regular
+    @extend $button--regular
+
 .pho-create-album-form
     @extend $form-text
 

--- a/src/photos/styles/nav.styl
+++ b/src/photos/styles/nav.styl
@@ -1,31 +1,27 @@
 @require 'cozy-ui'
 
 .coz-nav
-    @extend .c-nav
+    @extend $nav
 
 .coz-nav-item
-    @extend .c-nav-item
+    @extend $nav-item
 
 .coz-nav-link
-    @extend .c-nav-link
+    @extend $nav-link
 
 .pho-cat-photos
     background-image: embedurl("../assets/icons/icon-image.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-image-active.svg")
 .pho-cat-albums
     background-image: embedurl("../assets/icons/icon-album.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-album-active.svg")
 .pho-cat-shared
     background-image: embedurl("../assets/icons/icon-share.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-share-active.svg")
 .pho-cat-trash
     background-image: embedurl("../assets/icons/icon-trash.svg")
     &.active
-        @extend .c-nav-link.is-active
         background-image: embedurl("../assets/icons/icon-trash-active.svg")

--- a/src/photos/styles/newAlbum.styl
+++ b/src/photos/styles/newAlbum.styl
@@ -1,5 +1,14 @@
 @require 'cozy-ui'
 
+.c-btn
+    @extend $button
+
+.c-btn--regular
+    @extend $button--regular
+
+.c-btn--secondary
+    @extend $button--secondary
+
 .pho-panel
     position          fixed
     top               0

--- a/src/photos/styles/sidebar.styl
+++ b/src/photos/styles/sidebar.styl
@@ -1,4 +1,4 @@
 @require 'cozy-ui'
 
 .coz-sidebar
-    @extend .o-sidebar
+    @extend $sidebar

--- a/src/photos/styles/toolbar.styl
+++ b/src/photos/styles/toolbar.styl
@@ -1,5 +1,44 @@
 @require 'cozy-ui'
 
+.c-btn
+    @extend $button
+
+.c-btn--regular
+    @extend $button--regular
+
+.c-btn--secondary
+    @extend $button--secondary
+
+.c-btn--danger
+    @extend $button--danger
+
+.c-btn--danger-outline
+    @extend $button--danger-outline
+
+.c-btn--share
+    @extend $button--share
+
+.c-btn--send
+    @extend $button--send
+
+.c-btn--download
+    @extend $button--download
+
+.c-btn--upload
+    @extend $button--upload
+
+.c-link--upload
+    @extend $link--upload
+
+.c-btn--delete
+    @extend $button--delete
+
+.u-hide--mob
+    @extend $hide--mob
+
+.u-hide--desk
+    @extend $hide--desk
+
 .pho-toolbar
     display flex
     margin-left auto
@@ -22,7 +61,7 @@
             background embedurl("../assets/icons/icon-trash-red.svg") em(16px) center no-repeat
 
     .pho-btn-new
-        @extend .c-btn
-        @extend .c-btn--secondary
-        @extend .c-btn--upload
+        @extend $button
+        @extend $button--secondary
+        @extend $button--upload
         background-image embedurl("../assets/icons/icon-album-add.svg")

--- a/src/sharing/components/button.styl
+++ b/src/sharing/components/button.styl
@@ -1,5 +1,14 @@
 @require 'cozy-ui'
 
+.c-btn
+    @extend $button
+
+.c-btn--secondary
+    @extend $button--secondary
+
+.c-btn--share
+    @extend $button--share
+
 .coz-btn-shared
     @extend $button--share
     background-image embedurl('../assets/icon-share-white.svg')

--- a/src/sharing/components/recipient.styl
+++ b/src/sharing/components/recipient.styl
@@ -56,7 +56,7 @@
     color cool-grey
 
 .pho-recipient-menu-btn
-    @extend .c-btn
+    @extend $button
     text-transform capitalize
     padding-right  em(48px)
     background embedurl("../assets/icon-arrow-down.svg") right em(16px) center no-repeat

--- a/targets/photos/web/public/index.styl
+++ b/targets/photos/web/public/index.styl
@@ -21,7 +21,7 @@
 
 .pho-content-header.--no-icon
     left 0
-    left-padded(15px)
+    padding-left em(15px)
 
 .pho-public-download
     padding-left         em(44px, 16px)


### PR DESCRIPTION
I used the new version (not yet released) with no more output classes. (`.c-btn`, `.nav`, etc) for performance purpose.
So I had to manually recall every missing part, mostly buttons. It could better, it should be better but I think that for most cases we should use the `<Button />` component at some point.