### PR TITLE
Don't show the desktop banner or button if already installed

### DIFF
--- a/src/components/pushClient/Banner.jsx
+++ b/src/components/pushClient/Banner.jsx
@@ -5,30 +5,42 @@ import styles from './pushClient'
 import { translate } from 'cozy-ui/react/I18n'
 
 import React, { Component } from 'react'
-import { track, isLinux, isAndroid, isIOS, DESKTOP_BANNER } from '.'
+import {
+  track,
+  isLinux,
+  isAndroid,
+  isIOS,
+  isClientAlreadyInstalled,
+  DESKTOP_BANNER
+} from '.'
 import { Button, ButtonLink, Icon } from 'cozy-ui/react'
 
 import localforage from 'localforage'
 
 class BannerClient extends Component {
   state = {
-    seen: true
+    mustShow: false
   }
 
   async componentWillMount() {
     const seen = (await localforage.getItem(DESKTOP_BANNER)) || false
-    this.setState(state => ({ ...state, seen }))
+    if (!seen) {
+      const mustSee = !await isClientAlreadyInstalled()
+      if (mustSee) {
+        this.setState(state => ({ ...state, mustShow: true }))
+      }
+    }
   }
 
   markAsSeen(element) {
     localforage.setItem(DESKTOP_BANNER, true)
-    this.setState(state => ({ ...state, seen: true }))
+    this.setState(state => ({ ...state, mustShow: false }))
     track(element)
   }
 
   render() {
     const { t } = this.props
-    if (this.state.seen) return null
+    if (!this.state.mustShow) return null
 
     const mobileLink = isIOS()
       ? 'Nav.link-client-ios'

--- a/src/components/pushClient/Button.jsx
+++ b/src/components/pushClient/Button.jsx
@@ -4,22 +4,28 @@ import { translate } from 'cozy-ui/react/I18n'
 
 import React, { Component } from 'react'
 import localforage from 'localforage'
-import { track, isLinux, DESKTOP_BANNER } from '.'
+import { track, isLinux, isClientAlreadyInstalled, DESKTOP_BANNER } from '.'
 
 class ButtonClient extends Component {
   state = {
-    seen: false
+    mustShow: false
   }
 
   async componentWillMount() {
     const seen = (await localforage.getItem(DESKTOP_BANNER)) || false
-    this.setState(state => ({ ...state, seen }))
+    // we want to show the button if the banner has been marked as seen *and*
+    // the client hasn't been already installed
+    if (seen) {
+      const mustSee = !await isClientAlreadyInstalled()
+      if (mustSee) {
+        this.setState(state => ({ ...state, mustShow: true }))
+      }
+    }
   }
 
   render() {
     const { t } = this.props
-    // show the button if the banner has been marked as seen
-    return this.state.seen ? (
+    return this.state.mustShow ? (
       <a
         href={t(isLinux() ? 'Nav.link-client' : 'Nav.link-client-desktop')}
         target="_blank"

--- a/src/components/pushClient/index.js
+++ b/src/components/pushClient/index.js
@@ -1,3 +1,4 @@
+/* global cozy */
 import { getTracker } from 'cozy-ui/react/helpers/tracker'
 
 export const track = element => {
@@ -18,3 +19,11 @@ export const isIOS = () =>
   /iPad|iPhone|iPod/.test(window.navigator.userAgent)
 
 export const DESKTOP_BANNER = 'desktop_banner'
+
+export const isClientAlreadyInstalled = async () => {
+  const resp = await cozy.client.fetchJSON('GET', '/settings/clients')
+  return resp.some(
+    device =>
+      device.attributes.software_id === 'github.com/cozy-labs/cozy-desktop'
+  )
+}

--- a/targets/drive/manifest.webapp
+++ b/targets/drive/manifest.webapp
@@ -76,6 +76,11 @@
       "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
       "type": "io.cozy.settings",
       "verbs": ["GET"]
+    },
+    "oauth": {
+      "description": "Required to display the cozy-desktop banner",
+      "type": "io.cozy.oauth.clients",
+      "verbs": ["GET"]
     }
   }
 }


### PR DESCRIPTION
Cela m'embête un peu (beaucoup) d'être obligé de faire un fetch pour chaque composant, mais ils sont totalement décorrélés dans le layout et je ne voyais pas trop comment faire mieux sans sortir l'artillerie lourde (redux). En espérant que cela vous convienne malgré tout (et en sachant qu'il faut qu'on en discute avec notre PO étant donné que cela nécessite de demander une perm de plus).