### PR TITLE
fix: proper client revokation detection

### DIFF
--- a/src/lib/cozy-client/CozyClient.js
+++ b/src/lib/cozy-client/CozyClient.js
@@ -58,12 +58,14 @@ export default class CozyClient {
       await cozy.client.auth.getClient(clientInfos)
       return true
     } catch (err) {
-      // this is the error sent if we are offline
-      if (err.message === 'Failed to fetch') {
-        return true
-      } else {
-        console.warn(err)
+      if (err.message === 'Client has been revoked') {
         return false
+      } else {
+        console.log(
+          'Error while retrieving oauth client information, but client is not revoked'
+        )
+        console.warn(err)
+        return true
       }
     }
   }


### PR DESCRIPTION
I've essentially inverted the logic — instead of treating everything like a revocation *except* offline errors, we know consider every error as "it's fine, we're just offline" *except* the ones that really tell us that the client has been revoked.