### PR TITLE
feat: load more files on scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "diacritics": "^1.3.0",
     "filesize": "^3.3.0",
     "hammerjs": "^2.0.8",
+    "intersection-observer": "^0.5.0",
     "justified-layout": "^2.1.0",
     "localforage": "^1.4.3",
     "node-polyglot": "^2.2.0",

--- a/src/drive/components/FileList.jsx
+++ b/src/drive/components/FileList.jsx
@@ -4,11 +4,43 @@ import { translate } from 'cozy-ui/react/I18n'
 import File, { FilePlaceholder } from '../containers/File'
 import LoadMore from './LoadMore'
 
+require('intersection-observer') // polyfill for safari
+
 const LIMIT = 30
 
 class FileList extends PureComponent {
   state = {
     isLoading: false
+  }
+
+  intersectionObserver = null
+  loadMoreElement = null
+
+  componentWillMount() {
+    this.intersectionObserver = new IntersectionObserver(
+      this.checkIntersectionsEntries
+    )
+  }
+
+  checkIntersectionsEntries = intersectionEntries => {
+    if (intersectionEntries.filter(entry => entry.isIntersecting).length > 0) {
+      this.loadMoreRows(LIMIT)
+    }
+  }
+
+  updateLoadMoreElement = element => {
+    if (this.loadMoreElement) {
+      this.intersectionObserver.unobserve(this.loadMoreElement)
+    }
+
+    if (element) {
+      this.loadMoreElement = React.findDOMNode(element)
+      this.intersectionObserver.observe(this.loadMoreElement)
+    }
+  }
+
+  componentWillUnmount() {
+    this.intersectionObserver.disconnect()
   }
 
   render() {
@@ -19,9 +51,7 @@ class FileList extends PureComponent {
         })}
         {this.props.files.length < this.props.fileCount && (
           <LoadMore
-            ref={elt => {
-              this.button = elt
-            }}
+            ref={this.updateLoadMoreElement}
             onClick={() => {
               this.loadMoreRows(LIMIT)
             }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,9 +2098,9 @@ cozy-client-js@^0.3.19:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.19.tgz#c20361a8bc6b23eb4d092360040e8765ef5e59a3"
 
-cozy-ui@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-5.0.2.tgz#89c3712fb2645535e5a06e9ae7296cea572d4a9c"
+cozy-ui@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-6.0.0.tgz#29ddfb28e18c94518bc5b1ec3a9d6e4799447522"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"
@@ -4244,6 +4244,10 @@ insight@~0.8.2:
 interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
+
+intersection-observer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.0.tgz#9fe8bee3953c755b1485c38efd9633d535775ea6"
 
 invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
Pretty straightforward : i'm using the [InterSectionObserver](https://developer.mozilla.org/fr/docs/Web/API/IntersectionObserver) to detect when the "More" button comes into view, and then I fetch more files.
The only "complexity" comes from observing the button in case it gets re-rendered.