### PR TITLE
chore: Update file-opener plugin

### DIFF
--- a/targets/drive/mobile/config.xml
+++ b/targets/drive/mobile/config.xml
@@ -80,7 +80,7 @@
     <plugin name="cordova-plugin-inappbrowser" spec="1.7.0" />
     <plugin name="cordova-plugin-file" spec="4.3.1" />
     <plugin name="cordova-plugin-appinfo" spec="2.1.1" />
-    <plugin name="cordova-plugin-file-opener2" spec="2.0.19" />
+    <plugin name="cordova-plugin-file-opener2" spec="https://github.com/pwlin/cordova-plugin-file-opener2.git" />
     <plugin name="cordova-plugin-network-information" spec="1.3.2" />
     <plugin name="cordova-plugin-background-fetch" spec="4.0.0" />
     <plugin name="cordova-plugin-ios-no-export-compliance" spec="https://github.com/mikaoelitiana/cordova-plugin-ios-no-export-compliance.git" />


### PR DESCRIPTION
The file-opener plugin is out of date. Sadly there's no new official release, so in the meantime I've switched us to `master`. I've also opened an issue : https://github.com/pwlin/cordova-plugin-file-opener2/issues/219