### PR TITLE
fix: revoke sharing links on delete

### DIFF
--- a/src/drive/actions/index.js
+++ b/src/drive/actions/index.js
@@ -12,6 +12,7 @@ import {
   isReferencedByAlbum,
   ALBUMS_DOCTYPE
 } from '../ducks/files/files'
+import { revokeLink as revokeSharingLink } from 'cozy-client'
 import * as availableOffline from '../ducks/files/availableOffline'
 
 import { ROOT_DIR_ID, TRASH_DIR_ID } from '../constants/config.js'
@@ -432,6 +433,8 @@ export const trashFiles = files => {
             }
           }
         }
+
+        dispatch(revokeSharingLink(file))
       }
     } catch (err) {
       if (!isAlreadyInTrash(err)) {

--- a/src/photos/ducks/albums/components/AlbumToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumToolbar.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter, Link } from 'react-router'
-import { leave } from 'cozy-client'
+import { leave, revokeLink as revokeSharingLink } from 'cozy-client'
 import { translate } from 'cozy-ui/react/I18n'
 
 import Alerter from '../../../components/Alerter'
@@ -196,7 +196,8 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
   selectItems: () => dispatch(showSelectionBar()),
   deleteAlbum: album =>
     confirm(<DestroyConfirm t={ownProps.t} albumName={album.name} />, () =>
-      dispatch(deleteAlbum(album))
+      dispatch(revokeSharingLink(album))
+        .then(dispatch(deleteAlbum(album)))
         .then(() => {
           ownProps.router.replace('albums')
           Alerter.success('Albums.remove_album.success', { name: album.name })


### PR DESCRIPTION
Revokes sharings when an album, a file or a folder is deleted.