### PR TITLE
fix: merge-skip bug

### DIFF
--- a/src/lib/cozy-client/reducer.js
+++ b/src/lib/cozy-client/reducer.js
@@ -218,9 +218,9 @@ const collection = (state = collectionInitialState, action) => {
             ? response.meta.count
             : response.data.length,
         ids:
-          !action.skip || !action.merge
-            ? response.data.map(doc => doc.id)
-            : uniq([...state.ids, ...response.data.map(doc => doc.id)])
+          action.skip || action.merge
+            ? uniq([...state.ids, ...response.data.map(doc => doc.id)])
+            : response.data.map(doc => doc.id)
       }
     case ADD_REFERENCED_FILES:
       return {


### PR DESCRIPTION
I think a small bug slipped [here](https://github.com/cozy/cozy-drive/commit/696bc3b6d3b9700d60e00e7dfdb984056993854d) : after that change, in order to combine the results instead of replacing them, the action would need to have both `skip` and `merge` to `true`, but I'm pretty sure any one of them is enough.