### PR TITLE
fix: unify file opening in recent and trash views

### DIFF
--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -259,18 +259,16 @@ class File extends Component {
         this.props.router.push(getFolderUrl(attributes.id, this.props.location))
       })
     } else {
+      const viewPath = this.props.location.pathname
       if (this.props.isAvailableOffline) {
         this.props.onFileOpen({
           ...attributes,
           availableOffline: this.props.isAvailableOffline
         })
-      } else if (this.props.withFilePath) {
-        // we're in /recent view and, as a mango query lacks the thumbnails links, we can't use the viewer
+      } else if (viewPath === '/recent' || viewPath === '/trash') {
         this.props.onFileOpen({ ...attributes })
       } else {
-        this.props.router.push(
-          `${this.props.location.pathname}/file/${attributes.id}`
-        )
+        this.props.router.push(`${viewPath}/file/${attributes.id}`)
       }
     }
   }


### PR DESCRIPTION
Opening files from the trash was broken. For now, we'll use the same behavior on the recent and trash views — open files in new tabs.