### PR TITLE
chore: add ios permission descriptions

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -98,4 +98,5 @@
     <plugin name="cordova-plugin-customurlscheme" spec="~4.3.0">
         <variable name="URL_SCHEME" value="cozydrive" />
     </plugin>
+    <plugin name="cordova-plugin-localization-strings" spec="https://github.com/kelvinhokk/cordova-plugin-localization-strings.git" />
 </widget>

--- a/targets/drive/mobile/translations/app/en.json
+++ b/targets/drive/mobile/translations/app/en.json
@@ -1,0 +1,6 @@
+{
+  "config_ios" : {
+    "NSContactsUsageDescription": "Save your phone's contact on your Cozy — this will facilitate sharing files with them.",
+    "NSPhotoLibraryUsageDescription": "Instantly back up and sync your photos and videos in your Cozy — so you never lose them."
+  }
+}

--- a/targets/drive/mobile/translations/app/fr.json
+++ b/targets/drive/mobile/translations/app/fr.json
@@ -1,0 +1,6 @@
+{
+  "config_ios" : {
+    "NSContactsUsageDescription": "Sauvegardez les contacts de votre appareil sur votre Cozy — cela facilitera le partage de fichiers avec eux.",
+    "NSPhotoLibraryUsageDescription": "Sauvegarde et synchronisation automatique de vos photos pour ne plus jamais les perdre."
+  }
+}


### PR DESCRIPTION
Adds descriptions for permission requests on iOS.

The file and folder structure is required by the plugin we use, so unfortunately these strings won't be in our translation system.
For languages without translation file, the app falls back on english or french, depending on how iOS is configured.