### PR TITLE
fix: reload after upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ desktop.ini
 # Editors / IDEs
 .floo
 .flooignore
+.brackets.json
 
 # Mobile
 targets/*/mobile/hooks

--- a/src/drive/ducks/files/Toolbar.jsx
+++ b/src/drive/ducks/files/Toolbar.jsx
@@ -245,7 +245,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       addToUploadQueue(
         files,
         displayedFolder.id,
-        file => uploadedFile(file),
+        file => dispatch(uploadedFile(file)),
         (loaded, quotas, conflicts, errors) =>
           uploadQueueProcessed(loaded, quotas, conflicts, errors, ownProps.t)
       )

--- a/src/drive/ducks/upload/index.js
+++ b/src/drive/ducks/upload/index.js
@@ -57,8 +57,6 @@ const queue = (state = [], action) => {
 }
 export default combineReducers({ queue })
 
-const extractFileAttributes = f => Object.assign({}, f, f.attributes)
-
 const processNextFile = (
   fileUploadedCallback,
   queueCompletedCallback,
@@ -73,8 +71,7 @@ const processNextFile = (
     dispatch({ type: UPLOAD_FILE, file })
     const uploadedFile = await cozy.client.files.create(file, { dirID })
     dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file })
-    // TODO: is the extractFileAttributes call really necessary?
-    fileUploadedCallback(extractFileAttributes(uploadedFile))
+    fileUploadedCallback(uploadedFile)
   } catch (error) {
     console.warn(error)
     const statusError = {

--- a/src/drive/mobile/lib/intents.js
+++ b/src/drive/mobile/lib/intents.js
@@ -85,7 +85,7 @@ const uploadFiles = (files, store) => {
     addToUploadQueue(
       files,
       ROOT_DIR_ID,
-      uploadedFile,
+      file => store.dispatch(uploadedFile(file)),
       (loaded, quotas, conflicts, errors) =>
         uploadQueueProcessed(loaded, quotas, conflicts, errors)
     )


### PR DESCRIPTION
We need to call [this function](https://github.com/cozy/cozy-drive/blob/master/src/drive/actions/index.jsx#L231) to update the redux state after uploading a file, so that the file actually appears.

This function is used 3 times, but with 3 different forms. Only one of them actually worked. This PR fixes the two others.