### PR TITLE
Fixed search performance on first search

### DIFF
--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -48,23 +48,13 @@ class SuggestionProvider extends React.Component {
   // fetches pretty much all the files and preloads FuzzyPathSearch
   async indexFiles() {
     return new Promise(async resolve => {
-      const index = await cozy.client.data.defineIndex('io.cozy.files', ['_id'])
-
-      let files = []
-      const limit = 100
-      const pageLimit = 500 // that's 50 000 files max
-      let page = 0
-      let response
-      do {
-        response = await cozy.client.data.query(index, {
-          selector: { _id: { $gt: null } },
-          limit: limit,
-          skip: page * limit,
-          wholeResponse: true
-        })
-        files = files.concat(response.docs)
-        ++page
-      } while (response.next && page < pageLimit)
+      const resp = await cozy.client.fetchJSON(
+        'GET',
+        `/data/io.cozy.files/_all_docs?include_docs=true`
+      )
+      const files = resp.rows
+        .filter(row => !row.doc.hasOwnProperty('views'))
+        .map(row => ({ id: row.id, ...row.doc }))
 
       const folders = files.filter(file => file.type === TYPE_DIRECTORY)
 


### PR DESCRIPTION
Using a different route allows us to fetch all files in a single request, performance should be better on instances with a lot of files.