### PR TITLE
Sharing unit tests

### DIFF
--- a/src/lib/cozy-client/__fixtures__/sharings.js
+++ b/src/lib/cozy-client/__fixtures__/sharings.js
@@ -1,0 +1,143 @@
+export const FAKE_FOLDER = {
+  _id: '02fc14dc3c447824dc32d9198300f57d',
+  _type: 'io.cozy.files'
+}
+
+export const KNOWN_CONTACT = {
+  id: '02fc14dc3c447824dc32d91983010c2d',
+  type: 'io.cozy.contacts',
+  attributes: {
+    name: {},
+    email: [{ address: 'jane@doe.com', primary: true }]
+  }
+}
+
+export const SHARING_1 = {
+  type: 'io.cozy.sharings',
+  id: '02fc14dc3c447824dc32d9198301170b',
+  attributes: {
+    sharing_type: 'two-way',
+    owner: true,
+    description: 'Test',
+    app_slug: 'drive',
+    created_at: '2018-01-08T09:03:33.777003842+01:00',
+    updated_at: '2018-01-08T09:03:33.777003842+01:00'
+  },
+  meta: { rev: '1-c9913518ec98ab980e3ffab07da26b86' },
+  links: { self: '/sharings/02fc14dc3c447824dc32d9198301170b' },
+  relationships: {
+    permissions: {
+      links: { self: '/permissions/02fc14dc3c447824dc32d91983011fa2' },
+      data: {
+        id: '02fc14dc3c447824dc32d91983011fa2',
+        type: 'shared-by-me'
+      }
+    },
+    recipients: {
+      data: [
+        {
+          id: KNOWN_CONTACT.id,
+          type: 'io.cozy.contacts',
+          status: 'pending'
+        }
+      ]
+    }
+  }
+}
+
+export const APPS_RESPONSE = {
+  data: [
+    {
+      _type: 'io.cozy.apps',
+      _id: 'io.cozy.apps/drive',
+      attributes: {
+        name: 'Drive',
+        editor: 'Cozy',
+        slug: 'drive',
+        state: 'ready'
+      },
+      meta: { rev: '1-9dfe2ff6a4ef9df38d1ea2c36964aec6' },
+      links: {
+        self: '/apps/drive',
+        related: 'http://drive.cozy.tools:8080/',
+        icon: '/apps/drive/icon'
+      }
+    },
+    {
+      _type: 'io.cozy.apps',
+      _id: 'io.cozy.apps/photos',
+      attributes: {
+        name: 'Photos',
+        editor: 'Cozy',
+        slug: 'photos',
+        state: 'ready'
+      },
+      meta: { rev: '1-c1221d1b45fa592ea7fa25922733b260' },
+      links: {
+        self: '/apps/photos',
+        related: 'http://photos.cozy.tools:8080/',
+        icon: '/apps/photos/icon'
+      }
+    }
+  ]
+}
+
+export const CREATE_SHARING_RESPONSE = {
+  data: SHARING_1,
+  included: [
+    {
+      type: 'io.cozy.permissions',
+      id: '02fc14dc3c447824dc32d91983011fa2',
+      attributes: {
+        type: 'shared-by-me',
+        source_id: 'io.cozy.sharings/02fc14dc3c447824dc32d9198301170b',
+        permissions: {
+          files: {
+            type: 'io.cozy.files',
+            values: ['02fc14dc3c447824dc32d9198300f57d']
+          }
+        },
+        codes: {
+          [KNOWN_CONTACT.id]:
+            'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzaGFyZSIsImlhdCI6MTUxNTM5ODYxMywiaXNzIjoiY296eS50b29sczo4MDgwIiwic3ViIjoiMDJmYzE0ZGMzYzQ0NzgyNGRjMzJkOTE5ODMwMTBjMmQifQ.dfJw68rgvQZ0NfCGWUZ4hB1d44kaWbIpM5GpY0KclA1cZjWSUopArLYNC1XpNhpA4XjFy0GL55Ab0vkEVNqazA'
+        }
+      },
+      meta: { rev: '1-f490eb611a9a4ee0a7d92bf5e8c5f933' },
+      links: {
+        self: '/permissions/02fc14dc3c447824dc32d91983011fa2',
+        related: '/sharings/02fc14dc3c447824dc32d9198301170b'
+      }
+    },
+    {
+      ...KNOWN_CONTACT,
+      meta: { rev: '1-931869e3b25095bbeb1ba09b982b00b8' },
+      links: {
+        self: `/data/io.cozy.contacts/${KNOWN_CONTACT.id}`
+      }
+    }
+  ]
+}
+
+export const CREATE_SHARED_LINK_RESPONSE = {
+  data: {
+    type: 'io.cozy.permissions',
+    id: '02fc14dc3c447824dc32d91983013761',
+    attributes: {
+      type: 'share',
+      source_id: 'io.cozy.apps/drive',
+      permissions: {
+        files: {
+          type: 'io.cozy.files',
+          verbs: ['GET'],
+          values: ['02fc14dc3c447824dc32d9198300f57d']
+        }
+      },
+      codes: {
+        email:
+          'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzaGFyZSIsImlhdCI6MTUxNTU4ODk2OSwiaXNzIjoiY296eS50b29sczo4MDgwIiwic3ViIjoiZW1haWwifQ.s4jZoFKym2grmEaO4YlCxzznr9dqiU7IIvgx5cds2oBrM_Cvg0rO1kShqvM3m9CjNSMd-OrlqPfdRVd7_hFy8g'
+      }
+    },
+    meta: { rev: '1-f98188c09fcce6f3bc4ff998476d3962' },
+    links: { self: '/permissions/02fc14dc3c447824dc32d91983013761' }
+  }
+}

--- a/src/lib/cozy-client/__mocks__/cozy-client-js.js
+++ b/src/lib/cozy-client/__mocks__/cozy-client-js.js
@@ -1,0 +1,10 @@
+const cozy = {
+  client: {
+    init: jest.genMockFunction(),
+    fetchJSON: jest.genMockFunction()
+  }
+}
+
+global.cozy = cozy
+
+export default cozy

--- a/src/lib/cozy-client/__mocks__/pouchdb.js
+++ b/src/lib/cozy-client/__mocks__/pouchdb.js
@@ -1,3 +1,4 @@
 var PouchDB = jest.genMockFunction()
+PouchDB.plugin = jest.genMockFunction()
 
 module.exports = PouchDB

--- a/src/lib/cozy-client/__tests__/sharings.spec.js
+++ b/src/lib/cozy-client/__tests__/sharings.spec.js
@@ -1,0 +1,134 @@
+import cozy from 'cozy-client-js'
+import { createStore, applyMiddleware, combineReducers } from 'redux'
+import thunkMiddleware from 'redux-thunk'
+import CozyClient from '../CozyClient'
+import cozyMiddleware from '../middleware'
+import { reducer as cozyReducer } from '..'
+import {
+  share,
+  shareByLink,
+  getSharingStatus,
+  getSharingLink,
+  fetchApps
+} from '../slices/sharings'
+
+import {
+  FAKE_FOLDER,
+  KNOWN_CONTACT,
+  APPS_RESPONSE,
+  CREATE_SHARING_RESPONSE,
+  CREATE_SHARED_LINK_RESPONSE,
+  SHARING_1
+} from '../__fixtures__/sharings'
+
+const mockResponseOnce = response =>
+  cozy.client.fetchJSON.mockImplementationOnce(
+    async () =>
+      // TODO: fetchJSON only returns the data prop of the response when data is an object,
+      // thus we're losing the included docs, which is sad
+      response.data
+  )
+
+describe('Sharings', () => {
+  let client, store
+
+  beforeEach(() => {
+    client = new CozyClient({
+      cozyURL: 'http://cozy.tools:8080',
+      token: 'AZERTY'
+    })
+    store = createStore(
+      combineReducers({ cozy: cozyReducer }),
+      applyMiddleware(cozyMiddleware(client), thunkMiddleware)
+    )
+  })
+
+  afterEach(() => {
+    cozy.client.fetchJSON.mockClear()
+  })
+
+  describe('Given a folder is shared by link', () => {
+    beforeEach(done => {
+      mockResponseOnce(APPS_RESPONSE)
+      mockResponseOnce(CREATE_SHARED_LINK_RESPONSE)
+      Promise.all([
+        store.dispatch(fetchApps()),
+        store.dispatch(shareByLink(FAKE_FOLDER))
+      ]).then(() => done())
+    })
+
+    it('Should call the right route', () => {
+      expect(cozy.client.fetchJSON.mock.calls[1][0]).toEqual('POST')
+      expect(cozy.client.fetchJSON.mock.calls[1][1]).toEqual(
+        '/permissions?codes=email'
+      )
+    })
+
+    it('Should send the right payload to the stack', () => {
+      expect(cozy.client.fetchJSON.mock.calls[1][2]).toEqual({
+        data: {
+          type: 'io.cozy.permissions',
+          attributes: {
+            permissions: {
+              files: {
+                type: 'io.cozy.files',
+                verbs: ['GET'],
+                values: [FAKE_FOLDER._id]
+              }
+            }
+          }
+        }
+      })
+    })
+
+    it('Should have a local status', () => {
+      expect(
+        getSharingLink(store.getState(), FAKE_FOLDER._type, FAKE_FOLDER._id)
+      ).toEqual(
+        'http://drive.cozy.tools:8080/public?sharecode=eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzaGFyZSIsImlhdCI6MTUxNTU4ODk2OSwiaXNzIjoiY296eS50b29sczo4MDgwIiwic3ViIjoiZW1haWwifQ.s4jZoFKym2grmEaO4YlCxzznr9dqiU7IIvgx5cds2oBrM_Cvg0rO1kShqvM3m9CjNSMd-OrlqPfdRVd7_hFy8g&id=02fc14dc3c447824dc32d9198300f57d'
+      )
+    })
+  })
+
+  describe('Given a folder is shared with a known contact', () => {
+    beforeEach(done => {
+      mockResponseOnce(CREATE_SHARING_RESPONSE)
+      store
+        .dispatch(
+          share(FAKE_FOLDER, [KNOWN_CONTACT], 'two-way', 'Our holidays')
+        )
+        .then(() => done())
+    })
+
+    it('Should call the right route', () => {
+      expect(cozy.client.fetchJSON.mock.calls[0][0]).toEqual('POST')
+      expect(cozy.client.fetchJSON.mock.calls[0][1]).toEqual('/sharings/')
+    })
+
+    it('Should send the right payload to the stack', () => {
+      expect(cozy.client.fetchJSON.mock.calls[0][2]).toEqual({
+        description: 'Our holidays',
+        permissions: {
+          files: {
+            type: 'io.cozy.files',
+            values: [FAKE_FOLDER._id],
+            verbs: ['ALL']
+          }
+        },
+        recipients: [KNOWN_CONTACT.id],
+        sharing_type: 'two-way'
+      })
+    })
+
+    it('Should have a local status', () => {
+      expect(
+        getSharingStatus(store.getState(), FAKE_FOLDER._type, FAKE_FOLDER._id)
+      ).toEqual({
+        shared: true,
+        owner: true,
+        sharingType: 'two-way',
+        sharings: [SHARING_1]
+      })
+    })
+  })
+})

--- a/src/lib/cozy-client/index.js
+++ b/src/lib/cozy-client/index.js
@@ -31,6 +31,7 @@ export {
   fetchApps,
   getSharings,
   getSharingDetails,
+  getSharingLink,
   share,
   unshare,
   leave,


### PR DESCRIPTION
Cette PR ajoute des tests autour du partage. Pour l'instant, seules la création d'un partage et d'un lien de partage sont couverts. La stratégie employée est de mocker la réponse JSON de la stack, afin de documenter cette réponse attendue d'une part, et de vérifier le bon fonctionnement du store et des différents sélecteurs.

J'en ai profité pour faire un petit refacto des reducers des permissions afin de régler le pb des erreurs de type `byMe is undefined` : https://github.com/cozy/cozy-drive/pull/681/files#diff-9adf7fd271915ca7d36b207126236acb