### PR TITLE
fix: renamed index

### DIFF
--- a/src/drive/actions/async.js
+++ b/src/drive/actions/async.js
@@ -171,12 +171,12 @@ class Stack {
 }
 
 class PouchDB {
-  constructor({ byName, byUpdatedAt, bySize, recentFiles }) {
+  constructor({ byName, byUpdatedAt, bySize, recent }) {
     this.indexes = {
       name: byName,
       updated_at: byUpdatedAt,
       size: bySize,
-      recentFiles: recentFiles
+      recent: recent
     }
   }
 
@@ -278,7 +278,7 @@ class PouchDB {
 
   getRecentFiles = async () => {
     const db = cozy.client.offline.getDatabase('io.cozy.files')
-    const files = await db.query(this.indexes.recentFiles, {
+    const files = await db.query(this.indexes.recent, {
       limit: FILES_FETCH_LIMIT,
       include_docs: true,
       descending: true

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -37,7 +37,7 @@ export const startReplication = async (
       indexesCreated(indexes)
     }
 
-    if (!indexes.recentFiles) {
+    if (!indexes.recent) {
       const ddoc = {
         _id: '_design/my_index',
         views: {
@@ -49,7 +49,7 @@ export const startReplication = async (
         }
       }
       await db.put(ddoc)
-      indexes.recentFiles = 'my_index/recent_files'
+      indexes.recent = 'my_index/recent_files'
       indexesCreated(indexes)
     }
 


### PR DESCRIPTION
Renaming the index was unnecessary and caused the index to be recreated, leading to potential errors.