### PR TITLE
fix: filter out orphans from search results

### DIFF
--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -54,27 +54,32 @@ class SuggestionProvider extends React.Component {
       const folders = files.filter(file => file.type === TYPE_DIRECTORY)
 
       const notInTrash = file =>
-        !file.trashed || !/^\/\.cozy_trash/.test(file.path)
+        !file.trashed && !/^\/\.cozy_trash/.test(file.path)
+      const notOrphans = file =>
+        folders.find(folder => folder._id === file.dir_id) !== undefined
 
-      const normalizedFiles = files.filter(notInTrash).map(file => {
-        const isDir = file.type === TYPE_DIRECTORY
-        const dirId = isDir ? file._id : file.dir_id
-        let path
-        if (isDir) {
-          path = file.path
-        } else {
-          const parentDir = folders.find(folder => folder._id === file.dir_id)
-          path = parentDir && parentDir.path ? parentDir.path : ''
-        }
+      const normalizedFiles = files
+        .filter(notInTrash)
+        .filter(notOrphans)
+        .map(file => {
+          const isDir = file.type === TYPE_DIRECTORY
+          const dirId = isDir ? file._id : file.dir_id
+          let path
+          if (isDir) {
+            path = file.path
+          } else {
+            const parentDir = folders.find(folder => folder._id === file.dir_id)
+            path = parentDir && parentDir.path ? parentDir.path : ''
+          }
 
-        return {
-          id: file._id,
-          name: file.name,
-          path,
-          url: window.location.origin + '/#/folder/' + dirId,
-          icon: getIconUrl(file)
-        }
-      })
+          return {
+            id: file._id,
+            name: file.name,
+            path,
+            url: window.location.origin + '/#/folder/' + dirId,
+            icon: getIconUrl(file)
+          }
+        })
 
       this.fuzzyPathSearch = new FuzzyPathSearch(normalizedFiles)
       this.hasIndexedFiles = true


### PR DESCRIPTION
- There was a bug with filtering trashed results, again.
- Sometimes, there are orphan files — the files exist, but their parent folder does not. It has not been investigated yet, but in the meantime we need to filter out those files from search results.