### PR TITLE
fix: specific message when upload fails because of the network

### DIFF
--- a/src/drive/actions/index.jsx
+++ b/src/drive/actions/index.jsx
@@ -236,7 +236,14 @@ export const uploadedFile = file => {
   }
 }
 
-export const uploadQueueProcessed = (loaded, quotas, conflicts, errors, t) => {
+export const uploadQueueProcessed = (
+  loaded,
+  quotas,
+  conflicts,
+  networkErrors,
+  errors,
+  t
+) => {
   if (quotas.length > 0) {
     // quota errors have their own modal instead of a notification, if possible
     if (t) {
@@ -249,8 +256,10 @@ export const uploadQueueProcessed = (loaded, quotas, conflicts, errors, t) => {
       smart_count: loaded.length,
       conflictNumber: conflicts.length
     })
+  } else if (networkErrors.length > 0) {
+    Alerter.info('upload.alert.network')
   } else if (errors.length > 0) {
-    Alerter.error('upload.alert.errors')
+    Alerter.info('upload.alert.errors')
   } else {
     Alerter.success('upload.alert.success', {
       smart_count: loaded.length

--- a/src/drive/containers/FileExplorer.jsx
+++ b/src/drive/containers/FileExplorer.jsx
@@ -114,8 +114,15 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         files,
         folderId,
         file => dispatch(uploadedFile(file)),
-        (loaded, quotas, conflicts, errors) =>
-          uploadQueueProcessed(loaded, quotas, conflicts, errors, ownProps.t)
+        (loaded, quotas, conflicts, networkErrors, errors) =>
+          uploadQueueProcessed(
+            loaded,
+            quotas,
+            conflicts,
+            networkErrors,
+            errors,
+            ownProps.t
+          )
       )
     )
   }

--- a/src/drive/ducks/files/Toolbar.jsx
+++ b/src/drive/ducks/files/Toolbar.jsx
@@ -246,8 +246,15 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         files,
         displayedFolder.id,
         file => dispatch(uploadedFile(file)),
-        (loaded, quotas, conflicts, errors) =>
-          uploadQueueProcessed(loaded, quotas, conflicts, errors, ownProps.t)
+        (loaded, quotas, conflicts, networkErrors, errors) =>
+          uploadQueueProcessed(
+            loaded,
+            quotas,
+            conflicts,
+            networkErrors,
+            errors,
+            ownProps.t
+          )
       )
     )
   },

--- a/src/drive/ducks/upload/UploadQueue.jsx
+++ b/src/drive/ducks/upload/UploadQueue.jsx
@@ -36,7 +36,7 @@ const Item = translate()(({ t, file, status, type }) => {
       className={classNames(styles['upload-queue-item'], {
         [styles['upload-queue-item--done']]: status === 'loaded',
         [styles['upload-queue-item--error']]:
-          status === 'failed' || status === 'conflict'
+          status === 'failed' || status === 'conflict' || status === 'network'
       })}
     >
       <div

--- a/src/drive/ducks/upload/styles.styl
+++ b/src/drive/ducks/upload/styles.styl
@@ -142,12 +142,9 @@ progress.upload-queue-progress::-moz-progress-bar
         @extend $icon
         background-image embedurl('./assets/icons/icon-cross.svg')
 
-    .item-failed
-        @extend $icon-16
-        @extend $icon
-        background-image embedurl('./assets/icons/icon-warning.svg')
-
-    .item-conflict
+    .item-failed,
+    .item-conflict,
+    .item-network
         @extend $icon-16
         @extend $icon
         background-image embedurl('./assets/icons/icon-warning.svg')

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -426,7 +426,8 @@
         "%{smart_count} file uploaded with success. |||| %{smart_count} files uploaded with success.",
       "success_conflicts":
         "%{smart_count} file uploaded with %{conflictNumber} conflict(s). |||| %{smart_count} files uploaded with %{conflictNumber} conflict(s).",
-      "errors": "Errors occurred during the file upload."
+      "errors": "Errors occurred during the file upload.",
+      "network": "You are currenly offline. Please try again once you're connected."
     }
   },
   "intents": {

--- a/src/drive/mobile/lib/intents.js
+++ b/src/drive/mobile/lib/intents.js
@@ -86,8 +86,7 @@ const uploadFiles = (files, store) => {
       files,
       ROOT_DIR_ID,
       file => store.dispatch(uploadedFile(file)),
-      (loaded, quotas, conflicts, errors) =>
-        uploadQueueProcessed(loaded, quotas, conflicts, errors)
+      uploadQueueProcessed
     )
   )
 }


### PR DESCRIPTION
- Detects network errors
- Shows a specific message when they happen
- Regular, unspecified errors are now grey instead of bright red