### PR TITLE
fix: super-impose the upload progression on the cozy bar border

### DIFF
--- a/src/drive/mobile/ducks/mediaBackup/UploadProgression.jsx
+++ b/src/drive/mobile/ducks/mediaBackup/UploadProgression.jsx
@@ -4,7 +4,7 @@ import styles from './styles'
 
 const UploadProgression = ({ t, current, total }) => {
   return (
-    <div>
+    <div className={styles['coz-upload-status-wrapper']}>
       <progress max={total} value={current} />
       <div className={styles['coz-upload-status']}>
         <div className={styles['coz-progress-pic']} />

--- a/src/drive/mobile/ducks/mediaBackup/styles.styl
+++ b/src/drive/mobile/ducks/mediaBackup/styles.styl
@@ -1,6 +1,9 @@
 @require 'settings/palette.styl'
 @require '../../styles/feedback'
 
+.coz-upload-status-wrapper
+    position relative
+
 .coz-upload-status
     display flex
     align-items center
@@ -12,6 +15,9 @@
     transition bottom 0.5s ease-out, top 0.5s ease-out, opacity 0.2s ease-out
 
 progress
+    position absolute
+    top 0
+    left 0
     -webkit-appearance none
     -moz-appearance    none
     border     none


### PR DESCRIPTION
before : 
<img width="317" alt="capture d ecran 2018-01-22 17 32 58" src="https://user-images.githubusercontent.com/2261445/35231911-5f13221a-ff9a-11e7-80b9-e04c89b3ccd4.png">

after : 
<img width="290" alt="capture d ecran 2018-01-22 17 31 53" src="https://user-images.githubusercontent.com/2261445/35231846-27d14e62-ff9a-11e7-87fd-2fcf15de8ef3.png">
