### PR TITLE
fix: exception log on file error

### DIFF
--- a/src/viewer/NoViewer.jsx
+++ b/src/viewer/NoViewer.jsx
@@ -98,7 +98,7 @@ class NoViewer extends React.Component {
             if (/^Activity not found/.test(error.message)) {
               Alerter.error('Viewer.error.noapp', error)
             } else {
-              logException('a debug exception', error)
+              logException(error)
               Alerter.error('Viewer.error.generic', error)
             }
           }}


### PR DESCRIPTION
I think this was a mistake ? [`logException`](https://github.com/cozy/cozy-drive/blob/df16620b204a36a85bcf6ac9a4ff222d4fbd62d0/src/drive/mobile/lib/reporter.js#L28) only accepts one argument.