### PR TITLE
Fix Revoked component for Banks

### DIFF
--- a/src/authentication/Revoked.jsx
+++ b/src/authentication/Revoked.jsx
@@ -11,8 +11,10 @@ class Revoked extends Component {
   }
 
   async logBackIn() {
-    const url = cozy.client._url
-    cozy.client._storage.clear()
+    const url = this.props.url || cozy.client._url
+    if (cozy.client) {
+      cozy.client._storage.clear()
+    }
     try {
       const cozyClient = this.context.client
       const { client, token } = await cozyClient.register(url)
@@ -47,7 +49,8 @@ class Revoked extends Component {
 Revoked.propTypes = {
   onLogout: PropTypes.func.isRequired,
   onLogBackIn: PropTypes.func.isRequired,
-  router: PropTypes.object
+  router: PropTypes.object,
+  url: PropTypes.string
 }
 
 export default translate()(Revoked)

--- a/src/authentication/package.json
+++ b/src/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-authentication",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Component providing login to a Cozy",
   "main": "build/index.js",
   "author": "Cozy",

--- a/src/authentication/package.json
+++ b/src/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-authentication",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Component providing login to a Cozy",
   "main": "build/index.js",
   "author": "Cozy",


### PR DESCRIPTION
This very simple PR adds the ability to give an `url` prop to `Revoked` so that `cozy-client-js` is not needed for this.