### PR TITLE
hotfix: photos has a white screen

### DIFF
--- a/src/components/pushClient/Banner.jsx
+++ b/src/components/pushClient/Banner.jsx
@@ -53,7 +53,7 @@ class BannerClient extends Component {
       <div className={styles['coz-banner-client']}>
         <ButtonLink
           href={t(mobileLink)}
-          target
+          target="_blank"
           className={styles['coz-btn-clientMobile']}
           onClick={e => {
             this.markAsSeen('banner')
@@ -64,7 +64,7 @@ class BannerClient extends Component {
           <span>{t('Nav.banner-txt-client')}</span>
           <ButtonLink
             href={t(desktopLink)}
-            target
+            target="_blank"
             theme="alpha"
             onClick={e => {
               this.markAsSeen('banner')

--- a/src/photos/reducers/index.js
+++ b/src/photos/reducers/index.js
@@ -1,5 +1,5 @@
 import upload from '../ducks/upload'
-import alerterReducer from 'cozy-ui/react/Alerter'
+import alerterReducer from '../../drive/ducks/alerter'
 
 export default {
   upload,


### PR DESCRIPTION
Includes two fixes:
- 6789554e (Enguerran, 19 seconds ago) fix: cozy/cozy-ui/react/Alerter update. It does not have an exported reducer anymore: https://github.com/cozy/cozy-ui/pull/400/files\#diff-1806f13b3bea81343299a91e179d3803L36 in https://github.com/cozy/cozy-ui/pull/400. Drive were updated https://github.com/cozy/cozy-drive/pull/862/commits/3056cea4a8b8cc90c03b9ae19a1641c5cecad2f8 but not photos
- 900abd07 (Enguerran, 4 minutes ago) fix: propTypes for ButtonLink is string. Changed in https://github.com/cozy/cozy-ui/pull/327