### PR TITLE
feat: navigate when handling cozydrive:// url

### DIFF
--- a/src/drive/mobile/lib/handleDeepLink.js
+++ b/src/drive/mobile/lib/handleDeepLink.js
@@ -1,0 +1,7 @@
+const PROTOCOL = 'cozydrive://'
+const RX = new RegExp('^' + PROTOCOL)
+
+export default history => url => {
+  const stripped = url.replace(RX, '')
+  history.push(stripped)
+}

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -38,6 +38,9 @@ if (__DEVELOPMENT__) {
   require('preact/devtools')
 }
 
+// Register callback for when the app is launched through cozydrive:// link
+window.handleOpenURL = require('drive/mobile/lib/handleDeepLink').default(hashHistory)
+
 const renderAppWithPersistedState = (persistedState = {}) => {
   const cozyURL = persistedState.mobile
     ? persistedState.mobile.settings.serverUrl


### PR DESCRIPTION
We use the `history` to navigate when we handle an URL `cozydrive://mylink`.