### PR TITLE
fix: refactoring for sharedBadge Component

### DIFF
--- a/src/sharing/components/SharedBadge.jsx
+++ b/src/sharing/components/SharedBadge.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
+import { Icon } from 'cozy-ui/react'
 import styles from './badge'
 
 const SharedBadge = ({ byMe, className, small, xsmall }) => (
@@ -8,15 +9,11 @@ const SharedBadge = ({ byMe, className, small, xsmall }) => (
       styles['shared-badge'],
       className,
       { [styles['--small']]: small },
-      { [styles['--xsmall']]: xsmall }
+      { [styles['--xsmall']]: xsmall },
+      styles[byMe ? '--by-me' : '--with-me']
     )}
   >
-    <div
-      className={classNames(
-        styles['shared-badge-icon'],
-        styles[byMe ? '--by-me' : '--with-me']
-      )}
-    />
+    <Icon icon="share" color="white" className={styles['shared-badge-icon']} />
   </div>
 )
 

--- a/src/sharing/components/badge.styl
+++ b/src/sharing/components/badge.styl
@@ -1,28 +1,32 @@
 @require 'cozy-ui'
 
 .shared-badge
-    background-color  white
-    border-radius     50%
-    padding           .125rem
+    display flex
+    align-items center
+    justify-content center
+    border-radius 50%
+    background-clip padding-box
 
     &.--small
-        .shared-badge-icon
-            padding         .6rem
-            background-size 50%
-    &.--xsmall
-        padding .0625rem
-        .shared-badge-icon
-            padding         .3rem
-            background-size 60%
+        border .125rem solid white
+        width 1.5rem
+        height 1.5rem
 
-.shared-badge-icon
-    padding              1rem
-    background-image     embedurl('../assets/icon-share-white.svg')
-    background-position  center
-    background-repeat    no-repeat
-    border-radius        50%
+        .shared-badge-icon
+            width .75rem
+            height .75rem
+
+    &.--xsmall
+        border .0625rem solid white
+        width .75rem
+        height .75rem
+
+        .shared-badge-icon
+            width .375rem
+            height .375rem
 
     &.--by-me
         background-color emerald
+
     &.--with-me
         background-color portage


### PR DESCRIPTION
Refactoring of SharedBadge component:
- Use of `<Icon />` instead of background image
- proper width/height values instead of playing with padding

🗒️ On a side note, I was not sure what the size should do, I guess there could be some improvement to do here, like a default size and modifiers classes but as this was not the purpose of this refactoring and giving the fact that I don't know this component this well, I'll leave you judge if it's a good thing or not to do.