### PR TITLE
Rate prompt delay

### DIFF
--- a/src/drive/mobile/containers/RatingModal.jsx
+++ b/src/drive/mobile/containers/RatingModal.jsx
@@ -15,7 +15,8 @@ const ALERT_RATING = 'ALERT_RATING'
 const BUTTON_INDEX_RATE = 1
 const BUTTON_INDEX_LATER = 2
 
-const PROMPT_AFTER_BOOTS = 5
+const PROMPT_AFTER_BOOTS = 10
+const PROMPT_AFTER_DAYS = 7
 
 // RatingModal is the base component
 class RatingModal extends Component {
@@ -138,6 +139,8 @@ const withBootDelay = (WrappedComponent, showAfterBoots) => {
   class WithBootDelay extends Component {
     state = {
       bootCount: 0,
+      promptAfter:
+        new Date().getTime() + PROMPT_AFTER_DAYS * 24 * 60 * 60 * 1000,
       prompted: false
     }
 
@@ -163,8 +166,12 @@ const withBootDelay = (WrappedComponent, showAfterBoots) => {
     }
 
     render() {
-      const { bootCount, prompted } = this.state
-      const visible = prompted === false && bootCount >= showAfterBoots
+      const { bootCount, promptAfter, prompted } = this.state
+      const timeRemainingBeforePrompt = promptAfter - new Date().getTime()
+      const visible =
+        prompted === false &&
+        bootCount >= showAfterBoots &&
+        timeRemainingBeforePrompt <= 0
       return (
         visible && (
           <WrappedComponent

--- a/src/drive/mobile/containers/RatingModal.jsx
+++ b/src/drive/mobile/containers/RatingModal.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 import { Button } from 'cozy-ui/react'
 import { connect } from 'react-redux'
@@ -71,6 +72,12 @@ class RatingModal extends Component {
   }
 }
 
+RatingModal.propTypes = {
+  alert: PropTypes.func.isRequired,
+  dontShowAgain: PropTypes.func.isRequired,
+  showLater: PropTypes.func.isRequired
+}
+
 // sub-components
 const EnjoyCozy = (props, context) => {
   const { onReply } = props
@@ -89,6 +96,10 @@ const EnjoyCozy = (props, context) => {
       </ModalContent>
     </Modal>
   )
+}
+
+EnjoyCozy.propTypes = {
+  onReply: PropTypes.func.isRequired
 }
 
 // promptRating is not a component because the native UI is used instead

--- a/src/drive/mobile/containers/RatingModal.jsx
+++ b/src/drive/mobile/containers/RatingModal.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
-import Button from 'cozy-ui/react/Button'
+import { Button } from 'cozy-ui/react'
 import { connect } from 'react-redux'
 import withPersistentState from '../lib/withPersistentState'
 import { SOFTWARE_ID, SOFTWARE_NAME } from '../lib/constants'

--- a/src/drive/mobile/containers/RatingModal.jsx
+++ b/src/drive/mobile/containers/RatingModal.jsx
@@ -102,7 +102,7 @@ const promptRating = async ({
   softwareID
 }) =>
   new Promise((resolve, reject) => {
-    if (!window.AppRate) resolve('No AppRate found')
+    if (!window.AppRate) reject(new Error('No AppRate found'))
     try {
       window.AppRate.preferences = {
         displayAppName: softwareName,


### PR DESCRIPTION
1. First commit: we show the rating prompt after 10 boots and a minimum of one week after the first usage
2. Second commit: fix the button styles (I'm working on a PR for cozy-ui to fix the initial problem)
3. Third commit: not essential, but when the cordova plugin can't be found, we want to reject the promise and handle the error