### PR TITLE
fix: table's last row bottom border

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "cozy-bar": "5.0.7",
     "cozy-client": "1.0.0-beta.14",
     "cozy-client-js": "0.10.0",
-    "cozy-ui": "10.1.0",
+    "cozy-ui": "^10.1.2",
     "create-react-context": "0.2.2",
     "date-fns": "1.29.0",
     "diacritics": "1.3.0",

--- a/src/drive/mobile/ducks/mediaBackup/styles.styl
+++ b/src/drive/mobile/ducks/mediaBackup/styles.styl
@@ -8,7 +8,6 @@
     display flex
     align-items center
     box-sizing border-box
-    border-bottom .0625rem solid silver
     min-height 2.5rem
     padding .5rem 1rem
     background-color paleGrey

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,9 +2681,9 @@ cozy-stack-client@^1.0.0-beta.14:
   dependencies:
     mime-types "^2.1.18"
 
-cozy-ui@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-10.1.0.tgz#99d346b95b8e76c6e471ed555c1c18092b3217c2"
+cozy-ui@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-10.1.2.tgz#ce137100425e6cc2f7de42410d69652cd84a54f3"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"


### PR DESCRIPTION
I introduced a regression a few days ago by moving the border of a table-row from the bottom to the top. But I forgot a usecase, so I added a bottom border to the last row of a table (fix in UI update) and because the border is now at the top we had a disgraceful double border on the mobile app with the `.coz-upload-status` element.
This PR  fixes that by removing this element's border.