### PR TITLE
fix: longer file name length on mobile

### DIFF
--- a/src/drive/styles/table.styl
+++ b/src/drive/styles/table.styl
@@ -135,9 +135,13 @@
     .fil-content-offline
         display none
         width 1.25rem
+        margin-left 1rem
         height 1.25rem
         background malachite embedurl('../assets/icons/icon-phone-download-white.svg') center center / .9rem no-repeat
         border-radius 50%
+
+    .fil-content-sharestatus
+        margin-left 1rem
 
 .fil-content-file-select
     flex       0 0 2rem
@@ -296,8 +300,8 @@ mime-types('fil-file-', '../assets/icons/')
 
     .fil-content-status
         display    block
-        flex       0 0 1.875rem
-        padding    0 0 0 1rem
+        flex       0 0 auto
+        padding    0
 
         .fil-content-offline
             display inline-block
@@ -307,12 +311,13 @@ mime-types('fil-file-', '../assets/icons/')
 
     .fil-content-file-action
         display    block
-        flex       0 0 2.875rem
+        flex       0 0 3rem
         padding    0
 
     .fil-content-cell.fil-content-file
         padding-left 3.8125rem
         background-position 1rem center
+        padding-right 0
 
     .fil-content-cell.fil-content-file-select
         display none


### PR DESCRIPTION
Better use of space on mobile, especially when "offline" icon is on.

![capture d ecran - 2018-04-23 a 15 19 34](https://user-images.githubusercontent.com/1280069/39129933-1fcdfd5a-470c-11e8-9c6e-acd545e1b07a.png)
