### PR TITLE
fix: inject cozy-bar in services

### DIFF
--- a/targets/drive/web/services.ejs
+++ b/targets/drive/web/services.ejs
@@ -12,6 +12,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <% if (__STACK_ASSETS__) { %>
   {{.CozyClientJS}}
+  {{.CozyBar}}
   <% } %>
 </head>
 <div


### PR DESCRIPTION
The cozy-bar was not injected in the services part of cozy-drive, causing errors when components were relying on cozy-bar's `BarLeft`, `BarCenter` or `BarRight` components.

Currently I propose a quick fix that consists in injecting the bar. Maybe there is a better way to fix this problem we can discuss.
