### PR TITLE
chore: alias create-react-class with preact

### DIFF
--- a/config/webpack.config.preact.js
+++ b/config/webpack.config.preact.js
@@ -14,7 +14,8 @@ module.exports = {
     extensions: ['.jsx'],
     alias: {
       react: 'preact-compat',
-      'react-dom': 'preact-compat'
+      'react-dom': 'preact-compat',
+      'create-react-class': 'preact-compat/lib/create-react-class'
     }
   }
 }


### PR DESCRIPTION
With #612, react-router will need a new alias to stay preact-compatible. See [this issue](https://github.com/developit/preact/issues/739#issuecomment-316684628).