### PR TITLE
Fix offline boot

### DIFF
--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -83,13 +83,15 @@ const startApplication = async function(store, client, polyglot) {
     shouldInitBar = true
     startReplication(store.dispatch, store.getState) // don't like to pass `store.dispatch` and `store.getState` as parameters, big coupling
   } catch (e) {
-    if (e.message === 'Failed to fetch') {
-      // the server is not responding, but it doesn't mean we're revoked yet
-      shouldInitBar = true
-    } else if (store.getState().mobile.settings.serverUrl) {
+    console.warn(e)
+    if (store.getState().mobile.settings.serverUrl && (e.status === 404 || e.status === 401)) {
       console.warn('Your device is not connected to your server anymore')
       store.dispatch(revokeClient())
       resetClient(client)
+    }
+    else {
+      // the server is not responding, but it doesn't mean we're revoked yet
+      shouldInitBar = true
     }
   } finally {
     if (shouldInitBar) initBar(client)

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -77,9 +77,9 @@ const startApplication = async function(store, client, polyglot) {
     const oauthClient = client.getOrCreateStackClient()
     oauthClient.setOAuthOptions(clientInfos)
     oauthClient.setCredentials(token)
+    await restoreCozyClientJs(client.options.uri, clientInfos, token)
 
     await oauthClient.fetchInformation()
-    await restoreCozyClientJs(client.options.uri, clientInfos, token)
     shouldInitBar = true
     startReplication(store.dispatch, store.getState) // don't like to pass `store.dispatch` and `store.getState` as parameters, big coupling
   } catch (e) {


### PR DESCRIPTION
There were é issues when starting the app offline:

- at least on iOS, the error we received was interpreted as meaning we had been disconnected. I inverted the logic — now we only consider ourselves revoked when we encounter specific error codes, in all other cases, we consider ourselves offline
- cozy-client-js was not restored at the application start, so PouchDB databases were unavailable