### PR TITLE
feat: allow several fetches from several queries to be merged into a single collection

### DIFF
--- a/src/lib/cozy-client/reducer.js
+++ b/src/lib/cozy-client/reducer.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux'
 import { mapValues } from './utils'
 import omit from 'lodash/omit'
+import uniq from 'lodash/uniqBy'
 import sharings, {
   FETCH_SHARINGS,
   getSharings,
@@ -216,9 +217,10 @@ const collection = (state = collectionInitialState, action) => {
           response.meta && response.meta.count
             ? response.meta.count
             : response.data.length,
-        ids: !action.skip
-          ? response.data.map(doc => doc.id)
-          : [...state.ids, ...response.data.map(doc => doc.id)]
+        ids:
+          !action.skip || !action.merge
+            ? response.data.map(doc => doc.id)
+            : uniq([...state.ids, ...response.data.map(doc => doc.id)])
       }
     case ADD_REFERENCED_FILES:
       return {


### PR DESCRIPTION
Problem 1
========

Example : Fetching of banking operations, query depends on the account currently shown,
all operations are stored in the same collection.

Observed behavior : the collection is reset for each query, unless the action has a `skip` attribute.

Desired behavior : the collection should not be reset, and any new data should be merged.

Proposal : added the `merge` attribute to the action.


Problem 2
=========

Observed behavior : Now that we have the merge attribute, ids are duplicated if there
are multiple fetches.

Proposal : deduplicate the ids of the collection