### PR TITLE
Auth component npm

### DIFF
--- a/src/authentication/Standalone.jsx
+++ b/src/authentication/Standalone.jsx
@@ -7,12 +7,16 @@ import PropTypes from 'prop-types'
 const withLocales = Wrapped => {
   const Wrapper = (props, context) => {
     const { lang } = context
-    // We pluck a subset of the locales not to ship all Drive locales
-    // when we distribute our component
-    const locales = require(`!!./json-pluck-loader?key=mobile.onboarding;mobile.revoked!drive/locales/${lang}.json`)
     return (
       // Wrap into its own I18n to provide its own locales
-      <I18n dictRequire={() => locales} lang={lang}>
+      // We pluck a subset of the locales not to ship all Drive locales
+      // when we distribute our component
+      <I18n
+        dictRequire={lang =>
+          require(`!!./json-pluck-loader?key=mobile.onboarding;mobile.revoked!drive/locales/${lang}.json`)
+        }
+        lang={lang}
+      >
         <Wrapped {...props} />
       </I18n>
     )

--- a/src/authentication/package.json
+++ b/src/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-authentication",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "description": "Component providing login to a Cozy",
   "main": "build/index.js",
   "author": "Cozy",


### PR DESCRIPTION
Fallback to English if locale is not available.

`<I18n />` already does that for us but we have to use the callback dictRequire to load the locale data.