### PR TITLE
chore: bump version numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-drive",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "src/main.jsx",
   "scripts": {
     "build:drive": "npm run build:drive:browser",

--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.cozy.drive.mobile" version="0.9.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="io.cozy.drive.mobile" version="0.9.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Drive</name>
     <description>Sync files from your Cozy.</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>


### PR DESCRIPTION
There have been a few bugfix releases and the version numbers haven't been updated along the way.