### PR TITLE
feat: add an error field on collections in the reducer

### DIFF
--- a/src/lib/cozy-client/reducer.js
+++ b/src/lib/cozy-client/reducer.js
@@ -234,7 +234,8 @@ const collection = (state = collectionInitialState, action) => {
         ids:
           action.skip || action.merge
             ? uniq([...state.ids, ...response.data.map(doc => doc.id)])
-            : response.data.map(doc => doc.id)
+            : response.data.map(doc => doc.id),
+        error: null
       }
     case ADD_REFERENCED_FILES:
       return {
@@ -252,7 +253,8 @@ const collection = (state = collectionInitialState, action) => {
     case RECEIVE_ERROR:
       return {
         ...state,
-        fetchStatus: 'failed'
+        fetchStatus: 'failed',
+        error: action.error
       }
     case RECEIVE_NEW_DOCUMENT:
       return {


### PR DESCRIPTION
In banks we need to access to the errors that occurs during cozy-client's fetchCollection to show something for certain errors (a blocking modal for HTTP 402 return code here).

This PR adds an `error` property on collections do handle that.