### PR TITLE
[cozy-client] fix: add missing offline property on DataAccessFacade config

### DIFF
--- a/src/lib/cozy-client/DataAccessFacade.js
+++ b/src/lib/cozy-client/DataAccessFacade.js
@@ -18,16 +18,20 @@ export default class DataAccessFacade {
     this.pouchAdapter = new PouchdbAdapter()
   }
 
-  setup(cozyUrl, options) {
-    this.url = cozyUrl
-    const { offline, ...rest } = options
+  setup(cozyURL, options) {
+    this.url = cozyURL
+    const { offline } = options
+
     // TODO: For now we let cozy-client-js handle offline for files so that we don't break cozy-drive
-    const config =
-      offline &&
-      offline.doctypes &&
-      offline.doctypes.indexOf(FILES_DOCTYPE) !== -1
-        ? { cozyURL: cozyUrl, offline: { doctypes: [FILES_DOCTYPE] }, ...rest }
-        : { cozyURL: cozyUrl, ...rest }
+    const hasFilesDoctype =
+      offline && offline.doctypes && offline.doctypes.includes(FILES_DOCTYPE)
+
+    const config = {
+      ...options,
+      cozyURL,
+      offline: hasFilesDoctype ? { doctypes: [FILES_DOCTYPE] } : offline
+    }
+
     // TODO: Get rid of cozy-client-js
     cozy.client.init(config)
     if (offline && offline.doctypes) {

--- a/src/lib/cozy-client/__mocks__/pouchdb.js
+++ b/src/lib/cozy-client/__mocks__/pouchdb.js
@@ -1,3 +1,4 @@
-var PouchDB = jest.genMockFunction()
+var PouchDB = jest.fn()
+PouchDB.plugin = jest.fn()
 
 module.exports = PouchDB

--- a/src/lib/cozy-client/__tests__/DataAccessFacade.spec.js
+++ b/src/lib/cozy-client/__tests__/DataAccessFacade.spec.js
@@ -1,0 +1,40 @@
+import DataAccessFacade from '../DataAccessFacade'
+
+describe('DataAccessFacade', () => {
+  global.cozy = {
+    client: {
+      init: jest.fn()
+    }
+  }
+
+  const facade = new DataAccessFacade()
+
+  it('without files doctype: should call cozy.client.init with the proper configuration', () => {
+    const cozyURL = 'https://localhost'
+    const doctypes = ['this', 'is', 'a', 'test']
+
+    facade.setup(cozyURL, {
+      offline: { doctypes }
+    })
+
+    expect(global.cozy.client.init.mock.calls[0][0]).toEqual({
+      offline: { doctypes },
+      cozyURL
+    })
+  })
+
+  it('with files doctype: should call cozy.client.init with the proper configuration', () => {
+    const filesDoctype = 'io.cozy.files'
+    const cozyURL = 'https://localhost'
+    const doctypes = ['this', 'is', 'a', 'test', filesDoctype]
+
+    facade.setup(cozyURL, {
+      offline: { doctypes }
+    })
+
+    expect(global.cozy.client.init.mock.calls[1][0]).toEqual({
+      offline: { doctypes: [filesDoctype] },
+      cozyURL
+    })
+  })
+})


### PR DESCRIPTION
Add the offline property in the config object formed in `DataAccessFacade::setup` and passed to `cozy.client.init`. When checking if the doctypes contain the files doctype, this property was missing on the `else` side. So when we don't use the files doctype, we were losing all the doctypes. This is why the reset button of cozy-bank app didn't flush pouchdb databases.
