### PR TITLE
fix: make mimetype to file type function standalone

### DIFF
--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -15,6 +15,7 @@ import Preview from '../components/Preview'
 import { withBreakpoints } from 'cozy-ui/react'
 import { SharedBadge } from 'sharing'
 import { getSharingDetails } from 'cozy-client'
+import { getFileTypeFromMime } from 'drive/lib/getFileTypeFromMime'
 
 import { getFolderUrl } from '../reducers'
 
@@ -26,30 +27,6 @@ export const splitFilename = file =>
         filename: file.name.slice(0, file.name.lastIndexOf('.') + 1)
       }
 
-const mappingMimetypeSubtype = {
-  word: 'text',
-  zip: 'zip',
-  pdf: 'pdf',
-  spreadsheet: 'sheet',
-  excel: 'sheet',
-  presentation: 'slide',
-  powerpoint: 'slide'
-}
-
-export const getTypeFromMimeType = (collection, prefix = '') => mimetype => {
-  const [type, subtype] = mimetype.split('/')
-  if (collection[prefix + type]) {
-    return type
-  }
-  if (type === 'application') {
-    const existingType = subtype.match(
-      Object.keys(mappingMimetypeSubtype).join('|')
-    )
-    return existingType ? mappingMimetypeSubtype[existingType[0]] : undefined
-  }
-  return undefined
-}
-
 export const getClassFromMime = attrs => {
   if (isDirectory(attrs)) {
     return styles['fil-file-folder']
@@ -57,7 +34,7 @@ export const getClassFromMime = attrs => {
 
   return styles[
     'fil-file-' +
-      (getTypeFromMimeType(styles, 'fil-file-')(attrs.mime) ||
+      (getFileTypeFromMime(styles, 'fil-file-')(attrs.mime) ||
         console.warn(
           `No icon found, you may need to add a mapping for ${attrs.mime}`
         ) ||

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import FuzzyPathSearch from '../FuzzyPathSearch'
-import { getTypeFromMimeType } from '../../../containers/File'
+import { getFileTypeFromMime } from 'drive/lib/getFileTypeFromMime'
 
 class SuggestionProvider extends React.Component {
   componentDidMount() {
@@ -92,7 +92,7 @@ const icons = iconsContext.keys().reduce((acc, item) => {
 
 function getIconUrl(mimetype) {
   const keyIcon =
-    getTypeFromMimeType(icons)(mimetype) ||
+    getFileTypeFromMime(icons)(mimetype) ||
     console.warn(
       `No icon found, you may need to add a mapping for ${mimetype}`
     ) ||

--- a/src/drive/lib/getFileTypeFromMime.js
+++ b/src/drive/lib/getFileTypeFromMime.js
@@ -1,0 +1,23 @@
+const mappingMimetypeSubtype = {
+  word: 'text',
+  zip: 'zip',
+  pdf: 'pdf',
+  spreadsheet: 'sheet',
+  excel: 'sheet',
+  presentation: 'slide',
+  powerpoint: 'slide'
+}
+
+export const getFileTypeFromMime = (collection, prefix = '') => mimetype => {
+  const [type, subtype] = mimetype.split('/')
+  if (collection[prefix + type]) {
+    return type
+  }
+  if (type === 'application') {
+    const existingType = subtype.match(
+      Object.keys(mappingMimetypeSubtype).join('|')
+    )
+    return existingType ? mappingMimetypeSubtype[existingType[0]] : undefined
+  }
+  return undefined
+}


### PR DESCRIPTION
- We had an error on our `services` page, the one used for intents. `Cannot read property BarCenter of undefined`.
- `BarCenter` is a component exposed by the cozy bar, and there is no cozy bar on the `services` page because we don't need it. So why is `BarCenter` called at all?
- When we provide suggestions for the search bar, we also provide icons. To get the correct icon, we import a function that was defined in the `File` component.
- The `File` component itself imports half of our code base, including things that eventually call `BarCenter`

So

- I put the function in a standalone file that doesn't import anything else.
- No calling `BarCenter` anymore.
- The `services.js` file is 2x smaller now.

What I still don't like : the `Services` duck relies on a `lib` file that is not part of the duck itself. Not a big deal imo.