### PR TITLE
fix: taps on more button

### DIFF
--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -55,11 +55,11 @@ const enableTouchEvents = ev => {
     return false
   }
 
-  // remove event when it's checkbox (it's already trigger, but Hammer don't respect stopPropagation)
+  const parentDiv = getParentDiv(ev.target)
+  // remove event when it's the checkbox or the more button
   if (
-    getParentDiv(ev.target).className.indexOf(
-      styles['fil-content-file-select']
-    ) !== -1
+    parentDiv.className.indexOf(styles['fil-content-file-select']) !== -1 ||
+    parentDiv.className.indexOf(styles['fil-content-file-action']) !== -1
   ) {
     return false
   }


### PR DESCRIPTION
On touch devices, taping the "more" button on the right of a file would sometimes not work, depending on what element exactly was the `target`. When it didn't work, the file was opened in the viewer instead.

This fixes the problem, so tapping the "more" button should always bring up the FileActionMenu now.