### PR TITLE
Fix remove obj property

### DIFF
--- a/src/lib/cozy-client/helpers.js
+++ b/src/lib/cozy-client/helpers.js
@@ -1,5 +1,6 @@
 /* global cozy */
-import { retry, removeObjectProperties } from './utils'
+import omit from 'lodash/omit'
+import { retry } from './utils'
 
 const slugify = text =>
   text
@@ -60,7 +61,7 @@ export const getIndexFields = query => {
 
 /** Remove special fields */
 export const sanitizeDoc = doc => {
-  return removeObjectProperties(doc, ['_type'])
+  return omit(doc, ['_type'])
 }
 
 export const isV2 = url =>

--- a/src/lib/cozy-client/reducer.js
+++ b/src/lib/cozy-client/reducer.js
@@ -1,9 +1,6 @@
 import { combineReducers } from 'redux'
-import {
-  removeObjectProperty,
-  removeObjectProperties,
-  mapValues
-} from './utils'
+import { mapValues } from './utils'
+import omit from 'lodash/omit'
 import sharings, {
   FETCH_SHARINGS,
   getSharings,
@@ -77,7 +74,7 @@ const documents = (state = {}, action) => {
       const deleted = action.response.data[0]
       return {
         ...state,
-        [deleted._type]: removeObjectProperty(state[deleted._type], deleted.id)
+        [deleted._type]: omit(state[deleted._type], deleted.id)
       }
     case RECEIVE_DELETED_DOCUMENTS:
       if (action.response.data.length === 0) {
@@ -87,7 +84,7 @@ const documents = (state = {}, action) => {
       const firstDeleted = docs[0]
       return {
         ...state,
-        [firstDeleted._type]: removeObjectProperties(
+        [firstDeleted._type]: omit(
           state[firstDeleted._type],
           docs.map(d => d.id)
         )

--- a/src/lib/cozy-client/utils.js
+++ b/src/lib/cozy-client/utils.js
@@ -16,26 +16,6 @@ export const filterValues = (object, filter) => {
   return result
 }
 
-export const removeObjectProperty = (obj, prop) => {
-  return Object.keys(obj).reduce((result, key) => {
-    if (key !== prop) {
-      result[key] = obj[key]
-    }
-    return result
-  }, {})
-}
-
-export const removeObjectProperties = (obj, props) => {
-  const sProps = new Set(props)
-  const res = Object.keys(obj).reduce((result, key) => {
-    if (!sProps.has(key)) {
-      result[key] = obj[key]
-    }
-    return result
-  }, {})
-  return res
-}
-
 export const sleep = (time, args) => {
   return new Promise(resolve => {
     setTimeout(resolve, time, args)


### PR DESCRIPTION
`removeObjectProperty` does not take into account if the "object" passed is undefined. There was an edge case in the `reducer` when it happened. I replaced it by "lodash/omit" which does the same thing, has IMHO a better API (supports both array form and single value form), returns `{}` if the object passed is undefined, and is already loaded since `lodash` is loaded.