### PR TITLE
Added viewer to trash and recent views

### DIFF
--- a/src/drive/actions/index.js
+++ b/src/drive/actions/index.js
@@ -86,33 +86,132 @@ export const openFolder = folderId => {
     })
     try {
       const settings = getState().settings
-      const offline = settings.offline && settings.firstReplication
-      const folder = await cozy.client.files.statById(folderId, offline)
-      const parentId = folder.attributes.dir_id
-      const parent =
-        !!parentId &&
-        (await cozy.client.files.statById(parentId, offline).catch(ex => {
-          if (ex.status === 403) {
-            console.warn("User don't have access to parent folder")
-          } else {
-            throw ex
-          }
-        }))
-      const contents = folder.relationships.contents
-      // folder.relations('contents') returns null when the trash is empty
-      // the filter call is a temporary fix due to a cozy-client-js bug
-      const files =
-        folder.relations('contents').filter(f => f !== undefined) || []
+      const offline =
+        settings.offline && settings.firstReplication && settings.indexes
+      // PB: Pouch Mango queries don't return the total count...
+      // and so the fetchMore button would not be displayed unless... see FileList
+      const folder = offline
+        ? await getFolderFromPouchDB(settings.indexes.folders, folderId)
+        : await getFolderFromStack(folderId)
+
       return dispatch({
         type: OPEN_FOLDER_SUCCESS,
-        folder: Object.assign(extractFileAttributes(folder), {
-          parent: !!parent && extractFileAttributes(parent)
-        }),
-        fileCount: contents.meta.count || 0,
-        files: files.map(c => extractFileAttributes(c))
+        folder,
+        fileCount: folder.contents.meta.count || 0,
+        files: folder.contents.data
       })
     } catch (err) {
       return dispatch({ type: OPEN_FOLDER_FAILURE, error: err })
+    }
+  }
+}
+
+const getFolderFromStack = async folderId => {
+  const folder = await cozy.client.files.statById(folderId, false, {
+    limit: 30
+  })
+  const parentId = folder.attributes.dir_id
+  const parent =
+    !!parentId &&
+    (await cozy.client.files.statById(parentId).catch(ex => {
+      if (ex.status === 403) {
+        console.warn("User don't have access to parent folder")
+      } else {
+        throw ex
+      }
+    }))
+  // folder.relations('contents') returns null when the trash is empty
+  // the filter call is a temporary fix due to a cozy-client-js bug
+  const files = folder.relations('contents').filter(f => f !== undefined) || []
+  return {
+    ...extractFileAttributes(folder),
+    contents: {
+      data: files.map(f => extractFileAttributes(f)),
+      meta: {
+        count: folder.relationships.contents.meta.count
+      }
+    },
+    parent: !!parent && extractFileAttributes(parent)
+  }
+}
+
+const getFolderContentsFromStack = async (folderId, skip = 0, limit = 30) => {
+  const folder = await cozy.client.files.statById(folderId, false, {
+    skip,
+    limit
+  })
+  const files = folder.relations('contents').filter(f => f !== undefined) || []
+  return files.map(c => extractFileAttributes(c))
+}
+
+const normalizeFileFromPouchDB = f => ({
+  ...f,
+  id: f._id,
+  _type: 'io.cozy.files'
+})
+
+const getFolderFromPouchDB = async (index, folderId) => {
+  const db = cozy.client.offline.getDatabase('io.cozy.files')
+  const folder = await db.get(folderId)
+  const parent = !!folder.dir_id && (await db.get(folder.dir_id))
+  const files = await getFolderContentsFromPouchDB(index, folderId)
+  return {
+    ...normalizeFileFromPouchDB(folder),
+    contents: {
+      data: files,
+      meta: {}
+    },
+    parent: !!parent && normalizeFileFromPouchDB(parent)
+  }
+}
+
+const getFolderContentsFromPouchDB = async (
+  index,
+  folderId,
+  skip = 0,
+  limit = 30
+) => {
+  const db = cozy.client.offline.getDatabase('io.cozy.files')
+  const resp = await db.find({
+    selector: {
+      dir_id: folderId,
+      name: { $gte: null },
+      type: { $gte: null }
+    },
+    use_index: index,
+    sort: ['dir_id', { type: 'desc' }, { name: 'desc' }],
+    limit,
+    skip
+  })
+  const files = resp.docs
+    .filter(f => f._id !== TRASH_DIR_ID)
+    .map(f => normalizeFileFromPouchDB(f))
+  return files
+}
+
+export const fetchMoreFiles = (folderId, skip, limit) => {
+  return async (dispatch, getState) => {
+    dispatch({ type: FETCH_MORE_FILES, folderId, skip, limit })
+    try {
+      const settings = getState().settings
+      const offline =
+        settings.offline && settings.firstReplication && settings.indexes
+      const files = offline
+        ? await getFolderContentsFromPouchDB(
+            settings.indexes.folders,
+            folderId,
+            skip,
+            limit
+          )
+        : await getFolderContentsFromStack(folderId, skip, limit)
+      return dispatch({
+        type: FETCH_MORE_FILES_SUCCESS,
+        files,
+        skip,
+        limit
+      })
+    } catch (err) {
+      return dispatch({ type: FETCH_MORE_FILES_FAILURE, error: err })
     }
   }
 }
@@ -127,9 +226,11 @@ export const fetchRecentFiles = () => {
     })
 
     try {
-      const isLocallyAvailable = isCordova()
+      const settings = getState().settings
+      const isLocallyAvailable =
+        isCordova() && settings.firstReplication && settings.indexes
       const files = await (isLocallyAvailable
-        ? getRecentFilesFromPouchDB()
+        ? getRecentFilesFromPouchDB(settings.indexes.recent)
         : fetchRecentFilesFromStack())
 
       // fetch the list of parent dirs to get the path of recent files
@@ -167,7 +268,7 @@ const RECENT_FILES_QUERY_OPTIONS = {
     trashed: false
   },
   sort: [{ updated_at: 'desc' }],
-  limit: 50
+  limit: 30
 }
 
 export const fetchRecentFilesFromStack = async () => {
@@ -187,15 +288,18 @@ export const fetchRecentFilesFromStack = async () => {
   }))
 }
 
-const getRecentFilesFromPouchDB = async () => {
+const getRecentFilesFromPouchDB = async index => {
   const db = cozy.client.offline.getDatabase('io.cozy.files')
-  await db.createIndex({
-    index: {
-      fields: RECENT_FILES_INDEX_FIELDS
-    }
+  const files = await db.query(index, {
+    limit: 30,
+    include_docs: true,
+    descending: true
   })
-  const files = await db.find(RECENT_FILES_QUERY_OPTIONS)
-  return files.docs
+  return files.rows.map(f => ({
+    ...f.doc,
+    id: f.id,
+    _type: 'io.cozy.files'
+  }))
 }
 
 const fetchFilesInBatchFromStack = ids =>
@@ -211,30 +315,6 @@ const getFilesInBatchFromPouchDB = ids => {
     include_docs: true,
     keys: ids
   })
-}
-
-export const fetchMoreFiles = (folderId, skip, limit) => {
-  return async (dispatch, getState) => {
-    dispatch({ type: FETCH_MORE_FILES, folderId, skip, limit })
-    try {
-      const settings = getState().settings
-      const offline = settings.offline && settings.firstReplication
-      const folder = await cozy.client.files.statById(folderId, offline, {
-        skip,
-        limit
-      })
-      const files =
-        folder.relations('contents').filter(f => f !== undefined) || []
-      return dispatch({
-        type: FETCH_MORE_FILES_SUCCESS,
-        files: files.map(c => extractFileAttributes(c)),
-        skip,
-        limit
-      })
-    } catch (err) {
-      return dispatch({ type: FETCH_MORE_FILES_FAILURE, error: err })
-    }
-  }
 }
 
 export const getFileDownloadUrl = async id => {

--- a/src/drive/actions/settings.js
+++ b/src/drive/actions/settings.js
@@ -1,10 +1,15 @@
 export const SET_CLIENT = 'SET_CLIENT'
 export const SET_OFFLINE = 'SET_OFFLINE'
 export const SET_FIRST_REPLICATION = 'SET_FIRST_REPLICATION'
+export const SET_POUCH_INDEXES = 'SET_POUCH_INDEXES'
 
 export const setClient = client => ({ type: SET_CLIENT, client })
 export const setOffline = offline => ({ type: SET_OFFLINE, offline })
 export const setFirstReplication = firstReplication => ({
   type: SET_FIRST_REPLICATION,
   firstReplication
+})
+export const setPouchIndexes = indexes => ({
+  type: SET_POUCH_INDEXES,
+  indexes
 })

--- a/src/drive/components/AppRoute.jsx
+++ b/src/drive/components/AppRoute.jsx
@@ -27,8 +27,15 @@ const AppRoute = (
         <Route path="folder/:folderId" component={Folder}>
           <Route path="file/:fileId" component={FilesViewer} />
         </Route>
-        <Route path="recent" component={Recent} />
-        <Route path="trash(/:folderId)" component={Trash} />
+        <Route path="recent" component={Recent}>
+          <Route path="file/:fileId" component={FilesViewer} />
+        </Route>
+        <Route path="trash" component={Trash}>
+          <Route path="file/:fileId" component={FilesViewer} />
+        </Route>
+        <Route path="trash/:folderId" component={Trash}>
+          <Route path="file/:fileId" component={FilesViewer} />
+        </Route>
       </Route>
       {__TARGET__ === 'mobile' && (
         <Route path="settings" component={Settings} />

--- a/src/drive/components/FilesViewer.jsx
+++ b/src/drive/components/FilesViewer.jsx
@@ -1,10 +1,8 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import Viewer from 'viewer'
-import { LoadingViewer } from 'viewer/Viewer'
-import Alerter from 'photos/components/Alerter'
 import { getFolderIdFromRoute } from '../reducers/view'
-import { fetchMoreFiles, fetchRecentFilesFromStack } from '../actions'
+import { fetchMoreFiles } from '../actions'
 
 const LIMIT = 30
 
@@ -14,87 +12,23 @@ const getParentPath = router => {
 }
 
 class FilesViewer extends Component {
-  state = {
-    filesWithLinks: null,
-    loading: false
-  }
-
-  componentWillMount() {
-    if (this.needLinks()) {
-      this.setState(state => ({ ...state, loading: true }))
-      this.fetchFilesWithLinks()
-        .then(files => {
-          this.setState(state => ({
-            ...state,
-            filesWithLinks: files,
-            loading: false
-          }))
-        })
-        .catch(() => Alerter.error('Viewer.error.noNetwork'))
-    }
-  }
-
   componentDidMount() {
-    this.fetchMore()
+    this.fetchMoreIfNecessary()
   }
 
   componentWillReceiveProps(props, nextProps) {
-    this.fetchMore()
-  }
-
-  needLinks() {
-    return this.props.files.some(f => f.class === 'image' && !f.links)
-  }
-
-  isFetchingLinks() {
-    return this.needLinks() && this.state.loading
-  }
-
-  getFiles() {
-    return this.needLinks()
-      ? this.state.filesWithLinks
-          .filter(f => f.type !== 'directory')
-          .map(f => ({
-            ...f,
-            isAvailableOffline: this.props.isAvailableOffline(f.id)
-          }))
-      : this.props.files.filter(f => f.type !== 'directory')
+    this.fetchMoreIfNecessary()
   }
 
   // if we get close of the last file fetched, but we know there are more in the folder
   // (it shouldn't happen in /recent), we fetch 50 more files
-  fetchMore() {
-    if (this.isFetchingLinks()) return
-    const files = this.needLinks()
-      ? this.state.filesWithLinks
-      : this.props.files
-    const { params, location, fetchMoreFiles, fileCount } = this.props
+  fetchMoreIfNecessary() {
+    const { files, params, location, fetchMoreFiles, fileCount } = this.props
+    if (files.length === 0) return // we get there when loading a direct URL and the folder's content is still loading
     const currentIndex = files.findIndex(f => f.id === params.fileId)
     if (files.length !== fileCount && files.length - currentIndex <= 5) {
       const folderId = getFolderIdFromRoute(location, params)
-      if (this.needLinks()) {
-        this.context.client
-          .fetchFilesForLinks(folderId, files.length)
-          .then(files => {
-            this.setState(state => ({
-              ...state,
-              filesWithLinks: [...state.filesWithLinks, ...files]
-            }))
-          })
-      } else {
-        fetchMoreFiles(folderId, files.length, LIMIT)
-      }
-    }
-  }
-
-  fetchFilesWithLinks() {
-    const { params, location } = this.props
-    const folderId = getFolderIdFromRoute(location, params)
-    if (!folderId) {
-      // we must be in /recent
-      return fetchRecentFilesFromStack()
-    } else {
-      return this.context.client.fetchFilesForLinks(folderId)
+      fetchMoreFiles(folderId, files.length, LIMIT)
     }
   }
 
@@ -106,19 +40,20 @@ class FilesViewer extends Component {
     })
   }
 
+  getCurrentIndex() {
+    const { files, params } = this.props
+    return files.findIndex(f => f.id === params.fileId)
+  }
+
   render() {
-    if (this.isFetchingLinks()) {
-      return <LoadingViewer />
-    }
-    const files = this.getFiles()
+    const { files, router } = this.props
     if (files.length === 0) return null
-    const { params, router } = this.props
-    const currentIndex = files.findIndex(f => f.id === params.fileId)
+    const currentIndex = this.getCurrentIndex()
     // TODO: if we can't find the file, that's probably because the user is trying to open
     // a direct link to a file that wasn't in the first 50 files of the containing folder
     // (it comes from a fetchMore...)
     if (currentIndex === -1) {
-      console.warn("can't find the file " + params.fileId)
+      console.warn("can't find the file")
       this.onClose()
       return null
     }

--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -247,8 +247,6 @@ class File extends Component {
           ...attributes,
           availableOffline: this.props.isAvailableOffline
         })
-        // } else if (viewPath === '/recent' || viewPath === '/trash') {
-        //   this.props.onFileOpen({ ...attributes })
       } else {
         this.props.router.push(`${viewPath}/file/${attributes.id}`)
       }

--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -247,8 +247,8 @@ class File extends Component {
           ...attributes,
           availableOffline: this.props.isAvailableOffline
         })
-      } else if (viewPath === '/recent' || viewPath === '/trash') {
-        this.props.onFileOpen({ ...attributes })
+        // } else if (viewPath === '/recent' || viewPath === '/trash') {
+        //   this.props.onFileOpen({ ...attributes })
       } else {
         this.props.router.push(`${viewPath}/file/${attributes.id}`)
       }

--- a/src/drive/containers/FileExplorer.jsx
+++ b/src/drive/containers/FileExplorer.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 
-import { withClient, fetchSharings, getSharingDetails } from 'cozy-client'
+import { fetchSharings, getSharingDetails } from 'cozy-client'
 
 import {
   toggleItemSelection,
@@ -94,13 +94,12 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchRecentFiles: () => dispatch(fetchRecentFiles()),
   fetchMoreFiles: (folderId, skip, limit) =>
     dispatch(fetchMoreFiles(folderId, skip, limit)),
-  // TODO: we must pass the client here so that we can fetch the thumbnails links on mobile
-  onFolderOpen: folderId => dispatch(openFolder(folderId, ownProps.client)),
+  onFolderOpen: folderId => dispatch(openFolder(folderId)),
   onFileOpen: file => dispatch(openFileInNewTab(file)),
   onFileToggle: (file, selected) =>
     dispatch(toggleItemSelection(file, selected))
 })
 
-export default withClient(
-  connect(mapStateToProps, mapDispatchToProps)(withRouter(FileExplorer))
+export default connect(mapStateToProps, mapDispatchToProps)(
+  withRouter(FileExplorer)
 )

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -447,7 +447,8 @@
     },
     "error": {
       "noapp": "No application found to handle this file.",
-      "generic": "An error occurred when opening this file, please try again."
+      "generic": "An error occurred when opening this file, please try again.",
+      "noNetwork": "You're currently offline."
     }
   }
 }

--- a/src/drive/mobile/actions/settings.js
+++ b/src/drive/mobile/actions/settings.js
@@ -1,5 +1,9 @@
 import { startReplication as startPouchReplication } from '../lib/replication'
-import { setClient, setFirstReplication } from '../../actions/settings'
+import {
+  setClient,
+  setFirstReplication,
+  setPouchIndexes
+} from '../../actions/settings'
 import { openFolder, getOpenedFolderId } from '../../actions'
 import { startTracker, stopTracker } from '../lib/tracker'
 import { revokeClient as reduxRevokeClient } from './authorization'
@@ -50,6 +54,7 @@ export const saveCredentials = (client, token) => (dispatch, getState) => {
 
 export const startReplication = (dispatch, getState) => {
   const firstReplication = getState().settings.firstReplication
+  const hasIndexes = getState().settings.indexes
   const refreshFolder = () => {
     dispatch(openFolder(getOpenedFolderId(getState())))
   }
@@ -60,11 +65,16 @@ export const startReplication = (dispatch, getState) => {
   const firstReplicationFinished = () => {
     dispatch(setFirstReplication(true))
   }
+  const indexesCreated = indexes => {
+    dispatch(setPouchIndexes(indexes))
+  }
 
   startPouchReplication(
+    hasIndexes,
     firstReplication,
     firstReplicationFinished,
     refreshFolder,
-    revokeClient
+    revokeClient,
+    indexesCreated
   )
 }

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -21,7 +21,7 @@ export const startReplication = async (
         views: {
           recent_files: {
             map: function(doc) {
-              if (!doc.trashed) emit(doc.updated_at)
+              if (!doc.trashed && doc.type !== 'directory') emit(doc.updated_at)
             }.toString()
           }
         }

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -14,9 +14,10 @@ export const startReplication = async (
       firstReplicationFinished()
     }
 
-    const docsWritten = await startRepeatedReplication()
+    /* const docsWritten = */ await startRepeatedReplication()
     cozy.client.settings.updateLastSync()
-    if (docsWritten !== 0) refreshFolder()
+    // NB: this refresh breaks the recent view if it is displayed during replication
+    // if (docsWritten !== 0) refreshFolder()
   } catch (err) {
     if (
       err.message === clientRevokedMsg ||

--- a/src/drive/reducers/settings.js
+++ b/src/drive/reducers/settings.js
@@ -1,12 +1,14 @@
 import {
   SET_CLIENT,
   SET_OFFLINE,
-  SET_FIRST_REPLICATION
+  SET_FIRST_REPLICATION,
+  SET_POUCH_INDEXES
 } from '../actions/settings'
 
 export const initialState = {
   offline: false,
-  firstReplication: false
+  firstReplication: false,
+  indexes: null
 }
 
 export const settings = (state = initialState, action) => {
@@ -17,6 +19,8 @@ export const settings = (state = initialState, action) => {
       return { ...state, offline: action.offline }
     case SET_FIRST_REPLICATION:
       return { ...state, firstReplication: action.firstReplication }
+    case SET_POUCH_INDEXES:
+      return { ...state, indexes: action.indexes }
     default:
       return state
   }

--- a/src/drive/reducers/view.js
+++ b/src/drive/reducers/view.js
@@ -194,17 +194,6 @@ const lastFetch = (state = null, action) => {
   }
 }
 
-// TODO: temp
-const filesWithLinks = (state = {}, action) => {
-  switch (action.type) {
-    case 'FETCH_FILES_LINKS_SUCCESS':
-      const { folderId, files } = action
-      return { ...state, [folderId]: files }
-    default:
-      return state
-  }
-}
-
 export default combineReducers({
   hasDisplayedSomething,
   isOpening,
@@ -212,8 +201,6 @@ export default combineReducers({
   openedFolderId,
   fileCount,
   files,
-  // TODO: temp
-  filesWithLinks,
   fetchStatus,
   lastFetch
 })

--- a/src/lib/cozy-client/CozyClient.js
+++ b/src/lib/cozy-client/CozyClient.js
@@ -121,8 +121,8 @@ export default class CozyClient {
 
   // TODO: temp method for drive mobile so that we can fetch the thumbnails links
   // that are absent from the Pouch docs
-  fetchFilesForLinks(folderId) {
-    return this.facade.stackAdapter.fetchFilesForLinks(folderId)
+  fetchFilesForLinks(folderId, skip = 0) {
+    return this.facade.stackAdapter.fetchFilesForLinks(folderId, skip)
   }
 
   fetchReferencedFiles(doc, skip = 0) {

--- a/src/lib/cozy-client/adapters/CozyStackAdapter.js
+++ b/src/lib/cozy-client/adapters/CozyStackAdapter.js
@@ -130,11 +130,12 @@ export default class CozyStackAdapter {
 
   // TODO: temp method for drive mobile so that we can fetch the thumbnails links
   // that are absent from the Pouch docs
-  // it only fetches 200 docs, so the viewer won't work with large folders :/
-  async fetchFilesForLinks(folderId) {
+  async fetchFilesForLinks(folderId, skip = 0) {
     const response = await cozy.client.fetchJSON(
       'GET',
-      `/files/${encodeURIComponent(folderId)}?page[skip]=0&page[limit]=200`
+      `/files/${encodeURIComponent(
+        folderId
+      )}?page[skip]=${skip}&page[limit]=${FETCH_LIMIT}`
     )
     return response.relations('contents').map(f => normalizeFile(f))
   }

--- a/src/viewer/ImageViewer.jsx
+++ b/src/viewer/ImageViewer.jsx
@@ -148,7 +148,6 @@ export default class ImageViewer extends Component {
 
     // during a pan, we add the gestures delta to the initial offset to get the new offset. The new offset is then scaled : if the pan distance was 100px, but the image was scaled 2x, the actual offset should only be 50px. FInally, this value is clamped to make sure the user can't pan further than the edges.
     this.gestures.on('pan', e => {
-      console.log('pan', e)
       this.setState(state => {
         const maxOffset = this.computeMaxOffset()
         return {

--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -8,6 +8,8 @@ import PdfViewer from './PdfViewer'
 import NativePdfViewer from './NativePdfViewer'
 import NoViewer from './NoViewer'
 
+import Spinner from 'cozy-ui/react/Spinner'
+
 import styles from './styles'
 
 const KEY_CODE_LEFT = 37
@@ -21,6 +23,12 @@ const isIOS = () =>
   /iPad|iPhone|iPod/.test(window.navigator.userAgent)
 const isMobile = () => isAndroid() || isIOS()
 const isCordova = () => window.cordova !== undefined
+
+const ViewerWrapper = ({ children }) => (
+  <div className={styles['pho-viewer-wrapper']} role="viewer">
+    {children}
+  </div>
+)
 
 export default class Viewer extends Component {
   componentDidMount() {
@@ -71,7 +79,7 @@ export default class Viewer extends Component {
     // this `expanded` property makes the next/previous controls cover the displayed image
     const expanded = currentFile && currentFile.class === 'image'
     return (
-      <div className={styles['pho-viewer-wrapper']} role="viewer">
+      <ViewerWrapper>
         <ViewerControls
           currentFile={currentFile}
           onClose={onClose}
@@ -84,7 +92,7 @@ export default class Viewer extends Component {
         >
           {this.renderViewer(currentFile)}
         </ViewerControls>
-      </div>
+      </ViewerWrapper>
     )
   }
 
@@ -110,3 +118,10 @@ export default class Viewer extends Component {
     }
   }
 }
+
+// TODO: This is a temporary export for FilesViewer that has to deal with fetching file links on mobile
+export const LoadingViewer = () => (
+  <ViewerWrapper>
+    <Spinner size="xxlarge" middle="true" noMargin color="white" />
+  </ViewerWrapper>
+)


### PR DESCRIPTION
Dans cette PR j'ai ajouté les routes nécessaires pour que le viewer fonctionne depuis /recent et /trash. De plus, étant donné que sur mobile, les données viennent de PouchDB et que les fichiers n'ont pas de liens vers les vignettes, je me suis efforcé d'isoler ce code de récupération des vignettes ~~dans le wrapper `FilesViewer`~~ dans l'`ImageViewer` au final : c'est moins optimum, car une requête sera faite pour chaque image (mais seulement au moment où on essaie de l'afficher), mais c'est plus simple et plus sûr dans l'immédiat.

Dans un second temps, j'ai résolu un certain nb de pbs liées à l'utilisation de PouchDB : 
 - dorénavant, l'appli tape sur la stack tant que la première réplication n'est pas faite (ou les indexes n'ont pas été créés) ;
 - on utilise maintenant une query map/reduce pour les fichiers récents et on force l'utilisation de l'index pour les fichiers d'un dossier ~~(il reste un pb à résoudre : les premières requêtes sont lentes car elles initialisent l'index, il faudrait les jouer après la création des indexes)~~ ;
 - réécriture de la requête Mango pour les fichiers d'un dossier : les fichiers retournés n'étaient pas ordonnés de la bonne façon.