### PR TITLE
fix: cozy link in settings

### DIFF
--- a/src/drive/mobile/containers/settings/About.jsx
+++ b/src/drive/mobile/containers/settings/About.jsx
@@ -23,7 +23,7 @@ class About extends Component {
           {
             type: ELEMENT_TEXT,
             label: t('mobile.settings.about.account'),
-            value: <a href="{serverUrl}">{serverUrl}</a>
+            value: <a href={serverUrl}>{serverUrl}</a>
           },
           {
             type: ELEMENT_TEXT,


### PR DESCRIPTION
It was due to a jsx error, it's been there for a while apparently.