### PR TITLE
fix: replace finally call for unsupported browsers

### DIFF
--- a/src/components/Image/ImageLoader.jsx
+++ b/src/components/Image/ImageLoader.jsx
@@ -45,6 +45,13 @@ class ImageLoader extends React.Component {
   }
 
   checkImageSource(src) {
+    const cleanImageLoader = () => {
+      clearTimeout(this.timeout)
+      this.img.onload = this.img.onerror = null
+      this.img.src = ''
+      this.img = null
+    }
+
     return new Promise((resolve, reject) => {
       this.img = new Image()
       this.img.onload = resolve
@@ -54,12 +61,7 @@ class ImageLoader extends React.Component {
         () => reject(new Error('Loading image took too long')),
         TTL
       )
-    }).finally(() => {
-      clearTimeout(this.timeout)
-      this.img.onload = this.img.onerror = null
-      this.img.src = ''
-      this.img = null
-    })
+    }).then(cleanImageLoader, cleanImageLoader)
   }
 
   async getFileLinks(file) {


### PR DESCRIPTION
Firefox ESR, probably among others, doesn't yet support `Promise().finally`.