### PR TITLE
feat: Export files on mobile

### DIFF
--- a/src/drive/actions/index.jsx
+++ b/src/drive/actions/index.jsx
@@ -361,6 +361,36 @@ export const trashFiles = files => async (dispatch, _, { client }) => {
   })
 }
 
+export const exportFilesNative = files => {
+  return async dispatch => {
+    const downloadAllFiles = files.map(async file => {
+      const response = await cozy.client.files.downloadById(file.id)
+      const blob = await response.blob()
+      const filename = file.name
+      const localFile = await saveFileWithCordova(blob, filename)
+      return localFile.nativeURL
+    })
+
+    try {
+      Alerter.info('alert.preparing', {
+        duration: Math.min(downloadAllFiles.length * 2000, 6000)
+      })
+      const urls = await Promise.all(downloadAllFiles)
+      window.plugins.socialsharing.shareWithOptions(
+        {
+          files: urls
+        },
+        null,
+        error => {
+          throw error
+        }
+      )
+    } catch (error) {
+      Alerter.info(downloadFileError(error))
+    }
+  }
+}
+
 export const downloadFiles = files => {
   const meta = META_DEFAULTS
   return async dispatch => {
@@ -423,11 +453,7 @@ const downloadFile = (file, meta) => {
     const blob = await response.blob()
     const filename = file.name
 
-    if (isCordova() && window.cordova.file) {
-      saveFileWithCordova(blob, filename)
-    } else {
-      forceFileDownload(window.URL.createObjectURL(blob), filename)
-    }
+    forceFileDownload(window.URL.createObjectURL(blob), filename)
     return dispatch({ type: DOWNLOAD_FILE, file, meta })
   }
 }

--- a/src/drive/ducks/files/Container.jsx
+++ b/src/drive/ducks/files/Container.jsx
@@ -18,6 +18,7 @@ import {
   createFolder,
   openFileWith,
   downloadFiles,
+  exportFilesNative,
   trashFiles,
   toggleAvailableOffline
 } from '../../actions'
@@ -58,9 +59,19 @@ const mapDispatchToProps = (dispatch, ownProps) => {
           displayCondition: selections =>
             hasWriteAccess && selections.length === 1
         },
-        download: {
-          action: files => dispatch(downloadFiles(files))
-        },
+        download:
+          __TARGET__ === 'mobile'
+            ? {
+                action: files => dispatch(exportFilesNative(files)),
+                displayCondition: files =>
+                  files.reduce(
+                    (onlyFiles, file) => onlyFiles && isFile(file),
+                    true
+                  )
+              }
+            : {
+                action: files => dispatch(downloadFiles(files))
+              },
         trash: {
           action: files =>
             confirm(

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -253,7 +253,8 @@
     "folder_generic": "An error occurred, please try again.",
     "folder_abort":
       "You need to add a name to your new folder if you would like to save it. Your information has not been saved.",
-    "offline": "This feature is not available offline."
+    "offline": "This feature is not available offline.",
+    "preparing": "Preparing your files…"
   },
   "mobile": {
     "onboarding": {

--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -102,4 +102,5 @@
     <plugin name="cordova-android-support-gradle-release" spec="~1.4.2">
         <variable name="ANDROID_SUPPORT_VERSION" value="27.+" />
     </plugin>
+    <plugin name="cordova-plugin-x-socialsharing" spec="~5.4.1" />
 </widget>


### PR DESCRIPTION
Using [this plugin](https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin#8-whitelisting-on-ios-9), i've replaced the (broken) file download feature on mobile by one that exports files to other apps.