### PR TITLE
fix: raven errors on mobile

### DIFF
--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -32,8 +32,8 @@ module.exports = function(production, app) {
         __ALLOW_HTTP__: !production,
         __TARGET__: JSON.stringify('mobile'),
         __SENTRY_TOKEN__: production
-          ? JSON.stringify('9259817fbb44484b8b7a0a817d968ae4')
-          : JSON.stringify('29bd1255b6d544a1b65435a634c9ff67'),
+          ? JSON.stringify('9259817fbb44484b8b7a0a817d968ae4:171a3bcb3095448484aa3e709ea47e9b')
+          : JSON.stringify('29bd1255b6d544a1b65435a634c9ff67:ba312a96643d4f98aee26c6378c74212'),
         __APP_VERSION__: JSON.stringify(pkg.version)
       }),
       new ProvidePlugin({

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "preact": "8.2.7",
     "preact-compat": "3.17.0",
     "prop-types": "^15.5.10",
-    "raven-js": "^3.10.0",
+    "raven-js": "3.22.1",
     "react-autosuggest": "^9.3.2",
     "react-copy-to-clipboard": "^5.0.0",
     "react-markdown": "^3.0.0",

--- a/src/drive/mobile/lib/reporter.js
+++ b/src/drive/mobile/lib/reporter.js
@@ -1,4 +1,4 @@
-/* global __SENTRY_TOKEN__, __DEVELOPMENT__ */
+/* global __SENTRY_TOKEN__, __DEVELOPMENT__, __APP_VERSION__ */
 import Raven from 'raven-js'
 
 const getAnalyticsUrl = () => {
@@ -15,7 +15,9 @@ export const ANALYTICS_URL = getAnalyticsUrl()
 
 export const getReporterConfiguration = () => ({
   shouldSendCallback: true,
-  environment: __DEVELOPMENT__ ? 'development' : 'production'
+  environment: __DEVELOPMENT__ ? 'development' : 'production',
+  release: __APP_VERSION__,
+  allowSecretKey: true
 })
 
 export const configureReporter = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8385,7 +8385,11 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@^3.1.1, raven-js@^3.10.0:
+raven-js@3.22.1:
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.22.1.tgz#1117f00dfefaa427ef6e1a7d50bbb1fb998a24da"
+
+raven-js@^3.1.1:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.21.0.tgz#609236eb0ec30faf696b552f842a80b426be6258"
 


### PR DESCRIPTION
For some reason I still have to investigate, our version or raven-js is not pinned. This resulted in us shipping the app with a new minor version of raven, v3.21 — and that's where the actual problem starts.
From that version on, raven uses `fetch` instead of `XHR` when available. Somehow, when using `fetch` from cordova, the `Origin` header is set to `null` and this [causes the error](https://github.com/getsentry/sentry/issues/4060) we experienced.

One way to work around this is to use the secret DSN, as described [here](https://docs.sentry.io/clients/javascript/config/) in the section about `allowSecretKey`. 
 The only alternative I found would be to downgrade `raven-js`.