### PR TITLE
feat: log file metadata when upload hangs

### DIFF
--- a/src/drive/mobile/ducks/mediaBackup/index.js
+++ b/src/drive/mobile/ducks/mediaBackup/index.js
@@ -105,6 +105,7 @@ const uploadPhoto = (dirName, dirID, photo) => async (dispatch, getState) => {
   const MINUTE = 60 * SECOND
   const maxBackupTime = 5 * MINUTE
   const timeout = setTimeout(() => {
+    console.info(JSON.stringify(photo))
     logException(`Backup duration exceeded ${maxBackupTime} milliseconds`)
   }, maxBackupTime)
 


### PR DESCRIPTION
We'd like to find out why the upload sometimes hand, but since the file metadata is only displayed when there is an error at the moment, it's hard to know. This will provide more data to work with.