### PR TITLE
Compatibility with React

### DIFF
--- a/src/lib/cozy-client/connect.jsx
+++ b/src/lib/cozy-client/connect.jsx
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types'
 import { applySelectorForAction, enhancePropsForActions } from '.'
 import { mapValues, filterValues } from './utils'
 
+const storeShape = PropTypes.shape({
+  subscribe: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  getState: PropTypes.func.isRequired
+})
+
 const connect = (
   mapDocumentsToProps,
   mapActionsToProps = null
@@ -32,7 +38,7 @@ const connect = (
   }
 
   Wrapper.contextTypes = {
-    store: PropTypes.object.isRequired
+    store: storeShape.isRequired
   }
 
   const makeMapStateToProps = (initialState, initialOwnProps) => {

--- a/src/lib/cozy-client/connect.jsx
+++ b/src/lib/cozy-client/connect.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect as reduxConnect } from 'react-redux'
-
+import PropTypes from 'prop-types'
 import { applySelectorForAction, enhancePropsForActions } from '.'
 import { mapValues, filterValues } from './utils'
 
@@ -29,6 +29,10 @@ const connect = (
       }
       return <WrappedComponent {...props} />
     }
+  }
+
+  Wrapper.contextTypes = {
+    store: PropTypes.object.isRequired
   }
 
   const makeMapStateToProps = (initialState, initialOwnProps) => {


### PR DESCRIPTION
Since we test with React, we must be compatible with React.

EDIT : More context : 

For React to pass context properties down to children components, contextTypes must be defined with the properties that are passed. In preact, access to the context is not restricted like this. 

https://reactjs.org/docs/context.html

> If contextTypes is not defined, then context will be an empty object.

- [x] React compatibility

EDIT: Removed : 

- [ ] Fix collection "creation" with a receive data