### PR TITLE
fix: perms.byMe is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-drive",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "src/main.jsx",
   "scripts": {
     "build:drive": "npm run build:drive:browser",

--- a/src/lib/cozy-client/collections/SharingsCollection.js
+++ b/src/lib/cozy-client/collections/SharingsCollection.js
@@ -44,15 +44,21 @@ export default class SharingsCollection {
         `/permissions/doctype/${doctype}/${sharingType}`
       )
 
-    const byMe = await fetchPermissions(doctype, SHARED_WITH_OTHERS)
-    const byLink = await fetchPermissions(doctype, SHARED_BY_LINK)
-    const withMe = await fetchPermissions(doctype, SHARED_WITH_ME)
-
+    // if we catch an exception (server's error), we init values with empty array
+    const byMe = await fetchPermissions(doctype, SHARED_WITH_OTHERS).catch(
+      () => []
+    )
+    const byLink = await fetchPermissions(doctype, SHARED_BY_LINK).catch(
+      () => []
+    )
+    const withMe = await fetchPermissions(doctype, SHARED_WITH_ME).catch(
+      () => []
+    )
     return { byMe, byLink, withMe }
   }
 
   fetchSharing(id) {
-    return cozy.client.fetchJSON('GET', `/sharings/${id}`)
+    return cozy.client.fetchJSON('GET', `/sharings/${id}`).catch(() => ({}))
   }
 
   revoke(sharingId) {

--- a/src/lib/cozy-client/package.json
+++ b/src/lib/cozy-client/package.json
@@ -1,7 +1,8 @@
 {
   "name": "cozy-client",
-  "version": "0.3.0",
-  "description": "A simple and declarative way of managing cozy-stack API calls and resulting data.",
+  "version": "0.3.1",
+  "description":
+    "A simple and declarative way of managing cozy-stack API calls and resulting data.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/lib/cozy-client/slices/sharings.js
+++ b/src/lib/cozy-client/slices/sharings.js
@@ -340,7 +340,9 @@ const getPermissionsFor = (document, publicLink = false) => {
 
 // selectors
 const getSharing = (state, id) =>
-  state.cozy.sharings.documents.find(s => s.attributes.sharing_id === id)
+  state.cozy.sharings.documents.find(
+    s => s.attributes && s.attributes.sharing_id === id
+  )
 const getContact = (state, id) => getDocument(state, 'io.cozy.contacts', id)
 const getDoctypePermissions = (state, doctype) => {
   if (state.cozy.sharings.permissions[doctype]) {
@@ -360,7 +362,11 @@ const getSharingLinkPermission = (state, doctype, id) => {
   const perms = getDoctypePermissions(state, doctype)
   const type = isFile({ _type: doctype }) ? 'files' : 'collection'
   return perms.byLink.find(
-    p => p.attributes.permissions[type].values.indexOf(id) !== -1
+    p =>
+      p.attributes &&
+      p.attributes.permissions &&
+      p.attributes.permissions[type] &&
+      p.attributes.permissions[type].values.indexOf(id) !== -1
   )
 }
 
@@ -370,8 +376,13 @@ const getSharingForRecipient = (state, document, recipient) => {
     document._type,
     document._id
   )
-  return sharings.find(s =>
-    s.attributes.recipients.find(r => r.recipient.id === recipient._id)
+  return sharings.find(
+    s =>
+      s.attributes &&
+      s.attributes.recipients &&
+      s.attributes.recipients.find(
+        r => r.recipient && r.recipient.id === recipient._id
+      )
   )
 }
 
@@ -386,7 +397,7 @@ const getDocumentActiveSharings = (state, doctype, id) => {
     )
   ]
     .map(p => getSharing(state, p.attributes.source_id))
-    .filter(s => !s.attributes.revoked)
+    .filter(s => s && s.attributes && !s.attributes.revoked)
 }
 
 export const getSharings = (state, doctype, options = {}) => {


### PR DESCRIPTION
with minified source it is r.byMe is undefined.

This is cause by fetching inconsistent data between
- `/permissions/doctype/:doctype/:sharingtype`
- `/sharings/:id`

- [x] commits that fix
- [x] upgrade version in cozy-drive's package.json
- [x] upgrade version in cozy-client lib's package.json