### PR TITLE
Don't show the viewer cross when displayed in an intent modal

### DIFF
--- a/src/drive/ducks/files/FileOpenerExternal.jsx
+++ b/src/drive/ducks/files/FileOpenerExternal.jsx
@@ -59,12 +59,10 @@ class FileOpener extends Component {
         {fileNotFound && <FileNotFoundError />}
         {!loading &&
           !fileNotFound && (
-            <Viewer
-              files={[file]}
-              currentIndex={0}
-              onClose={doNothing}
-              onChange={doNothing}
-            />
+            <div>
+              <h3>{file.name}</h3>
+              <Viewer files={[file]} currentIndex={0} onChange={doNothing} />
+            </div>
           )}
       </div>
     )

--- a/src/viewer/ViewerControls.jsx
+++ b/src/viewer/ViewerControls.jsx
@@ -103,13 +103,15 @@ class ViewerControls extends Component {
               {t('Viewer.actions.download')}
             </button>
           </div>
-          <div
-            className={styles['pho-viewer-toolbar-close']}
-            onClick={onClose}
-            title={t('Viewer.close')}
-          >
-            <div className={styles['pho-viewer-toolbar-close-cross']} />
-          </div>
+          {onClose && (
+            <div
+              className={styles['pho-viewer-toolbar-close']}
+              onClick={onClose}
+              title={t('Viewer.close')}
+            >
+              <div className={styles['pho-viewer-toolbar-close-cross']} />
+            </div>
+          )}
         </div>
         {!isMobile &&
           hasPrevious && (


### PR DESCRIPTION
I choosed to not show the cross when the `onClose` prop isn't provided. That's a simpler solution than what we thought about.