### PR TITLE
Fix link to sharing in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ your app is available at http://drive.cozy.tools:8080.
 
 ### Share and send mails in development
 
-[See specific documentation](src/ducks/sharing/README.md)
+[See specific documentation](src/sharing/README.md)
 
 ### Run on you mobile phone or your tablet :phone:
 


### PR DESCRIPTION
#### Description

It fixes a typo in the main README.md with the previous location of the sharing documentation

#### Checklist

Before merging this PR, the following things must have been done:

~~- [ ] Faithful integration of the mockups at all screen sizes~~
~~- [ ] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)~~
~~- [ ] Localized in english and french~~
~~- [ ] All changes have test coverage~~
- [ ] Updated README, if necessary




