### PR TITLE
Change support email to contact

### DIFF
--- a/src/drive/mobile/containers/RatingModal.jsx
+++ b/src/drive/mobile/containers/RatingModal.jsx
@@ -15,7 +15,7 @@ const ALERT_RATING = 'ALERT_RATING'
 const BUTTON_INDEX_RATE = 1
 const BUTTON_INDEX_LATER = 2
 
-const FEEDBACK_EMAIL = 'feedback@cozycloud.cc'
+const FEEDBACK_EMAIL = 'contact@cozycloud.cc'
 const PROMPT_AFTER_BOOTS = 5
 
 // RatingModal is the base component

--- a/src/drive/mobile/ducks/mediaBackup/UploadQuotaError.jsx
+++ b/src/drive/mobile/ducks/mediaBackup/UploadQuotaError.jsx
@@ -5,7 +5,7 @@ import { Button, Icon } from 'cozy-ui/react'
 import classnames from 'classnames'
 import styles from './styles'
 
-const FEEDBACK_EMAIL = 'feedback@cozycloud.cc'
+const FEEDBACK_EMAIL = 'contact@cozycloud.cc'
 
 class QuotaModal extends Component {
   state = {


### PR DESCRIPTION
We've been using different emails for different purposes in the past. We decided to drive all user email interactions to contact@cozycloud.cc. As a result I suggest this change.