### PR TITLE
feat: open pdf with cordova plugin

### DIFF
--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -425,6 +425,7 @@
   },
   "Viewer": {
     "close": "Close",
+    "reopen": "Open again",
     "noviewer": {
       "title": "The viewer doesn't know how to read this type of file yet.",
       "download": "Download this file",

--- a/src/drive/mobile/lib/filesystem.js
+++ b/src/drive/mobile/lib/filesystem.js
@@ -94,7 +94,7 @@ const saveFile = (dirEntry, fileData, fileName) =>
     )
   })
 
-const openFileWithCordova = (uri, mimetype) =>
+export const openFileWithCordova = (uri, mimetype) =>
   new Promise((resolve, reject) => {
     window.cordova.plugins.fileOpener2.open(decodeURIComponent(uri), mimetype, {
       error: reject,
@@ -132,10 +132,15 @@ export const saveAndOpenWithCordova = (file, filename) =>
       .catch(reject)
   })
 
-export const openOfflineFile = file =>
+export const getNativeFile = file =>
   new Promise(async (resolve, reject) => {
     const entry = await getCozyEntry()
-    const fileEntry = await getEntry(`${entry.nativeURL}${file.id}`)
+    resolve(getEntry(`${entry.nativeURL}${file.id}`))
+  })
+
+export const openOfflineFile = file =>
+  new Promise(async (resolve, reject) => {
+    const fileEntry = await getNativeFile(file)
     return openFileWithCordova(fileEntry.nativeURL, file.mime)
       .then(resolve)
       .catch(reject)

--- a/src/viewer/NativePdfViewer.jsx
+++ b/src/viewer/NativePdfViewer.jsx
@@ -1,0 +1,146 @@
+/* global cozy cordova */
+import React, { Component } from 'react'
+import {
+  temporarySave,
+  getNativeFile,
+  openFileWithCordova
+} from 'drive/mobile/lib/filesystem'
+import NoViewer from './NoViewer'
+import Spinner from 'cozy-ui/react/Spinner'
+import classNames from 'classnames'
+import Button from 'cozy-ui/react/Button'
+import { translate } from 'cozy-ui/react/I18n'
+
+import styles from './styles'
+
+const VIEWER_OPTIONS = {
+  email: {
+    enabled: true
+  },
+  print: {
+    enabled: true
+  },
+  openWith: {
+    enabled: false
+  },
+  bookmarks: {
+    enabled: true
+  },
+  search: {
+    enabled: false
+  },
+  autoClose: {
+    onPause: false
+  }
+}
+
+class NativePdfViewer extends Component {
+  state = {
+    opening: true,
+    error: null
+  }
+
+  nativeFileUrl = null
+
+  onOpen = () => {
+    this.setState({ opening: false })
+  }
+
+  onClose = () => {
+    this.props.onClose()
+  }
+
+  onError = e => {
+    console.warn(e)
+    this.setState({ error: e })
+  }
+
+  componentWillMount = async () => {
+    try {
+      if (this.props.file.isAvailableOffline) {
+        const file = await getNativeFile(this.props.file)
+        this.nativeFileUrl = file.nativeURL
+      } else {
+        const response = await cozy.client.files.downloadById(
+          this.props.file.id
+        )
+        const blob = await response.blob()
+        const file = await temporarySave(blob, this.props.file.name)
+        this.nativeFileUrl = file.nativeURL
+      }
+
+      this.openPdfInExternalViewer()
+    } catch (e) {
+      this.onError(e)
+    }
+  }
+
+  openPdfInExternalViewer = () => {
+    cordova.plugins.SitewaertsDocumentViewer.viewDocument(
+      this.nativeFileUrl,
+      'application/pdf',
+      {
+        ...VIEWER_OPTIONS,
+        documentView: {
+          closeLabel: this.props.t('Viewer.close')
+        },
+        navigationView: {
+          closeLabel: this.props.t('Viewer.close')
+        },
+        title: this.props.file.name
+      },
+      this.onOpen,
+      this.onClose,
+      this.openPdfWithSystem,
+      this.onError
+    )
+  }
+
+  openPdfWithSystem = async () => {
+    try {
+      document.addEventListener('resume', this.onSystemPdfViewerExit, false)
+      await openFileWithCordova(this.nativeFileUrl, 'application/pdf')
+      this.onOpen()
+    } catch (e) {
+      this.onError(e)
+    }
+  }
+
+  onSystemPdfViewerExit = () => {
+    document.removeEventListener('resume', this.onSystemPdfViewerExit)
+    this.onClose()
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('resume', this.onSystemPdfViewerExit)
+  }
+
+  render() {
+    const { file, t } = this.props
+    const { opening, error } = this.state
+
+    if (opening && !error)
+      return <Spinner size="xxlarge" middle="true" noMargin color="white" />
+    else if (error) return <NoViewer file={file} />
+    else
+      return (
+        <div
+          className={classNames(
+            styles['pho-viewer-noviewer'],
+            styles[`pho-viewer-noviewer--${file.class}`]
+          )}
+        >
+          <p className={styles['pho-viewer-filename']}>{file.name}</p>
+          <Button
+            theme="regular"
+            className={styles['pho-viewer-noviewer-download']}
+            onClick={this.openPdfInExternalViewer}
+          >
+            {t('Viewer.reopen')}
+          </Button>
+        </div>
+      )
+  }
+}
+
+export default translate()(NativePdfViewer)

--- a/src/viewer/README.md
+++ b/src/viewer/README.md
@@ -1,0 +1,11 @@
+## Viewer Component
+
+### TODO
+
+These components should be standalone, but they currently have dependencies on a Cordova plugin and some Cordova helper functions. To remedy that, the plan is to:
+
+- [ ] Provide only a set of basic, truly standalone viewers here
+- [ ] Add the ability to configure the module to use specific Viewers under certain conditions
+- [ ] Provide the `NativePdfViewer` through these options, as a replacement for the default PDF viewer in native apps
+- [ ] Reduce the `NoViewer` to a more simple version of itself
+- [ ] Provide an extended `NoViewer` that can open files in native apps

--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -5,6 +5,7 @@ import ImageViewer from './ImageViewer'
 import AudioViewer from './AudioViewer'
 import VideoViewer from './VideoViewer'
 import PdfViewer from './PdfViewer'
+import NativePdfViewer from './NativePdfViewer'
 import NoViewer from './NoViewer'
 
 import styles from './styles'
@@ -89,8 +90,9 @@ export default class Viewer extends Component {
 
   renderViewer(file) {
     if (!file) return null
+    const { onClose } = this.props
     const ComponentName = this.getViewerComponentName(file)
-    return <ComponentName file={file} />
+    return <ComponentName file={file} onClose={onClose} />
   }
 
   getViewerComponentName(file) {
@@ -102,7 +104,7 @@ export default class Viewer extends Component {
       case 'video':
         return isMobile() ? NoViewer : VideoViewer
       case 'pdf':
-        return isCordova() ? NoViewer : PdfViewer
+        return isCordova() ? NativePdfViewer : PdfViewer
       default:
         return NoViewer
     }

--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -94,4 +94,5 @@
     <plugin name="cordova-plugin-device-name" spec="1.3.2" />
     <plugin name="cordova-plugin-sqlite-2" spec="~1.0.4" />
     <plugin name="de.appplant.cordova.plugin.local-notification" spec="0.8.5" />
+    <plugin name="cordova-plugin-document-viewer" spec="~0.9.7" />
 </widget>


### PR DESCRIPTION
We try to open pdf files with [this plugin](https://github.com/sitewaerts/cordova-plugin-document-viewer) — it requires local so we download the file first if it's not available offline already.
If the plugin can't open the pdf, we fallback to the system's default pdf viewer.

While the PDF is being viewed, the app shows a screen with an icon and a button to open the file again — but if everything goes well, no one will ever see it.

After the PDF is closed, we close the whole viewer.