### PR TITLE
fix: polyfill search params

### DIFF
--- a/src/sharing/ShareModal.jsx
+++ b/src/sharing/ShareModal.jsx
@@ -16,6 +16,8 @@ import Modal from 'cozy-ui/react/Modal'
 import ShareByLink from './components/ShareByLink'
 import ShareByEmail from './components/ShareByEmail'
 
+require('url-polyfill')
+
 const shunt = (cond, BaseComponent, OtherComponent) => props =>
   cond() ? <BaseComponent {...props} /> : <OtherComponent {...props} />
 


### PR DESCRIPTION
Added missing polyfill for `URL.searchParams`, required for MS Edge (and others).