### PR TITLE
[WIP] Viewer enhancements

### DIFF
--- a/src/components/Image/ImageLoader.jsx
+++ b/src/components/Image/ImageLoader.jsx
@@ -1,46 +1,157 @@
 import React, { Component } from 'react'
 import { getDownloadLink } from 'cozy-client'
 
+const TTL = 6000
+
+const LOADING = 'LOADING'
+const LOADED = 'LOADED'
+const PENDING = 'PENDING'
+const FAILED = 'FAILED'
+
+// This component handles the load and display of an image fetched from the cozy-stack:
+// It first tries to load the provided `src` (it should be the link to a thumbnail) ;
+// If it fails, it tries to fetch the download url for the provided `photo`, and then
+// it tries to load the raw image. If one of these image loadings (done by instantiating an `Image`)
+// is successful, the image is shown.
 export default class ImageLoader extends Component {
   state = {
-    fallback: null
+    fallbackUrl: null,
+    primaryStatus: LOADING,
+    fallbackStatus: PENDING
   }
 
-  onLoad = () => {
-    if (this.props.onLoad) this.props.onLoad()
+  isLoadingPrimary() {
+    return this.state.primaryStatus === LOADING
+  }
+  shouldLoadPrimary() {
+    return this.isLoadingPrimary() && !this.img
+  }
+  isPrimaryLoaded() {
+    return this.state.primaryStatus === LOADED
+  }
+  isLoadingFallback() {
+    return (
+      this.state.primaryStatus === FAILED &&
+      this.state.fallbackStatus === LOADING
+    )
+  }
+  shouldLoadFallbackUrl() {
+    return this.isLoadingFallback() && !this.state.fallbackUrl
+  }
+  shouldLoadFallback() {
+    return this.isLoadingFallback() && this.state.fallbackUrl && !this.img
+  }
+  isFallbackLoaded() {
+    return this.state.fallbackStatus === LOADED
+  }
+  hasSomethingToShow() {
+    return this.isPrimaryLoaded() || this.isFallbackLoaded()
   }
 
-  onError = () => {
-    if (!this.img) return // if we already unmounted
-    if (this.state.fallback !== null) return
-    // extreme fallback: uses a direct download link to the raw image
-    getDownloadLink(this.props.photo).then(url => {
-      this.img.src = url
-      this.setState({ fallback: url })
-      if (this.props.onLoad) this.props.onLoad()
-    })
+  componentDidMount() {
+    if (this.shouldLoadPrimary()) {
+      this.createLoader(this.props.src)
+    }
+  }
+
+  // If the component is reused to display another image, we reset the state so that
+  // `componentWillUpdate` gets triggered
+  componentWillReceiveProps(nextProps) {
+    if (this.props.src !== nextProps.src) {
+      this.setState(state => ({
+        primaryStatus: nextProps.src ? LOADING : PENDING,
+        fallbackUrl: null,
+        fallbackStatus: PENDING
+      }))
+    }
+  }
+
+  // Here is the main logic: depending on the state, we trigger the different fetch we need
+  componentDidUpdate() {
+    if (this.shouldLoadPrimary()) {
+      this.createLoader(this.props.src)
+    } else if (this.shouldLoadFallbackUrl()) {
+      getDownloadLink(this.props.photo)
+        .then(url => this.setState(state => ({ ...state, fallbackUrl: url })))
+        .catch(error => this.allIsLost(error))
+    } else if (this.shouldLoadFallback()) {
+      this.createLoader(this.state.fallbackUrl)
+    }
   }
 
   componentWillUnmount() {
-    // this is needed because when opening 2 times in a row the same photo in the viewer,
-    // the second time the onLoad is not fired... This will fire the onError (see above)
-    this.img.src = ''
+    this.destroyLoader()
+  }
+
+  createLoader(src) {
+    this.destroyLoader()
+    this.img = new Image()
+    this.img.onload = this.handleLoad
+    this.img.onerror = this.handleError
+    this.img.src = src
+    this.timeout = setTimeout(this.allIsLost, TTL)
+  }
+
+  destroyLoader() {
+    clearTimeout(this.timeout)
+    if (this.img) {
+      this.img.onload = null
+      this.img.onerror = null
+      this.img = null
+    }
+  }
+
+  handleLoad = event => {
+    this.destroyLoader()
+    if (this.isLoadingPrimary()) {
+      this.setState(state => ({ ...state, primaryStatus: LOADED }))
+    } else {
+      this.setState(state => ({ ...state, fallbackStatus: LOADED }))
+    }
+    if (this.props.onLoad) this.props.onLoad(event)
+  }
+
+  handleError = error => {
+    this.destroyLoader()
+    if (this.isLoadingPrimary()) {
+      this.setState(state => ({
+        ...state,
+        primaryStatus: FAILED,
+        fallbackStatus: LOADING
+      }))
+    } else {
+      this.allIsLost(error)
+    }
+  }
+
+  allIsLost = error => {
+    // As this method can be called in 3 different contexts, we have to ensure a coherent state
+    this.destroyLoader()
+    this.setState(state => ({
+      ...state,
+      primaryStatus: FAILED,
+      fallbackStatus: FAILED
+    }))
+    if (this.props.onError) this.props.onError(error)
   }
 
   render() {
-    const { photo, src, alt, className, style = {} } = this.props
-    return (
-      <img
-        ref={img => {
-          this.img = img
-        }}
-        className={className}
-        onLoad={this.onLoad}
-        onError={this.onError}
-        style={Object.assign({}, style)}
-        alt={alt || photo.name}
-        src={src}
-      />
-    )
+    if (this.hasSomethingToShow()) {
+      const { photo, src, alt, className, style = {} } = this.props
+      const loadedSource = this.isPrimaryLoaded() ? src : this.state.fallbackUrl
+      return (
+        <img
+          ref={img => {
+            this.img = img
+          }}
+          className={className}
+          style={Object.assign({}, style)}
+          alt={alt || photo.name}
+          src={loadedSource}
+        />
+      )
+    } else {
+      return this.props.preloader(this.props)
+    }
   }
 }

--- a/src/drive/components/FilesViewer.jsx
+++ b/src/drive/components/FilesViewer.jsx
@@ -17,7 +17,12 @@ class FilesViewer extends Component {
     // TODO: temp fix for thumbnail links on mobile
     if (isCordova() && !this.props.filesWithLinks) return null
     const files = isCordova()
-      ? this.props.filesWithLinks.filter(f => f.type !== 'directory')
+      ? this.props.filesWithLinks
+          .filter(f => f.type !== 'directory')
+          .map(f => ({
+            ...f,
+            isAvailableOffline: this.props.isAvailableOffline(f.id)
+          }))
       : this.props.files.filter(f => f.type !== 'directory')
     const { params, router } = this.props
     const currentIndex = files.findIndex(f => f.id === params.fileId)

--- a/src/drive/components/FolderView.jsx
+++ b/src/drive/components/FolderView.jsx
@@ -124,7 +124,8 @@ class FolderView extends Component {
     if (!children) return null
     return React.Children.map(children, child =>
       React.cloneElement(child, {
-        files: this.props.files || []
+        files: this.props.files || [],
+        isAvailableOffline: this.props.isAvailableOffline
       })
     )
   }

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -426,7 +426,8 @@
     "close": "Close",
     "noviewer": {
       "title": "The viewer doesn't know how to read this type of file yet.",
-      "download": "Download this file"
+      "download": "Download this file",
+      "openWith": "Open with..."
     },
     "actions": {
       "download": "Download"

--- a/src/photos/locales/en.json
+++ b/src/photos/locales/en.json
@@ -225,7 +225,8 @@
     "close": "Close",
     "noviewer": {
       "title": "The viewer doesn't know how to read this type of file yet.",
-      "download": "Download this file"
+      "download": "Download this file",
+      "openWith": "Open with..."
     },
     "actions": {
       "download": "Download"

--- a/src/viewer/AudioViewer.jsx
+++ b/src/viewer/AudioViewer.jsx
@@ -1,31 +1,13 @@
-import React, { Component } from 'react'
-import { getDownloadLink } from 'cozy-client'
-import Spinner from 'cozy-ui/react/Spinner'
+import React from 'react'
 
+import withFileUrl from './withFileUrl'
 import styles from './styles'
 
-export default class AudioViewer extends Component {
-  state = {
-    fileDownloadUrl: null
-  }
+const AudioViewer = ({ file, url }) => (
+  <div className={styles['pho-viewer-audioviewer']}>
+    <p className={styles['pho-viewer-filename']}>{file.name}</p>
+    <audio src={url} controls="controls" />
+  </div>
+)
 
-  componentWillMount() {
-    getDownloadLink(this.props.file).then(url =>
-      this.setState({ fileDownloadUrl: url })
-    )
-  }
-
-  render() {
-    const { file } = this.props
-    const { fileDownloadUrl } = this.state
-    return (
-      <div className={styles['pho-viewer-audioviewer']}>
-        <p className={styles['pho-viewer-filename']}>{file.name}</p>
-        {fileDownloadUrl && <audio src={fileDownloadUrl} controls="controls" />}
-        {!fileDownloadUrl && (
-          <Spinner size="xxlarge" middle="true" noMargin color="white" />
-        )}
-      </div>
-    )
-  }
-}
+export default withFileUrl(AudioViewer)

--- a/src/viewer/NoNetwork.jsx
+++ b/src/viewer/NoNetwork.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Button from 'cozy-ui/react/Button'
+import { translate } from 'cozy-ui/react/I18n'
+
+import styles from './styles'
+
+const NoNetwork = ({ t, onReload }) => (
+  <div className={styles['pho-viewer-canceled']}>
+    <h2>{t('Viewer.loading.error')}</h2>
+    <Button theme="regular" onClick={onReload}>
+      {t('Viewer.loading.retry')}
+    </Button>
+  </div>
+)
+
+export default translate()(NoNetwork)

--- a/src/viewer/NoViewer.jsx
+++ b/src/viewer/NoViewer.jsx
@@ -1,33 +1,39 @@
-import React, { Component } from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import { downloadFile } from 'cozy-client'
+import { openOfflineFile } from 'drive/mobile/lib/filesystem'
 import { translate } from 'cozy-ui/react/I18n'
 import Button from 'cozy-ui/react/Button'
 
 import styles from './styles'
 
-export default translate()(
-  class NoViewer extends Component {
-    render() {
-      const { t, file } = this.props
-      return (
-        <div
-          className={classNames(
-            styles['pho-viewer-noviewer'],
-            styles[`pho-viewer-noviewer--${file.class}`]
-          )}
-        >
-          <p className={styles['pho-viewer-filename']}>{file.name}</p>
-          <h2>{t('Viewer.noviewer.title')}</h2>
-          <Button
-            theme="regular"
-            className={styles['pho-viewer-noviewer-download']}
-            onClick={() => downloadFile(file)}
-          >
-            {t('Viewer.noviewer.download')}
-          </Button>
-        </div>
-      )
-    }
-  }
+const NoViewer = ({ t, file }) => (
+  <div
+    className={classNames(
+      styles['pho-viewer-noviewer'],
+      styles[`pho-viewer-noviewer--${file.class}`]
+    )}
+  >
+    <p className={styles['pho-viewer-filename']}>{file.name}</p>
+    <h2>{t('Viewer.noviewer.title')}</h2>
+    {file.isAvailableOffline ? (
+      <Button
+        theme="regular"
+        className={styles['pho-viewer-noviewer-download']}
+        onClick={() => openOfflineFile(file)}
+      >
+        {t('Viewer.noviewer.openWith')}
+      </Button>
+    ) : (
+      <Button
+        theme="regular"
+        className={styles['pho-viewer-noviewer-download']}
+        onClick={() => downloadFile(file)}
+      >
+        {t('Viewer.noviewer.download')}
+      </Button>
+    )}
+  </div>
 )
+
+export default translate()(NoViewer)

--- a/src/viewer/VideoViewer.jsx
+++ b/src/viewer/VideoViewer.jsx
@@ -1,33 +1,13 @@
-import React, { Component } from 'react'
-import { getDownloadLink } from 'cozy-client'
-import Spinner from 'cozy-ui/react/Spinner'
+import React from 'react'
 
+import withFileUrl from './withFileUrl'
 import styles from './styles'
 
-export default class VideoViewer extends Component {
-  state = {
-    fileDownloadUrl: null
-  }
+const VideoViewer = ({ file, url }) => (
+  <div className={styles['pho-viewer-videoviewer']}>
+    <video src={url} controls="controls" />
+    <p className={styles['pho-viewer-filename']}>{file.name}</p>
+  </div>
+)
 
-  componentWillMount() {
-    getDownloadLink(this.props.file).then(url =>
-      this.setState({ fileDownloadUrl: url })
-    )
-  }
-
-  render() {
-    const { file } = this.props
-    const { fileDownloadUrl } = this.state
-    return (
-      <div className={styles['pho-viewer-videoviewer']}>
-        {fileDownloadUrl && <video src={fileDownloadUrl} controls="controls" />}
-        {fileDownloadUrl && (
-          <p className={styles['pho-viewer-filename']}>{file.name}</p>
-        )}
-        {!fileDownloadUrl && (
-          <Spinner size="xxlarge" middle="true" noMargin color="white" />
-        )}
-      </div>
-    )
-  }
-}
+export default withFileUrl(VideoViewer)

--- a/src/viewer/withFileUrl.jsx
+++ b/src/viewer/withFileUrl.jsx
@@ -1,0 +1,72 @@
+import React, { Component } from 'react'
+import { getDownloadLink } from 'cozy-client'
+import Spinner from 'cozy-ui/react/Spinner'
+
+import NoNetwork from './NoNetwork'
+
+const TTL = 6000
+
+const LOADING = 'LOADING'
+const LOADED = 'LOADED'
+const FAILED = 'FAILED'
+
+const withFileUrl = WrappedComponent =>
+  class Wrapper extends Component {
+    state = {
+      status: LOADING,
+      downloadUrl: null
+    }
+
+    componentWillMount() {
+      this.loadDownloadUrl()
+    }
+
+    componentWillReceiveProps(nextProps) {
+      if (nextProps.file.id !== this.props.file.id) {
+        this.reset()
+      }
+    }
+
+    componentDidUpdate() {
+      if (this.state.status === LOADING && !this.timeout) {
+        this.loadDownloadUrl()
+      }
+    }
+
+    loadDownloadUrl() {
+      this.timeout = setTimeout(
+        () => this.setState(state => ({ ...state, status: FAILED })),
+        TTL
+      )
+      getDownloadLink(this.props.file)
+        .then(url => {
+          this.clearTimeout()
+          this.setState(state => ({ downloadUrl: url, status: LOADED }))
+        })
+        .catch(() => {
+          this.clearTimeout()
+          this.setState(state => ({ ...state, status: FAILED }))
+        })
+    }
+
+    clearTimeout() {
+      clearTimeout(this.timeout)
+      this.timeout = null
+    }
+
+    reset = () => {
+      this.setState(state => ({ status: LOADING, downloadUrl: null }))
+    }
+
+    render() {
+      if (this.state.status === LOADING) {
+        return <Spinner size="xxlarge" middle="true" noMargin color="white" />
+      }
+      if (this.state.status === FAILED) {
+        return <NoNetwork onReload={this.reset} />
+      }
+      return <WrappedComponent {...this.props} url={this.state.downloadUrl} />
+    }
+  }
+
+export default withFileUrl


### PR DESCRIPTION
 - All viewers now have a loading timeout and show the "no-good-network" screen. To do this, I implemented a `withFileUrl` [HOC](https://github.com/cozy/cozy-drive/pull/563/files#diff-75dfe39feb623ef6c3433f43d0e06fc3) that simplify a lot the audio & video viewers ;
 - If there is no network (instead of a slow one), we now display the "no-good-network" screen without waiting for the timeout ;
 - the `<ImageLoader />` no longer downloads the raw image when not necessary (it was a bug) ;