### PR TITLE
Fixed missing icons in the search suggestions

### DIFF
--- a/src/drive/ducks/files/FileOpenerExternal.jsx
+++ b/src/drive/ducks/files/FileOpenerExternal.jsx
@@ -1,3 +1,4 @@
+/* global cozy */
 /**
  * This component was previously named FileOpener
  * It has been renamed since it is used in :
@@ -7,14 +8,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { flowRight as compose } from 'lodash'
 
 import { Spinner, translate } from 'cozy-ui/react'
 import util from 'cozy-ui/stylus/utilities/text'
 import styles from './styles'
 import Viewer from 'viewer'
-import { fetchDocument, getDocument } from 'cozy-client'
 
 const doNothing = () => {}
 
@@ -25,33 +23,26 @@ const FileNotFoundError = translate()(({ t }) => (
 ))
 
 class FileOpener extends Component {
-  state = { loading: true }
+  state = {
+    loading: true,
+    file: null
+  }
   componentWillMount() {
     this.loadFileInfo()
   }
 
   async loadFileInfo() {
-    const { alert } = this.props
     try {
       this.setState({ fileNotFound: false })
-
-      const res = await this.props.fetchFile()
-
-      if (!res) {
-        this.setState({ fileNotFound: true })
-      }
+      const file = await cozy.client.files.statById(getFileId(this.props))
+      this.setState({ file, loading: false })
     } catch (e) {
-      alert({
-        message: 'alert.could_not_open_file'
-      })
-    } finally {
-      this.setState({ loading: false })
+      this.setState({ fileNotFound: true, loading: false })
     }
   }
 
   render() {
-    const { file } = this.props
-    const { loading, fileNotFound } = this.state
+    const { file, loading, fileNotFound } = this.state
 
     return (
       <div className={styles.fileOpener}>
@@ -75,17 +66,6 @@ const getFileId = ownProps => {
   return ownProps.fileId || ownProps.router.params.fileId
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  alert: data => dispatch({ type: 'ALERT', alert: data }),
-  fetchFile: async () => {
-    return dispatch(fetchDocument('io.cozy.files', getFileId(ownProps)))
-  }
-})
-
-const mapStateToProps = (state, ownProps) => ({
-  file: getDocument(state, 'io.cozy.files', getFileId(ownProps))
-})
-
 FileOpener.PropTypes = {
   router: PropTypes.shape({
     params: PropTypes.shape({
@@ -95,7 +75,4 @@ FileOpener.PropTypes = {
   fileId: PropTypes.number
 }
 
-export default compose(
-  translate(),
-  connect(mapStateToProps, mapDispatchToProps)
-)(FileOpener)
+export default translate()(FileOpener)

--- a/targets/drive/web/services.jsx
+++ b/targets/drive/web/services.jsx
@@ -1,4 +1,4 @@
-/* global __DEVELOPMENT__ */
+/* global __DEVELOPMENT__, cozy */
 
 import 'babel-polyfill'
 
@@ -6,8 +6,6 @@ import React from 'react'
 import { render } from 'react-dom'
 import IntentHandler from 'drive/ducks/services'
 import { I18n } from 'cozy-ui/react/I18n'
-import { CozyClient, CozyProvider } from 'cozy-client'
-import configureStore from 'drive/store/configureStore'
 
 if (__DEVELOPMENT__) {
   // Enables React dev tools for Preact
@@ -39,21 +37,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const { intent } = getQueryParameter()
 
-  const client = new CozyClient({
+  // we still need cozy-client-js for intents and offline
+  // cozy-client is not used right now
+  cozy.client.init({
     cozyURL: cozyUrl,
-    token: data.cozyToken
+    token: data.cozyToken,
+    offline: { doctypes: ['io.cozy.files'] }
   })
-
-  const store = configureStore(client)
 
   render(
     <I18n
       lang={data.cozyLocale}
       dictRequire={lang => require(`drive/locales/${lang}`)}
     >
-      <CozyProvider store={store} client={client}>
-        <IntentHandler intentId={intent} />
-      </CozyProvider>
+      <IntentHandler intentId={intent} />
     </I18n>,
     root
   )


### PR DESCRIPTION
The icons were missing because we sent wrong URLs. With that fix, we now send [data URIs](https://github.com/cozy/cozy-drive/compare/master...goldoraf:fix-search-icons?expand=1#diff-ab8f134c72c2b24476f993fcb9f5c5e2R129).

I also reverted back to using cozy-client-js for the file list fetching and the file opener intent because we want to get rid of the old cozy-client, but the PouchDB integration in the new cozy-client is not dry enough.