### PR TITLE
Share modal access

### DIFF
--- a/src/sharing/ShareModal.jsx
+++ b/src/sharing/ShareModal.jsx
@@ -62,6 +62,7 @@ export default class ShareModal extends Component {
               onDisable={onRevokeLink}
             />
             <WhoHasAccess
+              className={styles['share-modal-access']}
               isOwner={isOwner}
               recipients={recipients}
               document={document}

--- a/src/sharing/components/recipient.styl
+++ b/src/sharing/components/recipient.styl
@@ -116,6 +116,10 @@
     &:not([disabled]):not([aria-disabled=true]):hover
         background-color transparent
 
+// bit of a hack because the menu is inside a scrollable area
+.recipient-menu > div
+  margin-bottom .5rem
+
 .action-unshare
     color pomegranate !important
     text-decoration none !important

--- a/src/sharing/components/recipient.styl
+++ b/src/sharing/components/recipient.styl
@@ -129,7 +129,7 @@
     padding   .5rem 0
     font-size .8125rem
 
-@media (max-width 32em)
++small-screen()
     .recipient-ident-status
         display block
 

--- a/src/sharing/share.styl
+++ b/src/sharing/share.styl
@@ -79,6 +79,9 @@
       > div
           margin-bottom 2rem
 
+    .share-modal-access
+      padding-right .5rem
+
 @media (max-width 32em)
     .share-modal-secondary
         > div


### PR DESCRIPTION
The menu to revoke a sharing participant is a pain in the ass. It was not positioned quite right and had some issues on tablet, this PR fixes these problems.