### PR TITLE
fix: reducer throws when updating/deleting no documents

### DIFF
--- a/src/lib/cozy-client/__tests__/store.spec.js
+++ b/src/lib/cozy-client/__tests__/store.spec.js
@@ -123,6 +123,28 @@ describe('Redux store tests', () => {
       })
     })
 
+    describe('When no document have been updated on the server', () => {
+      const fakeResponse = { data: [] }
+
+      it('should do nothing', () => {
+        collection = getCollection(state, 'rockets')
+        const before = collection.data[0]
+        state = dispatchSuccessfulAction(
+          updateDocument(
+            'io.cozy.rockets',
+            { name: 'Saturn V' },
+            {
+              updateCollections: ['rockets']
+            }
+          ),
+          fakeResponse,
+          state
+        )
+        collection = getCollection(state, 'rockets')
+        expect(collection.data[0]).toEqual(before)
+      })
+    })
+
     describe('When a document is successfully updated on the server', () => {
       const fakeResponse = {
         data: [
@@ -181,6 +203,28 @@ describe('Redux store tests', () => {
         )
         collection = getCollection(state, 'rockets')
         expect(collection.data[0]).toEqual(fakeResponse.data[0])
+      })
+    })
+
+    describe('When no documents have been deleted on the server', () => {
+      const fakeResponse = { data: [] }
+
+      it('should do nothing', () => {
+        collection = getCollection(state, 'rockets')
+        const before = collection.ids
+        state = dispatchSuccessfulAction(
+          deleteDocuments(
+            'io.cozy.rockets',
+            { selector: {} },
+            {
+              updateCollections: ['rockets']
+            }
+          ),
+          fakeResponse,
+          state
+        )
+        collection = getCollection(state, 'rockets')
+        expect(collection.ids).toEqual(before)
       })
     })
 

--- a/src/lib/cozy-client/reducer.js
+++ b/src/lib/cozy-client/reducer.js
@@ -32,8 +32,10 @@ const REMOVE_REFERENCED_FILES = 'REMOVE_REFERENCED_FILES'
 const documents = (state = {}, action) => {
   switch (action.type) {
     case RECEIVE_DATA:
+      if (action.response.data.length === 0) {
+        return state
+      }
       const { data } = action.response
-      if (data.length === 0) return state
       const dataDoctype = getArrayDoctype(data)
       return {
         ...state,
@@ -44,6 +46,9 @@ const documents = (state = {}, action) => {
       }
     case RECEIVE_NEW_DOCUMENT:
     case RECEIVE_UPDATED_DOCUMENT:
+      if (action.response.data.length === 0) {
+        return state
+      }
       const doc = action.response.data[0]
       return {
         ...state,
@@ -53,6 +58,9 @@ const documents = (state = {}, action) => {
         }
       }
     case RECEIVE_UPDATED_DOCUMENTS:
+      if (action.response.data.length === 0) {
+        return state
+      }
       const udocs = action.response.data
       const doctype = udocs[0]._type
       return {
@@ -63,12 +71,18 @@ const documents = (state = {}, action) => {
         }
       }
     case RECEIVE_DELETED_DOCUMENT:
+      if (action.response.data.length === 0) {
+        return state
+      }
       const deleted = action.response.data[0]
       return {
         ...state,
         [deleted._type]: removeObjectProperty(state[deleted._type], deleted.id)
       }
     case RECEIVE_DELETED_DOCUMENTS:
+      if (action.response.data.length === 0) {
+        return state
+      }
       const docs = action.response.data
       const firstDeleted = docs[0]
       return {


### PR DESCRIPTION
Previously, when no data was updated/deleted, the reducer would throw.