### PR TITLE
[cozy-client] feat: add destroyAllDatabases method

### DIFF
--- a/src/lib/cozy-client/CozyClient.js
+++ b/src/lib/cozy-client/CozyClient.js
@@ -41,6 +41,7 @@ export default class CozyClient {
 
   resetStore() {
     this.store.dispatch({ type: 'RESET_STORE' })
+    this.facade.destroyAllDatabases()
   }
 
   getUrl() {

--- a/src/lib/cozy-client/DataAccessFacade.js
+++ b/src/lib/cozy-client/DataAccessFacade.js
@@ -62,6 +62,10 @@ export default class DataAccessFacade {
   startReplicationFrom(dispatch) {
     return this.pouchAdapter.startSync(dispatch, SYNC_FROM)
   }
+
+  destroyAllDatabases() {
+    this.pouchAdapter.destroyAllDatabases()
+  }
 }
 
 class PouchFirstStrategy {


### PR DESCRIPTION
I ported [`destroyAllDatabase`](https://github.com/cozy/cozy-client-js/blob/master/src/offline.js#L87-L91) function (+ added mechanism to stop synchronization) from cozy-client-js to cozy-client.
  