### PR TITLE
work on the mobile viewer

### DIFF
--- a/src/components/Button/MoreButton.jsx
+++ b/src/components/Button/MoreButton.jsx
@@ -1,23 +1,19 @@
 import React from 'react'
 import classNames from 'classnames'
 import { translate } from 'cozy-ui/react/I18n'
+import { Button } from 'cozy-ui/react'
 
 import styles from './index.styl'
 
-const MoreButton = ({ t, disabled, onClick }) => (
-  <button
-    role="button"
-    className={classNames(
-      styles['c-btn'],
-      styles['c-btn--secondary'],
-      styles['c-btn--more'],
-      styles['dri-btn--more']
-    )}
+const MoreButton = ({ t, disabled, onClick, children }) => (
+  <Button
+    className={classNames(styles['c-btn--more'], styles['dri-btn--more'])}
+    theme="secondary"
     disabled={disabled}
     onClick={onClick}
   >
-    <span className={styles['u-visuallyhidden']}>{t('Toolbar.more')}</span>
-  </button>
+    <span className={styles['u-visuallyhidden']}>{children}</span>
+  </Button>
 )
 
 export default translate()(MoreButton)

--- a/src/drive/ducks/files/Toolbar.jsx
+++ b/src/drive/ducks/files/Toolbar.jsx
@@ -70,7 +70,7 @@ class Toolbar extends Component {
         title={t('toolbar.item_more')}
         disabled={disabled}
         className={styles['fil-toolbar-menu']}
-        button={<MoreButton />}
+        button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
       >
         {notRootfolder &&
           !shared.withMe && (

--- a/src/drive/ducks/trash/Toolbar.jsx
+++ b/src/drive/ducks/trash/Toolbar.jsx
@@ -28,7 +28,7 @@ const Toolbar = ({
       title={t('toolbar.item_more')}
       disabled={disabled}
       className={styles['fil-toolbar-menu']}
-      button={<MoreButton />}
+      button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
     >
       <Item>
         <a className={styles['fil-action-delete']} onClick={() => emptyTrash()}>

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -84,7 +84,8 @@
         "send": "Send",
         "genericSuccess": "You sent an invite to %{count} contacts.",
         "success": "You sent an invite to %{email}.",
-        "comingsoon": "Coming soon! You will be able to share documents and photos in a single click with your family, your friends, and even your coworkers. Don't worry, we'll let you know when it's ready!"
+        "comingsoon":
+          "Coming soon! You will be able to share documents and photos in a single click with your family, your friends, and even your coworkers. Don't worry, we'll let you know when it's ready!"
       },
       "unshare": {
         "title": "Remove from sharing",
@@ -243,7 +244,8 @@
           "You have just entered the address of old Cozy version. This application is only compatible with the latest version. [Please refer to our site for more information.](https://blog.cozycloud.cc/post/2016/11/21/On-the-road-to-Cozy-version-3?lang=en)",
         "wrong_address":
           "This address doesn’t seem to be a cozy. Please check the address you provide.",
-        "wrong_address_cosy": "Woops, the address is not correct. Try with \"cozy\" with a \"z\"!"
+        "wrong_address_cosy":
+          "Woops, the address is not correct. Try with \"cozy\" with a \"z\"!"
       },
       "files": {
         "title": "Access your drive",
@@ -381,11 +383,13 @@
     },
     "quota_feedback": {
       "title": "Need more storage space?",
-      "description": "Let us know your storage needs for your files and photos. We will contact you to adapt our offer.",
+      "description":
+        "Let us know your storage needs for your files and photos. We will contact you to adapt our offer.",
       "button": "Send",
       "email_subject": "Extra storage space request",
       "title_sent": "Thanks for your message!",
-      "text_sent": "We're going to look into your request and we'll reach out to you as soon as possible.",
+      "text_sent":
+        "We're going to look into your request and we'll reach out to you as soon as possible.",
       "button_sent": "Close"
     },
     "first_sync": {
@@ -434,8 +438,13 @@
       "download": "Download"
     },
     "loading": {
-      "error": "This file could not be loaded. Do you have a working internet connection right now?",
+      "error":
+        "This file could not be loaded. Do you have a working internet connection right now?",
       "retry": "Retry"
+    },
+    "error": {
+      "noapp": "No application found to handle this file.",
+      "generic": "An error occurred when opening this file, please try again."
     }
   }
 }

--- a/src/drive/mobile/lib/filesystem.js
+++ b/src/drive/mobile/lib/filesystem.js
@@ -25,30 +25,14 @@ export const getEntry = path =>
   })
 
 export const getCozyEntry = () =>
-  new Promise((resolve, reject) => {
-    getEntry(getRootPath() + getCozyPath())
-      .then(resolve)
-      .catch(() => {
-        createCozyPath()
-          .then(resolve)
-          .catch(reject)
-      })
-  })
+  getEntry(getRootPath() + getCozyPath()).catch(() => createCozyPath())
 
 export const createCozyPath = () =>
-  new Promise((resolve, reject) => {
-    getEntry(getRootPath())
-      .then(entry => {
-        getDirectory(entry, COZY_PATH)
-          .then(entry => {
-            getDirectory(entry, COZY_FILES_PATH)
-              .then(resolve)
-              .catch(reject)
-          })
-          .catch(reject)
-      })
-      .catch(reject)
-  })
+  getEntry(getRootPath()).then(entry =>
+    getDirectory(entry, COZY_PATH).then(entry =>
+      getDirectory(entry, COZY_FILES_PATH)
+    )
+  )
 
 export const getDirectory = (rootDirEntry, folderName) =>
   new Promise((resolve, reject) => {
@@ -94,12 +78,14 @@ const saveFile = (dirEntry, fileData, fileName) =>
     )
   })
 
-export const openFileWithCordova = (uri, mimetype) =>
+export const openFileWithCordova = (URI, mimetype) =>
   new Promise((resolve, reject) => {
-    window.cordova.plugins.fileOpener2.open(decodeURIComponent(uri), mimetype, {
+    const decodedURI = decodeURIComponent(URI)
+    const callbacks = {
       error: reject,
       success: resolve
-    })
+    }
+    window.cordova.plugins.fileOpener2.open(decodedURI, mimetype, callbacks)
   })
 
 export const deleteOfflineFile = async filename => {
@@ -109,48 +95,30 @@ export const deleteOfflineFile = async filename => {
 }
 
 export const saveFileWithCordova = (fileData, fileName) =>
-  new Promise((resolve, reject) => {
-    getCozyEntry()
-      .then(entry => saveFile(entry, fileData, fileName))
-      .then(resolve)
-      .catch(reject)
-  })
+  getCozyEntry().then(entry => saveFile(entry, fileData, fileName))
 
 export const temporarySave = (file, filename) =>
-  new Promise((resolve, reject) => {
-    getEntry(getTemporaryRootPath())
-      .then(entry => saveFile(entry, file, filename))
-      .then(resolve)
-      .catch(reject)
-  })
+  getEntry(getTemporaryRootPath()).then(entry =>
+    saveFile(entry, file, filename)
+  )
 
 export const saveAndOpenWithCordova = (file, filename) =>
-  new Promise((resolve, reject) => {
-    temporarySave(file, filename)
-      .then(entry => openFileWithCordova(entry.nativeURL, file.type))
-      .then(resolve)
-      .catch(reject)
-  })
+  temporarySave(file, filename).then(entry =>
+    openFileWithCordova(entry.nativeURL, file.type)
+  )
 
-export const getNativeFile = file =>
-  new Promise(async (resolve, reject) => {
-    const entry = await getCozyEntry()
-    resolve(getEntry(`${entry.nativeURL}${file.id}`))
-  })
+export const getNativeFile = async file => {
+  const entry = await getCozyEntry()
+  return getEntry(`${entry.nativeURL}${file.id}`)
+}
 
-export const openOfflineFile = file =>
-  new Promise(async (resolve, reject) => {
-    const fileEntry = await getNativeFile(file)
-    return openFileWithCordova(fileEntry.nativeURL, file.mime)
-      .then(resolve)
-      .catch(reject)
-  })
+export const openOfflineFile = async file => {
+  const fileEntry = await getNativeFile(file)
+  return openFileWithCordova(fileEntry.nativeURL, file.mime)
+}
 
-export const openOnlineFile = file =>
-  new Promise(async (resolve, reject) => {
-    const response = await cozy.client.files.downloadById(file.id)
-    const blob = await response.blob()
-    return saveAndOpenWithCordova(blob, file.name)
-      .then(resolve)
-      .catch(reject)
-  })
+export const openOnlineFile = async file => {
+  const response = await cozy.client.files.downloadById(file.id)
+  const blob = await response.blob()
+  return saveAndOpenWithCordova(blob, file.name)
+}

--- a/src/drive/mobile/lib/filesystem.js
+++ b/src/drive/mobile/lib/filesystem.js
@@ -117,8 +117,9 @@ export const openOfflineFile = async file => {
   return openFileWithCordova(fileEntry.nativeURL, file.mime)
 }
 
-export const openOnlineFile = async file => {
-  const response = await cozy.client.files.downloadById(file.id)
+export const createTemporaryLocalFile = async (id, filename) => {
+  const response = await cozy.client.files.downloadById(id)
   const blob = await response.blob()
-  return saveAndOpenWithCordova(blob, file.name)
+  const localFile = await temporarySave(blob, filename)
+  return localFile
 }

--- a/src/photos/ducks/albums/components/AlbumToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumToolbar.jsx
@@ -92,7 +92,7 @@ class AlbumToolbar extends Component {
         <Menu
           disabled={disabled}
           className={styles['pho-toolbar-menu']}
-          button={<MoreButton />}
+          button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
         >
           {!sharedWithMe && (
             <Item>

--- a/src/photos/ducks/albums/components/AlbumsToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumsToolbar.jsx
@@ -21,7 +21,7 @@ const AlbumsToolbar = ({ t }) => (
     </div>
     <Menu
       className={classNames(styles['pho-toolbar-menu'], styles['u-hide--desk'])}
-      button={<MoreButton />}
+      button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
     >
       <Item>
         <div>

--- a/src/photos/ducks/timeline/components/Toolbar.jsx
+++ b/src/photos/ducks/timeline/components/Toolbar.jsx
@@ -25,7 +25,7 @@ export const Toolbar = ({ t, disabled = false, uploadPhotos, selectItems }) => (
     <Menu
       disabled={disabled}
       className={styles['pho-toolbar-menu']}
-      button={<MoreButton />}
+      button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
     >
       <Item>
         <UploadButton

--- a/src/viewer/ImageViewer.jsx
+++ b/src/viewer/ImageViewer.jsx
@@ -7,7 +7,7 @@ import Hammer from 'hammerjs'
 import Spinner from 'cozy-ui/react/Spinner'
 import { ImageLoader } from 'components/Image'
 
-import NoNetwork from './NoNetwork'
+import NoNetworkViewer from './NoNetworkViewer'
 
 const MIN_SCALE = 1
 const MAX_SCALE = 6
@@ -192,7 +192,7 @@ export default class ImageViewer extends Component {
 
   render() {
     if (this.state.canceled) {
-      return <NoNetwork onReload={this.reload} />
+      return <NoNetworkViewer onReload={this.reload} />
     }
     const { file } = this.props
 

--- a/src/viewer/NoNetworkViewer.jsx
+++ b/src/viewer/NoNetworkViewer.jsx
@@ -4,7 +4,7 @@ import { translate } from 'cozy-ui/react/I18n'
 
 import styles from './styles'
 
-const NoNetwork = ({ t, onReload }) => (
+const NoNetworkViewer = ({ t, onReload }) => (
   <div className={styles['pho-viewer-canceled']}>
     <h2>{t('Viewer.loading.error')}</h2>
     <Button theme="regular" onClick={onReload}>
@@ -13,4 +13,4 @@ const NoNetwork = ({ t, onReload }) => (
   </div>
 )
 
-export default translate()(NoNetwork)
+export default translate()(NoNetworkViewer)

--- a/src/viewer/NoViewer.jsx
+++ b/src/viewer/NoViewer.jsx
@@ -1,26 +1,54 @@
 import React from 'react'
 import classNames from 'classnames'
 import { downloadFile } from 'cozy-client'
-import { isCordova } from 'drive/mobile/lib/device'
-import { openOfflineFile, openOnlineFile } from 'drive/mobile/lib/filesystem'
+import { logException } from '../drive/mobile/lib/reporter'
 import { translate } from 'cozy-ui/react/I18n'
 import Button from 'cozy-ui/react/Button'
+import Alerter from 'photos/components/Alerter'
+import { isCordova } from 'drive/mobile/lib/device'
+import {
+  openOfflineFile,
+  createTemporaryLocalFile,
+  openFileWithCordova
+} from 'drive/mobile/lib/filesystem'
 
 import styles from './styles'
 
-const OpenWithCordova = ({ t, file }) => (
-  <Button
-    theme="regular"
-    className={styles['pho-viewer-noviewer-download']}
-    onClick={() =>
-      file.isAvailableOffline ? openOfflineFile(file) : openOnlineFile(file)
-    }
-  >
-    {t('Viewer.noviewer.openWith')}
-  </Button>
-)
+class OpenWithCordovaButton extends React.Component {
+  state = {
+    loading: false
+  }
 
-const OpenWithWeb = ({ t, url }) => (
+  openFile = async file => {
+    this.setState(state => ({ ...state, loading: true }))
+    const localFile = await createTemporaryLocalFile(file.id, file.name)
+    this.setState(state => ({ ...state, loading: false }))
+    return openFileWithCordova(localFile.nativeURL, file.mime)
+  }
+
+  onClick = () => {
+    const { file, onError } = this.props
+    file.isAvailableOffline
+      ? openOfflineFile(file).catch(onError)
+      : this.openFile(file, onError).catch(onError)
+  }
+
+  render() {
+    const { t } = this.props
+    return (
+      <Button
+        busy={this.state.loading}
+        theme="regular"
+        className={styles['pho-viewer-noviewer-download']}
+        onClick={this.onClick}
+      >
+        {t('Viewer.noviewer.openWith')}
+      </Button>
+    )
+  }
+}
+
+const OpenWithWebButton = ({ t, url }) => (
   <Button
     theme="regular"
     className={styles['pho-viewer-noviewer-download']}
@@ -30,7 +58,7 @@ const OpenWithWeb = ({ t, url }) => (
   </Button>
 )
 
-const Download = ({ t, file }) => (
+const DownloadButton = ({ t, file }) => (
   <Button
     theme="regular"
     className={styles['pho-viewer-noviewer-download']}
@@ -40,24 +68,44 @@ const Download = ({ t, file }) => (
   </Button>
 )
 
-const NoViewer = ({ t, file, fallbackUrl = false }) => {
-  let action
-  if (isCordova()) action = <OpenWithCordova t={t} file={file} />
-  else if (fallbackUrl) action = <OpenWithWeb t={t} url={fallbackUrl} />
-  else action = <Download t={t} file={file} />
+const NoViewerButton = ({ file, fallbackUrl, t, onError }) => {
+  if (isCordova())
+    return <OpenWithCordovaButton t={t} file={file} onError={onError} />
+  else if (fallbackUrl) return <OpenWithWebButton t={t} url={fallbackUrl} />
+  else return <DownloadButton t={t} file={file} />
+}
 
-  return (
-    <div
-      className={classNames(
-        styles['pho-viewer-noviewer'],
-        styles[`pho-viewer-noviewer--${file.class}`]
-      )}
-    >
-      <p className={styles['pho-viewer-filename']}>{file.name}</p>
-      <h2>{t('Viewer.noviewer.title')}</h2>
-      {action}
-    </div>
-  )
+class NoViewer extends React.Component {
+  state = {
+    error: null
+  }
+  render() {
+    const { t, file, fallbackUrl = false } = this.props
+    return (
+      <div
+        className={classNames(
+          styles['pho-viewer-noviewer'],
+          styles[`pho-viewer-noviewer--${file.class}`]
+        )}
+      >
+        <p className={styles['pho-viewer-filename']}>{file.name}</p>
+        <h2>{t('Viewer.noviewer.title')}</h2>
+        <NoViewerButton
+          file={file}
+          fallbackUrl={fallbackUrl}
+          t={t}
+          onError={error => {
+            if (/^Activity not found/.test(error.message)) {
+              Alerter.error('Viewer.error.noapp', error)
+            } else {
+              logException('a debug exception', error)
+              Alerter.error('Viewer.error.generic', error)
+            }
+          }}
+        />
+      </div>
+    )
+  }
 }
 
 export default translate()(NoViewer)

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -7,7 +7,7 @@
     right           0
     top             0
     bottom          0
-    z-index         $modal-index
+    z-index         $overlay-index
     background      charcoalGrey
     width           100%
     height          100%

--- a/src/viewer/withFileUrl.jsx
+++ b/src/viewer/withFileUrl.jsx
@@ -10,8 +10,8 @@ const LOADING = 'LOADING'
 const LOADED = 'LOADED'
 const FAILED = 'FAILED'
 
-const withFileUrl = WrappedComponent =>
-  class Wrapper extends Component {
+const withFileUrl = BaseComponent =>
+  class extends Component {
     state = {
       status: LOADING,
       downloadUrl: null
@@ -65,7 +65,7 @@ const withFileUrl = WrappedComponent =>
       if (this.state.status === FAILED) {
         return <NoNetworkViewer onReload={this.reset} />
       }
-      return <WrappedComponent {...this.props} url={this.state.downloadUrl} />
+      return <BaseComponent {...this.props} url={this.state.downloadUrl} />
     }
   }
 

--- a/src/viewer/withFileUrl.jsx
+++ b/src/viewer/withFileUrl.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { getDownloadLink } from 'cozy-client'
 import Spinner from 'cozy-ui/react/Spinner'
 
-import NoNetwork from './NoNetwork'
+import NoNetworkViewer from './NoNetworkViewer'
 
 const TTL = 6000
 
@@ -63,7 +63,7 @@ const withFileUrl = WrappedComponent =>
         return <Spinner size="xxlarge" middle="true" noMargin color="white" />
       }
       if (this.state.status === FAILED) {
-        return <NoNetwork onReload={this.reset} />
+        return <NoNetworkViewer onReload={this.reset} />
       }
       return <WrappedComponent {...this.props} url={this.state.downloadUrl} />
     }

--- a/targets/photos/web/public/App.jsx
+++ b/targets/photos/web/public/App.jsx
@@ -138,7 +138,7 @@ class App extends Component {
             <Menu
               title={t('Toolbar.more')}
               className={classNames(styles['pho-toolbar-menu'])}
-              button={<MoreButton />}
+              button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
             >
               <Item>
                 <a


### PR DESCRIPTION
I would like to enhance the viewer behavior when we're on mobile as requested in https://trello.com/c/t7lvpy6G

- [x] refactor MoreButton to use `cozy-ui/React/Button`. It still throw an proptypes error that will be fix with the next release of cozy-ui as it will include https://github.com/cozy/cozy-ui/pull/241/commits/ad4cb4466b6ec0adea31d6de2960c62fed84d1d3
- [x] very simple simplification of `withFileUrl` code
- [x] rename `NoNetwork` component to `NoNetworkViewer` because this is the Viewer that is displayed when there is no network.
- [x] remove `Promise` when handling promise in `filesystem.js`

In `NoViewer` I added a `Spinner` when fetching/saving remote file. I guess we could refactor the different `Button` that are used in `NoViewer`.

I also added a `Alerter` error when there is no app or if something happens.