### PR TITLE
fix: signed build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "run:drive:android:emulator": "(cd targets/drive/mobile && cordova run android --emulator)",
     "build:drive:android": "npm run build:drive:mobile && (cd targets/drive/mobile && cordova build android --release)",
     "sign:drive:android": "(cd targets/drive/mobile && apksigner sign --ks keys/android/cozy-drive-release-key.jks --out build/android/cozy-drive.apk platforms/android/build/outputs/apk/android-release-unsigned.apk)",
-    "buildsigner:drive:android": "npm run build:drive:android && sign:drive:android",
+    "buildsigned:drive:android": "npm run build:drive:android && npm run sign:drive:android",
     "publish:drive:android": "(cd targets/drive/mobile && fastlane supply)",
     "run:drive:ios": "(cd targets/drive/mobile && cordova run ios --device)",
     "run:drive:ios:emulator": "(cd targets/drive/mobile && cordova run ios --emulator)",


### PR DESCRIPTION
The second part of the command was missing a `npm run`.