### PR TITLE
refactor: use getFolderIdFromRoute

### DIFF
--- a/src/drive/components/FilesViewer.jsx
+++ b/src/drive/components/FilesViewer.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import Viewer from 'viewer'
 
 import { getFolderUrl } from '../reducers'
-import { getFilesWithLinks } from '../reducers/view'
+import { getFilesWithLinks, getFolderIdFromRoute } from '../reducers/view'
 import { isCordova } from '../mobile/lib/device'
 import { fetchMoreFiles } from '../actions'
 
@@ -16,10 +16,14 @@ const getParentPath = router => {
 
 class FilesViewer extends Component {
   fetchMore() {
-    const { files, params, fetchMoreFiles } = this.props
+    const { files, params, location, fetchMoreFiles } = this.props
     const currentIndex = files.findIndex(f => f.id === params.fileId)
     if (files.length - currentIndex <= 5) {
-      fetchMoreFiles(params.folderId, files.length, LIMIT)
+      fetchMoreFiles(
+        getFolderIdFromRoute(location, params),
+        files.length,
+        LIMIT
+      )
     }
   }
 
@@ -76,7 +80,7 @@ class FilesViewer extends Component {
 const mapStateToProps = (state, ownProps) => ({
   filesWithLinks: getFilesWithLinks(
     state,
-    ownProps.params.folderId || 'io.cozy.files.root-dir'
+    getFolderIdFromRoute(ownProps.location, ownProps.params)
   )
 })
 

--- a/src/drive/components/FolderView.jsx
+++ b/src/drive/components/FolderView.jsx
@@ -9,6 +9,7 @@ import FileListHeader from './FileListHeader'
 import { ROOT_DIR_ID } from '../constants/config'
 import Breadcrumb from '../containers/Breadcrumb'
 import { SelectionBar } from '../ducks/selection'
+import { getFolderIdFromRoute } from '../reducers/view'
 import AddFolder from './AddFolder'
 import FileActionMenu from './FileActionMenu'
 import MediaBackupProgression from '../mobile/containers/MediaBackupProgression'
@@ -48,7 +49,6 @@ class FolderView extends Component {
       selectionModeActive
     } = this.props
     const {
-      params,
       files,
       selected,
       actionable,
@@ -64,9 +64,11 @@ class FolderView extends Component {
     const fetchFailed = this.props.fetchStatus === 'failed'
     const fetchPending = this.props.fetchStatus === 'pending'
     const nothingToDo = isTrashContext && files.length === 0
-    const isRootfolder =
-      this.props.displayedFolder &&
-      this.props.displayedFolder.id === ROOT_DIR_ID
+    const folderId = getFolderIdFromRoute(
+      this.props.location,
+      this.props.params
+    )
+    const isRootfolder = folderId === ROOT_DIR_ID
 
     const toolbarActions = {}
     if (canCreateFolder) toolbarActions.addFolder = this.toggleAddFolder
@@ -75,7 +77,7 @@ class FolderView extends Component {
         <Topbar>
           <Breadcrumb />
           <Toolbar
-            folderId={params.folderId}
+            folderId={folderId}
             actions={toolbarActions}
             canUpload={canUpload}
             disabled={

--- a/src/drive/components/LightFolderView.jsx
+++ b/src/drive/components/LightFolderView.jsx
@@ -23,6 +23,7 @@ import { getVisibleFiles } from '../reducers'
 
 import styles from '../styles/folderview'
 import toolbarstyles from '../styles/toolbar'
+import { getFolderIdFromRoute } from '../reducers/view'
 
 class DumbFolderView extends React.Component {
   state = {
@@ -30,14 +31,18 @@ class DumbFolderView extends React.Component {
   }
 
   componentWillMount() {
-    this.props.onFolderOpen(this.props.params.folderId).then(e => {
-      if (
-        e.type === 'OPEN_FOLDER_FAILURE' &&
-        /no permission doc for token/.test(e.error.reason.errors[0].detail)
-      ) {
-        this.setState(state => ({ ...state, revoked: true }))
-      }
-    })
+    this.props
+      .onFolderOpen(
+        getFolderIdFromRoute(this.props.location, this.props.params)
+      )
+      .then(e => {
+        if (
+          e.type === 'OPEN_FOLDER_FAILURE' &&
+          /no permission doc for token/.test(e.error.reason.errors[0].detail)
+        ) {
+          this.setState(state => ({ ...state, revoked: true }))
+        }
+      })
   }
 
   render() {

--- a/src/drive/containers/FileExplorer.jsx
+++ b/src/drive/containers/FileExplorer.jsx
@@ -75,7 +75,11 @@ const mapStateToProps = (state, ownProps) => ({
   files: getVisibleFiles(state),
   selected: getSelectedFiles(state),
   actionable: getActionableFiles(state),
-  shared: getSharingDetails(state, 'io.cozy.files', ownProps.params.folderId),
+  shared: getSharingDetails(
+    state,
+    'io.cozy.files',
+    getFolderIdFromRoute(ownProps.location, ownProps.params)
+  ),
   selectionModeActive: isSelectionBarVisible(state),
   actionMenuActive: isActionMenuVisible(state)
 })

--- a/src/photos/ducks/timeline/components/Toolbar.jsx
+++ b/src/photos/ducks/timeline/components/Toolbar.jsx
@@ -14,14 +14,7 @@ import { showSelectionBar, isSelectionBarVisible } from '../../selection'
 import { addToUploadQueue } from '../../upload'
 import { uploadPhoto } from '../'
 
-export const Toolbar = ({
-  t,
-  disabled = false,
-  uploadPhotos,
-  deleteAlbum,
-  selectItems,
-  params
-}) => (
+export const Toolbar = ({ t, disabled = false, uploadPhotos, selectItems }) => (
   <div className={styles['pho-toolbar']} role="toolbar">
     <UploadButton
       className={styles['u-hide--mob']}


### PR DESCRIPTION
on `root_dir`, `params.folderId` is `undefined` this is handled by `getFolderIdFromRoute`