### PR TITLE
WIP chore: only require what we need

### DIFF
--- a/src/components/Button/index.styl
+++ b/src/components/Button/index.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
+@require 'utilities/display.styl'
 
 .u-visuallyhidden
     @extend $visuallyhidden

--- a/src/components/Error/empty.styl
+++ b/src/components/Error/empty.styl
@@ -1,5 +1,5 @@
-@import 'cozy-ui/'
-
+@require 'components/empty.styl'
+@require 'settings/breakpoints.styl'
 
 .c-empty-drive
     @extend $empty

--- a/src/components/Error/oops.styl
+++ b/src/components/Error/oops.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'components/empty.styl'
 @require './empty'
 
 .fil-oops

--- a/src/components/Menu/index.styl
+++ b/src/components/Menu/index.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
+@require 'components/popover.styl'
 
 .coz-menu
     position relative

--- a/src/components/pushClient/pushClient.styl
+++ b/src/components/pushClient/pushClient.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'components/button.styl'
+@require 'settings/breakpoints.styl'
 
 // Desktop Button
 .coz-btn-client

--- a/src/drive/ducks/upload/styles.styl
+++ b/src/drive/ducks/upload/styles.styl
@@ -1,4 +1,9 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
+@require 'components/popover.styl'
+@require 'settings/icons.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/z-index.styl'
+
 @import '../../styles/mimetypes'
 
 .upload-queue

--- a/src/drive/mobile/ducks/mediaBackup/styles.styl
+++ b/src/drive/mobile/ducks/mediaBackup/styles.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
 @require '../../styles/feedback'
 
 .coz-upload-status

--- a/src/drive/mobile/styles/feedback.styl
+++ b/src/drive/mobile/styles/feedback.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
 
 .feedback-form
     @extend $form

--- a/src/drive/mobile/styles/onboarding.styl
+++ b/src/drive/mobile/styles/onboarding.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
+@require 'settings/palette.styl'
+@require 'settings/z-index.styl'
 
 .wizard
     @extend $form

--- a/src/drive/mobile/styles/uploadstatus.styl
+++ b/src/drive/mobile/styles/uploadstatus.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'components/alerts.styl'
+@require 'components/button.styl'
 
 .coz-alerter
     @extend $alerts

--- a/src/drive/styles/actionmenu.styl
+++ b/src/drive/styles/actionmenu.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'components/popover.styl'
+@require 'settings/z-index.styl'
 
 .fil-actionmenu-backdrop
     position   fixed

--- a/src/drive/styles/breadcrumb.styl
+++ b/src/drive/styles/breadcrumb.styl
@@ -1,4 +1,7 @@
-@require 'cozy-ui'
+@require 'components/popover.styl'
+@require 'settings/palette.styl'
+@require 'settings/breakpoints.styl'
+
 @require './topbar'
 
 .fil-path-title

--- a/src/drive/styles/filenameinput.styl
+++ b/src/drive/styles/filenameinput.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
 
 .fil-file-name-input
     @extend $form-text

--- a/src/drive/styles/foldercontent.styl
+++ b/src/drive/styles/foldercontent.styl
@@ -1,4 +1,5 @@
-@import 'settings/breakpoints'
+@require 'settings/breakpoints.styl'
+
 +medium-screen()
     .content-spinner
         position fixed

--- a/src/drive/styles/intentbutton.styl
+++ b/src/drive/styles/intentbutton.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
 
 // This ugly rules hide the default close button of the modal
 .intentButton

--- a/src/drive/styles/layout.styl
+++ b/src/drive/styles/layout.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'objects/layouts.styl'
 
 .fil-wrapper
     @extend    $app-2panes-sticky

--- a/src/drive/styles/main.styl
+++ b/src/drive/styles/main.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
 
 div:focus
     outline: none

--- a/src/drive/styles/nav.styl
+++ b/src/drive/styles/nav.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'components/nav.styl'
+@require 'settings/breakpoints.styl'
 
 .coz-nav
     @extend $nav

--- a/src/drive/styles/table.styl
+++ b/src/drive/styles/table.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
+@require 'settings/palette.styl'
 @import './mimetypes'
 
 .fil-content-table

--- a/src/drive/styles/toolbar.styl
+++ b/src/drive/styles/toolbar.styl
@@ -1,4 +1,7 @@
-@require 'cozy-ui'
+@require 'components/button.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/z-index.styl'
+@require 'utilities/display.styl'
 
 .c-btn
     @extend $button

--- a/src/drive/styles/topbar.styl
+++ b/src/drive/styles/topbar.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/z-index.styl'
 
 $coz-bar-size = 3rem
 

--- a/src/photos/ducks/upload/styles.styl
+++ b/src/photos/ducks/upload/styles.styl
@@ -1,4 +1,8 @@
-@require 'cozy-ui'
+@require 'components/popover.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/icons.styl'
+@require 'settings/palette.styl'
+@require 'settings/z-index.styl'
 
 .upload-queue
     @extend $popover

--- a/src/photos/styles/albumsList.styl
+++ b/src/photos/styles/albumsList.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
+@require 'settings/palette.styl'
 
 .pho-album-list
     display    flex

--- a/src/photos/styles/alerter.styl
+++ b/src/photos/styles/alerter.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'components/alerts.styl'
+@require 'settings/z-index.styl'
 
 .pho-alerter
     @extends $alerts

--- a/src/photos/styles/createAlbumForm.styl
+++ b/src/photos/styles/createAlbumForm.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/palette.styl'
 
 .pho-create-album-form
     @extend $form-text

--- a/src/photos/styles/layout.styl
+++ b/src/photos/styles/layout.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
+@require 'objects/layouts.styl'
 
 .pho-wrapper
     @extend    $app-2panes-sticky

--- a/src/photos/styles/loading.styl
+++ b/src/photos/styles/loading.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
+@require 'settings/icons.styl'
+@require 'settings/palette.styl'
 
 .pho-loading
   text-align center

--- a/src/photos/styles/newAlbum.styl
+++ b/src/photos/styles/newAlbum.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
+@require 'settings/palette.styl'
+@require 'settings/z-index.styl'
 
 .pho-panel
     position          fixed

--- a/src/photos/styles/photoList.styl
+++ b/src/photos/styles/photoList.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'settings/breakpoints.styl'
+@require 'settings/icons.styl'
+@require 'settings/palette.styl'
 
 :local
 

--- a/src/photos/styles/selectionbar.styl
+++ b/src/photos/styles/selectionbar.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'components/selectionbar.styl'
 
 :local
     @extend $selectionbar

--- a/src/photos/styles/toolbar.styl
+++ b/src/photos/styles/toolbar.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'components/button.styl'
+@require 'utilities/display.styl'
 
 .c-btn
     @extend $button

--- a/src/photos/styles/topbar.styl
+++ b/src/photos/styles/topbar.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/z-index.styl'
 
 $coz-bar-size = 3rem
 

--- a/src/sharing/components/autosuggest.styl
+++ b/src/sharing/components/autosuggest.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
+@require 'settings/z-index.styl'
 
 .container
     position relative

--- a/src/sharing/components/button.styl
+++ b/src/sharing/components/button.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
 
 .coz-btn-shared
     border-color     emerald

--- a/src/sharing/components/recipient.styl
+++ b/src/sharing/components/recipient.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'components/button.styl'
+@require 'settings/palette.styl'
 
 .pho-recipient
     display flex

--- a/src/sharing/share.styl
+++ b/src/sharing/share.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'components/forms.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/palette.styl'
 
 .divider
     border 0

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -1,4 +1,7 @@
-@require 'cozy-ui'
+@require 'components/selectionbar.styl'
+@require 'settings/breakpoints.styl'
+@require 'settings/palette.styl'
+@require 'settings/z-index.styl'
 
 // TODO: this is an overlay, we should use cozy-ui/react/Overlay
 .pho-viewer-wrapper


### PR DESCRIPTION
I've started replacing all the "require 'cozy-ui'" by their counterparts that only require what's needed.

I used this [script](https://gist.github.com/ptbrowne/41ef65b7097ea0977ddfa02b915cc19d) to show me the possible requires of a file to automate a bit the process. 

I've gotten good results so far, but I think thorough testing by someone more knowledgeable than me about the app should be done before merging.

```
Processed app.css. Length before: 859408, length after: 636587
Finish PostCSSAssetsPlugin
Hash: d315e25c78280cce38cd
Version: webpack 3.10.0
Time: 89626ms
                                   Asset       Size  Chunks                    Chunk Names
                                 app.css     637 kB       0  [emitted]  [big]  app
```

```
 94% asset optimizationStart PostCSSAssetsPlugin
Found external source map
Processing app.css...
Processed app.css. Length before: 530039, length after: 507620
Finish PostCSSAssetsPlugin
Hash: 3c594d5d00eb10a33788
Version: webpack 3.10.0
Time: 56464ms
                                   Asset       Size  Chunks                    Chunk Names
                                 app.css     508 kB       0  [emitted]  [big]  app
```

Reduction in app.css size pre PostCSSAssetsPlugin : 38%
Reduction in app.css size post PostCSSAssetsPlugin : 20%
Reduction in build time (first time) : 37%
Reduction in build time (incremental) : hard to measure, it is very dependent on the file that has been changed
