### PR TITLE
fix: Properly close action menu

### DIFF
--- a/src/drive/ducks/files/Container.jsx
+++ b/src/drive/ducks/files/Container.jsx
@@ -47,15 +47,18 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       selection: {
         share: {
           action: selected =>
-            dispatch(
-              showModal(
+            dispatch({
+              ...showModal(
                 <ShareModal
                   document={selected[0]}
                   documentType="Files"
                   sharingDesc={selected[0].name}
                 />
-              )
-            ),
+              ),
+              meta: {
+                hideActionMenu: true
+              }
+            }),
           displayCondition: selections =>
             hasWriteAccess && selections.length === 1
         },


### PR DESCRIPTION
Until now, the action menu was closed when sharing due to a bug in cozy-ui. This also had some very strange side effect: the sharing modal would sometimes get `translateY` instead of the menu (presumably a bug in preact?).

This change closes it in a better way while also avoiding the translate bug.