### PR TITLE
fix: init cozy-client-js offline databases

### DIFF
--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -62,7 +62,8 @@ export const restoreCozyClientJs = (uri, clientInfos, token) => {
         ...clientInfos,
         scopes: token.scope
       }
-    }
+    },
+    offline: { doctypes: ['io.cozy.files'] }
   })
 
   cozy.client.saveCredentials(clientInfos, token)


### PR DESCRIPTION
Forgot this during the recent cozy-client migration.