### PR TITLE
Upload fixups

### DIFF
--- a/src/drive/mobile/containers/MediaBackupProgression.jsx
+++ b/src/drive/mobile/containers/MediaBackupProgression.jsx
@@ -25,7 +25,7 @@ const mapStateToProps = state =>
 const UploadStatus = props => {
   const { t, current, total, media, aborted, quotaError } = props
 
-  if (media && current && total)
+  if (media !== undefined && current !== undefined && total !== undefined)
     return (
       <UploadProgression t={t} current={current} total={total} media={media} />
     )

--- a/src/drive/mobile/ducks/mediaBackup/index.js
+++ b/src/drive/mobile/ducks/mediaBackup/index.js
@@ -70,6 +70,7 @@ export const startMediaBackup = (
       for (const photo of photosToUpload) {
         if (
           getState().mobile.mediaBackup.cancelMediaBackup ||
+          getState().mobile.mediaBackup.diskQuotaReached ||
           !canBackup(isManualBackup, getState)
         ) {
           break


### PR DESCRIPTION
- Turns out we'd rather interrupt the upload as soon as we get a quota error, otherwise the user never sees it
- When the upload starts, `mobile.mediaBackup.something.current` is `0` so if we just test `current` instead of `current !== undefined` the uploader doesn't show up.