### PR TITLE
Added a 'permissions required' popin to the sharing modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "cozy-bar": "5.0.8",
-    "cozy-client": "1.0.0-beta.16",
+    "cozy-client": "1.0.0-beta.29",
     "cozy-client-js": "0.10.0",
     "cozy-ui": "10.6.1",
     "create-react-context": "0.2.2",

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -77,6 +77,14 @@
     "members": {
       "count": "%{count} members",
       "others": "and 1 other… |||| and %{smart_count} others…"
+    },
+    "contacts": {
+      "permissionRequired": {
+        "title": "Save your contacts in your Cozy?",
+        "desc": "Authorize the application to access to your Cozy's contacts: you'll be able to select them next time.",
+        "action": "Authorize access",
+        "success": "The application has access to your contacts"
+      }
     }
   },
   "Sharings": {

--- a/src/drive/mobile/actions/authorization.js
+++ b/src/drive/mobile/actions/authorization.js
@@ -1,5 +1,17 @@
+import { restoreCozyClientJs, updateBarAccessToken } from '../lib/cozy-helper'
+import { setUrl, saveCredentials } from './settings'
+
 export const REVOKE = 'REVOKE'
 export const UNREVOKE = 'UNREVOKE'
 
 export const revokeClient = () => ({ type: REVOKE })
 export const unrevokeClient = () => ({ type: UNREVOKE })
+
+export const renewAuthorization = client => async dispatch => {
+  const url = client.options.uri
+  const { infos, token } = await client.renewAuthorization(url)
+  await restoreCozyClientJs(url, infos, token)
+  updateBarAccessToken(token)
+  dispatch(setUrl(url))
+  dispatch(saveCredentials(infos, token))
+}

--- a/src/drive/mobile/reducers/index.js
+++ b/src/drive/mobile/reducers/index.js
@@ -1,21 +1,13 @@
 import { combineReducers } from 'redux'
 
-import { reducers } from '../../reducers'
-
 import { settings } from './settings'
 import { default as mediaBackup } from '../ducks/mediaBackup'
-
 import { ui } from './ui'
 import { authorization } from './authorization'
 
-const mobile = combineReducers({
+export default combineReducers({
   authorization,
   settings,
   mediaBackup,
   ui
 })
-
-export default {
-  ...reducers,
-  mobile
-}

--- a/src/drive/reducers/index.js
+++ b/src/drive/reducers/index.js
@@ -8,7 +8,7 @@ import upload from '../ducks/upload'
 import availableOffline from '../ducks/files/availableOffline'
 import uiReducer from 'react-cozy-helpers'
 
-export const reducers = {
+const reducers = {
   ui: uiReducer,
   view,
   settings,

--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -9,8 +9,8 @@ import {
 } from 'cozy-ui/react/helpers/tracker'
 import thunkMiddleware from 'redux-thunk'
 import eventTrackerMiddleware from '../middlewares/EventTracker'
-import rootReducer from '../reducers'
-import mobileRootReducer from '../mobile/reducers'
+import baseReducers from '../reducers'
+import mobileReducer from '../mobile/reducers'
 import { saveState } from './persistedState'
 import { ANALYTICS_URL, getReporterConfiguration } from '../mobile/lib/reporter'
 
@@ -29,11 +29,20 @@ const configureStore = (client, t, initialState = {}) => {
   const composeEnhancers =
     (__DEVELOPMENT__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
 
+  const reducers =
+    __TARGET__ === 'mobile'
+      ? combineReducers({
+          ...baseReducers,
+          mobile: mobileReducer,
+          cozy: client.reducer()
+        })
+      : combineReducers({
+          ...baseReducers,
+          cozy: client.reducer()
+        })
+
   const store = createStore(
-    combineReducers({
-      ...(__TARGET__ === 'mobile' ? mobileRootReducer : rootReducer),
-      cozy: client.reducer()
-    }),
+    reducers,
     initialState,
     composeEnhancers(applyMiddleware(...middlewares))
   )

--- a/src/sharing/ShareModal.jsx
+++ b/src/sharing/ShareModal.jsx
@@ -22,6 +22,7 @@ export default class ShareModal extends Component {
       link,
       recipients,
       documentType = 'Document',
+      needsContactsPermission,
       hasSharedParent,
       hasSharedChild,
       onClose,
@@ -46,6 +47,7 @@ export default class ShareModal extends Component {
             contacts={contacts}
             createContact={createContact}
             onShare={onShare}
+            needsContactsPermission={needsContactsPermission}
             hasSharedParent={hasSharedParent}
             hasSharedChild={hasSharedChild}
           />
@@ -81,6 +83,7 @@ ShareModal.propTypes = {
   recipients: PropTypes.array.isRequired,
   link: PropTypes.string,
   documentType: PropTypes.string,
+  needsContactsPermission: PropTypes.bool,
   hasSharedParent: PropTypes.bool,
   hasSharedChild: PropTypes.bool,
   onClose: PropTypes.func.isRequired,

--- a/src/sharing/components/ShareAutosuggest.jsx
+++ b/src/sharing/components/ShareAutosuggest.jsx
@@ -75,6 +75,10 @@ export default class ShareAutocomplete extends Component {
     }
   }
 
+  onFocus = () => {
+    this.props.onFocus()
+  }
+
   onBlur = (event, { highlightedSuggestion }) => {
     if (highlightedSuggestion) {
       this.props.onPick(highlightedSuggestion)
@@ -136,6 +140,7 @@ export default class ShareAutocomplete extends Component {
         renderInputComponent={props => this.renderInput(props)}
         highlightFirstSuggestion
         inputProps={{
+          onFocus: this.onFocus,
           onChange: this.onChange,
           onBlur: this.onBlur,
           value: inputValue,

--- a/src/sharing/index.jsx
+++ b/src/sharing/index.jsx
@@ -345,7 +345,10 @@ const EditableSharingModal = ({ document, ...rest }) => (
       hasSharedChild
     }) => (
       <Query query={cozy => cozy.all('io.cozy.contacts')}>
-        {({ data }, { createDocument: createContact }) => (
+        {(
+          { data, fetchStatus, lastError },
+          { createDocument: createContact }
+        ) => (
           <DumbShareModal
             document={document}
             documentType={documentType}
@@ -354,6 +357,9 @@ const EditableSharingModal = ({ document, ...rest }) => (
             recipients={getRecipients(document.id)}
             link={getSharingLink(document.id)}
             isOwner={isOwner(document.id)}
+            needsContactsPermission={
+              fetchStatus === 'failed' && lastError.status === 403
+            }
             hasSharedParent={hasSharedParent(document)}
             hasSharedChild={hasSharedChild(document)}
             onShare={share}

--- a/src/sharing/share.styl
+++ b/src/sharing/share.styl
@@ -1,4 +1,5 @@
 @require 'components/forms.styl'
+@require 'components/popover.styl'
 @require 'settings/breakpoints.styl'
 @require 'settings/palette.styl'
 
@@ -171,6 +172,39 @@ input[type=text]
     width 100%
     height 3rem
     margin 0
+
+.permission-required-popin
+    @extend $popover
+    display flex
+    flex-direction column
+    position relative
+    line-height 1.25rem
+    margin-top .25rem
+
+    .permission-required-popin-close
+        position absolute
+        top 0
+        right .9375rem
+        margin 0
+        padding 0
+        background-size .875rem
+        background-color transparent
+        cursor pointer
+        display block
+        width .875rem
+        height .875rem
+        z-index $modal-index
+
+    h4
+        font-size .875rem
+        margin 1.5rem 1rem 0 1rem
+    p
+        font-size .875rem
+        margin 0 1rem 1rem 1rem
+
+    .permission-required-popin-accept
+        color white
+        margin 0 1rem 1.5rem 1rem
 
 .share-details-created
 .share-details-perm

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,20 +2652,20 @@ cozy-client-js@^0.3.19:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
 
-cozy-client@1.0.0-beta.16:
-  version "1.0.0-beta.16"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-1.0.0-beta.16.tgz#8b686261af07472a7dccf1c97aef367ffaade082"
+cozy-client@1.0.0-beta.29:
+  version "1.0.0-beta.29"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-1.0.0-beta.29.tgz#53245784127aebb31c31777be50c52ffbd55cf93"
   dependencies:
-    cozy-stack-client "^1.0.0-beta.16"
+    cozy-stack-client "^1.0.0-beta.29"
     lodash "^4.17.5"
     prop-types "^15.6.0"
     react "^16.2.0"
     react-redux "^5.0.6"
     redux "^3.7.2"
 
-cozy-stack-client@^1.0.0-beta.16:
-  version "1.0.0-beta.16"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-1.0.0-beta.16.tgz#9731951d9dd322a673150d5c291d2c5f6af3633b"
+cozy-stack-client@^1.0.0-beta.29:
+  version "1.0.0-beta.29"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-1.0.0-beta.29.tgz#94c7e274c5c2db6b31734a4cb8f3293fcd103be6"
   dependencies:
     mime-types "^2.1.18"
 


### PR DESCRIPTION
Some users that have installed the application a long time ago didn't ask for contacts' perm when they authorized the app (it wasn't in the OAuth scope yet). This PR detects 403s on contacts fetch and displays a popin for the user to renew authorization with the good scope.