### PR TITLE
Added sharing recipients to the more menu

### DIFF
--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -50,7 +50,14 @@ export default class Menu extends Component {
   }
 
   render() {
-    const { title, disabled, className, button, buttonClassName } = this.props
+    const {
+      title,
+      disabled,
+      className,
+      innerClassName,
+      button,
+      buttonClassName
+    } = this.props
     const { opened } = this.state
     return (
       <div
@@ -72,7 +79,7 @@ export default class Menu extends Component {
           </button>
         )}
         <div
-          className={classNames(styles['coz-menu-inner'], {
+          className={classNames(styles['coz-menu-inner'], innerClassName, {
             [styles['coz-menu-inner--opened']]: opened
           })}
         >

--- a/src/drive/ducks/files/Container.jsx
+++ b/src/drive/ducks/files/Container.jsx
@@ -26,12 +26,18 @@ import {
   toggleAvailableOffline
 } from '../../actions'
 
+import styles from '../../styles/actionmenu'
+
 const ShareMenuItem = ({ docId, ...rest }, { t }) => (
   <SharedDocument docId={docId}>
     {({ isSharedWithMe }) => (
       <MenuItem {...rest}>
         {isSharedWithMe ? t('Files.share.sharedWithMe') : t('Files.share.cta')}
-        <SharedRecipients docId={docId} size="small" />
+        <SharedRecipients
+          className={styles['fil-actionmenu-recipients']}
+          docId={docId}
+          size="small"
+        />
       </MenuItem>
     )}
   </SharedDocument>

--- a/src/drive/ducks/files/Toolbar.jsx
+++ b/src/drive/ducks/files/Toolbar.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import classNames from 'classnames'
+import { showModal } from 'react-cozy-helpers'
 
 import { ROOT_DIR_ID } from '../../constants/config'
 import { translate } from 'cozy-ui/react/I18n'
@@ -32,16 +33,7 @@ import {
 
 const { BarRight } = cozy.bar
 
-const toggleShowShareModal = state => ({
-  ...state,
-  showShareModal: !state.showShareModal
-})
-
 class Toolbar extends Component {
-  state = {
-    showShareModal: false
-  }
-
   render() {
     const cozyDev = cozy.client._url === 'http://cozy.tools:8080'
     const cozyRecette = cozy.client._url === 'https://recette.cozy.works'
@@ -56,6 +48,7 @@ class Toolbar extends Component {
       isShared,
       isSharedWithMe,
       uploadFiles,
+      share,
       downloadAll,
       trashFolder,
       onLeave,
@@ -75,7 +68,7 @@ class Toolbar extends Component {
           <Item>
             <a
               className={styles['fil-action-share']}
-              onClick={() => this.setState(toggleShowShareModal)}
+              onClick={() => share(displayedFolder)}
             >
               {t(isSharedWithMe ? 'Files.share.sharedWithMe' : 'toolbar.share')}
             </a>
@@ -178,21 +171,12 @@ class Toolbar extends Component {
           <ShareButton
             docId={displayedFolder.id}
             disabled={disabled}
-            onClick={() => this.setState(toggleShowShareModal)}
+            onClick={() => share(displayedFolder)}
             className={styles['u-hide--mob']}
           />
         )}
 
         {isMobile ? <BarRight>{MoreMenu}</BarRight> : MoreMenu}
-
-        {this.state.showShareModal && (
-          <ShareModal
-            document={displayedFolder}
-            documentType="Files"
-            sharingDesc={displayedFolder.name}
-            onClose={() => this.setState(toggleShowShareModal)}
-          />
-        )}
       </div>
     )
   }
@@ -221,6 +205,19 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       )
     )
   },
+  share: displayedFolder =>
+    dispatch({
+      ...showModal(
+        <ShareModal
+          document={displayedFolder}
+          documentType="Files"
+          sharingDesc={displayedFolder.name}
+        />
+      ),
+      meta: {
+        hideActionMenu: true
+      }
+    }),
   downloadAll: folder => dispatch(downloadFiles(folder)),
   trashFolder: folder =>
     dispatch(trashFiles([folder])).then(() => {

--- a/src/drive/ducks/files/Toolbar.jsx
+++ b/src/drive/ducks/files/Toolbar.jsx
@@ -30,6 +30,7 @@ import {
   SharedDocument,
   SharedRecipients
 } from 'sharing'
+import { RecipientsAvatars } from '../../../sharing/components/Recipient'
 
 const { BarRight } = cozy.bar
 
@@ -47,6 +48,8 @@ class Toolbar extends Component {
       hasWriteAccess,
       isShared,
       isSharedWithMe,
+      sharingRecipients,
+      sharingLink,
       uploadFiles,
       share,
       downloadAll,
@@ -62,6 +65,7 @@ class Toolbar extends Component {
         title={t('toolbar.item_more')}
         disabled={disabled}
         className={styles['fil-toolbar-menu']}
+        innerClassName={styles['fil-toolbar-inner-menu']}
         button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
       >
         {notRootfolder && (
@@ -71,6 +75,12 @@ class Toolbar extends Component {
               onClick={() => share(displayedFolder)}
             >
               {t(isSharedWithMe ? 'Files.share.sharedWithMe' : 'toolbar.share')}
+              <RecipientsAvatars
+                className={styles['fil-toolbar-menu-recipients']}
+                recipients={sharingRecipients}
+                link={sharingLink}
+                size="small"
+              />
             </a>
           </Item>
         )}
@@ -230,12 +240,21 @@ const ToolbarWithSharingContext = props =>
     <Toolbar {...props} />
   ) : (
     <SharedDocument docId={props.displayedFolder.id}>
-      {({ isShared, isSharedWithMe, hasWriteAccess, onLeave }) => (
+      {({
+        isShared,
+        isSharedWithMe,
+        hasWriteAccess,
+        recipients,
+        link,
+        onLeave
+      }) => (
         <Toolbar
           {...props}
           hasWriteAccess={hasWriteAccess}
           isShared={isShared}
           isSharedWithMe={isSharedWithMe}
+          sharingRecipients={recipients}
+          sharingLink={link}
           onLeave={onLeave}
         />
       )}

--- a/src/drive/styles/actionmenu.styl
+++ b/src/drive/styles/actionmenu.styl
@@ -48,7 +48,7 @@
     background embedurl("../assets/icons/icon-share-grey.svg") 1rem center no-repeat
     position   relative
     
-    > div
+    .fil-actionmenu-recipients
         position absolute
         right    1rem
         top      .1rem

--- a/src/drive/styles/toolbar.styl
+++ b/src/drive/styles/toolbar.styl
@@ -50,6 +50,11 @@
         &.fil-action-share
             background embedurl('../assets/icons/icon-share-dark.svg') 1rem center no-repeat
 
+            .fil-toolbar-menu-recipients
+                position absolute
+                right    1rem
+                top      .1rem
+
     .fil-action-upload
     .fil-action-share
         display none
@@ -65,6 +70,10 @@
             display block
 
 +small-screen()
+    .fil-toolbar-inner-menu
+        position fixed
+        margin   .5rem
+        width    calc(100% - 1rem)
     .fil-toolbar-files
     .fil-toolbar-trash
         position fixed

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -10,24 +10,29 @@ import { getDisplayName, getPrimaryEmail, getPrimaryCozy } from '..'
 
 const MAX_DISPLAYED_RECIPIENTS = 3
 
-export const RecipientsAvatars = ({ recipients, link, size }) => (
-  <div className={styles['recipients-avatars']}>
-    {link && <AvatarLink size={size} />}
-    {recipients.length > MAX_DISPLAYED_RECIPIENTS && (
-      <AvatarPlusX
-        extraRecipients={recipients
-          .slice(MAX_DISPLAYED_RECIPIENTS)
-          .map(recipient => getDisplayName(recipient))}
-        size={size}
-      />
-    )}
-    {recipients
-      .slice(0, MAX_DISPLAYED_RECIPIENTS)
-      .map(recipient => (
-        <Avatar name={getDisplayName(recipient)} size={size} />
-      ))}
-  </div>
-)
+export const RecipientsAvatars = ({ recipients, link, size, className }) => {
+  // we reverse the recipients array because we use `flex-direction: row-reverse` to display them correctly
+  // we slice first to clone the original array because reverse() mutates it
+  const reversedRecipients = recipients.slice().reverse()
+  return (
+    <div className={classNames(styles['recipients-avatars'], className)}>
+      {link && <AvatarLink size={size} />}
+      {recipients.length > MAX_DISPLAYED_RECIPIENTS && (
+        <AvatarPlusX
+          extraRecipients={reversedRecipients
+            .slice(MAX_DISPLAYED_RECIPIENTS)
+            .map(recipient => getDisplayName(recipient))}
+          size={size}
+        />
+      )}
+      {reversedRecipients
+        .slice(0, MAX_DISPLAYED_RECIPIENTS)
+        .map(recipient => (
+          <Avatar name={getDisplayName(recipient)} size={size} />
+        ))}
+    </div>
+  )
+}
 
 const Identity = ({ name, url }) => (
   <div className={styles['recipient-idents']}>

--- a/src/sharing/index.jsx
+++ b/src/sharing/index.jsx
@@ -243,7 +243,14 @@ export const SharedDocuments = ({ children }) => (
 
 export const SharedDocument = ({ docId, children }) => (
   <SharingContext.Consumer>
-    {({ byDocId, isOwner, getSharingType, revokeSelf } = {}) =>
+    {({
+      byDocId,
+      isOwner,
+      getSharingType,
+      getRecipients,
+      getSharingLink,
+      revokeSelf
+    } = {}) =>
       children({
         hasWriteAccess:
           !byDocId ||
@@ -254,6 +261,8 @@ export const SharedDocument = ({ docId, children }) => (
         isSharedByMe: byDocId !== undefined && byDocId[docId] && isOwner(docId),
         isSharedWithMe:
           byDocId !== undefined && byDocId[docId] && !isOwner(docId),
+        recipients: getRecipients(docId),
+        link: getSharingLink(docId) !== null,
         onLeave: revokeSelf
       })
     }}
@@ -292,7 +301,7 @@ export const SharedRecipients = ({ docId, ...rest }) => (
     {({ byDocId, getRecipients, getSharingLink } = {}) =>
       !byDocId || !byDocId[docId] ? null : (
         <RecipientsAvatars
-          recipients={getRecipients(docId).reverse()}
+          recipients={getRecipients(docId)}
           link={getSharingLink(docId) !== null}
           {...rest}
         />


### PR DESCRIPTION
As the more menu on mobile is injected into the cozy-bar, it doesn't have access to the sharing context. That's why I had to use `RecipientsAvatars` [here](https://github.com/cozy/cozy-drive/pull/1074/files#diff-12918a0e2886ac9526cde1534cc4ca9fR78) instead of `SharedRecipients` and pass the recipients to the Toolbar.