### PR TITLE
Viewer in the public shared folder view

### DIFF
--- a/src/drive/actions/index.js
+++ b/src/drive/actions/index.js
@@ -322,28 +322,20 @@ export const getFileDownloadUrl = async id => {
   return `${cozy.client._url}${link}`
 }
 
-export const openFileInNewTab = file => {
+export const openLocalFile = file => {
   return async dispatch => {
-    if (file.availableOffline) {
-      openOfflineFile(file).catch(error => {
-        console.error('openFileInNewTab', error)
-        dispatch(
-          openWithNoAppError({
-            cancelSelection: true,
-            hideActionMenu: true
-          })
-        )
-      })
-    } else {
-      const newTab = window.open('about:blank', '_blank') // must be done before the async calls, otherwise pop-up blockers are trigered
-
-      const href = await getFileDownloadUrl(file.id)
-      if (isCordova()) {
-        newTab.executeScript({ code: `window.location.href = '${href}'` })
-      } else {
-        newTab.location.href = href
-      }
+    if (!file.availableOffline) {
+      console.error('openLocalFile: this file is not available offline')
     }
+    openOfflineFile(file).catch(error => {
+      console.error('openLocalFile', error)
+      dispatch(
+        openWithNoAppError({
+          cancelSelection: true,
+          hideActionMenu: true
+        })
+      )
+    })
   }
 }
 

--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -241,15 +241,10 @@ class File extends Component {
         this.props.router.push(getFolderUrl(attributes.id, this.props.location))
       })
     } else {
-      const viewPath = this.props.location.pathname
-      if (this.props.isAvailableOffline) {
-        this.props.onFileOpen({
-          ...attributes,
-          availableOffline: this.props.isAvailableOffline
-        })
-      } else {
-        this.props.router.push(`${viewPath}/file/${attributes.id}`)
-      }
+      this.props.onFileOpen({
+        ...attributes,
+        availableOffline: this.props.isAvailableOffline
+      })
     }
   }
 

--- a/src/drive/containers/FileExplorer.jsx
+++ b/src/drive/containers/FileExplorer.jsx
@@ -15,7 +15,7 @@ import {
   getOpenedFolderId,
   fetchRecentFiles,
   fetchMoreFiles,
-  openFileInNewTab
+  openLocalFile
 } from '../actions'
 import {
   getFolderIdFromRoute,
@@ -95,7 +95,13 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchMoreFiles: (folderId, skip, limit) =>
     dispatch(fetchMoreFiles(folderId, skip, limit)),
   onFolderOpen: folderId => dispatch(openFolder(folderId)),
-  onFileOpen: file => dispatch(openFileInNewTab(file)),
+  onFileOpen: file => {
+    if (file.availableOffline) {
+      return dispatch(openLocalFile(file))
+    }
+    const viewPath = ownProps.location.pathname
+    ownProps.router.push(`${viewPath}/file/${file.id}`)
+  },
   onFileToggle: (file, selected) =>
     dispatch(toggleItemSelection(file, selected))
 })

--- a/targets/drive/web/public/main.jsx
+++ b/targets/drive/web/public/main.jsx
@@ -48,8 +48,7 @@ const init = async () => {
       const { data = [] } = response
       const isFile = data.length > 0 && data[0].type === 'file'
       useDirectDownload = isFile
-    }
-    catch (e) {
+    } catch (e) {
       console.warn(e)
       useDirectDownload = false
     }


### PR DESCRIPTION
Please note that for simplicity reasons I decided to not use routing to open/close the viewer, but used a local state instead. I also cleaned up a bit of code now that we don't have to open files in tabs anymore.