### PR TITLE
feat(cozy-client): export data access strategies

### DIFF
--- a/src/lib/cozy-client/DataAccessFacade.js
+++ b/src/lib/cozy-client/DataAccessFacade.js
@@ -68,7 +68,7 @@ export default class DataAccessFacade {
   }
 }
 
-class PouchFirstStrategy {
+export class PouchFirstStrategy {
   getAdapter(doctype, stackAdapter, pouchAdapter) {
     if (pouchAdapter.getDatabase(doctype) === undefined) {
       return stackAdapter
@@ -77,7 +77,7 @@ class PouchFirstStrategy {
   }
 }
 
-class StackOnlyStrategy {
+export class StackOnlyStrategy {
   getAdapter(doctype, stackAdapter, pouchAdapter) {
     return stackAdapter
   }


### PR DESCRIPTION
In banks, we need to use the `StackOnlyStrategy` for the first data fetch, then `PouchFirstStrategy` for subsequent fetches. So we need to be able to import the strategies to dynamically switch it when we need to.
