### PR TITLE
[WIP] Open files shared by link in the viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "cozy-bar": "5.0.7",
     "cozy-client": "1.0.0-beta.14",
     "cozy-client-js": "0.10.0",
-    "cozy-ui": "10.0.0",
+    "cozy-ui": "10.1.0",
     "create-react-context": "0.2.2",
     "date-fns": "1.29.0",
     "diacritics": "1.3.0",

--- a/src/components/Button/CozyHomeLink.jsx
+++ b/src/components/Button/CozyHomeLink.jsx
@@ -2,10 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'cozy-ui/react/I18n'
 import { ButtonLink } from 'cozy-ui/react'
+import styles from './index.styl'
 
-const CozyHomeLink = ({ from }, { t }) => (
+const CozyHomeLink = ({ from, embedInCozyBar = false }, { t }) => (
   <ButtonLink
+    subtle
     label={t('Share.create-cozy')}
+    icon="cozy-negative"
+    className={embedInCozyBar ? styles['bar-homelink'] : ''}
     href={` https://manager.cozycloud.cc/cozy/create${
       from ? `?pk_campaign=${encodeURIComponent(from)}` : ''
     }`}
@@ -13,7 +17,8 @@ const CozyHomeLink = ({ from }, { t }) => (
 )
 
 CozyHomeLink.propTypes = {
-  from: PropTypes.string
+  from: PropTypes.string,
+  embedInCozyBar: PropTypes.bool
 }
 
 CozyHomeLink.defaultProps = {

--- a/src/components/Button/index.styl
+++ b/src/components/Button/index.styl
@@ -1,5 +1,6 @@
 @require 'settings/breakpoints.styl'
 @require 'utilities/display.styl'
+@require 'settings/z-index.styl'
 
 .u-visuallyhidden
     @extend $visuallyhidden
@@ -20,3 +21,9 @@
         padding          .5rem .75rem
         opacity          .5
         background-color transparent
+
+.bar-homelink
+    position absolute
+    top      .25rem
+    right    1rem
+    z-index  ($bar-index + 1)

--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -26,10 +26,13 @@ const isIOS = () =>
 const isMobile = () => isAndroid() || isIOS()
 const isCordova = () => window.cordova !== undefined
 
-const ViewerWrapper = ({ style, className, children }) => (
+const ViewerWrapper = ({ style, className, children, fullscreen, dark }) => (
   <div
     style={style}
-    className={cx(styles['pho-viewer-wrapper'], className)}
+    className={cx(styles['pho-viewer-wrapper'], className, {
+      [styles['pho-viewer-wrapper--notfullscreen']]: !fullscreen,
+      [styles['pho-viewer-wrapper--light']]: !dark
+    })}
     role="viewer"
   >
     {children}
@@ -84,7 +87,16 @@ export default class Viewer extends Component {
   }
 
   render() {
-    const { files, style, className, currentIndex, onClose } = this.props
+    const {
+      files,
+      style,
+      className,
+      currentIndex,
+      onClose,
+      fullscreen = true,
+      dark = true,
+      controls = true
+    } = this.props
     const currentFile = files[currentIndex]
     const fileCount = files.length
     const hasPrevious = currentIndex > 0
@@ -92,7 +104,12 @@ export default class Viewer extends Component {
     // this `expanded` property makes the next/previous controls cover the displayed image
     const expanded = currentFile && currentFile.class === 'image'
     return (
-      <ViewerWrapper style={style} className={className}>
+      <ViewerWrapper
+        style={style}
+        className={className}
+        fullscreen={fullscreen}
+        dark={dark}
+      >
         <ViewerControls
           currentFile={currentFile}
           onClose={onClose}
@@ -102,6 +119,7 @@ export default class Viewer extends Component {
           onNext={this.onNext}
           isMobile={isMobile()}
           expanded={expanded}
+          controls={controls}
         >
           {this.renderViewer(currentFile)}
         </ViewerControls>

--- a/src/viewer/ViewerControls.jsx
+++ b/src/viewer/ViewerControls.jsx
@@ -68,6 +68,7 @@ class ViewerControls extends Component {
       onNext,
       isMobile,
       expanded,
+      controls,
       children
     } = this.props
     const { hidden } = this.state
@@ -80,40 +81,43 @@ class ViewerControls extends Component {
           this.wrapped = wrapped
         }}
       >
-        <div
-          className={classNames(styles['pho-viewer-toolbar'], {
-            [styles['pho-viewer-toolbar--hidden']]: hidden
-          })}
-          role="viewer-toolbar"
-          onMouseEnter={this.showControls}
-          onMouseLeave={this.hideControls}
-        >
+        {controls && (
           <div
-            className={classNames(
-              styles['coz-selectionbar'],
-              styles['pho-viewer-toolbar-actions']
-            )}
+            className={classNames(styles['pho-viewer-toolbar'], {
+              [styles['pho-viewer-toolbar--hidden']]: hidden
+            })}
+            role="viewer-toolbar"
+            onMouseEnter={this.showControls}
+            onMouseLeave={this.hideControls}
           >
-            <button
-              className={styles['coz-action-download']}
-              onClick={() => {
-                downloadFile(currentFile)
-              }}
-            >
-              {t('Viewer.actions.download')}
-            </button>
-          </div>
-          {onClose && (
             <div
-              className={styles['pho-viewer-toolbar-close']}
-              onClick={onClose}
-              title={t('Viewer.close')}
+              className={classNames(
+                styles['coz-selectionbar'],
+                styles['pho-viewer-toolbar-actions']
+              )}
             >
-              <div className={styles['pho-viewer-toolbar-close-cross']} />
+              <button
+                className={styles['coz-action-download']}
+                onClick={() => {
+                  downloadFile(currentFile)
+                }}
+              >
+                {t('Viewer.actions.download')}
+              </button>
             </div>
-          )}
-        </div>
-        {!isMobile &&
+            {onClose && (
+              <div
+                className={styles['pho-viewer-toolbar-close']}
+                onClick={onClose}
+                title={t('Viewer.close')}
+              >
+                <div className={styles['pho-viewer-toolbar-close-cross']} />
+              </div>
+            )}
+          </div>
+        )}
+        {controls &&
+          !isMobile &&
           hasPrevious && (
             <div
               role="button"
@@ -132,7 +136,8 @@ class ViewerControls extends Component {
             </div>
           )}
         {this.renderChildren(children)}
-        {!isMobile &&
+        {controls &&
+          !isMobile &&
           hasNext && (
             <div
               role="button"

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -17,6 +17,16 @@
     overflow        hidden
     color           white
 
+    &--notfullscreen
+        top         3rem
+        height      calc(100% - 3rem)
+        z-index     ($bar-index - 2)
+
+    &--light
+        background  white
+        color       black
+
+
 .pho-viewer-controls
     display         flex
     flex-direction  row

--- a/targets/drive/web/public/main.jsx
+++ b/targets/drive/web/public/main.jsx
@@ -5,7 +5,9 @@ import React from 'react'
 import { render } from 'react-dom'
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 import CozyClient, { CozyProvider } from 'cozy-client'
+import Viewer from 'viewer'
 import { I18n, initTranslation } from 'cozy-ui/react/I18n'
+import { CozyHomeLink } from 'components/Button'
 
 import configureStore from 'drive/store/configureStore'
 import PublicLayout from 'drive/components/PublicLayout'
@@ -25,110 +27,101 @@ const getQueryParameter = () =>
     .map(varval => varval.split('='))
     .reduce(arrToObj, {})
 
+const initCozyBar = data => {
+  if (
+    data.cozyAppName &&
+    data.cozyAppEditor &&
+    data.cozyIconPath &&
+    data.cozyLocale
+  ) {
+    cozy.bar.init({
+      appName: data.cozyAppName,
+      appEditor: data.cozyAppEditor,
+      iconPath: data.cozyIconPath,
+      lang: data.cozyLocale,
+      replaceTitleOnMobile: true
+    })
+  }
+}
+
+const renderError = (lang, root) =>
+  render(
+    <I18n lang={lang} dictRequire={lang => require(`drive/locales/${lang}`)}>
+      <ErrorShare errorType={`public_unshared`} />
+    </I18n>,
+    root
+  )
+
 const init = async () => {
   const lang = document.documentElement.getAttribute('lang') || 'en'
   const root = document.querySelector('[role=application]')
-  const data = root.dataset
-  const { id, sharecode, directdownload } = getQueryParameter()
+  const dataset = root.dataset
+  const { id, sharecode } = getQueryParameter()
 
   const protocol = window.location ? window.location.protocol : 'https:'
-  const cozyUrl = `${protocol}//${data.cozyDomain}`
+  const cozyUrl = `${protocol}//${dataset.cozyDomain}`
 
   const client = new CozyClient({
     uri: cozyUrl,
     token: sharecode
   })
 
-  let useDirectDownload
+  if (__DEVELOPMENT__) {
+    // Enables React dev tools for Preact
+    // Cannot use import as we are in a condition
+    require('preact/devtools')
 
-  if (directdownload !== undefined) useDirectDownload = true
-  else {
-    try {
-      const response = await client.collection('io.cozy.files').get(id)
-      const { data } = response
-      const isFile = data && data.type === 'file'
-      useDirectDownload = isFile
-    } catch (e) {
-      console.warn(e)
-      useDirectDownload = false
-    }
+    // Export React to window for the devtools
+    window.React = React
   }
 
-  if (useDirectDownload) {
-    client
-      .collection('io.cozy.files')
-      .getDownloadLinkById(id)
-      .then(link => {
-        window.location = link
-      })
-      .catch(e => {
-        cozy.bar.init({
-          appName: data.cozyAppName,
-          appEditor: data.cozyAppEditor,
-          iconPath: data.cozyIconPath,
-          lang: data.cozyLocale,
-          replaceTitleOnMobile: true
-        })
-        render(
-          <I18n
-            lang={lang}
-            dictRequire={lang => require(`drive/locales/${lang}`)}
-          >
-            <ErrorShare errorType={`public_unshared`} />
-          </I18n>,
-          root
-        )
-      })
-  } else {
-    if (__DEVELOPMENT__) {
-      // Enables React dev tools for Preact
-      // Cannot use import as we are in a condition
-      require('preact/devtools')
+  // we still need cozy-client-js for opening a folder
+  cozy.client.init({
+    cozyURL: cozyUrl,
+    token: sharecode
+  })
 
-      // Export React to window for the devtools
-      window.React = React
-    }
+  const polyglot = initTranslation(dataset.cozyLocale, lang =>
+    require(`drive/locales/${lang}`)
+  )
 
-    // we still need cozy-client-js for opening a folder
-    cozy.client.init({
-      cozyURL: cozyUrl,
-      token: sharecode
-    })
+  const store = configureStore(client, polyglot.t.bind(polyglot))
 
-    const polyglot = initTranslation(data.cozyLocale, lang =>
-      require(`drive/locales/${lang}`)
-    )
-
-    const store = configureStore(client, polyglot.t.bind(polyglot))
-
-    if (
-      data.cozyAppName &&
-      data.cozyAppEditor &&
-      data.cozyIconPath &&
-      data.cozyLocale
-    ) {
-      cozy.bar.init({
-        appName: data.cozyAppName,
-        appEditor: data.cozyAppEditor,
-        iconPath: data.cozyIconPath,
-        lang: data.cozyLocale,
-        replaceTitleOnMobile: true
-      })
-    }
-
+  try {
+    const response = await client.collection('io.cozy.files').get(id)
+    const { data } = response
+    const isFile = data && data.type === 'file'
+    initCozyBar(dataset)
     render(
       <I18n lang={lang} polyglot={polyglot}>
         <CozyProvider store={store} client={client}>
-          <Router history={hashHistory}>
-            <Route component={PublicLayout}>
-              <Route path="files(/:folderId)" component={LightFolderView} />
-            </Route>
-            <Redirect from="/*" to={`files/${id}`} />
-          </Router>
+          {isFile ? (
+            <div>
+              <CozyHomeLink embedInCozyBar from="sharing-drive" />
+              <Viewer
+                files={[data]}
+                currentIndex={0}
+                fullscreen={false}
+                dark={false}
+                controls={false}
+              />
+            </div>
+          ) : (
+            <Router history={hashHistory}>
+              <Route component={PublicLayout}>
+                <Route path="files(/:folderId)" component={LightFolderView} />
+              </Route>
+              <Redirect from="/*" to={`files/${id}`} />
+            </Router>
+          )}
         </CozyProvider>
       </I18n>,
       root
     )
+  } catch (e) {
+    console.warn(e)
+    initCozyBar(dataset)
+    renderError(lang, root)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,9 +2681,9 @@ cozy-stack-client@^1.0.0-beta.14:
   dependencies:
     mime-types "^2.1.18"
 
-cozy-ui@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-10.0.0.tgz#c2331246906082ecba85530fb052460271b35e5b"
+cozy-ui@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-10.1.0.tgz#99d346b95b8e76c6e471ed555c1c18092b3217c2"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"


### PR DESCRIPTION
Previously, when sharing a single file by link, we redirected to a download URL. We now want to open it in a light version of the viewer, with a white background and with a special version of the cozy-bar on top. I had to add a few props to `Viewer` to enable that.
