### PR TITLE
fix: Only init bar if there's a server url

### DIFF
--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -89,7 +89,7 @@ const startApplication = async function(store, client, polyglot) {
       store.dispatch(revokeClient())
       resetClient(client)
     }
-    else {
+    else if (store.getState().mobile.settings.serverUrl) {
       // the server is not responding, but it doesn't mean we're revoked yet
       shouldInitBar = true
     }


### PR DESCRIPTION
If you revoke the client, kill the app and restart it, the cozy bar would be initialized. This PR fixes it.