### PR TITLE
fix: create cozy url

### DIFF
--- a/src/authentication/steps/Welcome.jsx
+++ b/src/authentication/steps/Welcome.jsx
@@ -5,6 +5,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import { Button } from 'cozy-ui/react'
 
 import styles from '../styles'
+import { getPlatformId } from '../../drive/mobile/lib/device'
 
 export class Welcome extends Component {
   render() {
@@ -34,9 +35,8 @@ export class Welcome extends Component {
             </a>
           ) : (
             <a
-              href={`https://cozy.io/fr/try-it?from=io.cozy.drive.mobile&os=${
-                this.platform
-              }`}
+              href={`https://manager.cozycloud.cc/cozy/create?pk_campaign=drive-${getPlatformId() ||
+                'browser'}`}
               className={styles['link']}
             >
               {t('mobile.onboarding.welcome.no_account_link')}

--- a/src/components/Button/CozyHomeLink.jsx
+++ b/src/components/Button/CozyHomeLink.jsx
@@ -6,8 +6,8 @@ import { ButtonLink } from 'cozy-ui/react'
 const CozyHomeLink = ({ from }, { t }) => (
   <ButtonLink
     label={t('Share.create-cozy')}
-    href={`https://cozy.io/try-it${
-      from ? `?from=${encodeURIComponent(from)}` : ''
+    href={` https://manager.cozycloud.cc/cozy/create${
+      from ? `?pk_campaign=${encodeURIComponent(from)}` : ''
     }`}
   />
 )

--- a/src/drive/components/LightFolderView.jsx
+++ b/src/drive/components/LightFolderView.jsx
@@ -86,7 +86,7 @@ class DumbFolderView extends React.Component {
               }
               theme="secondary"
             />
-            <CozyHomeLink from="link-sharing-drive" />
+            <CozyHomeLink from="sharing-drive" />
             <Menu
               title={t('toolbar.item_more')}
               className={classnames(

--- a/targets/photos/web/public/App.jsx
+++ b/targets/photos/web/public/App.jsx
@@ -75,7 +75,7 @@ class App extends Component {
                     icon="download"
                     label={t('Toolbar.album_download')}
                   />
-                  <CozyHomeLink from="link-sharing-photos" />
+                  <CozyHomeLink from="sharing-photos" />
                   <Menu
                     title={t('Toolbar.more')}
                     className={classNames(styles['pho-toolbar-menu'])}


### PR DESCRIPTION
We changed the webpage's URL where users are redirected if they want to create a cozy.

Related to https://github.com/cozy/cozy-banks/pull/19 (see https://trello.com/c/TMNxeLZO/917-1-changer-les-urls-pour-la-cr%C3%A9ation-de-cozy)