### PR TITLE
release 1.4.1 with intent disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-drive",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "src/main.jsx",
   "scripts": {
     "build:drive": "npm run build:drive:browser",

--- a/targets/drive/manifest.webapp
+++ b/targets/drive/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Drive",
   "slug": "drive",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "webapp",
   "licence": "AGPL-3.0",
   "icon": "public/app-icon.svg",

--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -22,9 +22,9 @@
         <allow-intent href="market:*" />
         <custom-config-file target="AndroidManifest.xml" parent="./application/activity/[@android:name='MainActivity']">
             <intent-filter android:label="Cozy Drive">
-                <action android:name="android.intent.action.SEND" />
-                <action android:name="android.intent.action.SEND_MULTIPLE" />
-                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.intent.action.SEND__DISABLED" />
+                <action android:name="android.intent.action.SEND_MULTIPLE__DISABLED" />
+                <category android:name="android.intent.category.DEFAULT__DISABLED" />
                 <data android:mimeType="*/*" />
             </intent-filter>
         </custom-config-file>

--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.cozy.drive.mobile" version="1.4.0"
+<widget id="io.cozy.drive.mobile" version="1.4.1"
     xmlns="http://www.w3.org/ns/widgets"
     xmlns:cdv="http://cordova.apache.org/ns/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">

--- a/targets/drive/mobile/fastlane/metadata/android/en-US/changelogs/140.txt
+++ b/targets/drive/mobile/fastlane/metadata/android/en-US/changelogs/140.txt
@@ -1,0 +1,8 @@
+Thank you for using Cozy Drive! ☁️
+Here are the changes in the latest version of the app:
+
+- Add sort by name & date
+- Improve folder loading state
+- Search results now open within the viewer
+- (mobile) Improve readability (bigger lines with more information)
+- Minor bug fixes

--- a/targets/drive/mobile/fastlane/metadata/android/en-US/changelogs/141.txt
+++ b/targets/drive/mobile/fastlane/metadata/android/en-US/changelogs/141.txt
@@ -1,0 +1,8 @@
+Thank you for using Cozy Drive! ☁️
+Here are the changes in the latest version of the app:
+
+- Add sort by name & date
+- Improve folder loading state
+- Search results now open within the viewer
+- (mobile) Improve readability (bigger lines with more information)
+- Minor bug fixes

--- a/targets/drive/mobile/fastlane/metadata/android/fr-FR/changelogs/140.txt
+++ b/targets/drive/mobile/fastlane/metadata/android/fr-FR/changelogs/140.txt
@@ -1,0 +1,8 @@
+Merci d'utiliser Cozy Drive ! ☁️
+Dans cette version:
+
+- Ajout du tri par nom et date
+- Amélioration de l'état de chargement d'un dossier
+- Les résultats de recherche s'ouvrent désormais dans la visionneuse
+- (mobile) Amélioration de la lisibilité (des lignes plus grandes avec plus d'informations)
+- Correction de bogues mineurs

--- a/targets/drive/mobile/fastlane/metadata/android/fr-FR/changelogs/141.txt
+++ b/targets/drive/mobile/fastlane/metadata/android/fr-FR/changelogs/141.txt
@@ -1,0 +1,8 @@
+Merci d'utiliser Cozy Drive ! ☁️
+Dans cette version:
+
+- Ajout du tri par nom et date
+- Amélioration de l'état de chargement d'un dossier
+- Les résultats de recherche s'ouvrent désormais dans la visionneuse
+- (mobile) Amélioration de la lisibilité (des lignes plus grandes avec plus d'informations)
+- Correction de bogues mineurs

--- a/targets/photos/manifest.webapp
+++ b/targets/photos/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Photos",
   "slug": "photos",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "webapp",
   "licence": "AGPL-3.0",
   "icon": "public/app-icon.svg",


### PR DESCRIPTION
In release `1.4.0` we forgot to disable the "share to Cozy Drive" feature on Android.
Here is a fix for the previous release, `master` will be tagged `1.4.1`.