### PR TITLE
fix: sharing infos

### DIFF
--- a/src/components/Toolbar/index.jsx
+++ b/src/components/Toolbar/index.jsx
@@ -19,9 +19,23 @@ class Toolbar extends Component {
       breakpoints: { isMobile }
     } = this.props
 
-    const actions = React.Children.toArray(children)
-    const highlightedActions = actions.filter(child => child.props.highlighted)
-    const secondaryActions = actions.filter(child => !child.props.highlighted)
+    const sortActions = (sortedActions, action) =>
+      action.props.highlighted
+        ? {
+            secondaryActions: [...sortedActions.secondaryActions],
+            highlightedActions: [...sortedActions.highlightedActions, action]
+          }
+        : {
+            secondaryActions: [...sortedActions.secondaryActions, action],
+            highlightedActions: [...sortedActions.highlightedActions]
+          }
+
+    const { highlightedActions, secondaryActions } = React.Children.toArray(
+      children
+    ).reduce(sortActions, {
+      highlightedActions: [],
+      secondaryActions: []
+    })
 
     const MoreMenu = (
       <Menu

--- a/src/components/Toolbar/index.jsx
+++ b/src/components/Toolbar/index.jsx
@@ -1,0 +1,121 @@
+/* global cozy */
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import Menu, { Item } from 'components/Menu'
+import styles from './index.styl'
+
+import { withBreakpoints } from 'cozy-ui/react'
+
+const { BarRight } = cozy.bar
+
+class Toolbar extends Component {
+  render() {
+    const {
+      children,
+      moreMenuTitle,
+      moreMenuDisabled,
+      moreMenuClassName,
+      moreMenuButton,
+      breakpoints: { isMobile }
+    } = this.props
+
+    const actions = React.Children.toArray(children)
+    const highlightedActions = actions.filter(child => child.props.highlighted)
+    const secondaryActions = actions.filter(child => !child.props.highlighted)
+
+    const MoreMenu = (
+      <Menu
+        title={moreMenuTitle}
+        disabled={moreMenuDisabled}
+        className={moreMenuClassName}
+        button={moreMenuButton}
+      >
+        {highlightedActions.map(component =>
+          this.wrapInItem(
+            React.cloneElement(component, {
+              highlighted: false,
+              isSecondaryAction: false
+            })
+          )
+        )}
+        {secondaryActions.map(component =>
+          this.wrapInItem(
+            React.cloneElement(component, {
+              highlighted: false,
+              isSecondaryAction: true
+            })
+          )
+        )}
+      </Menu>
+    )
+
+    return (
+      <div role="toolbar">
+        {highlightedActions.map(component =>
+          React.cloneElement(component, {
+            highlighted: true,
+            isSecondaryAction: false
+          })
+        )}
+        {isMobile ? <BarRight>{MoreMenu}</BarRight> : MoreMenu}
+      </div>
+    )
+  }
+
+  wrapInItem(component) {
+    return <Item>{component}</Item>
+  }
+}
+
+Toolbar.propTypes = {
+  moreMenuTitle: PropTypes.string.isRequired,
+  moreMenuDisabled: PropTypes.bool,
+  moreMenuClassName: PropTypes.string,
+  moreMenuButton: PropTypes.element.isRequired,
+  children: PropTypes.node,
+  breakpoints: PropTypes.object
+}
+
+Toolbar.defaultProps = {
+  moreMenuDisabled: false,
+  moreMenuClassName: ''
+}
+
+export class ToolbarAction extends Component {
+  render() {
+    try {
+      const { children, visible, highlighted, isSecondaryAction } = this.props
+
+      if (!visible) return null
+
+      const child = React.cloneElement(React.Children.only(children), {
+        highlighted
+      })
+
+      if (isSecondaryAction) return child
+      else {
+        const hiddenStyle = highlighted
+          ? styles['u-hide--mob']
+          : styles['u-hide--desk']
+        return <span className={hiddenStyle}>{child}</span>
+      }
+    } catch (_) {
+      return null
+    }
+  }
+} // needs to extend Component to have `props.children`
+
+ToolbarAction.propTypes = {
+  visible: PropTypes.bool,
+  highlighted: PropTypes.bool,
+  isSecondaryAction: PropTypes.bool,
+  children: PropTypes.element.isRequired
+}
+
+ToolbarAction.defaultProps = {
+  visible: true,
+  highlighted: false,
+  isSecondaryAction: true
+}
+
+export default withBreakpoints()(Toolbar)

--- a/src/components/Toolbar/index.styl
+++ b/src/components/Toolbar/index.styl
@@ -1,0 +1,7 @@
+@require 'cozy-ui'
+
+.u-hide--mob
+    @extend $hide--mob
+
+.u-hide--desk
+    @extend $hide--desk

--- a/src/drive/ducks/files/Container.jsx
+++ b/src/drive/ducks/files/Container.jsx
@@ -39,7 +39,7 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   const hasWriteAccess =
-    !ownProps.shared.withMe || ownProps.shared.sharingType === 'master-master'
+    !ownProps.shared.withMe || ownProps.shared.sharingType === 'two-way'
   return {
     actions: Object.assign({}, ownProps.actions, {
       list: {

--- a/src/drive/styles/toolbar.styl
+++ b/src/drive/styles/toolbar.styl
@@ -45,19 +45,11 @@
         &.fil-action-share
             background embedurl('../assets/icons/icon-share-dark.svg') 1rem center no-repeat
 
-    .fil-action-upload
-    .fil-action-share
-        display none
-
 
 +medium-screen()
     .fil-toolbar-menu
         display block
         left 1em
-        .fil-action-upload
-        .fil-action-share
-        .fil-action-select
-            display block
 
 +small-screen()
     .fil-toolbar-files
@@ -66,9 +58,6 @@
         top      0
         right    0
         z-index  $nav-index
-
-    .fil-public-download
-        display none
 
 +small-screen('min')
     .fil-toolbar-menu--public

--- a/src/drive/styles/topbar.styl
+++ b/src/drive/styles/topbar.styl
@@ -12,4 +12,4 @@ $coz-bar-size = 3rem
 
 +small-screen()
     .fil-topbar
-        display none
+        margin 0

--- a/src/lib/cozy-client/slices/sharings.js
+++ b/src/lib/cozy-client/slices/sharings.js
@@ -339,9 +339,7 @@ const getPermissionsFor = (document, publicLink = false) => {
 
 // selectors
 const getSharing = (state, id) =>
-  state.cozy.sharings.documents.find(
-    s => s.attributes && s.attributes.sharing_id === id
-  )
+  state.cozy.sharings.documents.find(s => s._id === id)
 const getContact = (state, id) => getDocument(state, 'io.cozy.contacts', id)
 
 const getDoctypePermissions = (state, doctype) =>
@@ -390,14 +388,14 @@ const getSharingForRecipient = (state, document, recipient) => {
 const getDocumentActiveSharings = (state, doctype, id) => {
   const perms = getDoctypePermissions(state, doctype)
   return [
-    ...perms.byMe.filter(
-      perm => perm.attributes.permissions.files.values.indexOf(id) !== -1
+    ...perms.byMe.filter(perm =>
+      perm.attributes.permissions.files.values.includes(id)
     ),
-    ...perms.withMe.filter(
-      perm => perm.attributes.permissions.rule0.values.indexOf(id) !== -1
+    ...perms.withMe.filter(perm =>
+      perm.attributes.permissions.rule0.values.includes(id)
     )
   ]
-    .map(p => getSharing(state, p.attributes.source_id))
+    .map(p => getSharing(state, p.attributes.source_id.split('/')[1]))
     .filter(s => s && s.attributes && !s.attributes.revoked)
 }
 
@@ -436,10 +434,7 @@ export const getSharingDetails = (state, doctype, id, options = {}) => {
     owner,
     sharingType,
     sharingLink,
-    sharer:
-      shared && !owner
-        ? { name: 'John Doe', url: sharings[0].attributes.sharer.url }
-        : null,
+    sharer: null,
     readOnly: !owner && sharingType === 'one-way',
     recipients: shared && owner ? getSharingRecipients(state, sharings) : [],
     byMe: shared && owner === true,

--- a/src/lib/cozy-client/slices/sharings.js
+++ b/src/lib/cozy-client/slices/sharings.js
@@ -445,10 +445,10 @@ export const getSharingDetails = (state, doctype, id, options = {}) => {
 
 const getSharingRecipients = (state, sharings) =>
   sharings
-    .filter(sharing => sharing.attributes.recipients)
+    .filter(sharing => sharing.relationships.recipients.data)
     .map(sharing =>
-      sharing.attributes.recipients.map(info => ({
-        contact: getContact(state, info.recipient.id),
+      sharing.relationships.recipients.data.map(info => ({
+        contact: getContact(state, info.id),
         status: info.status,
         type: sharing.attributes.sharing_type
       }))

--- a/src/photos/components/UploadButton.jsx
+++ b/src/photos/components/UploadButton.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
-import { Icon } from 'cozy-ui/react'
 import classNames from 'classnames'
 
 import button from '../styles/toolbar'
@@ -39,7 +38,6 @@ export const UploadButton = ({
     }`}
     style={styles.parent}
   >
-    <Icon icon="upload" />
     {label}
     <input
       type="file"

--- a/src/sharing/SharingDetailsModal.jsx
+++ b/src/sharing/SharingDetailsModal.jsx
@@ -2,10 +2,8 @@ import styles from './share.styl'
 
 import React, { Component } from 'react'
 import { cozyConnect, fetchSharings } from 'cozy-client'
-import { UserAvatar } from './components/Recipient'
+import { UserAvatar as Owner } from './components/Recipient'
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
-
-const Owner = UserAvatar
 
 export class SharingDetailsModal extends Component {
   render() {

--- a/src/sharing/SharingDetailsModal.jsx
+++ b/src/sharing/SharingDetailsModal.jsx
@@ -3,7 +3,7 @@ import styles from './share.styl'
 import React, { Component } from 'react'
 import { cozyConnect, fetchSharings } from 'cozy-client'
 import { UserAvatar } from './components/Recipient'
-import Modal from 'cozy-ui/react/Modal'
+import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 
 const Owner = UserAvatar
 
@@ -16,24 +16,21 @@ export class SharingDetailsModal extends Component {
         title={t(`${documentType}.share.details.title`)}
         secondaryAction={onClose}
       >
-        <div className={styles['pho-share-modal-content']}>
-          <Owner
-            name={t(`${documentType}.share.sharedWithMe`)}
-            url={sharing.sharer.url}
-          />
-          <div className={styles['pho-share-details-created']}>
+        <ModalContent>
+          <Owner name={t(`${documentType}.share.sharedWithMe`)} />
+          <div className={styles['share-details-created']}>
             {t(`${documentType}.share.details.createdAt`, {
               date: f(document.created_at || null, 'Do MMMM YYYY')
             })}
           </div>
-          <div className={styles['pho-share-details-perm']}>
+          <div className={styles['share-details-perm']}>
             {t(
               `${documentType}.share.details.${
                 sharing.sharingType === 'one-way' ? 'ro' : 'rw'
               }`
             )}
           </div>
-        </div>
+        </ModalContent>
       </Modal>
     )
   }

--- a/src/sharing/components/Avatar.jsx
+++ b/src/sharing/components/Avatar.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import ColorHash from './colorhash'
 import styles from './recipient.styl'
 

--- a/src/sharing/components/Avatar.jsx
+++ b/src/sharing/components/Avatar.jsx
@@ -1,0 +1,16 @@
+import ColorHash from './colorhash'
+import styles from './recipient.styl'
+
+export const Avatar = ({ name, className }) => {
+  const initial = name.charAt(0)
+  const bg = ColorHash().getColor(name)
+  const style = {
+    'background-color': bg
+  }
+  return (
+    <div className={styles['pho-recipient-avatar']} style={style}>
+      <span>{initial}</span>
+    </div>
+  )
+}
+export default Avatar

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -4,23 +4,10 @@ import React, { Component } from 'react'
 import classNames from 'classnames'
 import { translate } from 'cozy-ui/react/I18n'
 import Spinner from 'cozy-ui/react/Spinner'
-import ColorHash from './colorhash'
 import Menu, { Item } from 'components/Menu'
+import Avatar from './Avatar'
 
 import { getPrimaryEmail, getPrimaryCozy } from '..'
-
-const Avatar = ({ name }) => {
-  const initial = name.charAt(0)
-  const bg = ColorHash().getColor(name)
-  const style = {
-    'background-color': bg
-  }
-  return (
-    <div className={styles['pho-recipient-avatar']} style={style}>
-      <span>{initial}</span>
-    </div>
-  )
-}
 
 const Identity = ({ name, url }) => (
   <div className={styles['pho-recipient-idents']}>

--- a/src/sharing/index.js
+++ b/src/sharing/index.js
@@ -18,6 +18,7 @@ export const getPrimaryCozy = contact =>
 export { default as ShareModal } from './ShareModal'
 export { default as SharingDetailsModal } from './SharingDetailsModal'
 export { default as SharedBadge } from './components/SharedBadge'
+export { default as Avatar } from './components/Avatar'
 export {
   default as ShareButton,
   SharedByMeButton,


### PR DESCRIPTION
This PR does 2 things:

- re-enables the icons for shared folders (folders that *I* share should have a green icon, folders that are shared *with me* a purple one.)
- The "share" button is different for folders that are shared, and if a folder is shared, the upload button is moved to the side menu

<img width="326" alt="capture d ecran 2018-01-10 13 26 11" src="https://user-images.githubusercontent.com/2261445/34772862-d89ced18-f609-11e7-9d63-5d181d69008b.png">

The second part required some heavy work on the `Toolbar` component. I'm quite happy [with the current API](https://github.com/cozy/cozy-drive/pull/679/files#diff-12918a0e2886ac9526cde1534cc4ca9fR108) but unhappy with [the implementation](https://github.com/cozy/cozy-drive/pull/679/files#diff-cd8ecf10d1445222404e50d7f56d783fR10). I'll add some review comments to point out things where I'd like feedback. 

edit: actually I've reworked the implementation a bit and am relative happy with it. It could be extended a lot more but I think it's a good start!
