### PR TITLE
chore: upgrade file opener plugin

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -83,7 +83,7 @@
     <plugin name="cordova-plugin-inappbrowser" spec="1.7.0" />
     <plugin name="cordova-plugin-file" spec="4.3.1" />
     <plugin name="cordova-plugin-appinfo" spec="2.1.1" />
-    <plugin name="cordova-plugin-file-opener2" spec="2.0.7" />
+    <plugin name="cordova-plugin-file-opener2" spec="2.0.19" />
     <plugin name="cordova-plugin-network-information" spec="1.3.2" />
     <plugin name="cordova-plugin-background-fetch" spec="4.0.0" />
     <plugin name="cordova-plugin-ios-no-export-compliance" spec="https://github.com/mikaoelitiana/cordova-plugin-ios-no-export-compliance.git" />


### PR DESCRIPTION
I found a strange bug on iOS - some file types like `pptx` or `docx` would not open. They were downloaded, but when we tried to open them we received an error `File does not exist`.

Not knowing where to look, I upgraded [the plugin](https://github.com/pwlin/cordova-plugin-file-opener2) — there's no changelog, but it fixed the problem and everything else works as before, as far as I can tell.