### PR TITLE
fix: ios app id for ratting

### DIFF
--- a/src/drive/mobile/containers/RatingModal.jsx
+++ b/src/drive/mobile/containers/RatingModal.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 import { Alerter, Button } from 'cozy-ui/react'
 import withPersistentState from '../lib/withPersistentState'
-import { SOFTWARE_ID, SOFTWARE_NAME } from '../lib/constants'
+import { SOFTWARE_ID, SOFTWARE_NAME, APP_STORE_ID } from '../lib/constants'
 import FeedbackForm from './FeedbackForm'
 
 import styles from '../styles/feedback'
@@ -34,6 +34,7 @@ class RatingModal extends Component {
           no: t('mobile.rating.rate.no'),
           later: t('mobile.rating.rate.later'),
           softwareID: SOFTWARE_ID,
+          appStoreID: APP_STORE_ID,
           softwareName: SOFTWARE_NAME
         })
 
@@ -110,7 +111,8 @@ const promptRating = async ({
   no,
   later,
   softwareName,
-  softwareID
+  softwareID,
+  appStoreID
 }) =>
   new Promise((resolve, reject) => {
     if (!window.AppRate) reject(new Error('No AppRate found'))
@@ -119,7 +121,7 @@ const promptRating = async ({
         displayAppName: softwareName,
         inAppReview: true,
         storeAppURL: {
-          ios: softwareID,
+          ios: appStoreID,
           android: `market://details?id=${softwareID}`
         },
         customLocale: {

--- a/src/drive/mobile/lib/constants.js
+++ b/src/drive/mobile/lib/constants.js
@@ -1,2 +1,3 @@
 export const SOFTWARE_ID = 'io.cozy.drive.mobile'
 export const SOFTWARE_NAME = 'Cozy Drive'
+export const APP_STORE_ID = '1224102389'


### PR DESCRIPTION
The plugin now needs the app store id number rather than the string?