### PR TITLE
fix: hide settings on mobile

### DIFF
--- a/src/drive/mobile/styles/main.styl
+++ b/src/drive/mobile/styles/main.styl
@@ -1,3 +1,5 @@
+@require 'settings/breakpoints.styl'
+
 html {
     -webkit-user-select: none;
 }
@@ -17,10 +19,12 @@ html {
           url('../assets/fonts/Lato-Bold.woff') format('woff');
 }
 
+// this weird selector is here to temporarily hide some buttons in the cozy-bar on mobile:
+// profile, connected devices, support, logout
 :global
-    // this weird selector is here to temporarily hide some buttons in the cozy-bar on mobile:
-    // profile, connected devices, support, logout
-    [role=banner] .coz-drawer--settings > div > hr:nth-child(1),
-    [role=banner] .coz-drawer--settings > div > ul:not(.coz-nav-group--inactive) {
-        visibility: hidden;
-    }
+    +small-screen()
+        [role=banner] .coz-drawer--settings
+            display none
+    +small-screen('min')
+        [role=banner] .coz-nav .coz-nav-section:nth-child(2)
+            display none


### PR DESCRIPTION
Evolution of the previous fix : now the app menu can take all the available height, and nothing iss displayed on tablets.

Note that this stylus file is only used for native builds, so it doesn't affect the web version of Cozy Drive.