### PR TITLE
Sharing fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,8 @@
           "skipUndeclared": true
         }
       ],
-      "react/jsx-no-bind": 1
+      "react/jsx-no-bind": 1,
+      "camelcase": "off"
     },
     "env": {
       "browser": true,

--- a/src/drive/components/FolderView.jsx
+++ b/src/drive/components/FolderView.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import Alerter from 'cozy-ui/react/Alerter'
+import { ModalManager } from 'react-cozy-helpers'
 
 import Main from './Main'
 import Topbar from './Topbar'
@@ -141,6 +142,7 @@ class FolderView extends Component {
             />
           )}
         </Dropzone>
+        <ModalManager />
       </Main>
     )
   }

--- a/src/drive/components/Layout.jsx
+++ b/src/drive/components/Layout.jsx
@@ -2,7 +2,6 @@ import styles from '../styles/layout'
 
 import React from 'react'
 import classNames from 'classnames'
-import { ModalManager } from 'react-cozy-helpers'
 import { translate } from 'cozy-ui/react/I18n'
 
 import Sidebar from 'cozy-ui/react/Sidebar'
@@ -20,7 +19,6 @@ const Layout = ({ t, children }) => (
     <Alerter t={t} />
     <UploadQueue />
     {children}
-    <ModalManager />
   </div>
 )
 

--- a/src/drive/ducks/files/Container.jsx
+++ b/src/drive/ducks/files/Container.jsx
@@ -2,8 +2,9 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { translate } from 'cozy-ui/react/I18n'
+import { showModal } from 'react-cozy-helpers'
 import confirm from '../../lib/confirm'
-import { SharedDocument } from 'sharing'
+import { SharedDocument, ShareModal } from 'sharing'
 
 import FolderView from '../../components/FolderView'
 import DeleteConfirm from '../../components/DeleteConfirm'
@@ -43,6 +44,20 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         createFolder: name => dispatch(createFolder(name))
       },
       selection: {
+        share: {
+          action: selected =>
+            dispatch(
+              showModal(
+                <ShareModal
+                  document={selected[0]}
+                  documentType="Files"
+                  sharingDesc={selected[0].name}
+                />
+              )
+            ),
+          displayCondition: selections =>
+            hasWriteAccess && selections.length === 1
+        },
         download: {
           action: files => dispatch(downloadFiles(files))
         },

--- a/src/sharing/SharingDetailsModal.jsx
+++ b/src/sharing/SharingDetailsModal.jsx
@@ -6,6 +6,8 @@ import WhoHasAccess from './components/WhoHasAccess'
 
 import Modal from 'cozy-ui/react/Modal'
 
+import { getDisplayName } from '.'
+
 export class SharingDetailsModal extends Component {
   render() {
     const { t, f } = this.context
@@ -28,7 +30,9 @@ export class SharingDetailsModal extends Component {
         <div className={styles['share-modal-content']}>
           <div className={styles['share-details']}>
             <Owner
-              name={t(`${documentType}.share.sharedBy`, { name: owner.name })}
+              name={t(`${documentType}.share.sharedBy`, {
+                name: getDisplayName(owner)
+              })}
               url={owner.instance}
             />
             <div className={styles['share-details-created']}>

--- a/src/sharing/__tests__/state.spec.js
+++ b/src/sharing/__tests__/state.spec.js
@@ -41,6 +41,37 @@ describe('Sharing state', () => {
     expect(state.sharings).toEqual([SHARING_1, SHARING_2])
   })
 
+  it('should filter out sharings revoked by all recipients', () => {
+    const SHARING_2bis = {
+      ...SHARING_2,
+      attributes: {
+        ...SHARING_2.attributes,
+        members: [
+          {
+            status: 'owner',
+            name: 'Jane Doe',
+            email: 'jane@doe.com',
+            instance: 'http://cozy.tools:8080'
+          },
+          {
+            status: 'revoked',
+            name: 'John Doe',
+            email: 'john@doe.com',
+            instance: 'http://cozy.local:8080'
+          }
+        ]
+      }
+    }
+    const state = reducer(
+      undefined,
+      receiveSharings({ sharings: [SHARING_1, SHARING_2bis] })
+    )
+    expect(state.byDocId).toEqual({
+      folder_1: { sharings: [SHARING_1.id], permissions: [] }
+    })
+    expect(state.sharings).toEqual([SHARING_1])
+  })
+
   it('should index received permissions', () => {
     const state = reducer(
       undefined,

--- a/src/sharing/__tests__/state.spec.js
+++ b/src/sharing/__tests__/state.spec.js
@@ -95,7 +95,6 @@ describe('Sharing state', () => {
       revokeSelf(SHARING_1)
     )
     expect(state.byDocId).toEqual({
-      folder_1: { sharings: [], permissions: [] },
       folder_2: { sharings: [SHARING_2.id], permissions: [] }
     })
   })

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -6,10 +6,7 @@ import Spinner from 'cozy-ui/react/Spinner'
 import ColorHash from './colorhash'
 import Menu, { Item } from 'components/Menu'
 
-import { getPrimaryEmail, getPrimaryCozy } from '..'
-
-const getDisplayName = ({ name, public_name, email }) =>
-  name || public_name || email
+import { getDisplayName, getPrimaryEmail, getPrimaryCozy } from '..'
 
 const Avatar = ({ name }) => {
   const initial = name.charAt(0)

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -8,6 +8,9 @@ import Menu, { Item } from 'components/Menu'
 
 import { getPrimaryEmail, getPrimaryCozy } from '..'
 
+const getDisplayName = ({ name, public_name, email }) =>
+  name || public_name || email
+
 const Avatar = ({ name }) => {
   const initial = name.charAt(0)
   const bg = ColorHash().getColor(name)
@@ -23,7 +26,7 @@ const Avatar = ({ name }) => {
 
 export const RecipientsAvatars = ({ recipients }) => (
   <div className={styles['pho-recipients-avatars']}>
-    {recipients.map(({ name }) => <Avatar name={name} />)}
+    {recipients.map(recipient => <Avatar name={getDisplayName(recipient)} />)}
   </div>
 )
 
@@ -34,10 +37,10 @@ const Identity = ({ name, url }) => (
   </div>
 )
 
-export const UserAvatar = ({ name, url }) => (
+export const UserAvatar = ({ url, ...rest }) => (
   <div className={styles['pho-avatar']}>
-    <Avatar name={name} />
-    <Identity name={name} url={url} />
+    <Avatar name={getDisplayName(rest)} />
+    <Identity name={getDisplayName(rest)} url={url} />
   </div>
 )
 
@@ -91,10 +94,10 @@ class Status extends Component {
   }
 }
 
-const Recipient = ({ instance, name, ...rest }) => (
+const Recipient = ({ instance, ...rest }) => (
   <div className={styles['pho-recipient']}>
-    <Avatar name={name} />
-    <Identity name={name} url={instance} />
+    <Avatar name={getDisplayName(rest)} />
+    <Identity name={getDisplayName(rest)} url={instance} />
     <Status instance={instance} {...rest} />
   </div>
 )

--- a/src/sharing/index.js
+++ b/src/sharing/index.js
@@ -35,6 +35,9 @@ const getPrimaryOrFirst = property => obj => {
   return obj[property].find(property => property.primary) || obj[property][0]
 }
 
+export const getDisplayName = ({ name, public_name, email }) =>
+  name || public_name || email
+
 // TODO: sadly we have different versions of contacts' doctype to handle...
 // A migration tool on the stack side is needed here
 export const getPrimaryEmail = contact =>


### PR DESCRIPTION
This PR fixes a few things:
 - when a sharing is revoked, if the corresponding `byId` entry is "empty" (no more sharings or perms), it is deleted ;
 - we filter out self-revoked sharings and sharings with all revoked recipients ;
 - UI fixes.