### PR TITLE
Polyfill

### DIFF
--- a/src/authentication/package.json
+++ b/src/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-authentication",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Component providing login to a Cozy",
   "main": "build/index.js",
   "author": "Cozy",

--- a/src/authentication/package.json
+++ b/src/authentication/package.json
@@ -23,6 +23,6 @@
     "cozy-ui": "^7.0.2"
   },
   "dependencies": {
-    "whatwg-url": "^6.4.0"
+    "url-polyfill": "^1.0.10"
   }
 }

--- a/src/authentication/steps/SelectServer.jsx
+++ b/src/authentication/steps/SelectServer.jsx
@@ -8,7 +8,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import { Button } from 'cozy-ui/react'
 import styles from '../styles'
 
-require('whatwg-url')
+require('url-polyfill')
 
 const ERR_WRONG_ADDRESS = 'mobile.onboarding.server_selection.wrong_address'
 const ERR_EMAIL = 'mobile.onboarding.server_selection.wrong_address_with_email'

--- a/src/authentication/yarn.lock
+++ b/src/authentication/yarn.lock
@@ -5917,6 +5917,10 @@ url-parse@^1.1.8:
     querystringify "~1.0.0"
     requires-port "~1.0.0"
 
+url-polyfill@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.0.10.tgz#097b81b3cf7556bfc396a3c8633044d410e36685"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -6157,7 +6161,7 @@ whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
-whatwg-url@^6.3.0, whatwg-url@^6.4.0:
+whatwg-url@^6.3.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
   dependencies:


### PR DESCRIPTION
Foolow up on #694 : turns out `whatwg-polyfill` is meant for node and isn't really safe to use with webpack, unless we add some extra configuration. it also provides a lot of things we don't really need, so i'm falling back to the other, simpler polyfill.

I'm also bumping the version number of cozy-authentication for an upcoming release.