### PR TITLE
feat: temp hide cozy bar apps button

### DIFF
--- a/src/drive/mobile/styles/main.styl
+++ b/src/drive/mobile/styles/main.styl
@@ -16,3 +16,9 @@ html {
     src:  url('../assets/fonts/Lato-Bold.woff2') format('woff2'),
           url('../assets/fonts/Lato-Bold.woff') format('woff');
 }
+
+:global
+    [role=banner] .coz-bar-btn.coz-bar-burger{
+        visibility hidden
+        flex 0 0 .22em
+    }


### PR DESCRIPTION
We're hiding the button that shows the list of apps on the mobile app, until we've made a few changes to this menu.