### PR TITLE
Search: result order and trashed dirs

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "roots": ["<rootDir>/src/lib"],
+  "roots": ["<rootDir>/src"],
   "transformIgnorePatterns": [
     "node_modules/(?!cozy-ui)/"
   ]

--- a/src/drive/ducks/services/FuzzyPathSearch.js
+++ b/src/drive/ducks/services/FuzzyPathSearch.js
@@ -74,6 +74,7 @@ class FuzzyPathSearch {
     let wordsFromPreviousQuery = []
 
     for (let currentQuerySegment of query) {
+      let wasInPreviousQuery = false
       for (let previousQuerySegment of this.previousQuery) {
         if (currentQuerySegment.word.includes(previousQuerySegment.word)) {
           if (currentQuerySegment.word !== previousQuerySegment.word) {
@@ -84,12 +85,13 @@ class FuzzyPathSearch {
             wordsFromPreviousQuery.push(currentQuerySegment)
           }
 
+          wasInPreviousQuery = true
           continue
         }
       }
 
       // this segment wasn't included in any previous query segment so it's a new word and we prioritize it
-      priorizedWords.push(currentQuerySegment)
+      if (!wasInPreviousQuery) priorizedWords.push(currentQuerySegment)
     }
 
     return this.sortQuerybyLength(priorizedWords).concat(
@@ -106,6 +108,11 @@ class FuzzyPathSearch {
 
     files.forEach(file => {
       let fileScore = 0
+      const pathArray = removeDiacritics(
+        (file.path + '/' + file.name).toLowerCase()
+      )
+        .split('/')
+        .filter(pathChunk => !!pathChunk)
 
       for (let word of words) {
         // let the magic begin...
@@ -113,9 +120,6 @@ class FuzzyPathSearch {
         let wordScore = 0
         let wordOccurenceValue = 10000
         let firstOccurence = true
-        const pathArray = removeDiacritics(
-          (file.path + '/' + file.name).toLowerCase()
-        ).split('/')
         const maxDepth = pathArray.length
 
         for (let depth = 0; depth < maxDepth; ++depth) {
@@ -159,7 +163,7 @@ class FuzzyPathSearch {
     })
 
     suggestions.sort((a, b) => {
-      const score = a.score - b.score
+      const score = b.score - a.score
       return score !== 0 ? score : a.file.path.localeCompare(b.file.path)
     })
 

--- a/src/drive/ducks/services/FuzzyPathSearch.spec.js
+++ b/src/drive/ducks/services/FuzzyPathSearch.spec.js
@@ -1,0 +1,237 @@
+import FuzzyPathSearch from './FuzzyPathSearch'
+
+describe('simple search', () => {
+  const guitars = [
+    { name: 'fender stratocaster', path: '' },
+    { name: 'fender telecaster', path: '' },
+    { name: 'gibson SG', path: '' }
+  ]
+
+  let fps
+  beforeEach(() => {
+    fps = new FuzzyPathSearch(guitars)
+  })
+
+  it('should return an exact match', () => {
+    const query = 'fender telecaster'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(1)
+    expect(result[0]).toBe(guitars[1])
+  })
+
+  it('should return all possible matches', () => {
+    const query = 'fender'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(2)
+    expect(result.includes(guitars[0])).toBe(true)
+    expect(result.includes(guitars[1])).toBe(true)
+  })
+})
+
+describe('search with path', () => {
+  const guitars = [
+    { name: 'stratocaster', path: '/fender/' },
+    { name: 'telecaster', path: '/fender/' },
+    { name: 'SG', path: '/Gibson/' }
+  ]
+
+  let fps
+  beforeEach(() => {
+    fps = new FuzzyPathSearch(guitars)
+  })
+
+  it('should return an exact match', () => {
+    const query = 'fender telecaster'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(1)
+    expect(result[0]).toBe(guitars[1])
+  })
+
+  it('should return all possible matches', () => {
+    const query = 'fender'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(2)
+    expect(result.includes(guitars[0])).toBe(true)
+    expect(result.includes(guitars[1])).toBe(true)
+  })
+})
+
+describe('malformed queries', () => {
+  const guitars = [
+    { name: 'fender stratocaster', path: '' },
+    { name: 'fender telecaster', path: '' },
+    { name: 'gibson SG', path: '' }
+  ]
+
+  let fps
+  beforeEach(() => {
+    fps = new FuzzyPathSearch(guitars)
+  })
+
+  it('should handle different orders', () => {
+    const query1 = 'telecaster fender'
+    const result1 = fps.search(query1)
+
+    const query2 = 'fender telecaster'
+    const result2 = fps.search(query2)
+
+    expect(result1).toEqual(result2)
+  })
+
+  it('should handle diacritics', () => {
+    const query = 'télécaster fender'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(1)
+    expect(result[0]).toBe(guitars[1])
+  })
+
+  it('should handle extra spaces', () => {
+    const query = 'fender   telecaster'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(1)
+    expect(result[0]).toBe(guitars[1])
+  })
+
+  it('should not care about casing', () => {
+    const query = 'FENDER TeLeCASTER'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(1)
+    expect(result[0]).toBe(guitars[1])
+  })
+})
+
+describe('result ordering', () => {
+  it('should favor names over pathes', () => {
+    const guitars = [
+      { name: 'telecaster', path: '/fender' },
+      { name: 'fender', path: '/telecaster' }
+    ]
+    const fps = new FuzzyPathSearch(guitars)
+
+    const query = 'tele'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(2)
+    expect(result[0]).toBe(guitars[0])
+    expect(result[1]).toBe(guitars[1])
+  })
+
+  it('should not care about the input order', () => {
+    const guitars = [
+      { name: 'telecaster', path: '/fender' },
+      { name: 'fender', path: '/telecaster' }
+    ]
+    const fps = new FuzzyPathSearch(guitars)
+
+    const query = 'tele'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(2)
+    expect(result[0]).toBe(guitars[0])
+    expect(result[1]).toBe(guitars[1])
+
+    const reversed = guitars.reverse()
+    const reversedFps = new FuzzyPathSearch(reversed)
+
+    const reversedResult = reversedFps.search(query)
+
+    expect(reversedResult).toBeInstanceOf(Array)
+    expect(reversedResult.length).toEqual(2)
+    expect(reversedResult[0]).toBe(guitars[1])
+    expect(reversedResult[1]).toBe(guitars[0])
+  })
+
+  it('should favor matches nearer the start of the path', () => {
+    const guitars = [
+      { name: '2015', path: '/fender/telecaster/stratocaster/' },
+      { name: '2015', path: '/fender/stratocaster/' }
+    ]
+
+    const fps = new FuzzyPathSearch(guitars)
+    const query = 'stratocaster'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(2)
+    expect(result[0]).toBe(guitars[1])
+    expect(result[1]).toBe(guitars[0])
+  })
+
+  it('should fallback to the shortest path', () => {
+    const guitars = [
+      { name: '2015', path: '/fender/telecaster/stratocaster/' },
+      { name: '2015', path: '/fender/stratocaster/' }
+    ]
+
+    const fps = new FuzzyPathSearch(guitars)
+    const query = '2015'
+    const result = fps.search(query)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(2)
+    expect(result[0]).toBe(guitars[1])
+    expect(result[1]).toBe(guitars[0])
+  })
+})
+
+describe('successive searches', () => {
+  it('should filter results as the query gets longer', () => {
+    const guitars = [
+      { name: 'fender stratocaster', path: '' },
+      { name: 'fender telecaster', path: '' },
+      { name: 'gibson SG', path: '' }
+    ]
+    const fps = new FuzzyPathSearch(guitars)
+
+    const result1 = fps.search('caster')
+
+    expect(result1).toBeInstanceOf(Array)
+    expect(result1.length).toEqual(2)
+    expect(result1.includes(guitars[0])).toBe(true)
+    expect(result1.includes(guitars[1])).toBe(true)
+
+    const result2 = fps.search('caster tele')
+
+    expect(result2).toBeInstanceOf(Array)
+    expect(result2.length).toEqual(1)
+    expect(result2.includes(guitars[1])).toBe(true)
+  })
+
+  it('should reset when queries backtrack', () => {
+    const guitars = [
+      { name: 'fender stratocaster', path: '' },
+      { name: 'fender telecaster', path: '' },
+      { name: 'gibson SG', path: '' }
+    ]
+    const fps = new FuzzyPathSearch(guitars)
+
+    const result1 = fps.search('telecaster')
+
+    expect(result1).toBeInstanceOf(Array)
+    expect(result1.length).toEqual(1)
+    expect(result1.includes(guitars[1])).toBe(true)
+
+    const result2 = fps.search('caster')
+
+    expect(result2).toBeInstanceOf(Array)
+    expect(result2.length).toEqual(2)
+    expect(result2.includes(guitars[0])).toBe(true)
+    expect(result2.includes(guitars[1])).toBe(true)
+  })
+})

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -53,7 +53,8 @@ class SuggestionProvider extends React.Component {
       const files = allDocs.data
       const folders = files.filter(file => file.type === TYPE_DIRECTORY)
 
-      const notInTrash = file => file.trashed !== true
+      const notInTrash = file =>
+        !file.trashed || !/^\/\.cozy_trash/.test(file.path)
 
       const normalizedFiles = files.filter(notInTrash).map(file => {
         const isDir = file.type === TYPE_DIRECTORY


### PR DESCRIPTION
- I amended the code that filters out trashed files and folders — it now *really* discards anything that's in the trash
- We had the correct results, but not in the correct order. This was due to a combination of several small problems, which I've all corrected