### PR TITLE
Sentry exception reporting during the onboarding

### DIFF
--- a/src/authentication/Authentication.jsx
+++ b/src/authentication/Authentication.jsx
@@ -3,6 +3,8 @@ import React, { Component } from 'react'
 import Welcome from './steps/Welcome'
 import SelectServer from './steps/SelectServer'
 
+import { logException } from 'drive/mobile/lib/reporter'
+
 const STEP_WELCOME = 'STEP_WELCOME'
 const STEP_EXISTING_SERVER = 'STEP_EXISTING_SERVER'
 
@@ -47,6 +49,10 @@ class Authentication extends Component {
       })
     } catch (err) {
       this.setState({ generalError: err })
+      logException(err, {
+        tentativeUrl: url,
+        onboardingStep: 'connecting to server'
+      })
     } finally {
       this.setState({ fetching: false })
     }

--- a/src/authentication/steps/SelectServer.jsx
+++ b/src/authentication/steps/SelectServer.jsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import classNames from 'classnames'
 
 import { translate } from 'cozy-ui/react/I18n'
+import { logException } from 'drive/mobile/lib/reporter'
 
 import styles from '../styles'
 
@@ -60,9 +61,7 @@ export class SelectServer extends Component {
       parsedURL = new URL(url)
 
       if (parsedURL.protocol === 'http:' && !__ALLOW_HTTP__) {
-        this.setState({ error: ERR_WRONG_ADDRESS })
-        console.warn('Only https protocol is allowed')
-        return
+        throw new Error('Only https protocol is allowed')
       }
 
       if (/\..*cosy.*\..+$/.test(parsedURL.host)) {
@@ -72,6 +71,7 @@ export class SelectServer extends Component {
       }
     } catch (e) {
       this.setState({ error: ERR_WRONG_ADDRESS })
+      logException(e, { tentativeUrl: url, onboardingStep: 'checking URL' })
       return
     }
 
@@ -82,6 +82,7 @@ export class SelectServer extends Component {
     try {
       isV2Instance = await cozyClient.isV2(url)
     } catch (err) {
+      logException(err, { tentativeUrl: url, onboardingStep: 'checking isV2' })
       // this can happen if the HTTP request to check the instance version fails; in that case, it is likely to fail again and be caught during the authorize process, which is designed to handle this
       isV2Instance = false
     }

--- a/src/drive/mobile/actions/settings.js
+++ b/src/drive/mobile/actions/settings.js
@@ -1,7 +1,6 @@
 import { startReplication as startPouchReplication } from '../lib/replication'
 import { setClient, setFirstReplication } from '../../actions/settings'
 import { openFolder, getOpenedFolderId } from '../../actions'
-import { configureReporter } from '../lib/reporter'
 import { startTracker, stopTracker } from '../lib/tracker'
 import { revokeClient as reduxRevokeClient } from './authorization'
 import { resetClient } from '../lib/cozy-helper'
@@ -26,7 +25,6 @@ export const setAnalytics = (analytics, source = 'settings') => (
 ) => {
   dispatch({ type: SET_ANALYTICS, analytics })
   const state = getState()
-  configureReporter(analytics)
   if (analytics && state.mobile) {
     startTracker(state.mobile.settings.serverUrl)
   } else if (analytics === false) {

--- a/src/drive/mobile/containers/settings/Support.jsx
+++ b/src/drive/mobile/containers/settings/Support.jsx
@@ -40,11 +40,7 @@ export const Support = ({
         onClick: async () => {
           if (isOnline()) {
             try {
-              await logInfo(
-                t('mobile.settings.support.logs.title'),
-                serverUrl,
-                true
-              )
+              await logInfo(t('mobile.settings.support.logs.title'), serverUrl)
               success()
             } catch (e) {
               failure()

--- a/src/drive/mobile/lib/background.js
+++ b/src/drive/mobile/lib/background.js
@@ -87,8 +87,7 @@ const backgroundService = () =>
     loadState()
       .then(persistedState => {
         const cozyURL = persistedState.mobile.settings.serverUrl
-        const analyticsEnabled = persistedState.mobile.settings.analytics
-        configureReporter(analyticsEnabled)
+        configureReporter()
         const client = initClient(cozyURL)
         const store = configureStore(client, persistedState)
         return store.dispatch(startMediaBackup(getMediaFolderName()))

--- a/src/drive/mobile/lib/reporter.js
+++ b/src/drive/mobile/lib/reporter.js
@@ -22,9 +22,11 @@ export const configureReporter = () => {
   Raven.config(ANALYTICS_URL, getReporterConfiguration()).install()
 }
 
-export const logException = err => {
+export const logException = (err, extraContext = null) => {
   return new Promise(resolve => {
-    Raven.captureException(err)
+    extraContext
+      ? Raven.captureException(err, { extra: extraContext })
+      : Raven.captureException(err)
     console.warn('Raven is recording exception')
     console.error(err)
     resolve()

--- a/src/drive/mobile/lib/reporter.js
+++ b/src/drive/mobile/lib/reporter.js
@@ -1,8 +1,6 @@
 /* global __SENTRY_TOKEN__, __DEVELOPMENT__ */
 import Raven from 'raven-js'
 
-let isEnabled = false
-
 const getAnalyticsUrl = () => {
   if (typeof __SENTRY_TOKEN__ === 'undefined') {
     return ''
@@ -16,12 +14,11 @@ const getAnalyticsUrl = () => {
 export const ANALYTICS_URL = getAnalyticsUrl()
 
 export const getReporterConfiguration = () => ({
-  shouldSendCallback: () => isEnabled,
+  shouldSendCallback: true,
   environment: __DEVELOPMENT__ ? 'development' : 'production'
 })
 
-export const configureReporter = enable => {
-  isEnabled = enable
+export const configureReporter = () => {
   Raven.config(ANALYTICS_URL, getReporterConfiguration()).install()
 }
 
@@ -34,23 +31,17 @@ export const logException = err => {
   })
 }
 
-const logMessage = (message, serverUrl, level = 'info', force) => {
+const logMessage = (message, serverUrl, level = 'info') => {
   return new Promise(resolve => {
-    if (force) {
-      configureReporter(true)
-    }
     Raven.setUserContext = {
       url: serverUrl
     }
     Raven.captureMessage(`[${serverUrl}] ${message}`, {
       level
     })
-    if (force) {
-      configureReporter(isEnabled)
-    }
     resolve()
   })
 }
 
-export const logInfo = (message, serverUrl, force = false) =>
-  logMessage(message, serverUrl, 'info', force)
+export const logInfo = (message, serverUrl) =>
+  logMessage(message, serverUrl, 'info')

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -27,11 +27,7 @@ import { backupContacts } from 'drive/mobile/actions/contactsBackup'
 import { getTranslateFunction } from 'drive/mobile/lib/i18n'
 import { scheduleNotification } from 'drive/mobile/lib/notification'
 import { isIos } from 'drive/mobile/lib/device'
-import {
-  getLang,
-  initClient,
-  initBar
-} from 'drive/mobile/lib/cozy-helper'
+import { getLang, initClient, initBar } from 'drive/mobile/lib/cozy-helper'
 import { revokeClient } from 'drive/mobile/actions/authorization'
 import { startReplication } from 'drive/mobile/actions/settings'
 import { configureReporter } from 'drive/mobile/lib/reporter'
@@ -46,9 +42,7 @@ const renderAppWithPersistedState = (persistedState = {}) => {
   const cozyURL = persistedState.mobile
     ? persistedState.mobile.settings.serverUrl
     : ''
-  const analyticsEnabled =
-    persistedState.mobile && persistedState.mobile.settings.analytics
-  configureReporter(analyticsEnabled)
+  configureReporter()
   const client = initClient(cozyURL)
   const store = configureStore(client, persistedState)
 
@@ -111,9 +105,7 @@ const renderAppWithPersistedState = (persistedState = {}) => {
       dictRequire={lang => require(`drive/locales/${lang}`)}
     >
       <CozyProvider store={store} client={client}>
-        <DriveMobileRouter
-          history={hashHistory}
-          />
+        <DriveMobileRouter history={hashHistory} />
       </CozyProvider>
     </I18n>,
     root


### PR DESCRIPTION
In the first commit, I removed the flag that allowed to disable Sentry, because we want to be able to report exceptions in all cases.

In the second commit, I added exception logging to the various errors that can occur when the user is entering its server url.