### PR TITLE
fix: show revoked error for all types of errors

### DIFF
--- a/src/drive/components/LightFolderView.jsx
+++ b/src/drive/components/LightFolderView.jsx
@@ -61,10 +61,7 @@ class DumbFolderView extends React.Component {
         getFolderIdFromRoute(this.props.location, this.props.params)
       )
       .then(e => {
-        if (
-          e.type === 'OPEN_FOLDER_FAILURE' &&
-          /no permission doc for token/.test(e.error.reason.errors[0].detail)
-        ) {
+        if (e.type === 'OPEN_FOLDER_FAILURE') {
           this.setState(state => ({ ...state, revoked: true }))
         }
       })


### PR DESCRIPTION
There are other types of errors where we want to display the "revoked" screen — for example 404, or expired tokens.