### PR TITLE
chore: fonts.css asset is already imported by the stack

### DIFF
--- a/targets/drive/web/index.ejs
+++ b/targets/drive/web/index.ejs
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title><%= htmlWebpackPlugin.options.title %></title>
-  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16">

--- a/targets/photos/web/index.ejs
+++ b/targets/photos/web/index.ejs
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title><%= htmlWebpackPlugin.options.title %></title>
-  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">


### PR DESCRIPTION
The `fonts.css` asset imported from the main domain is already injected by the stack, with an immutable hash. This PR removes the import made by the application to avoid wasting a network roundtrip.