### PR TITLE
feat: add infinite progress bar for individual photos

### DIFF
--- a/src/drive/mobile/containers/MediaBackupProgression.jsx
+++ b/src/drive/mobile/containers/MediaBackupProgression.jsx
@@ -10,12 +10,10 @@ import UploadUptodate from '../ducks/mediaBackup/UploadUptodate'
 const mapStateToProps = state =>
   state.mobile.mediaBackup.currentUpload
     ? {
-        media: state.mobile.mediaBackup.currentUpload.media,
         current: state.mobile.mediaBackup.currentUpload.messageData.current,
         total: state.mobile.mediaBackup.currentUpload.messageData.total
       }
     : {
-        media: undefined,
         current: undefined,
         total: undefined,
         aborted: state.mobile.mediaBackup.abortedMediaBackup,
@@ -23,12 +21,10 @@ const mapStateToProps = state =>
       }
 
 const UploadStatus = props => {
-  const { t, current, total, media, aborted, quotaError } = props
+  const { t, current, total, aborted, quotaError } = props
 
-  if (media !== undefined && current !== undefined && total !== undefined)
-    return (
-      <UploadProgression t={t} current={current} total={total} media={media} />
-    )
+  if (current !== undefined && total !== undefined)
+    return <UploadProgression t={t} current={current} total={total} />
   else if (aborted) return <UploadAbortedWifi t={t} />
   else if (quotaError) return <UploadQuotaError t={t} />
   else return <UploadUptodate t={t} />

--- a/src/drive/mobile/containers/MediaBackupProgression.jsx
+++ b/src/drive/mobile/containers/MediaBackupProgression.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { translate } from 'cozy-ui/react/I18n'
+import PropTypes from 'prop-types'
 
 import UploadProgression from '../ducks/mediaBackup/UploadProgression'
 import UploadAbortedWifi from '../ducks/mediaBackup/UploadAbortedWifi'
@@ -28,6 +29,14 @@ const UploadStatus = props => {
   else if (aborted) return <UploadAbortedWifi t={t} />
   else if (quotaError) return <UploadQuotaError t={t} />
   else return <UploadUptodate t={t} />
+}
+
+UploadStatus.propTypes = {
+  t: PropTypes.func.isRequired,
+  current: PropTypes.number,
+  total: PropTypes.number,
+  aborted: PropTypes.bool,
+  quotaError: PropTypes.bool
 }
 
 export default connect(mapStateToProps)(translate()(UploadStatus))

--- a/src/drive/mobile/ducks/mediaBackup/UploadAbortedWifi.jsx
+++ b/src/drive/mobile/ducks/mediaBackup/UploadAbortedWifi.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
+import PropTypes from 'prop-types'
 import styles from './styles'
 
 const UploadAbortedWifi = ({ t }) => (
@@ -14,5 +15,9 @@ const UploadAbortedWifi = ({ t }) => (
     </div>
   </div>
 )
+
+UploadAbortedWifi.propTypes = {
+  t: PropTypes.func.isRequired
+}
 
 export default UploadAbortedWifi

--- a/src/drive/mobile/ducks/mediaBackup/UploadProgression.jsx
+++ b/src/drive/mobile/ducks/mediaBackup/UploadProgression.jsx
@@ -1,36 +1,18 @@
 import React from 'react'
 import styles from './styles'
 
-const percent = (actual, total) => Math.floor(actual * 100 / total)
-
-const Progress = ({ percent, style, color, background }) => {
-  const containerStyle = {
-    opacity: percent < 100 ? 1 : 0,
-    transition: `${0.4}s opacity}`,
-    transitionDelay: `${percent < 100 ? 0 : 0.4}s`,
-    height: `${2}px`,
-    backgroundColor: background ? 'lightgray' : ''
-  }
-  const barStyle = {
-    width: `${percent}%`,
-    ...style
-  }
+const UploadProgression = ({ t, current, total }) => {
   return (
-    <div style={containerStyle}>
-      <div className={styles['coz-progress']} style={barStyle} />
-    </div>
-  )
-}
-
-const UploadProgression = ({ t, current, total, media }) => {
-  return (
-    <div className={styles['coz-upload-status']}>
-      <Progress percent={percent(current, total)} />
-      <div className={styles['coz-progress-pic']} />
-      <div className={styles['coz-upload-status-content']}>
-        {t('mobile.settings.media_backup.media_upload', {
-          smart_count: total - current
-        })}
+    <div>
+      <progress max={total} value={current} />
+      <div className={styles['coz-upload-status']}>
+        <div className={styles['coz-progress-pic']} />
+        <div className={styles['coz-upload-status-content']}>
+          {t('mobile.settings.media_backup.media_upload', {
+            smart_count: total - current
+          })}
+          <div className={styles['infinite-progress']} />
+        </div>
       </div>
     </div>
   )

--- a/src/drive/mobile/ducks/mediaBackup/UploadProgression.jsx
+++ b/src/drive/mobile/ducks/mediaBackup/UploadProgression.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styles from './styles'
 
 const UploadProgression = ({ t, current, total }) => {
@@ -16,6 +17,12 @@ const UploadProgression = ({ t, current, total }) => {
       </div>
     </div>
   )
+}
+
+UploadProgression.propTypes = {
+  current: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired,
+  t: PropTypes.func.isRequired
 }
 
 export default UploadProgression

--- a/src/drive/mobile/ducks/mediaBackup/UploadQuotaError.jsx
+++ b/src/drive/mobile/ducks/mediaBackup/UploadQuotaError.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 import { Button, Icon } from 'cozy-ui/react'
 import classnames from 'classnames'
+import PropTypes from 'prop-types'
 import styles from './styles'
 
 const FEEDBACK_EMAIL = 'contact@cozycloud.cc'
@@ -80,6 +81,11 @@ class QuotaModal extends Component {
   }
 }
 
+QuotaModal.propTypes = {
+  t: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired
+}
+
 class UploadQuotaError extends Component {
   state = {
     modalOpened: false
@@ -114,6 +120,10 @@ class UploadQuotaError extends Component {
       </div>
     )
   }
+}
+
+UploadQuotaError.propTypes = {
+  t: PropTypes.func.isRequired
 }
 
 export default UploadQuotaError

--- a/src/drive/mobile/ducks/mediaBackup/UploadUptodate.jsx
+++ b/src/drive/mobile/ducks/mediaBackup/UploadUptodate.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
+import PropTypes from 'prop-types'
 import styles from './styles'
 
 const UploadUptodate = ({ t }) => (
@@ -14,5 +15,9 @@ const UploadUptodate = ({ t }) => (
     </div>
   </div>
 )
+
+UploadUptodate.propTypes = {
+  t: PropTypes.func.isRequired
+}
 
 export default UploadUptodate

--- a/src/drive/mobile/ducks/mediaBackup/styles.styl
+++ b/src/drive/mobile/ducks/mediaBackup/styles.styl
@@ -11,16 +11,51 @@
     background-color paleGrey
     transition bottom 0.5s ease-out, top 0.5s ease-out, opacity 0.2s ease-out
 
-.coz-progress
-    position absolute
+progress
+    -webkit-appearance none
+    -moz-appearance    none
+    border     none
+    display    block
+    width      100%
+    height     .125rem
+    margin     0
+    background lightgray
+
+progress::-webkit-progress-bar
+    background-color silver
+progress::-webkit-progress-value
     background-color dodgerBlue
-    border-radius 0 .0625rem .0625rem 0
-    max-width 100%
-    height .125rem
+progress::-moz-progress-bar
+    background-color dodgerBlue
+
+.infinite-progress
+  width 100%
+  height .125rem
+  background lightgray
+  position relative
+  overflow hidden
+  margin-top .5rem
+
+  &:before
+    content ""
+    display block
+    height 100%
+    width 0
+    position absolute
     top 0
     left 0
-    display inline-block
-    transition 0.4s width, 0.4s background-color
+    background dodgerBlue
+    animation squashstretch 1s linear infinite alternate
+
+@keyframes squashstretch
+  0%
+    width 10%
+  50%
+    width 80%
+    left 10%
+  100%
+    width 10%
+    left 90%
 
 .coz-progress-pic
     position relative


### PR DESCRIPTION
I've added an infinite progress bar for individual files, like this : https://gfycat.com/InformalImpressionableDuckbillcat

I also remove a `div`-based progress bar with a `progress` element.