### PR TITLE
Improve revocation and expired token handling

### DIFF
--- a/src/drive/mobile/containers/DriveMobileRouter.jsx
+++ b/src/drive/mobile/containers/DriveMobileRouter.jsx
@@ -30,7 +30,10 @@ class DriveMobileRouter extends Component {
   render(props) {
     return (
       <MobileRouter
-        {...props}
+        isAuthenticated={props.isAuthenticated}
+        isRevoked={props.isRevoked}
+        appRoutes={props.appRoutes}
+        history={props.history}
         onAuthenticated={this.afterAuthentication}
         onLogout={this.afterLogout}
         allowRegistration={false}

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -17,6 +17,7 @@ export const initClient = url => {
     scope: [
       'io.cozy.files',
       'io.cozy.apps:GET',
+      'io.cozy.contacts',
       'io.cozy.jobs:POST:sendmail:worker'
     ],
     oauth: {
@@ -52,6 +53,9 @@ export const initBar = async client => {
     displayOnMobile: true
   })
 }
+
+export const updateBarAccessToken = accessToken =>
+  cozy.bar.updateAccessToken(accessToken)
 
 export const restoreCozyClientJs = (uri, clientInfos, token) => {
   cozy.client.init({

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -81,7 +81,7 @@ export const startReplication = async (
       firstReplicationFinished()
     }
 
-    await startRepeatedReplication({
+    startRepeatedReplication({
       afterReplication: infos => {
         if (infos.docs_written > 0) {
           if (indexes.byName) warmUpIndex(indexes.byName, 'name')
@@ -112,7 +112,10 @@ export const startReplication = async (
 const startRepeatedReplication = ({ afterReplication }) => {
   return new Promise((resolve, reject) => {
     const options = {
-      onError: reject,
+      onError: error => {
+        console.warn(error)
+        reject(error)
+      },
       onComplete: result => {
         resolve()
         afterReplication(result)

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -67,7 +67,6 @@ const getPreviousToken = async store => {
 }
 
 const isClientRevoked = (error, state) => {
-  console.log(error.message);
   return state.mobile.settings.serverUrl &&
   (error.status === 404 || error.status === 401 || error.message.match(/Client has been revoked/))
 }

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -65,6 +65,12 @@ const getPreviousToken = async store => {
   }
 }
 
+const isClientRevoked = (error, state) => {
+  console.log(error.message);
+  return state.mobile.settings.serverUrl &&
+  (error.status === 404 || error.status === 401 || error.message.match(/Client has been revoked/))
+}
+
 const startApplication = async function(store, client, polyglot) {
   configureReporter()
 
@@ -84,7 +90,7 @@ const startApplication = async function(store, client, polyglot) {
     startReplication(store.dispatch, store.getState) // don't like to pass `store.dispatch` and `store.getState` as parameters, big coupling
   } catch (e) {
     console.warn(e)
-    if (store.getState().mobile.settings.serverUrl && (e.status === 404 || e.status === 401)) {
+    if (isClientRevoked(e, store.getState())) {
       console.warn('Your device is not connected to your server anymore')
       store.dispatch(revokeClient())
       resetClient(client)

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -30,6 +30,7 @@ import {
   getLang,
   initClient,
   initBar,
+  updateBarAccessToken,
   restoreCozyClientJs,
   resetClient
 } from 'drive/mobile/lib/cozy-helper'
@@ -84,6 +85,12 @@ const startApplication = async function(store, client, polyglot) {
     oauthClient.setOAuthOptions(clientInfos)
     oauthClient.setCredentials(token)
     await restoreCozyClientJs(client.options.uri, clientInfos, token)
+
+    oauthClient.onTokenRefresh = token => {
+      updateBarAccessToken(token.accessToken)
+      restoreCozyClientJs(client.options.uri, clientInfos, token)
+      store.dispatch(setToken(token))
+    }
 
     await oauthClient.fetchInformation()
     shouldInitBar = true


### PR DESCRIPTION
There were a few issues when a token expired — the cozy-bar and cozy-client-js were keeping their old tokens, and their requests would fail.