### PR TITLE
Forbid some sharings

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "cozy-bar": "5.0.8",
-    "cozy-client": "1.0.0-beta.14",
+    "cozy-client": "1.0.0-beta.15",
     "cozy-client-js": "0.10.0",
     "cozy-ui": "10.1.2",
     "create-react-context": "0.2.2",

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -101,7 +101,10 @@
         "genericSuccess": "You sent an invite to %{count} contacts.",
         "success": "You sent an invite to %{email}.",
         "comingsoon":
-          "Coming soon! You will be able to share documents and photos in a single click with your family, your friends, and even your coworkers. Don't worry, we'll let you know when it's ready!"
+          "Coming soon! You will be able to share documents and photos in a single click with your family, your friends, and even your coworkers. Don't worry, we'll let you know when it's ready!",
+        "onlyByLink": "This %{type} can only be shared by link, because",
+        "hasSharedParent": "it has a shared parent",
+        "hasSharedChild": "it contains a shared element"
       },
       "revoke": {
         "title": "Remove from sharing",

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -76,8 +76,8 @@
       "details": {
         "title": "Sharing details",
         "createdAt": "On %{date}",
-        "ro": "Read only",
-        "rw": "Read/write",
+        "ro": "Can read",
+        "rw": "Can change",
         "desc": {
           "ro": "You can view, download, and add this content to your Cozy. You will get updates by the owner, but you won't be able to update this content yourself.",
           "rw": "You can view, update, delete and add this content to your Cozy. Updates you make will be seen on other Cozies."

--- a/src/sharing/ShareModal.jsx
+++ b/src/sharing/ShareModal.jsx
@@ -149,9 +149,6 @@ export default class ShareModal extends Component {
           />
           <WhoHasAccess
             isOwner
-            title={t(`${documentType}.share.whoHasAccess.title`, {
-              smart_count: recipients.length
-            })}
             recipients={recipients}
             document={document}
             documentType={documentType}

--- a/src/sharing/ShareModal.jsx
+++ b/src/sharing/ShareModal.jsx
@@ -108,6 +108,8 @@ export default class ShareModal extends Component {
       link,
       recipients,
       documentType = 'Document',
+      hasSharedParent,
+      hasSharedChild,
       onClose,
       onShare,
       onRevoke,
@@ -132,6 +134,8 @@ export default class ShareModal extends Component {
               createContact={createContact}
               onShare={onShare}
               locked={recipients.length > 0}
+              hasSharedParent={hasSharedParent}
+              hasSharedChild={hasSharedChild}
             />
           )}
           <hr className={styles['divider']} />
@@ -167,6 +171,8 @@ ShareModal.propTypes = {
   recipients: PropTypes.array.isRequired,
   link: PropTypes.string,
   documentType: PropTypes.string,
+  hasSharedParent: PropTypes.bool,
+  hasSharedChild: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   onRevoke: PropTypes.func.isRequired,

--- a/src/sharing/__tests__/state.spec.js
+++ b/src/sharing/__tests__/state.spec.js
@@ -25,7 +25,8 @@ describe('Sharing state', () => {
       byDocId: {},
       sharings: [],
       permissions: [],
-      apps: []
+      apps: [],
+      sharedPaths: []
     })
   })
 

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -120,8 +120,13 @@ const Recipient = (props, { t, client }) => {
   return (
     <div className={styles['pho-recipient']}>
       <Avatar name={name} />
-      <Identity name={isMe ? t('Share.recipients.you') : name} url={instance} />
-      <Status {...props} />
+      <div className={styles['pho-recipient-ident-status']}>
+        <Identity
+          name={isMe ? t('Share.recipients.you') : name}
+          url={instance}
+        />
+        <Status {...props} />
+      </div>
     </div>
   )
 }

--- a/src/sharing/components/ShareByEmail.jsx
+++ b/src/sharing/components/ShareByEmail.jsx
@@ -210,7 +210,32 @@ class ShareByEmail extends Component {
 
   render() {
     const { t } = this.context
-    const { contacts, documentType, document, locked } = this.props
+    const {
+      contacts,
+      documentType,
+      document,
+      locked,
+      hasSharedParent,
+      hasSharedChild
+    } = this.props
+
+    if (hasSharedParent || hasSharedChild) {
+      return (
+        <div className={styles['share-byemail-onlybylink']}>
+          {t(`${documentType}.share.shareByEmail.onlyByLink`, {
+            type: document.type === 'directory' ? 'folder' : 'file'
+          })}{' '}
+          <strong>
+            {t(
+              `${documentType}.share.shareByEmail.${
+                hasSharedParent ? 'hasSharedParent' : 'hasSharedChild'
+              }`
+            )}
+          </strong>
+        </div>
+      )
+    }
+
     const { recipients } = this.state
 
     return (
@@ -254,7 +279,9 @@ ShareByEmail.propTypes = {
   sharingDesc: PropTypes.string.isRequired,
   locked: PropTypes.bool,
   onShare: PropTypes.func.isRequired,
-  createContact: PropTypes.func.isRequired
+  createContact: PropTypes.func.isRequired,
+  hasSharedParent: PropTypes.bool,
+  hasSharedChild: PropTypes.bool
 }
 
 ShareByEmail.defaultProps = {

--- a/src/sharing/components/WhoHasAccess.jsx
+++ b/src/sharing/components/WhoHasAccess.jsx
@@ -2,27 +2,27 @@ import React from 'react'
 
 import Recipient from './Recipient'
 
-const WhoHasAccess = ({
-  title,
-  isOwner = false,
-  recipients,
-  document,
-  documentType,
-  onRevoke
-}) => (
+const WhoHasAccess = (
+  { isOwner = false, recipients, document, documentType, onRevoke },
+  { t }
+) => (
   <div>
-    {title && <h3>{title}</h3>}
-    {recipients
-      .filter(r => r.status !== 'revoked')
-      .map(recipient => (
-        <Recipient
-          {...recipient}
-          isOwner={isOwner}
-          document={document}
-          documentType={documentType}
-          onRevoke={onRevoke}
-        />
-      ))}
+    {recipients.length > 1 && (
+      <h3>
+        {t(`${documentType}.share.whoHasAccess.title`, {
+          smart_count: recipients.length
+        })}
+      </h3>
+    )}
+    {recipients.map(recipient => (
+      <Recipient
+        {...recipient}
+        isOwner={isOwner}
+        document={document}
+        documentType={documentType}
+        onRevoke={onRevoke}
+      />
+    ))}
   </div>
 )
 

--- a/src/sharing/components/recipient.styl
+++ b/src/sharing/components/recipient.styl
@@ -1,4 +1,5 @@
 @require 'components/button.styl'
+@require 'settings/breakpoints.styl'
 @require 'settings/palette.styl'
 
 .pho-recipient
@@ -41,6 +42,12 @@
     font-size .875rem
     color coolGrey
 
+.pho-recipient-ident-status
+    flex 1 1 auto
+    display flex
+    flex-direction row
+    align-items center
+
 .pho-recipient-user
 .pho-recipient-url
     text-overflow ellipsis
@@ -72,9 +79,9 @@
     background embedurl("../assets/icon-arrow-down.svg") right center no-repeat
     border     none
     min-width  1rem
-    padding-right 1.3rem
+    padding-right 1.1rem
     background-color transparent
-    color            black
+    color    black
 
     &:focus
     &:not([disabled]):not([aria-disabled=true]):hover
@@ -85,20 +92,30 @@
 
 .pho-recipient-menu-header--pending
 .pho-recipient-menu-header--mail-not-sent
-    background embedurl("../assets/icon-hourglass-16.svg") 1rem center no-repeat
+    background embedurl("../assets/icon-hourglass-16.svg") 1rem .4rem no-repeat
 
 .pho-recipient-menu-header--one-way
-    background embedurl("../assets/icon-eye-16.svg") 1rem center no-repeat
+    background embedurl("../assets/icon-eye-16.svg") 1rem .4rem no-repeat
 
 .pho-recipient-menu-header--two-way
-    background embedurl("../assets/icon-pen-write-16.svg") 1rem center no-repeat
+    background embedurl("../assets/icon-pen-write-16.svg") 1rem .4rem no-repeat
 
 .pho-action-unshare
     color pomegranate !important
     text-decoration none !important
-    background embedurl("../assets/icon-trash-red.svg") 1rem center no-repeat
+    background embedurl("../assets/icon-trash-red.svg") 1rem .4rem no-repeat
 
 .pho-action-unshare-desc
     margin    0
     padding   0 1.5rem .5rem 2.5rem
     font-size .8125rem
+
+@media (max-width 32em)
+    .pho-recipient-ident-status
+        display block
+
+    .pho-recipient-menu-btn
+        padding 0
+        padding-right 1.1rem
+        margin 0
+        min-height 0

--- a/src/sharing/share.styl
+++ b/src/sharing/share.styl
@@ -22,8 +22,8 @@
         margin-left auto
 
     .share-bylink-header-dot
-        height .5rem
-        width  .5rem
+        height .2rem
+        width  .2rem
         background-color black
         border-radius    50%
         display inline-block
@@ -32,6 +32,7 @@
     .share-bylink-header-copybtn
         color dodgerBlue
         font-weight bold
+        cursor pointer
 
     .share-bylink-header-copybtn
         background transparent
@@ -40,7 +41,11 @@
 
 .share-bylink-desc
     color     coolGrey
-    font-size .8125rem
+    font-size .875rem
+
+@media (max-width 32em)
+    .share-bylink-desc
+        width 80%
 
 .share-byemail-onlybylink
     background paleGrey
@@ -178,9 +183,11 @@ input[type=text]
 
 .share-details-perm
     background-image     embedurl('./assets/icon-pen-16.svg')
+    margin-bottom .2rem
 
 .share-details-perm-desc
     font-size     .875rem
-    margin        0.5rem 0 0.5rem 3rem
+    margin        0 0 0.5rem 3rem
     padding-left  1.5rem
+    line-height   1.5
     color         coolGrey

--- a/src/sharing/share.styl
+++ b/src/sharing/share.styl
@@ -42,152 +42,145 @@
     color     coolGrey
     font-size .8125rem
 
+.share-byemail-onlybylink
+    background paleGrey
+    padding    1rem 1.5rem
+    margin 0
+    border-top 1px solid silver
 
-:global
-    label[for='share-toggle']
-        cursor pointer
+.share-modal-content
+    @extend $form
+    @extend $form-text
+    @extend $form-button
 
-:local
-    .share-modal-content
-        @extend $form
-        @extend $form-text
-        @extend $form-button
+    > div
+        margin 0 1.5rem 1.5rem
 
-        > div
-            margin 0 1.5rem 1.5rem
-
-    .share-modal-footer
-        padding 0
-        background-color paleGrey
-        color            charcoalGrey
-        font-weight      bold
-
-        p
-            margin 0
-            padding 1rem 1.5rem
-
-    .coz-form-group
+    > .share-byemail-onlybylink
         margin 0
 
-        h3
-          margin .3rem 0 0
+.coz-form-group
+    margin 0
 
-        h4
-            margin 0 0 .3rem 0
+    h3
+        margin .3rem 0 0
 
-        .coz-form
-            margin 0
+    h4
+        margin 0 0 .3rem 0
 
-        .coz-form-desc
-          color coolGrey
+    .coz-form
+        margin 0
 
+    .coz-form-desc
+        color coolGrey
+
+.share-type-control
+    display flex
+    flex-direction row
+    justify-content space-between
+    padding 1rem 0 0
+
+    .select-wrapper
+        flex 0 0 49%
+        position relative
+
+        &.select-wrapper--locked
+            &:before
+                content ""
+                display inline-block
+                position absolute
+                width 1rem
+                left 1rem
+                top 0
+                bottom 0
+                background-image embedurl('./assets/icon-information.svg')
+                background-repeat no-repeat
+                background-size 100%
+                background-position center
+                opacity .4
+
+
+    select
+        @extend $select
+        @extend $select--fullwidth
+
+        &:disabled,
+        &:hover:disabled
+            padding-left 2.8rem
+            color silver
+            border-color silver
+
+    button
+        flex 0 0 49%
+        margin 0
+
+    .tooltip
+        background paleGrey
+        font-size 1rem
+        line-height 1.5
+        color charcoalGrey
+        max-width 24rem
+        width 90%
+        opacity 1
+        border-radius .5rem
+
+@media (max-width 32em)
     .share-type-control
-        display flex
-        flex-direction row
-        justify-content space-between
-        padding 1rem 0 0
+        flex-direction column
 
         .select-wrapper
-            flex 0 0 49%
-            position relative
-
-            &.select-wrapper--locked
-                &:before
-                    content ""
-                    display inline-block
-                    position absolute
-                    width 1rem
-                    left 1rem
-                    top 0
-                    bottom 0
-                    background-image embedurl('./assets/icon-information.svg')
-                    background-repeat no-repeat
-                    background-size 100%
-                    background-position center
-                    opacity .4
-
-
-        select
-            @extend $select
-            @extend $select--fullwidth
-
-            &:disabled,
-            &:hover:disabled
-                padding-left 2.8rem
-                color silver
-                border-color silver
-
-        button
-            flex 0 0 49%
-            margin 0
+            margin-bottom .5rem
 
         .tooltip
-            background paleGrey
-            font-size 1rem
-            line-height 1.5
-            color charcoalGrey
-            max-width 24rem
-            width 90%
-            opacity 1
-            border-radius .5rem
+            margin-left 0
 
-    @media (max-width 32em)
-        .share-type-control
-            flex-direction column
+input[type=text]
+    width 100%
 
-            .select-wrapper
-                margin-bottom .5rem
-
-            .tooltip
-                margin-left 0
+.input-dual
+    display flex
+    align-items center
 
     input[type=text]
         width 100%
-
-    .input-dual
-        display flex
-        align-items center
-
-        input[type=text]
-            width 100%
-            height 3rem
-
-        > :first-child
-            flex 2 0 1%
-            padding-right .5rem
-
-        > :last-child
-            flex 0 0 6rem
-            text-align right
-
-        .coz-form-desc
-            margin 0
-
-        +tiny-screen()
-            > :last-child
-                flex-basis auto
-
-    .btn-copy
-        width 100%
         height 3rem
+
+    > :first-child
+        flex 2 0 1%
+        padding-right .5rem
+
+    > :last-child
+        flex 0 0 6rem
+        text-align right
+
+    .coz-form-desc
         margin 0
 
-    .share-details-created
-    .share-details-perm
-        font-size            1rem
-        margin               0.5rem 0 0.5rem 3rem
-        padding-left         1.5rem
-        background-position  0 center
-        background-repeat    no-repeat
+    +tiny-screen()
+        > :last-child
+            flex-basis auto
 
-    .share-details-created
-        background-image     embedurl('./assets/icon-calendar-16.svg')
+.btn-copy
+    width 100%
+    height 3rem
+    margin 0
 
-    .share-details-perm
-        background-image     embedurl('./assets/icon-pen-16.svg')
+.share-details-created
+.share-details-perm
+    font-size            1rem
+    margin               0.5rem 0 0.5rem 3rem
+    padding-left         1.5rem
+    background-position  0 center
+    background-repeat    no-repeat
 
-    .share-details-perm-desc
-        font-size     .875rem
-        margin        0.5rem 0 0.5rem 3rem
-        padding-left  1.5rem
-        color         coolGrey
+.share-details-created
+    background-image     embedurl('./assets/icon-calendar-16.svg')
+
+.share-details-perm
+    background-image     embedurl('./assets/icon-pen-16.svg')
+
+.share-details-perm-desc
+    font-size     .875rem
+    margin        0.5rem 0 0.5rem 3rem
+    padding-left  1.5rem
+    color         coolGrey

--- a/src/sharing/state.js
+++ b/src/sharing/state.js
@@ -221,6 +221,7 @@ export const getRecipients = (state, docId) => {
       return sharing.attributes.members.map(m => ({ ...m, type }))
     })
     .reduce((acc, member) => acc.concat(member), [])
+    .filter(r => r.status !== 'revoked')
   if (recipients[0] && recipients[0].status === 'owner') {
     return [recipients[0], ...recipients.filter(r => r.status !== 'owner')]
   }


### PR DESCRIPTION
Like described in the Trello card, we have to forbid sharing of a folder/file whose parent is shared or who have a shared child. We therefore need to get the paths of all shared folders/files. This is straightforward for folders, because they have a `path` property, but for files, we need to fetch their parent dir to get the path and append the file name.

I also fine-tuned some CSS.