### PR TITLE
fix: init bar when offline

### DIFF
--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -44,13 +44,14 @@ export const initBar = async client => {
   if (document.getElementById('coz-bar')) {
     return
   }
+
   cozy.bar.init({
     appName: 'Drive',
     appEditor: 'Cozy',
     iconPath: require('../../../../targets/drive/vendor/assets/app-icon.svg'),
     lang: getLang(),
     cozyURL: client.getUrl(),
-    token: await getToken(),
+    token: getTokenWithNoException(),
     replaceTitleOnMobile: false,
     displayOnMobile: true
   })
@@ -81,6 +82,14 @@ export function resetClient(client, clientInfo = null) {
 export const getToken = async () => {
   const credentials = await cozy.client.authorize()
   return credentials.token.accessToken
+}
+
+const getTokenWithNoException = async () => {
+  try {
+    return await getToken()
+  } catch (_) {
+    return null
+  }
 }
 
 export const getClientUrl = () => cozy.client._url


### PR DESCRIPTION
When we are offline, we can't get a token to pass to the cozy-bar. But we still want to init the bar! Even without a token.

To test this, you can start the app in `standalone` mode, and then block all queries to `cozy.tools:8080` with the devtools. Without this PR, the cozy bar doesn't show up at all. With this PR, it appears as usual.