### PR TITLE
Redux store cleaning after unlink

### DIFF
--- a/src/drive/actions/async.js
+++ b/src/drive/actions/async.js
@@ -1,5 +1,4 @@
-/* global cozy */
-import { isCordova } from '../mobile/lib/device'
+/* global cozy __TARGET__ */
 import { TRASH_DIR_ID, FILES_FETCH_LIMIT } from '../constants/config.js'
 
 export const shouldShowRecentsFirst = (
@@ -308,7 +307,7 @@ export const getAdapter = state =>
 const shouldWorkFromPouchDB = state => {
   const settings = state.settings
   return (
-    isCordova() &&
+    __TARGET__ === 'mobile' &&
     settings.offline &&
     settings.firstReplication &&
     settings.indexes

--- a/src/drive/actions/settings.js
+++ b/src/drive/actions/settings.js
@@ -2,6 +2,7 @@ export const SET_CLIENT = 'SET_CLIENT'
 export const SET_OFFLINE = 'SET_OFFLINE'
 export const SET_FIRST_REPLICATION = 'SET_FIRST_REPLICATION'
 export const SET_POUCH_INDEXES = 'SET_POUCH_INDEXES'
+export const UNLINK = 'UNLINK'
 
 export const setClient = client => ({ type: SET_CLIENT, client })
 export const setOffline = offline => ({ type: SET_OFFLINE, offline })

--- a/src/drive/mobile/reducers/ui.js
+++ b/src/drive/mobile/reducers/ui.js
@@ -1,6 +1,7 @@
 import {
   SHOW_UNLINK_CONFIRMATION,
-  HIDE_UNLINK_CONFIRMATION
+  HIDE_UNLINK_CONFIRMATION,
+  UNLINK
 } from '../actions/unlink'
 
 export const initialState = {
@@ -12,6 +13,7 @@ export const ui = (state = initialState, action) => {
     case SHOW_UNLINK_CONFIRMATION:
       return { ...state, displayUnlinkConfirmation: true }
     case HIDE_UNLINK_CONFIRMATION:
+    case UNLINK:
       return { ...state, displayUnlinkConfirmation: false }
     default:
       return state

--- a/src/drive/reducers/settings.js
+++ b/src/drive/reducers/settings.js
@@ -2,7 +2,8 @@ import {
   SET_CLIENT,
   SET_OFFLINE,
   SET_FIRST_REPLICATION,
-  SET_POUCH_INDEXES
+  SET_POUCH_INDEXES,
+  UNLINK
 } from '../actions/settings'
 
 export const initialState = {
@@ -21,6 +22,8 @@ export const settings = (state = initialState, action) => {
       return { ...state, firstReplication: action.firstReplication }
     case SET_POUCH_INDEXES:
       return { ...state, indexes: action.indexes }
+    case UNLINK:
+      return initialState
     default:
       return state
   }


### PR DESCRIPTION
There's a section of the store that didn't get cleaned unlinking from a Cozy. I fixed it, but I also added a technical debt card — as it turns out we have 2 `settings` sections in the store, and both are bout mobile stuff, but one is loaded all the time.