### PR TITLE
chore: activate version pining for dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "pinVersions": true,
   "schedule": ["before 9am on Monday"],
   "timezone": "Europe/Paris"
 }


### PR DESCRIPTION
Following up on #696, activate pinning for regular dependencies too. We'll probably get a couple more PRs from renovate, but we won't have any sneaky `yarn.lock` updates to deal with either. 