### PR TITLE
Fix: rename bug

### DIFF
--- a/src/drive/ducks/files/rename.js
+++ b/src/drive/ducks/files/rename.js
@@ -1,7 +1,8 @@
 /* global cozy */
 
 import { getFiles } from './files'
-import { META_DEFAULTS as meta, extractFileAttributes } from '../../actions'
+import { META_DEFAULTS as meta } from '../../actions'
+import { extractFileAttributes } from '../../actions/async.js'
 
 // constants
 


### PR DESCRIPTION
After renaming a file, the text area was still active, and a warning was thrown in the console, which is not the good behaviour.
This fixes this bug.

#### Checklist

Before merging this PR, the following things must have been done:

- [ ] Faithful integration of the mockups at all screen sizes
- [ ] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [ ] Localized in english and french
- [ ] All changes have test coverage
- [ ] Updated README, if necessary

If this PR relies on changes in one of our internal libraries (cozy-client-js or cozy-ui, for example), please also do the following things:

- [ ] The package.json and yarn.lock files include the correct dependency version, in those versions have been released
- [ ] [cozy-client-js](https://github.com/cozy/cozy-client-js) documentation and tests are up to date
- [ ] [cozy-ui](https://github.com/cozy/cozy-ui) documentation and style guides are up to date

*(If not, please remove this last section.)*
