### PR TITLE
Enable folders in search results

### DIFF
--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import FuzzyPathSearch from '../FuzzyPathSearch'
 import { getFileTypeFromMime } from 'drive/lib/getFileTypeFromMime'
 
+const TYPE_DIRECTORY = 'directory'
+
 class SuggestionProvider extends React.Component {
   componentDidMount() {
     const { intent } = this.props
@@ -49,12 +51,12 @@ class SuggestionProvider extends React.Component {
       )
       const files = allDocs.data
 
-      const folders = files.filter(file => file.type === 'directory')
+      const folders = files.filter(file => file.type === TYPE_DIRECTORY)
 
       const normalizedFiles = files
-        .filter(file => file.trashed === false)
+        .filter(file => file.trashed !== true)
         .map(file => {
-          const isDir = file.type === 'directory'
+          const isDir = file.type === TYPE_DIRECTORY
           const dirId = isDir ? file._id : file.dir_id
           let path
           if (isDir) {
@@ -69,7 +71,7 @@ class SuggestionProvider extends React.Component {
             name: file.name,
             path,
             url: window.location.origin + '/#/folder/' + dirId,
-            icon: getIconUrl(file.mime)
+            icon: getIconUrl(file)
           }
         })
 
@@ -90,9 +92,11 @@ const icons = iconsContext.keys().reduce((acc, item) => {
   return acc
 }, {})
 
-function getIconUrl(mimetype) {
+function getIconUrl(file) {
   const keyIcon =
-    getFileTypeFromMime(icons)(mimetype) ||
+    (file.type === TYPE_DIRECTORY
+      ? 'folder'
+      : getFileTypeFromMime(icons)(file.mime)) ||
     console.warn(
       `No icon found, you may need to add a mapping for ${mimetype}`
     ) ||

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -94,13 +94,13 @@ const icons = iconsContext.keys().reduce((acc, item) => {
 
 function getIconUrl(file) {
   const keyIcon =
-    (file.type === TYPE_DIRECTORY
+    file.type === TYPE_DIRECTORY
       ? 'folder'
-      : getFileTypeFromMime(icons)(file.mime)) ||
-    console.warn(
-      `No icon found, you may need to add a mapping for ${mimetype}`
-    ) ||
-    'files'
+      : getFileTypeFromMime(icons)(file.mime) ||
+        console.warn(
+          `No icon found, you may need to add a mapping for ${file.mime}`
+        ) ||
+        'files'
 
   return `${window.location.origin}/${icons[keyIcon]}`
 }

--- a/src/drive/lib/getFileTypeFromMime.js
+++ b/src/drive/lib/getFileTypeFromMime.js
@@ -8,7 +8,9 @@ const mappingMimetypeSubtype = {
   powerpoint: 'slide'
 }
 
-export const getFileTypeFromMime = (collection, prefix = '') => mimetype => {
+export const getFileTypeFromMime = (collection, prefix = '') => (
+  mimetype = ''
+) => {
   const [type, subtype] = mimetype.split('/')
   if (collection[prefix + type]) {
     return type


### PR DESCRIPTION
[this is the actual fix](https://github.com/cozy/cozy-drive/pull/730/files#diff-ab8f134c72c2b24476f993fcb9f5c5e2R57) : folders don't have a `trashed` property, and `undefined === false` is falsy so the folders were filtered out.

After fixing *that*, the app crashed because we tried to get an icon based on the folders `mime` property which again, doesn't exist.
[I handled the case of folder icons](https://github.com/cozy/cozy-drive/pull/730/files#diff-ab8f134c72c2b24476f993fcb9f5c5e2R97) separately because `folder` isn't a mime type, technically speaking.
I also made sure that [`getFileTypeFromMime ` won't just crash if called with `undefined`](https://github.com/cozy/cozy-drive/pull/730/files#diff-b60035d97397e5f3b868c2846f4130c4R11).