### PR TITLE
Better handling of mimetype icons by guessing the type from the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-drive",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "main": "src/main.jsx",
   "scripts": {
     "build:drive": "npm run build:drive:browser",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "dependencies": {
     "classnames": "2.2.5",
     "cozy-bar": "5.0.6",
-    "cozy-client": "1.0.0-beta.13",
+    "cozy-client": "1.0.0-beta.14",
     "cozy-client-js": "0.6.2",
     "cozy-ui": "9.11.0",
     "create-react-context": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "intersection-observer": "0.5.0",
     "justified-layout": "2.1.1",
     "localforage": "1.7.1",
+    "mime-types": "^2.1.18",
     "node-polyglot": "2.2.2",
     "node-uuid": "1.4.8",
     "piwik-react-router": "0.8.2",

--- a/src/drive/containers/File.jsx
+++ b/src/drive/containers/File.jsx
@@ -12,7 +12,7 @@ import Spinner from 'cozy-ui/react/Spinner'
 import { ImageLoader } from 'components/Image'
 import { Button, Icon, withBreakpoints, MidEllipsis } from 'cozy-ui/react'
 import { SharedBadge, SharedStatus } from 'sharing'
-import { getFileTypeFromMime } from 'drive/lib/getFileTypeFromMime'
+import { getFileMimetype } from 'drive/lib/getFileMimetype'
 
 import { getFolderUrl } from '../reducers'
 
@@ -30,12 +30,7 @@ export const getClassFromMime = attrs => {
   }
 
   return styles[
-    'fil-file-' +
-      (getFileTypeFromMime(styles, 'fil-file-')(attrs.mime) ||
-        console.warn(
-          `No icon found, you may need to add a mapping for ${attrs.mime}`
-        ) ||
-        'files')
+    'fil-file-' + (getFileMimetype(styles, 'fil-file-')(attrs) || 'files')
   ]
 }
 

--- a/src/drive/ducks/services/components/SuggestionProvider.jsx
+++ b/src/drive/ducks/services/components/SuggestionProvider.jsx
@@ -1,7 +1,7 @@
 /* global cozy */
 import React from 'react'
 import FuzzyPathSearch from '../FuzzyPathSearch'
-import { getFileTypeFromMime } from 'drive/lib/getFileTypeFromMime'
+import { getFileMimetype } from 'drive/lib/getFileMimetype'
 
 const TYPE_DIRECTORY = 'directory'
 
@@ -112,7 +112,7 @@ function getIconUrl(file) {
   const keyIcon =
     file.type === TYPE_DIRECTORY
       ? 'folder'
-      : getFileTypeFromMime(icons)(file.mime) || 'files'
+      : getFileMimetype(icons)(file) || 'files'
 
   const icon = icons[keyIcon].default
 

--- a/src/drive/lib/getFileMimetype.js
+++ b/src/drive/lib/getFileMimetype.js
@@ -1,16 +1,29 @@
+import mime from 'mime-types'
+
+const getMimetypeFromFilename = name => {
+  if (/\.heic$/i.test(name)) return 'image/heic'
+  else if (/\.heif$/i.test(name)) return 'image/heif'
+  else return mime.lookup(name) || 'application/octet-stream'
+}
+
 const mappingMimetypeSubtype = {
   word: 'text',
+  text: 'text',
   zip: 'zip',
   pdf: 'pdf',
   spreadsheet: 'sheet',
   excel: 'sheet',
+  sheet: 'sheet',
   presentation: 'slide',
   powerpoint: 'slide'
 }
 
-export const getFileTypeFromMime = (collection, prefix = '') => (
-  mimetype = ''
-) => {
+export const getFileMimetype = (collection, prefix = '') => file => {
+  const mimetype =
+    file.mime === 'application/octet-stream'
+      ? getMimetypeFromFilename(file.name.toLowerCase())
+      : file.mime
+
   const [type, subtype] = mimetype.split('/')
   if (collection[prefix + type]) {
     return type

--- a/src/drive/lib/getFileMimetype.js
+++ b/src/drive/lib/getFileMimetype.js
@@ -1,9 +1,7 @@
 import mime from 'mime-types'
 
 const getMimetypeFromFilename = name => {
-  if (/\.heic$/i.test(name)) return 'image/heic'
-  else if (/\.heif$/i.test(name)) return 'image/heif'
-  else return mime.lookup(name) || 'application/octet-stream'
+  return mime.lookup(name) || 'application/octet-stream'
 }
 
 const mappingMimetypeSubtype = {

--- a/targets/drive/manifest.webapp
+++ b/targets/drive/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Drive",
   "slug": "drive",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "type": "webapp",
   "licence": "AGPL-3.0",
   "icon": "public/app-icon.svg",

--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.cozy.drive.mobile" version="1.5.7" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="io.cozy.drive.mobile" version="1.5.8" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Drive</name>
     <description>Sync files from your Cozy.</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>
@@ -12,7 +12,7 @@
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
     <hook src="scripts/update-config-version.sh" type="before_build" />
-    <preference name="AppendUserAgent" value="io.cozy.drive.mobile-1.5.7" />
+    <preference name="AppendUserAgent" value="io.cozy.drive.mobile-1.5.8" />
     <engine name="android" spec="6.4.0" />
     <platform name="android">
         <preference name="StatusBarBackgroundColor" value="#D6D8DA" />

--- a/targets/photos/manifest.webapp
+++ b/targets/photos/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Photos",
   "slug": "photos",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "type": "webapp",
   "licence": "AGPL-3.0",
   "icon": "public/app-icon.svg",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,22 +2722,22 @@ cozy-client-js@^0.3.19:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
 
-cozy-client@1.0.0-beta.13:
-  version "1.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-1.0.0-beta.13.tgz#f312b7484736a5f0bc773815318d1d767d30fe03"
+cozy-client@1.0.0-beta.14:
+  version "1.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-1.0.0-beta.14.tgz#5eae05496fdc67af1a72e6e3dfa14dc435be9cd9"
   dependencies:
-    cozy-stack-client "^1.0.0-beta.13"
+    cozy-stack-client "^1.0.0-beta.14"
     lodash "^4.17.5"
     prop-types "^15.6.0"
     react "^16.2.0"
     react-redux "^5.0.6"
     redux "^3.7.2"
 
-cozy-stack-client@^1.0.0-beta.13:
-  version "1.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-1.0.0-beta.13.tgz#1b3c9a1a732a6cdf0ad4e70658ba945dfc105d18"
+cozy-stack-client@^1.0.0-beta.14:
+  version "1.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-1.0.0-beta.14.tgz#744ea59a2777dbbadc97194d046f403e3bb78ee0"
   dependencies:
-    mimetype "^0.0.8"
+    mime-types "^2.1.18"
 
 cozy-ui@9.11.0:
   version "9.11.0"
@@ -7066,10 +7066,6 @@ mime@^1.5.0:
 mime@~1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
-
-mimetype@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mimetype/-/mimetype-0.0.8.tgz#fb30022794bbf7725cb7b46df820e87dd91fd086"
 
 mimic-fn@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7035,11 +7035,21 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+
 mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
     mime-db "~1.30.0"
+
+mime-types@^2.1.18:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  dependencies:
+    mime-db "~1.33.0"
 
 mime-types@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
I used a different lib for mimetype lookup because the one used by cozy-client seems problematic. I've made the change in cozy-client too.