### PR TITLE
Redux store and persisted state clean reset

### DIFF
--- a/src/drive/actions/settings.js
+++ b/src/drive/actions/settings.js
@@ -2,7 +2,6 @@ export const SET_CLIENT = 'SET_CLIENT'
 export const SET_OFFLINE = 'SET_OFFLINE'
 export const SET_FIRST_REPLICATION = 'SET_FIRST_REPLICATION'
 export const SET_POUCH_INDEXES = 'SET_POUCH_INDEXES'
-export const UNLINK = 'UNLINK'
 
 export const setClient = client => ({ type: SET_CLIENT, client })
 export const setOffline = offline => ({ type: SET_OFFLINE, offline })

--- a/src/drive/mobile/actions/unlink.js
+++ b/src/drive/mobile/actions/unlink.js
@@ -1,4 +1,5 @@
 import { resetClient } from '../lib/cozy-helper'
+import { resetPersistedState } from '../../store/persistedState'
 
 // constants
 export const SHOW_UNLINK_CONFIRMATION = 'SHOW_UNLINK_CONFIRMATION'
@@ -10,8 +11,9 @@ export const showUnlinkConfirmation = () => ({ type: SHOW_UNLINK_CONFIRMATION })
 export const hideUnlinkConfirmation = () => ({ type: HIDE_UNLINK_CONFIRMATION })
 
 // action creators async
-export const unlink = (client, clientInfo) => {
+export const unlink = (client, clientInfo) => async dispatch => {
   resetClient(client, clientInfo)
-
-  return { type: UNLINK }
+  await resetPersistedState()
+  // This action will be handled by the rootReducer: the store will be restored to its initial state
+  return dispatch({ type: UNLINK })
 }

--- a/src/drive/mobile/reducers/settings.js
+++ b/src/drive/mobile/reducers/settings.js
@@ -8,7 +8,6 @@ import {
   WIFI_ONLY,
   SET_TOKEN
 } from '../actions/settings'
-import { UNLINK } from '../actions/unlink'
 
 export const initialState = {
   serverUrl: '',
@@ -36,8 +35,6 @@ export const settings = (state = initialState, action) => {
       return { ...state, wifiOnly: action.wifiOnly }
     case SET_TOKEN:
       return { ...state, token: action.token }
-    case UNLINK:
-      return initialState
     default:
       return state
   }

--- a/src/drive/mobile/reducers/ui.js
+++ b/src/drive/mobile/reducers/ui.js
@@ -1,7 +1,6 @@
 import {
   SHOW_UNLINK_CONFIRMATION,
-  HIDE_UNLINK_CONFIRMATION,
-  UNLINK
+  HIDE_UNLINK_CONFIRMATION
 } from '../actions/unlink'
 
 export const initialState = {
@@ -13,7 +12,6 @@ export const ui = (state = initialState, action) => {
     case SHOW_UNLINK_CONFIRMATION:
       return { ...state, displayUnlinkConfirmation: true }
     case HIDE_UNLINK_CONFIRMATION:
-    case UNLINK:
       return { ...state, displayUnlinkConfirmation: false }
     default:
       return state

--- a/src/drive/reducers/settings.js
+++ b/src/drive/reducers/settings.js
@@ -2,8 +2,7 @@ import {
   SET_CLIENT,
   SET_OFFLINE,
   SET_FIRST_REPLICATION,
-  SET_POUCH_INDEXES,
-  UNLINK
+  SET_POUCH_INDEXES
 } from '../actions/settings'
 
 export const initialState = {
@@ -22,8 +21,6 @@ export const settings = (state = initialState, action) => {
       return { ...state, firstReplication: action.firstReplication }
     case SET_POUCH_INDEXES:
       return { ...state, indexes: action.indexes }
-    case UNLINK:
-      return initialState
     default:
       return state
   }

--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -1,5 +1,5 @@
 /* global __DEVELOPMENT__, __TARGET__ */
-import { compose, createStore, applyMiddleware, combineReducers } from 'redux'
+import { compose, createStore, applyMiddleware } from 'redux'
 import { createLogger } from 'redux-logger'
 import RavenMiddleWare from 'redux-raven-middleware'
 import {
@@ -9,8 +9,7 @@ import {
 } from 'cozy-ui/react/helpers/tracker'
 import thunkMiddleware from 'redux-thunk'
 import eventTrackerMiddleware from '../middlewares/EventTracker'
-import baseReducers from '../reducers'
-import mobileReducer from '../mobile/reducers'
+import createRootReducer from './rootReducer'
 import { saveState } from './persistedState'
 import { ANALYTICS_URL, getReporterConfiguration } from '../mobile/lib/reporter'
 
@@ -29,20 +28,10 @@ const configureStore = (client, t, initialState = {}) => {
   const composeEnhancers =
     (__DEVELOPMENT__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
 
-  const reducers =
-    __TARGET__ === 'mobile'
-      ? combineReducers({
-          ...baseReducers,
-          mobile: mobileReducer,
-          cozy: client.reducer()
-        })
-      : combineReducers({
-          ...baseReducers,
-          cozy: client.reducer()
-        })
+  const rootReducer = createRootReducer(client)
 
   const store = createStore(
-    reducers,
+    rootReducer,
     initialState,
     composeEnhancers(applyMiddleware(...middlewares))
   )

--- a/src/drive/store/persistedState.js
+++ b/src/drive/store/persistedState.js
@@ -15,9 +15,10 @@ export const loadState = async () => {
 
 export const saveState = async state => {
   try {
-    localforage.setItem('state', state)
+    await localforage.setItem('state', state)
   } catch (err) {
     console.warn(err)
-    // Errors handling
   }
 }
+
+export const resetPersistedState = () => localforage.clear()

--- a/src/drive/store/rootReducer.js
+++ b/src/drive/store/rootReducer.js
@@ -1,0 +1,31 @@
+/* global __TARGET__ */
+import { combineReducers } from 'redux'
+import baseReducers from '../reducers'
+import mobileReducer from '../mobile/reducers'
+import { UNLINK } from '../mobile/actions/unlink'
+
+// Per Dan Abramov: https://stackoverflow.com/questions/35622588/how-to-reset-the-state-of-a-redux-store/35641992#35641992
+const createRootReducer = client => {
+  const appReducer =
+    __TARGET__ === 'mobile'
+      ? combineReducers({
+          ...baseReducers,
+          mobile: mobileReducer,
+          cozy: client.reducer()
+        })
+      : combineReducers({
+          ...baseReducers,
+          cozy: client.reducer()
+        })
+
+  const rootReducer = (state, action) => {
+    if (action.type === UNLINK) {
+      state = undefined
+    }
+    return appReducer(state, action)
+  }
+
+  return rootReducer
+}
+
+export default createRootReducer


### PR DESCRIPTION
Here I used a [Dan Abramov strategy](https://stackoverflow.com/questions/35622588/how-to-reset-the-state-of-a-redux-store/35641992#35641992) to reset the redux store. There is no need to handle the `UNLINK` action in each duck anymore.