### PR TITLE
Added folder upload by DnD

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "dependencies": {
     "classnames": "2.2.5",
     "cozy-bar": "4.10.4",
-    "cozy-client": "1.0.0-beta.7",
+    "cozy-client": "1.0.0-beta.8",
     "cozy-client-js": "0.6.2",
     "cozy-ui": "9.0.1",
     "create-react-context": "0.2.2",

--- a/src/drive/ducks/upload/UploadQueue.jsx
+++ b/src/drive/ducks/upload/UploadQueue.jsx
@@ -125,7 +125,7 @@ class UploadQueue extends Component {
             {queue.map(item => (
               <Item
                 file={item.file.name}
-                type={item.file.type}
+                type={item.isDirectory ? 'folder' : item.file.type}
                 status={item.status}
               />
             ))}

--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -15,7 +15,7 @@ import { saveState } from './persistedState'
 import { ANALYTICS_URL, getReporterConfiguration } from '../mobile/lib/reporter'
 
 const configureStore = (client, initialState = {}) => {
-  const middlewares = [thunkMiddleware]
+  const middlewares = [thunkMiddleware.withExtraArgument(client)]
   if (__TARGET__ === 'mobile') {
     middlewares.push(RavenMiddleWare(ANALYTICS_URL, getReporterConfiguration()))
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,20 +2636,22 @@ cozy-client-js@^0.3.19:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
 
-cozy-client@1.0.0-beta.7:
-  version "1.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-1.0.0-beta.7.tgz#4489e50ff31a211b0537520a91dc7376053acf07"
+cozy-client@1.0.0-beta.8:
+  version "1.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-1.0.0-beta.8.tgz#b662660b10bf957b7ee66f0c08e2d0681bdd7154"
   dependencies:
-    cozy-stack-client "^1.0.0-beta.7"
+    cozy-stack-client "^1.0.0-beta.8"
     lodash "^4.17.5"
     prop-types "^15.6.0"
     react "^16.2.0"
     react-redux "^5.0.6"
     redux "^3.7.2"
 
-cozy-stack-client@^1.0.0-beta.7:
-  version "1.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-1.0.0-beta.7.tgz#a0703d7b544f45160795a0c4a8bb01e0eff648f4"
+cozy-stack-client@^1.0.0-beta.8:
+  version "1.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-1.0.0-beta.8.tgz#7f67e504b0e54394a9e65ac0a4ee695517497933"
+  dependencies:
+    mimetype "^0.0.8"
 
 cozy-ui@9.0.1:
   version "9.0.1"
@@ -6876,6 +6878,10 @@ mime@^1.5.0:
 mime@~1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
+
+mimetype@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mimetype/-/mimetype-0.0.8.tgz#fb30022794bbf7725cb7b46df820e87dd91fd086"
 
 mimic-fn@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Folder upload by Dn'd didn't work correctly: first, it simply didn't work at all on FF because of mimetypes (fixed with the new CC version), and second, it uploaded a flat list of files instead of creating dirs and sub-dirs. That's why I moved the folder handling code [in the upload module](https://github.com/cozy/cozy-drive/compare/master...goldoraf:folder-dnd-ff?expand=1#diff-a8db4e1272c43f0485054c5491a45fc0R104).

I also needed to have access to a CC instance in the upload thunks, so I used the [withExtraArgument method of redux-thunk](https://github.com/cozy/cozy-drive/compare/master...goldoraf:folder-dnd-ff?expand=1#diff-967a91470826706845a91e50ee1316c2R18).