### PR TITLE
Replaced Drive ActionMenu by the cozy-ui one

### DIFF
--- a/src/drive/components/FileActionMenu.jsx
+++ b/src/drive/components/FileActionMenu.jsx
@@ -3,10 +3,9 @@ import styles from '../styles/actionmenu'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import classNames from 'classnames'
+import ActionMenu from 'cozy-ui/react/ActionMenu'
 import { translate } from 'cozy-ui/react/I18n'
 import Toggle from 'cozy-ui/react/Toggle'
-import withGestures from '../lib/withGestures'
-import Hammer from 'hammerjs'
 
 import Spinner from 'cozy-ui/react/Spinner'
 import { splitFilename, getClassFromMime } from '../containers/File'
@@ -57,7 +56,7 @@ const mapStateToProps = (state, ownProps) => ({
 export const ConnectedToggleMenuItem = connect(mapStateToProps)(MenuItem)
 
 const Menu = props => {
-  const { t, files, actions } = props
+  const { t, files, actions, onClose } = props
   const actionNames = Object.keys(actions).filter(actionName => {
     const action = actions[actionName]
     return (
@@ -71,7 +70,7 @@ const Menu = props => {
       <MenuHeaderSelection {...props} />
     )
   return (
-    <div className={styles['fil-actionmenu']}>
+    <ActionMenu className={styles['fil-actionmenu']} onClose={onClose}>
       {header}
       <hr />
       {actionNames.map(actionName => {
@@ -86,7 +85,7 @@ const Menu = props => {
           </Component>
         )
       })}
-    </div>
+    </ActionMenu>
   )
 }
 
@@ -120,105 +119,4 @@ const MenuHeaderSelection = ({ t, files }) => {
   )
 }
 
-const ActionMenu = translate()(Menu)
-
-const Backdrop = withGestures(ownProps => ({
-  tap: () => ownProps.onClose()
-}))(() => <div className={styles['fil-actionmenu-backdrop']} />)
-
-class FileActionMenu extends Component {
-  componentDidMount() {
-    this.gesturesHandler = new Hammer.Manager(this.fam, {
-      recognizers: [[Hammer.Pan, { direction: Hammer.DIRECTION_VERTICAL }]]
-    })
-
-    this.actionMenuNode = this.actionMenu.getDOMNode()
-
-    this.dismissHandler = this.dismiss.bind(this)
-
-    // to be completely accurate, `maximumGestureDelta` should be the difference between the top of the menu and the bottom of the page; but using the height is much easier to compute and accurate enough.
-    const maximumGestureDistance = this.actionMenuNode.getBoundingClientRect()
-      .height
-    const minimumCloseDistance = 0.6 // between 0 and 1, how far down the gesture must be to be considered complete upon release
-    const minimumCloseVelocity = 0.6 // a gesture faster than this will dismiss the menu, regardless of distance traveled
-
-    let currentGestureProgress = null
-
-    this.gesturesHandler.on('panstart', e => {
-      // disable css transitions during the gesture
-      this.actionMenuNode.classList.remove(styles['with-transition'])
-      currentGestureProgress = 0
-    })
-    this.gesturesHandler.on('pan', e => {
-      currentGestureProgress = e.deltaY / maximumGestureDistance
-      this.applyTransformation(currentGestureProgress)
-    })
-    this.gesturesHandler.on('panend', e => {
-      // re enable css transitions
-      this.actionMenuNode.classList.add(styles['with-transition'])
-      // dismiss the menu if the swipe pan was bigger than the treshold, or if it was a fast, downward gesture
-      let shouldDismiss =
-        e.deltaY / maximumGestureDistance >= minimumCloseDistance ||
-        (e.deltaY > 0 && e.velocity >= minimumCloseVelocity)
-
-      if (shouldDismiss) {
-        if (currentGestureProgress >= 1) {
-          // the menu was already hidden, we can close it right away
-          this.dismissHandler()
-        } else {
-          // we need to transition the menu to the bottom before dismissing it
-          this.actionMenuNode.addEventListener(
-            'transitionend',
-            this.dismissHandler,
-            false
-          )
-          this.applyTransformation(1)
-        }
-      } else {
-        this.applyTransformation(0)
-      }
-    })
-  }
-
-  componentWillUnmount() {
-    this.gesturesHandler.destroy()
-  }
-
-  // applies a css trasnform to the element, based on the progress of the gesture
-  applyTransformation(progress) {
-    // wrap the progress between 0 and 1
-    progress = Math.min(1, Math.max(0, progress))
-    this.actionMenuNode.style.transform = 'translateY(' + progress * 100 + '%)'
-  }
-
-  dismiss() {
-    this.props.onClose()
-    // remove the event handler so subsequent transitions don't trigger dismissals
-    this.actionMenuNode.removeEventListener(
-      'transitionend',
-      this.dismissHandler
-    )
-    this.applyTransformation(0)
-  }
-
-  render(props) {
-    return (
-      <div
-        className={styles['fil-actionmenu-wrapper']}
-        ref={fam => {
-          this.fam = fam
-        }}
-      >
-        <Backdrop {...props} />
-        <ActionMenu
-          {...props}
-          ref={actionMenu => {
-            this.actionMenu = actionMenu
-          }}
-        />
-      </div>
-    )
-  }
-}
-
-export default translate()(FileActionMenu)
+export default translate()(Menu)

--- a/src/drive/styles/actionmenu.styl
+++ b/src/drive/styles/actionmenu.styl
@@ -1,28 +1,4 @@
-@require 'components/popover.styl'
-@require 'settings/z-index.styl'
-
-.fil-actionmenu-backdrop
-    position   fixed
-    z-index    $overlay-index
-    top        0
-    right      0
-    bottom     0
-    left       0
-    display    block
-    background rgba(50, 54, 63, 0.5)
-
 .fil-actionmenu
-    @extend        $popover
-    z-index        $file-action-menu
-    position       fixed
-    bottom         .5625rem
-    width          "calc(100% - %s)" % 1rem
-    margin         0 .5rem
-    padding-bottom .3125rem
-
-    &.with-transition
-        transition transform .1s ease-out
-
     hr
         margin-top 0
 


### PR DESCRIPTION
We have some UI fixes to implement on the ActionMenu (swipe RTL instead of top-down, ...), but as we'd like Banks to benefit from that fixes too, it's better to implement them in cozy-ui. So this PR makes Drive use the cozy-ui ActionMenu.