### PR TITLE
fix: remove fake link in onboarding

### DIFF
--- a/src/authentication/steps/SelectServer.jsx
+++ b/src/authentication/steps/SelectServer.jsx
@@ -191,6 +191,8 @@ export class SelectServer extends Component {
             <ReactMarkdown
               className={classNames(styles['description'], styles['info'])}
               source={t('mobile.onboarding.server_selection.description')}
+              disallowedTypes={['link']}
+              unwrapDisallowed
             />
           )}
           {error && (


### PR DESCRIPTION
I disabled links in the onboarding so it looks like this again:

<img width="240" alt="capture d ecran 2018-01-23 10 36 37" src="https://user-images.githubusercontent.com/2261445/35268401-4f6b6ba8-0029-11e8-8ef5-c5cf3195617d.png">

I didn't find a simpler way to disable that link — see https://github.com/rexxars/react-markdown/issues/139