### PR TITLE
Add custom url scheme

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -95,4 +95,7 @@
     <plugin name="cordova-plugin-sqlite-2" spec="~1.0.4" />
     <plugin name="de.appplant.cordova.plugin.local-notification" spec="0.8.5" />
     <plugin name="cordova-plugin-document-viewer" spec="~0.9.7" />
+    <plugin name="cordova-plugin-customurlscheme" spec="~4.3.0">
+        <variable name="URL_SCHEME" value="cozydrive" />
+    </plugin>
 </widget>


### PR DESCRIPTION
J'ai mis à jour cordova... mais pas les plugins, je vous laisse regarder ;)

On peut voir que même si "la communauté est morte", il y a des mises à jour, ça vaut le coup de les faire. Je pense qu'il faut jeter un œil tous les sprints sur https://cordova.apache.org/blog/

Sinon le 2eme commit correspond à l'ajout d'une url reconnu par l'application grâce au plugin [Custom-URL-scheme](https://github.com/EddyVerbruggen/Custom-URL-scheme). C'est à dire que l'on va pouvoir avoir des liens `cozydrive://blabla` qui redirigerons directement vers l'application. On s'en sert coté Bank pour rediriger vers l'application lorsque l'on veut voir une facture. Pour l'instant on arrive directement sur la home mais le but final sera évidemment d'ouvrir sur le bon fichier (J'imagine que l'on fera ça dans le prochain sprint).