### PR TITLE
pdf viewer fixes

### DIFF
--- a/src/viewer/assets/spinner.svg
+++ b/src/viewer/assets/spinner.svg
@@ -1,0 +1,5 @@
+<svg width="200px" height="200px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" class="lds-rolling" style="animation-play-state: running; animation-delay: 0s; background: rgba(0, 0, 0, 0) none repeat scroll 0% 0%;">
+    <circle cx="50" cy="50" fill="none" ng-attr-stroke="{{config.color}}" ng-attr-stroke-width="{{config.width}}" ng-attr-r="{{config.radius}}" ng-attr-stroke-dasharray="{{config.dasharray}}" stroke="#f8f8f8" stroke-width="8" r="35" stroke-dasharray="164.93361431346415 56.97787143782138" class="" style="animation-play-state: running; animation-delay: 0s;">
+      <animateTransform attributeName="transform" type="rotate" calcMode="linear" values="0 50 50;360 50 50" keyTimes="0;1" dur="1.5s" begin="0s" repeatCount="indefinite" class="" style="animation-play-state: running; animation-delay: 0s;"></animateTransform>
+    </circle>
+  </svg>

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -103,6 +103,8 @@
         flex-direction column
         justify-content center
         align-items center
+        background    embedurl('./assets/spinner.svg') center center no-repeat
+        background-size 7rem
 
     h2
         max-width   90%
@@ -144,6 +146,10 @@
         margin      0 auto
         width       10rem
         height      8.75rem
+
+.pho-viewer-pdfviewer .pho-viewer-noviewer
+    background charcoalGrey
+    height 100%
 
 .pho-viewer-canceled
     &:before

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -200,16 +200,6 @@
         justify-content flex-end
         padding-right   0
 
-// here we force the action buttons to not show the label even on desktop
-.pho-viewer-toolbar-actions
-    button
-        width         em(90px)
-        overflow      hidden
-        text-indent   -5000px
-        padding-left  0
-        color         transparent
-        background-position em(12px)
-
 .pho-viewer-toolbar
     position    fixed
     z-index     $modal-index + 1
@@ -218,6 +208,7 @@
     width       100%
     height      em(90px)
     transition .4s opacity ease-out
+    pointer-events none // especially important for pdf viewers, where there might be additional controls in the top area
 
     &--hidden
         opacity 0
@@ -232,6 +223,16 @@
     height            auto
     background-color  transparent
 
+    // here we force the action buttons to not show the label even on desktop
+    button
+        width         em(90px)
+        overflow      hidden
+        text-indent   -5000px
+        padding-left  0
+        color         transparent
+        background-position em(12px)
+        pointer-events initial
+
 
 .pho-viewer-toolbar-close
     position         fixed
@@ -243,6 +244,7 @@
     width            em(90px)
     height           em(90px)
     cursor           pointer
+    pointer-events   initial
 
 
 .pho-viewer-toolbar-close-cross

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,9 +2098,9 @@ cozy-client-js@^0.3.19:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.19.tgz#c20361a8bc6b23eb4d092360040e8765ef5e59a3"
 
-cozy-ui@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-5.0.1.tgz#5b8e9c027469300542e504d27d07b46a9f51757f"
+cozy-ui@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-5.0.2.tgz#89c3712fb2645535e5a06e9ae7296cea572d4a9c"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"


### PR DESCRIPTION
- Our toolbar overlaps the pdf viewer's native toolbar, making it unusable. I disabled pointer events on the wrapper element, but re-enabled them on the actual buttons.
- Especially in firefox, loading large pdf's introduces a notable lag and the screen stays dark for a while. There is no cross-browser compatible way to detect when the `object` is loaded, but we can put a waiting background underneath it.