### PR TITLE
[WIP] Fix tab switching performance problems

### DIFF
--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -4,8 +4,9 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 
 const Empty = translate()(({ t, type, canUpload, localeKey }) => {
+  // The role="main" is here to get a blur effect on mobile when loading
   return (
-    <div className={styles[`c-empty-${type}`]}>
+    <div role="main" className={styles[`c-empty-${type}`]}>
       {localeKey ? (
         <div>
           <h2>{t(`empty.${localeKey}_title`)}</h2>
@@ -27,7 +28,7 @@ export const EmptyPhotos = props => <Empty type="photos" {...props} />
 
 export const EmptyTrash = translate()(({ t }) => {
   return (
-    <div className={styles['c-trash-empty']}>
+    <div role="main" className={styles['c-trash-empty']}>
       <h2>{t('empty.trash.title')}</h2>
       <p>{t('empty.trash.text')}</p>
     </div>

--- a/src/drive/components/FileList.jsx
+++ b/src/drive/components/FileList.jsx
@@ -44,8 +44,9 @@ class FileList extends PureComponent {
   }
 
   render() {
+    // The role="main" is here to get a blur effect on mobile when loading
     return (
-      <div>
+      <div role="main">
         {this.props.files.map((file, index) => {
           return this.rowRenderer({ index, key: file.id })
         })}

--- a/src/drive/components/FolderView.jsx
+++ b/src/drive/components/FolderView.jsx
@@ -63,6 +63,7 @@ class FolderView extends Component {
 
     const fetchFailed = this.props.fetchStatus === 'failed'
     const fetchPending = this.props.fetchStatus === 'pending'
+    const isNavigating = this.props.isNavigating
     const nothingToDo = isTrashContext && files.length === 0
     const folderId = getFolderIdFromRoute(
       this.props.location,
@@ -73,7 +74,7 @@ class FolderView extends Component {
     const toolbarActions = {}
     if (canCreateFolder) toolbarActions.addFolder = this.toggleAddFolder
     return (
-      <Main>
+      <Main working={isNavigating}>
         <Topbar>
           <Breadcrumb />
           <Toolbar

--- a/src/drive/components/Main.jsx
+++ b/src/drive/components/Main.jsx
@@ -3,11 +3,16 @@
 import styles from '../styles/main'
 
 import React from 'react'
+import classNames from 'classnames'
 
 import BannerClient from '../../components/pushClient/Banner'
 
-const Main = ({ children }) => (
-  <main className={styles['fil-content']}>
+const Main = ({ children, working = false }) => (
+  <main
+    className={classNames(styles['fil-content'], {
+      '--working': working
+    })}
+  >
     {__TARGET__ !== 'mobile' && <BannerClient />}
     {children}
   </main>

--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -126,11 +126,17 @@ const FileName = ({
       ) : (
         <div className={styles['fil-file']}>
           <div className={styles['fil-file-filename']}>
-            {filename}
-            {extension && (
-              <span className={styles['fil-content-ext']}>{extension}</span>
-            )}
-            {opening === true && <Spinner />}
+            <div className={styles['fil-file-filename-wrapper']}>
+              <div className={styles['fil-file-filename-and-ext']}>
+                {filename}
+                {extension && (
+                  <span className={styles['fil-content-ext']}>{extension}</span>
+                )}
+              </div>
+              <div className={styles['fil-file-filename-spinner']}>
+                {opening === true && <Spinner />}
+              </div>
+            </div>
           </div>
           {withFilePath &&
             (isMobile ? (

--- a/src/drive/containers/FileExplorer.jsx
+++ b/src/drive/containers/FileExplorer.jsx
@@ -22,7 +22,8 @@ import {
   getVisibleFiles,
   getSelectedFiles,
   getActionableFiles,
-  isActionMenuVisible
+  isActionMenuVisible,
+  isNavigating
 } from '../reducers'
 
 const isRecentFilesView = props => props.location.pathname.match(/^\/recent/)
@@ -67,6 +68,7 @@ class FileExplorer extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => ({
+  isNavigating: isNavigating(state),
   displayedFolder: state.view.displayedFolder,
   openedFolderId: getOpenedFolderId(state),
   fileCount: state.view.fileCount,

--- a/src/drive/containers/Nav.jsx
+++ b/src/drive/containers/Nav.jsx
@@ -24,8 +24,10 @@ class CustomLink extends Component {
   open(e) {
     e.preventDefault()
     this.setState({ opening: true })
+    this.props.onActiveChange()
     this.props.onClick().then(() => {
       this.setState({ opening: false })
+      this.props.onActiveChange()
       this.props.router.push(this.props.to)
     })
   }
@@ -68,66 +70,83 @@ class CustomLink extends Component {
 
 const ActiveLink = withBreakpoints()(withRouter(CustomLink))
 
-const Nav = ({ t, location, openFiles, openRecent, openTrash }) => {
-  return (
-    <nav>
-      <ul className={styles['coz-nav']}>
-        <li className={styles['coz-nav-item']}>
-          <ActiveLink
-            to="/folder"
-            onClick={openFiles}
-            className={classNames(
-              styles['coz-nav-link'],
-              styles['fil-cat-files']
-            )}
-            activeClassName={styles['active']}
-          >
-            {t('Nav.item_drive')}
-          </ActiveLink>
-        </li>
-        <li className={styles['coz-nav-item']}>
-          <ActiveLink
-            to="/recent"
-            onClick={openRecent}
-            className={classNames(
-              styles['coz-nav-link'],
-              styles['fil-cat-recent']
-            )}
-            activeClassName={styles['active']}
-          >
-            {t('Nav.item_recent')}
-          </ActiveLink>
-        </li>
-        <li className={styles['coz-nav-item']}>
-          <ActiveLink
-            to="/trash"
-            onClick={openTrash}
-            className={classNames(
-              styles['coz-nav-link'],
-              styles['fil-cat-trash']
-            )}
-            activeClassName={styles['active']}
-          >
-            {t('Nav.item_trash')}
-          </ActiveLink>
-        </li>
-        {__TARGET__ === 'mobile' && (
+class Nav extends Component {
+  state = {
+    opening: false
+  }
+
+  toggleOpening = () => this.setState(state => ({ opening: !state.opening }))
+
+  render() {
+    const { t, openFiles, openRecent, openTrash } = this.props
+    const { opening } = this.state
+    return (
+      <nav>
+        <ul className={styles['coz-nav']}>
           <li className={styles['coz-nav-item']}>
-            <Link
-              to="/settings"
+            <ActiveLink
+              to="/folder"
+              onClick={openFiles}
+              onActiveChange={this.toggleOpening}
               className={classNames(
                 styles['coz-nav-link'],
-                styles['fil-cat-settings']
+                styles['fil-cat-files']
               )}
               activeClassName={styles['active']}
+              disabled={opening}
             >
-              {t('Nav.item_settings')}
-            </Link>
+              {t('Nav.item_drive')}
+            </ActiveLink>
           </li>
-        )}
-      </ul>
-    </nav>
-  )
+          <li className={styles['coz-nav-item']}>
+            <ActiveLink
+              to="/recent"
+              onClick={openRecent}
+              onActiveChange={this.toggleOpening}
+              className={classNames(
+                styles['coz-nav-link'],
+                styles['fil-cat-recent']
+              )}
+              activeClassName={styles['active']}
+              disabled={opening}
+            >
+              {t('Nav.item_recent')}
+            </ActiveLink>
+          </li>
+          <li className={styles['coz-nav-item']}>
+            <ActiveLink
+              to="/trash"
+              onClick={openTrash}
+              onActiveChange={this.toggleOpening}
+              className={classNames(
+                styles['coz-nav-link'],
+                styles['fil-cat-trash']
+              )}
+              activeClassName={styles['active']}
+              disabled={opening}
+            >
+              {t('Nav.item_trash')}
+            </ActiveLink>
+          </li>
+          {__TARGET__ === 'mobile' && (
+            <li className={styles['coz-nav-item']}>
+              <Link
+                to="/settings"
+                className={classNames(
+                  styles['coz-nav-link'],
+                  styles['fil-cat-settings']
+                )}
+                activeClassName={styles['active']}
+                disabled={opening}
+              >
+                {t('Nav.item_settings')}
+              </Link>
+            </li>
+          )}
+        </ul>
+      </nav>
+    )
+  }
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/drive/reducers/index.js
+++ b/src/drive/reducers/index.js
@@ -30,6 +30,7 @@ export default filesApp
 
 // Selectors
 export {
+  isNavigating,
   getVisibleFiles,
   getFileById,
   getFolderIdFromRoute,

--- a/src/drive/reducers/view.js
+++ b/src/drive/reducers/view.js
@@ -27,6 +27,32 @@ import { isDirectory } from '../ducks/files/files'
 
 import { ROOT_DIR_ID, TRASH_DIR_ID } from '../constants/config.js'
 
+const hasDisplayedSomething = (state = false, action) => {
+  switch (action.type) {
+    case OPEN_FOLDER_SUCCESS:
+    case FETCH_RECENT_SUCCESS:
+      return true
+    default:
+      return state
+  }
+}
+
+const isOpening = (state = false, action) => {
+  switch (action.type) {
+    case OPEN_FOLDER:
+    case FETCH_RECENT:
+      return true
+    case OPEN_FOLDER_SUCCESS:
+    case FETCH_RECENT_SUCCESS:
+      return false
+    default:
+      return state
+  }
+}
+
+export const isNavigating = ({ view }) =>
+  view.hasDisplayedSomething && view.isOpening
+
 // reducer for the currently displayed folder properties
 const displayedFolder = (state = null, action) => {
   switch (action.type) {
@@ -180,6 +206,8 @@ const filesWithLinks = (state = {}, action) => {
 }
 
 export default combineReducers({
+  hasDisplayedSomething,
+  isOpening,
   displayedFolder,
   openedFolderId,
   fileCount,

--- a/src/drive/styles/main.styl
+++ b/src/drive/styles/main.styl
@@ -8,3 +8,16 @@ div:focus
 
     +small-screen()
         padding 0
+
+:global
+    .--working
+        // we forbid clicks when loading something to avoid concurrent data fetches and consequent flash effects
+        pointer-events none
+
+        // on mobile, we blur the main content during loading for visual feedback
+        // due to a FF bug, we can't apply the blur on <main> because position:fixed contents (like the empty folder content)
+        // get position changes (they go to the top)
+        // Consequently, we add a role="main" attribute to the content to be blurred (FileList and Empty)
+        +small-screen()
+            [role=main]
+                filter blur(1px)

--- a/src/drive/styles/nav.styl
+++ b/src/drive/styles/nav.styl
@@ -11,6 +11,9 @@
     @extend $nav-link
     position relative
 
+.coz-nav-link[disabled]
+    pointer-events none
+
 .fil-cat-files
     background-image: embedurl("../assets/icons/icon-folder.svg")
     &.active

--- a/src/drive/styles/table.styl
+++ b/src/drive/styles/table.styl
@@ -83,7 +83,7 @@
     line-height    1.3
     white-space    nowrap
     overflow       hidden
-    text-overflow  ellipsis
+    
     color charcoalGrey
 
 .fil-content-file-openable
@@ -154,9 +154,23 @@ mime-types('fil-file-', '../assets/icons/')
 
 .fil-file-filename
     flex 0 0 1.3rem
-    overflow hidden
-    text-overflow ellipsis
-    white-space nowrap
+
+.fil-file-filename-wrapper
+    display table
+    width   100%
+    border-collapse collapse
+
+    .fil-file-filename-and-ext
+        display table-cell
+        max-width 1px
+        width 100%
+        overflow hidden
+        text-overflow ellipsis
+        white-space nowrap
+
+    .fil-file-filename-spinner
+        display table-cell
+        white-space nowrap
 
 .fil-file-path
     flex 0 0 1.2rem


### PR DESCRIPTION
Actuellement, si la vue générale et la vue de la corbeille récupère les données dont elles ont besoin dans l'instance Pouch locale sur mobile, ce n'est pas le cas de la vue "Récents" qui fetche les données par le réseau, d'où un sentiment de lenteur en cas de réseau de piètre qualité. Le problème peut être exacerbé si l'utilisateur s'impatiente et clique sur d'autres onglets.

Cette PR implémente : 
 - la récupération des fichiers récents depuis PouchDB ;
 - la désactivation des onglets lorsque l'un d'entre eux vient d'être cliqué et que du contenu est en train de charger ;
 - le floutage du contenu sur mobile au chargement : j'ai pour cela ajouté 2 reducers et un [selector](https://github.com/cozy/cozy-drive/pull/690/files#diff-dba5935292b52df2da17bc1ea6222f12R53), selector qui est utilisé dans le composant `Main` pour ajouter une classe `--working` au `<main>` (https://github.com/cozy/cozy-drive/pull/690/files#diff-7621d809714fca21768223864efb2b8bR12)
 - le spinner de chargement d'un dossier au nom long et donc tronqué est maintenant visible.