### PR TITLE
Sorting fixes

### DIFF
--- a/src/drive/actions/async.js
+++ b/src/drive/actions/async.js
@@ -85,9 +85,8 @@ class Stack {
         ...files
       ]
     } else {
-      return await query({ dir_id: folderId }).filter(
-        f => f.name !== '.cozy_trash'
-      )
+      const resp = await query({ dir_id: folderId })
+      return resp.filter(f => f.name !== '.cozy_trash')
     }
   }
 

--- a/src/drive/actions/async.js
+++ b/src/drive/actions/async.js
@@ -214,7 +214,7 @@ class PouchDB {
           : []
       return [...folders, ...files]
     } else {
-      return await query()
+      return query()
     }
   }
 
@@ -273,21 +273,3 @@ const normalizeFileFromPouchDB = f => ({
   id: f._id,
   _type: 'io.cozy.files'
 })
-
-const sortFilesAndFolders = (items, sortAttribute) => {
-  if (sortAttribute === 'updated_at') {
-    return items
-  }
-  // Sadly CouchDB only supports a single sort direction for all fields,
-  // so we can't sort by type to separate folders and files and have to
-  // do it by hand
-  const folders = items.reduce(
-    (acc, f) => (f.type === 'directory' ? [...acc, f] : acc),
-    []
-  )
-  const files = items.reduce(
-    (acc, f) => (f.type !== 'directory' ? [...acc, f] : acc),
-    []
-  )
-  return [...folders, ...files]
-}

--- a/src/drive/actions/index.js
+++ b/src/drive/actions/index.js
@@ -1,6 +1,10 @@
 /* global cozy */
 import { getAdapter, extractFileAttributes } from './async'
-import { getSort } from '../reducers'
+import {
+  getSort,
+  getLoadedFilesCount,
+  getLoadedFoldersCount
+} from '../reducers'
 import { isCordova } from '../mobile/lib/device'
 import {
   saveFileWithCordova,
@@ -143,7 +147,9 @@ export const fetchMoreFiles = (folderId, skip, limit) => {
               sort.attribute,
               sort.order,
               skip,
-              limit
+              limit,
+              getLoadedFoldersCount(getState()),
+              getLoadedFilesCount(getState())
             )
       return dispatch({
         type: FETCH_MORE_FILES_SUCCESS,

--- a/src/drive/components/FileList.jsx
+++ b/src/drive/components/FileList.jsx
@@ -49,6 +49,7 @@ class FileList extends PureComponent {
     // We're in /recent
     if (!this.props.displayedFolder) return false
     if (isCordova()) {
+      console.log(this.props.files.length < LIMIT, !this.state.hasNoMoreRows)
       if (this.props.files.length < LIMIT) return false
       return !this.state.hasNoMoreRows
     }

--- a/src/drive/components/FileList.jsx
+++ b/src/drive/components/FileList.jsx
@@ -49,7 +49,6 @@ class FileList extends PureComponent {
     // We're in /recent
     if (!this.props.displayedFolder) return false
     if (isCordova()) {
-      console.log(this.props.files.length < LIMIT, !this.state.hasNoMoreRows)
       if (this.props.files.length < LIMIT) return false
       return !this.state.hasNoMoreRows
     }

--- a/src/drive/reducers/index.js
+++ b/src/drive/reducers/index.js
@@ -36,7 +36,9 @@ export {
   getFolderIdFromRoute,
   getFolderPath,
   getFolderUrl,
-  getSort
+  getSort,
+  getLoadedFilesCount,
+  getLoadedFoldersCount
 } from './view'
 export { isMenuVisible as isActionMenuVisible } from '../ducks/actionmenu'
 

--- a/src/drive/reducers/view.js
+++ b/src/drive/reducers/view.js
@@ -263,6 +263,11 @@ export const getFilesWithLinks = ({ view }, folderId) =>
 
 export const getVisibleFiles = ({ view }) => view.files
 
+export const getLoadedFilesCount = ({ view }) =>
+  view.files.filter(f => f.type !== 'directory').length
+export const getLoadedFoldersCount = ({ view }) =>
+  view.files.filter(f => f.type === 'directory').length
+
 export const getSort = ({ view }) => view.sort
 
 export const getFileById = ({ view }, id) => {

--- a/src/drive/styles/table.styl
+++ b/src/drive/styles/table.styl
@@ -85,6 +85,12 @@
 .fil-content-header-sortasc
     color charcoalGrey
 
+.fil-content-header-sortdesc
+.fil-content-header-sortasc
+.fil-content-header-sortabledesc
+.fil-content-header-sortableasc
+    cursor pointer
+
 .fil-content-file-action
     display     none
     text-align  right


### PR DESCRIPTION
Sorting by name didn't work correctly on large folders because folders and files got mixed when fetching more. Because Couch and Pouch can't sort on 2 fields but different orders (it'd allow us to sort by type AND name and be done), I had to resort to fetch folders and files separately.