### PR TITLE
Use viewer for file

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -17,6 +17,7 @@ module.exports = function(production) {
         'react-cozy-helpers': path.resolve(SRC_DIR, './lib/react-cozy-helpers')
       }
     },
+    stats: { chunks: false, modules: false },
     module: {
       rules: [
         {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "eslint-plugin-standard": "3.0.1",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.6",
+    "fs-extra": "^5.0.0",
     "git-directory-deploy": "1.5.1",
     "html-webpack-plugin": "2.30.1",
     "husky": "0.14.3",
@@ -129,7 +130,8 @@
     "svg-sprite-loader": "0.0.31",
     "webpack": "3.10.0",
     "webpack-dev-server": "2.11.0",
-    "webpack-merge": "1.1.2"
+    "webpack-merge": "1.1.2",
+    "xml2js": "^0.4.19"
   },
   "dependencies": {
     "classnames": "^2.2.0",

--- a/src/drive/mobile/lib/device.js
+++ b/src/drive/mobile/lib/device.js
@@ -8,7 +8,11 @@ export const isAndroid = () => isPlatform('android')
 
 // device
 const hasCordovaDeviceNamePlugin = () =>
-  isCordova() && window.cordova.plugins.deviceName !== undefined
+  isCordova() &&
+  window.cordova &&
+  window.cordova.plugins &&
+  window.cordova.plugins.deviceName !== undefined
+
 export const getDeviceName = () =>
   hasCordovaDeviceNamePlugin()
     ? window.cordova.plugins.deviceName.name

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,6 +3841,14 @@ from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-vacuum@~1.2.9:
   version "1.2.10"
   resolved "https://registry.yarnpkg.com/fs-vacuum/-/fs-vacuum-1.2.10.tgz#b7629bec07a4031a2548fdf99f5ecf1cc8b31e36"
@@ -5563,6 +5571,12 @@ json3@^3.3.2:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -9158,7 +9172,7 @@ sax@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.4.tgz#74b6d33c9ae1e001510f179a91168588f1aedaa9"
 
-sax@^1.2.1, sax@~1.2.1:
+sax@>=0.6.0, sax@^1.2.1, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -10411,6 +10425,10 @@ unist-util-visit@^1.1.0, unist-util-visit@^1.1.3:
   dependencies:
     unist-util-is "^2.1.1"
 
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
+
 unorm@1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.3.3.tgz#16a8772671ebd6f7cde6f8c5e49bb60ac47dba93"
@@ -10929,6 +10947,13 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
+xml2js@^0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
 xmlbuilder@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.0.0.tgz#98b8f651ca30aa624036f127d11cc66dc7b907a3"
@@ -10938,6 +10963,10 @@ xmlbuilder@4.0.0:
 xmlbuilder@8.2.2:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+
+xmlbuilder@~9.0.1:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.4.tgz#519cb4ca686d005a8420d3496f3f0caeecca580f"
 
 xmldom@0.1.x:
   version "0.1.27"


### PR DESCRIPTION
## Background

From Bank, we need to be able to open Drive on a specific file. We cannot retrieve the parent of the file (we have no permission on io.cozy.files) so we cannot redirect to `/folder/$folderId/file/$fileId` from bank.


## Solution

I changed FileOpener which had already the role of fetching file information and displaying it to use the Viewer.

The `/file/$fileId` route now fetches the file and redirects (router.replace not to add an entry in the back button history) to `/folder/$fileFolderId/file/$fileId`.