### PR TITLE
Sharings view fixes

### DIFF
--- a/src/drive/containers/Breadcrumb.jsx
+++ b/src/drive/containers/Breadcrumb.jsx
@@ -11,6 +11,7 @@ import { openFolder } from '../actions'
 import classNames from 'classnames'
 import Spinner from 'cozy-ui/react/Spinner'
 import { withBreakpoints } from 'cozy-ui/react'
+import { SharedDocuments } from 'sharing'
 
 import { getFolderPath, getFolderUrl } from '../reducers'
 
@@ -204,7 +205,12 @@ const MobileAwareBreadcrumb = props => {
 
 const mapStateToProps = (state, ownProps) => ({
   path: renamePathNames(
-    getFolderPath(state, ownProps.location, ownProps.isPublic),
+    getFolderPath(
+      state,
+      ownProps.location,
+      ownProps.isPublic,
+      ownProps.sharedDocuments
+    ),
     ownProps.location,
     ownProps.t
   ),
@@ -215,10 +221,25 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   goToFolder: folderId => dispatch(openFolder(folderId))
 })
 
+const withSharedDocuments = Wrapped =>
+  class extends React.Component {
+    render() {
+      return (
+        <SharedDocuments>
+          {({ sharedDocuments }) => (
+            <Wrapped sharedDocuments={sharedDocuments} {...this.props} />
+          )}
+        </SharedDocuments>
+      )
+    }
+  }
+
 export default withBreakpoints()(
   withRouter(
     translate()(
-      connect(mapStateToProps, mapDispatchToProps)(MobileAwareBreadcrumb)
+      withSharedDocuments(
+        connect(mapStateToProps, mapDispatchToProps)(MobileAwareBreadcrumb)
+      )
     )
   )
 )

--- a/src/drive/ducks/files/SharingsContainer.jsx
+++ b/src/drive/ducks/files/SharingsContainer.jsx
@@ -25,7 +25,11 @@ class SharingFetcher extends React.Component {
       const resp = await client
         .collection('io.cozy.files')
         .all({ keys: sharedDocuments })
-      const files = resp.data
+      const files = resp.data.sort((a, b) => {
+        if (a.type === 'directory' && b.type !== 'directory') return -1
+        else if (a.type !== 'directory' && b.type === 'directory') return 1
+        else return a.name.localeCompare(b.name)
+      })
 
       this.props.fetchSuccess(files)
     } catch (e) {

--- a/src/drive/reducers/view.js
+++ b/src/drive/reducers/view.js
@@ -324,7 +324,12 @@ export const getFolderUrl = (folderId, location) => {
 }
 
 // reconstruct the whole path to the current folder (first element is the root, the last is the current folder)
-export const getFolderPath = ({ view }, location, isPublic) => {
+export const getFolderPath = (
+  { view },
+  location,
+  isPublic,
+  sharedDocuments
+) => {
   const { displayedFolder } = view
   const path = []
   const isBrowsingTrash = /^\/trash/.test(location.pathname)
@@ -335,18 +340,20 @@ export const getFolderPath = ({ view }, location, isPublic) => {
     path.push(displayedFolder)
     // does the folder have parents to display? The trash folder has the root folder as parent, but we don't want to show that. Sharings folder at the root level have the same problem.
     const parent = displayedFolder.parent
+    const isShared = sharedDocuments.includes(displayedFolder.id)
+    const isParentShared = sharedDocuments.includes(parent.id)
     if (
       parent &&
       parent.id &&
       !(isBrowsingTrash && parent.id === ROOT_DIR_ID) &&
-      !(isBrowsingSharings && parent.id === ROOT_DIR_ID)
+      !(isBrowsingSharings && isShared)
     ) {
       path.unshift(parent)
       // has the parent a parent too?
       if (
         parent.dir_id &&
         !(isBrowsingTrash && parent.dir_id === ROOT_DIR_ID) &&
-        !(isBrowsingSharings && parent.dir_id === ROOT_DIR_ID) &&
+        !(isBrowsingSharings && isParentShared) &&
         !isPublic
       ) {
         // since we don't *actually* have any information about the parent's parent, we have to fake it


### PR DESCRIPTION
The sorting fix is pretty straightforward.

For the breadcrumbs, when on the sharings view, we need to know if the folders are shared or not — because if they are, we don't want to show their (not shared) parent in the breadcrumb.