### PR TITLE
Photos: title and menus in the cozy bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "cozy-bar": "5.0.8",
-    "cozy-client": "1.0.0-beta.29",
+    "cozy-client": "2.7.0",
     "cozy-client-js": "0.10.0",
     "cozy-realtime": "1.1.0",
     "cozy-ui": "10.8.1",

--- a/src/photos/components/Topbar.jsx
+++ b/src/photos/components/Topbar.jsx
@@ -1,46 +1,39 @@
+/* global cozy  */
 import styles from '../styles/topbar'
 
 import React, { Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'
+import { withBreakpoints } from 'cozy-ui/react'
 import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
+
+const { BarCenter } = cozy.bar
 
 const KEYCODE_ENTER = 13
 const KEYCODE_ESC = 27
 
-class Topbar extends Component {
+class EditableAlbumName extends Component {
   constructor(props) {
     super(props)
-
     this.ignoreBlurEvent = false // we'll ignore blur events if they are triggered by pressing enter or escape, to prevent `onEdit` from firing twice
     this.inputElement = null
-
-    this.backToAlbums = this.backToAlbums.bind(this)
-    this.handleBlur = this.handleBlur.bind(this)
-    this.handleKeyDown = this.handleKeyDown.bind(this)
   }
 
-  componentDidUpdate() {
+  componentDidMount() {
     if (this.inputElement !== null) {
       this.inputElement.focus()
       this.inputElement.select()
     }
   }
 
-  backToAlbums() {
-    // go to parent
-    let url = this.props.router.location.pathname
-    this.props.router.push(url.substring(0, url.lastIndexOf('/')))
-  }
-
-  handleBlur(e) {
+  handleBlur = e => {
     if (!this.ignoreBlurEvent && this.props.onEdit)
       this.props.onEdit(
         e.target.value.trim() !== '' ? e.target.value : this.props.albumName
       )
   }
 
-  handleKeyDown(e) {
+  handleKeyDown = e => {
     if (e.keyCode === KEYCODE_ENTER && this.props.onEdit) {
       this.ignoreBlurEvent = true
       this.props.onEdit(e.target.value)
@@ -50,33 +43,64 @@ class Topbar extends Component {
     }
   }
 
-  render({ t, children, viewName, albumName = '', editing = false }) {
+  render() {
+    const { albumName } = this.props
+    return (
+      <input
+        type="text"
+        value={albumName}
+        onKeyDown={this.handleKeyDown}
+        onBlur={this.handleBlur}
+        ref={elem => {
+          this.inputElement = elem
+        }}
+      />
+    )
+  }
+}
+
+EditableAlbumName.propTypes = {
+  albumName: PropTypes.string,
+  onEdit: PropTypes.func.isRequired
+}
+
+const TopbarTitle = ({ children }) => (
+  <h2 className={styles['pho-content-title']}>{children}</h2>
+)
+
+class Topbar extends Component {
+  backToAlbums = () => {
+    // go to parent
+    let url = this.props.router.location.pathname
+    this.props.router.push(url.substring(0, url.lastIndexOf('/')))
+  }
+
+  renderTitle() {
+    const { t, viewName, albumName = '', onEdit, editing = false } = this.props
+    const isAlbumContent = viewName === 'albumContent'
+
+    if (!isAlbumContent) return t(`Nav.${viewName}`)
+    else if (editing)
+      return <EditableAlbumName albumName={albumName} onEdit={onEdit} />
+    else return albumName
+  }
+
+  render() {
+    const { children, viewName, breakpoints: { isMobile } } = this.props
+    const isAlbumContent = viewName === 'albumContent'
+    const title = <TopbarTitle>{this.renderTitle()}</TopbarTitle>
+    const responsiveTitle = isMobile ? <BarCenter>{title}</BarCenter> : title
+
     return (
       <div className={styles['pho-content-header']}>
-        {viewName === 'albumContent' && (
+        {isAlbumContent && (
           <div
             role="button"
             className={styles['pho-content-album-previous']}
             onClick={this.backToAlbums}
           />
         )}
-        <h2 className={styles['pho-content-title']}>
-          {viewName !== 'albumContent' ? (
-            t(`Nav.${viewName}`)
-          ) : editing ? (
-            <input
-              type="text"
-              value={albumName}
-              onKeyDown={this.handleKeyDown}
-              onBlur={this.handleBlur}
-              ref={elem => {
-                this.inputElement = elem
-              }}
-            />
-          ) : (
-            albumName
-          )}
-        </h2>
+        {responsiveTitle}
         {children}
       </div>
     )
@@ -88,7 +112,10 @@ Topbar.propTypes = {
   albumName: PropTypes.string,
   t: PropTypes.func.isRequired,
   editing: PropTypes.bool.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  router: PropTypes.object.isRequired,
+  breakpoints: PropTypes.object.isRequired,
+  children: PropTypes.node
 }
 
-export default translate()(withRouter(Topbar))
+export default withBreakpoints()(translate()(withRouter(Topbar)))

--- a/src/photos/components/Topbar.jsx
+++ b/src/photos/components/Topbar.jsx
@@ -7,7 +7,7 @@ import { withBreakpoints } from 'cozy-ui/react'
 import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
 
-const { BarCenter } = cozy.bar
+const { BarCenter, BarRight } = cozy.bar
 
 const KEYCODE_ENTER = 13
 const KEYCODE_ESC = 27
@@ -86,10 +86,17 @@ class Topbar extends Component {
   }
 
   render() {
-    const { children, viewName, breakpoints: { isMobile } } = this.props
+    const { t, children, viewName, breakpoints: { isMobile } } = this.props
     const isAlbumContent = viewName === 'albumContent'
     const title = <TopbarTitle>{this.renderTitle()}</TopbarTitle>
     const responsiveTitle = isMobile ? <BarCenter>{title}</BarCenter> : title
+
+    const menuWithTranslation = React.cloneElement(children, { t })
+    const responsiveMenu = isMobile ? (
+      <BarRight>{menuWithTranslation}</BarRight>
+    ) : (
+      menuWithTranslation
+    )
 
     return (
       <div className={styles['pho-content-header']}>
@@ -101,7 +108,7 @@ class Topbar extends Component {
           />
         )}
         {responsiveTitle}
-        {children}
+        {responsiveMenu}
       </div>
     )
   }

--- a/src/photos/components/Topbar.jsx
+++ b/src/photos/components/Topbar.jsx
@@ -3,6 +3,7 @@ import styles from '../styles/topbar'
 import React, { Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import { withRouter } from 'react-router'
+import PropTypes from 'prop-types'
 
 const KEYCODE_ENTER = 13
 const KEYCODE_ESC = 27
@@ -80,6 +81,14 @@ class Topbar extends Component {
       </div>
     )
   }
+}
+
+Topbar.propTypes = {
+  viewName: PropTypes.string.isRequired,
+  albumName: PropTypes.string,
+  t: PropTypes.func.isRequired,
+  editing: PropTypes.bool.isRequired,
+  onEdit: PropTypes.func.isRequired
 }
 
 export default translate()(withRouter(Topbar))

--- a/src/photos/components/Topbar.jsx
+++ b/src/photos/components/Topbar.jsx
@@ -6,6 +6,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import { withBreakpoints } from 'cozy-ui/react'
 import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
+import flow from 'lodash/flow'
 
 const { BarCenter, BarRight } = cozy.bar
 
@@ -86,17 +87,12 @@ class Topbar extends Component {
   }
 
   render() {
-    const { t, children, viewName, breakpoints: { isMobile } } = this.props
+    const { children, viewName, breakpoints: { isMobile } } = this.props
     const isAlbumContent = viewName === 'albumContent'
     const title = <TopbarTitle>{this.renderTitle()}</TopbarTitle>
     const responsiveTitle = isMobile ? <BarCenter>{title}</BarCenter> : title
 
-    const menuWithTranslation = React.cloneElement(children, { t })
-    const responsiveMenu = isMobile ? (
-      <BarRight>{menuWithTranslation}</BarRight>
-    ) : (
-      menuWithTranslation
-    )
+    const responsiveMenu = isMobile ? <BarRight>{children}</BarRight> : children
 
     return (
       <div className={styles['pho-content-header']}>
@@ -118,11 +114,16 @@ Topbar.propTypes = {
   viewName: PropTypes.string.isRequired,
   albumName: PropTypes.string,
   t: PropTypes.func.isRequired,
-  editing: PropTypes.bool.isRequired,
-  onEdit: PropTypes.func.isRequired,
-  router: PropTypes.object.isRequired,
+  editing: PropTypes.bool,
+  onEdit: PropTypes.func,
   breakpoints: PropTypes.object.isRequired,
+  router: PropTypes.object.isRequired,
   children: PropTypes.node
 }
 
-export default withBreakpoints()(translate()(withRouter(Topbar)))
+Topbar.defaultProps = {
+  editing: false,
+  onEdit: () => {}
+}
+
+export default flow(withRouter, withBreakpoints(), translate())(Topbar)

--- a/src/photos/components/UploadButton.jsx
+++ b/src/photos/components/UploadButton.jsx
@@ -23,7 +23,7 @@ const styles = {
 export const UploadButton = ({
   t,
   label,
-  type = 'button',
+  inMenu = false,
   disabled,
   onUpload,
   className = ''
@@ -31,11 +31,11 @@ export const UploadButton = ({
   <label
     role="button"
     disabled={disabled}
-    className={`${className} ${type === 'menu-item' ? '' : button['c-btn']}`}
+    className={`${className} ${inMenu ? '' : button['c-btn']}`}
     style={styles.parent}
   >
     <span>
-      <Icon icon="upload" />
+      {!inMenu && <Icon icon="upload" />}
       {label}
       <input
         type="file"

--- a/src/photos/ducks/albums/components/AlbumPhotos.jsx
+++ b/src/photos/ducks/albums/components/AlbumPhotos.jsx
@@ -1,6 +1,10 @@
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { showModal, ModalManager } from 'react-cozy-helpers'
 import { withRouter } from 'react-router'
 import { translate } from 'cozy-ui/react/I18n'
+import { ShareModal } from 'sharing'
+import flow from 'lodash/flow'
 
 import styles from '../../../styles/layout'
 
@@ -93,7 +97,7 @@ class AlbumPhotos extends Component {
     if (!this.props.album || !this.props.album.photos) {
       return null
     }
-    const { album } = this.props
+    const { t, router, album, shareAlbum } = this.props
     const { editing } = this.state
     const shared = {}
     return (
@@ -116,6 +120,8 @@ class AlbumPhotos extends Component {
                   onEdit={this.renameAlbum}
                 >
                   <AlbumToolbar
+                    t={t}
+                    router={router}
                     album={album}
                     sharedWithMe={shared.withMe}
                     sharedByMe={shared.byMe}
@@ -124,6 +130,7 @@ class AlbumPhotos extends Component {
                     downloadAlbum={this.downloadAlbum}
                     deleteAlbum={this.deleteAlbum}
                     leaveAlbum={this.leaveAlbum}
+                    shareAlbum={shareAlbum}
                   />
                 </Topbar>
               )}
@@ -149,6 +156,7 @@ class AlbumPhotos extends Component {
               />
             )}
             {this.renderViewer(this.props.children)}
+            <ModalManager />
           </div>
         )}
       </Selection>
@@ -169,4 +177,13 @@ class AlbumPhotos extends Component {
   }
 }
 
-export default withRouter(translate()(AlbumPhotos))
+const mapDispatchToProps = dispatch => ({
+  shareAlbum: album =>
+    dispatch(
+      showModal(<ShareModal document={album} sharingDesc={album.name} />)
+    )
+})
+
+export default flow(connect(null, mapDispatchToProps), withRouter, translate())(
+  AlbumPhotos
+)

--- a/src/photos/ducks/albums/components/AlbumToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumToolbar.jsx
@@ -1,15 +1,11 @@
 import React, { Component } from 'react'
-import { withRouter, Link } from 'react-router'
-import { translate } from 'cozy-ui/react/I18n'
-
-import Menu, { Item } from 'components/Menu'
+import { Menu, MenuItem, Icon, withBreakpoints } from 'cozy-ui/react'
 import { MoreButton } from 'components/Button'
-
 import { ShareButton, ShareModal } from 'sharing'
 
-import classNames from 'classnames'
+import styles from 'photos/styles/toolbar'
 
-import styles from '../../../styles/toolbar'
+import CheckboxIcon from 'photos/assets/icons/icon-checkbox.svg'
 
 class AlbumToolbar extends Component {
   state = {
@@ -27,106 +23,75 @@ class AlbumToolbar extends Component {
   render() {
     const {
       t,
-      location,
+      router,
       album,
       sharedWithMe,
       // sharedByMe,
       readOnly,
-      disabled = false
-    } = this.props
-    const {
+      disabled = false,
       downloadAlbum,
       deleteAlbum,
       // leaveAlbum,
       selectItems,
-      onRename
+      onRename,
+      breakpoints: { isMobile }
     } = this.props
     return (
       <div className={styles['pho-toolbar']} role="toolbar">
-        <div className={styles['u-hide--mob']}>
+        {!isMobile && (
           <ShareButton
             disabled={disabled}
             label={t('Albums.share.cta')}
             onClick={this.showShareModal}
           />
-        </div>
+        )}
         <Menu
           disabled={disabled}
           className={styles['pho-toolbar-menu']}
-          button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+          component={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+          position="right"
         >
           {!sharedWithMe && (
-            <Item>
-              <a
-                className={classNames(
-                  styles['pho-action-share'],
-                  styles['u-hide--desk']
-                )}
-                onClick={this.showShareModal}
-              >
-                {t('Albums.share.cta')}
-              </a>
-            </Item>
+            <MenuItem
+              className={styles['u-hide--desk']}
+              icon={<Icon icon="share" />}
+              onSelect={this.showShareModal}
+            >
+              {t('Albums.share.cta')}
+            </MenuItem>
           )}
-          <Item>
-            <a
-              className={classNames(styles['pho-action-download'])}
-              onClick={downloadAlbum}
-            >
-              {t('Toolbar.menu.download_album')}
-            </a>
-          </Item>
-          <Item>
-            <a
-              className={classNames(styles['pho-action-rename'])}
-              onClick={onRename}
-            >
-              {t('Toolbar.menu.rename_album')}
-            </a>
-          </Item>
+          <MenuItem onSelect={downloadAlbum} icon={<Icon icon="download" />}>
+            {t('Toolbar.menu.download_album')}
+          </MenuItem>
+          <MenuItem icon={<Icon icon="rename" />} onSelect={onRename}>
+            {t('Toolbar.menu.rename_album')}
+          </MenuItem>
           {!readOnly && (
-            <Item>
-              <Link
-                className={classNames(styles['pho-action-addphotos'])}
-                to={`${location.pathname}/edit`}
-              >
-                {t('Toolbar.menu.add_photos')}
-              </Link>
-            </Item>
+            <MenuItem
+              icon={<Icon icon="album-add" />}
+              onSelect={() => router.push(`${router.location.pathname}/edit`)}
+            >
+              {t('Toolbar.menu.add_photos')}
+            </MenuItem>
           )}
           <hr className={styles['u-hide--desk']} />
-          <Item>
-            <a
-              className={classNames(
-                styles['pho-action-select'],
-                styles['u-hide--desk']
-              )}
-              onClick={selectItems}
-            >
-              {t('Toolbar.menu.select_items')}
-            </a>
-          </Item>
+          <MenuItem
+            className={styles['u-hide--desk']}
+            icon={<Icon icon={CheckboxIcon} />}
+            onSelect={selectItems}
+          >
+            {t('Toolbar.menu.select_items')}
+          </MenuItem>
           <hr />
           {!sharedWithMe && (
-            <Item>
-              <a
-                className={classNames(styles['pho-action-delete'])}
-                onClick={deleteAlbum}
-              >
-                {t('Toolbar.menu.album_delete')}
-              </a>
-            </Item>
+            <MenuItem
+              className={styles['pho-action-delete']}
+              icon={<Icon icon="delete" />}
+              onClick={deleteAlbum}
+            >
+              {t('Toolbar.menu.album_delete')}
+            </MenuItem>
           )}
-          {/* sharedWithMe && (
-            <Item>
-              <a
-                className={classNames(styles['pho-action-delete'])}
-                onClick={leaveAlbum}
-              >
-                {t('Toolbar.menu.album_quit')}
-              </a>
-            </Item>
-          ) */}
         </Menu>
         {this.state.showShareModal && (
           <ShareModal
@@ -140,4 +105,4 @@ class AlbumToolbar extends Component {
   }
 }
 
-export default withRouter(translate()(AlbumToolbar))
+export default withBreakpoints()(AlbumToolbar)

--- a/src/photos/ducks/albums/components/AlbumToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumToolbar.jsx
@@ -1,25 +1,13 @@
 import React, { Component } from 'react'
 import { Menu, MenuItem, Icon, withBreakpoints } from 'cozy-ui/react'
 import { MoreButton } from 'components/Button'
-import { ShareButton, ShareModal } from 'sharing'
+import { ShareButton } from 'sharing'
 
 import styles from 'photos/styles/toolbar'
 
 import CheckboxIcon from 'photos/assets/icons/icon-checkbox.svg'
 
 class AlbumToolbar extends Component {
-  state = {
-    showShareModal: false
-  }
-
-  showShareModal = () => {
-    this.setState({ showShareModal: true })
-  }
-
-  closeShareModal = () => {
-    this.setState({ showShareModal: false })
-  }
-
   render() {
     const {
       t,
@@ -34,7 +22,8 @@ class AlbumToolbar extends Component {
       // leaveAlbum,
       selectItems,
       onRename,
-      breakpoints: { isMobile }
+      breakpoints: { isMobile },
+      shareAlbum
     } = this.props
     return (
       <div className={styles['pho-toolbar']} role="toolbar">
@@ -42,7 +31,7 @@ class AlbumToolbar extends Component {
           <ShareButton
             disabled={disabled}
             label={t('Albums.share.cta')}
-            onClick={this.showShareModal}
+            onClick={() => shareAlbum(album)}
           />
         )}
         <Menu
@@ -55,7 +44,7 @@ class AlbumToolbar extends Component {
             <MenuItem
               className={styles['u-hide--desk']}
               icon={<Icon icon="share" />}
-              onSelect={this.showShareModal}
+              onSelect={() => shareAlbum(album)}
             >
               {t('Albums.share.cta')}
             </MenuItem>
@@ -93,13 +82,6 @@ class AlbumToolbar extends Component {
             </MenuItem>
           )}
         </Menu>
-        {this.state.showShareModal && (
-          <ShareModal
-            document={album}
-            sharingDesc={album.name}
-            onClose={this.closeShareModal}
-          />
-        )}
       </div>
     )
   }

--- a/src/photos/ducks/albums/components/AlbumsToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumsToolbar.jsx
@@ -1,15 +1,13 @@
 import React from 'react'
-import { Link } from 'react-router'
+import { withRouter } from 'react-router'
 import classNames from 'classnames'
-import { translate } from 'cozy-ui/react/I18n'
-import { ButtonLink } from 'cozy-ui/react'
+import { ButtonLink, Menu, MenuItem, Icon } from 'cozy-ui/react'
 
-import Menu, { Item } from 'components/Menu'
 import { MoreButton } from 'components/Button'
 
-import styles from '../../../styles/toolbar'
+import styles from 'photos/styles/toolbar'
 
-const AlbumsToolbar = ({ t }) => (
+const AlbumsToolbar = ({ t, router }) => (
   <div className={styles['pho-toolbar']} role="toolbar">
     <div className={styles['u-hide--mob']}>
       <ButtonLink
@@ -21,17 +19,17 @@ const AlbumsToolbar = ({ t }) => (
     </div>
     <Menu
       className={classNames(styles['pho-toolbar-menu'], styles['u-hide--desk'])}
-      button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+      component={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+      position="right"
     >
-      <Item>
-        <div>
-          <Link to="/albums/new" className={styles['pho-action-newalbum']}>
-            {t('Toolbar.album_new')}
-          </Link>
-        </div>
-      </Item>
+      <MenuItem
+        onSelect={() => router.push('/albums/new')}
+        icon={<Icon icon="album-add" />}
+      >
+        {t('Toolbar.album_new')}
+      </MenuItem>
     </Menu>
   </div>
 )
 
-export default translate()(AlbumsToolbar)
+export default withRouter(AlbumsToolbar)

--- a/src/photos/ducks/albums/components/AlbumsView.jsx
+++ b/src/photos/ducks/albums/components/AlbumsView.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import styles from '../../../styles/layout'
+import { translate } from 'cozy-ui/react/I18n'
 
 import AlbumsToolbar from './AlbumsToolbar'
 import AlbumsList from './AlbumsList'
@@ -20,8 +21,9 @@ const Content = ({ list }) => {
   }
 }
 
-export default class AlbumsView extends Component {
+class AlbumsView extends Component {
   render() {
+    const { t } = this.props
     if (this.props.children) return this.props.children
     if (!this.props.albums) {
       return null
@@ -29,10 +31,12 @@ export default class AlbumsView extends Component {
     return (
       <div className={styles['pho-content-wrapper']}>
         <Topbar viewName="albums">
-          <AlbumsToolbar />
+          <AlbumsToolbar t={t} />
         </Topbar>
         <Content list={this.props.albums} />
       </div>
     )
   }
 }
+
+export default translate()(AlbumsView)

--- a/src/photos/ducks/albums/index.js
+++ b/src/photos/ducks/albums/index.js
@@ -114,7 +114,7 @@ const ConnectedAlbumPhotos = withRouter(props => (
   <Query query={ALBUM_QUERY} {...props} mutations={ALBUM_MUTATIONS}>
     {({ data }, { updateAlbum, deleteAlbum, removePhotos }) => (
       <AlbumPhotos
-        album={data ? data[0] : null}
+        album={data}
         updateAlbum={updateAlbum}
         deleteAlbum={deleteAlbum}
         removePhotos={removePhotos}
@@ -130,7 +130,7 @@ const ConnectedPhotosPicker = withRouter(({ params, ...props }) => {
   return params.albumId ? (
     <Query query={ALBUM_QUERY} mutations={ALBUMS_MUTATIONS} {...props}>
       {({ data }, { addPhotos }) => (
-        <PhotosPicker album={data ? data[0] : null} addPhotos={addPhotos} />
+        <PhotosPicker album={data} addPhotos={addPhotos} />
       )}
     </Query>
   ) : (

--- a/src/photos/ducks/timeline/components/Timeline.jsx
+++ b/src/photos/ducks/timeline/components/Timeline.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { translate } from 'cozy-ui/react/I18n'
 import styles from '../../../styles/layout'
 
 import { Content } from 'cozy-ui/react/Layout'
@@ -12,7 +13,7 @@ import { addToUploadQueue } from '../../upload'
 import { AddToAlbumModal, belongsToAlbums } from '../../albums'
 import Selection from '../../selection'
 
-export default class Timeline extends Component {
+class Timeline extends Component {
   state = {
     showAddAlbumModal: false
   }
@@ -57,7 +58,7 @@ export default class Timeline extends Component {
   }
 
   render() {
-    const { lists, fetchStatus, hasMore, fetchMore } = this.props
+    const { t, lists, fetchStatus, hasMore, fetchMore } = this.props
     return (
       <Selection
         actions={selection => ({
@@ -73,6 +74,7 @@ export default class Timeline extends Component {
                 disabled={active}
                 uploadPhotos={this.uploadPhotos}
                 selectItems={selection.show}
+                t={t}
               />
             </Topbar>
             <Content>
@@ -112,3 +114,5 @@ export default class Timeline extends Component {
     )
   }
 }
+
+export default translate()(Timeline)

--- a/src/photos/ducks/timeline/components/Toolbar.jsx
+++ b/src/photos/ducks/timeline/components/Toolbar.jsx
@@ -1,16 +1,14 @@
-/* global cozy */
 import styles from '../../../styles/toolbar'
 
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { Menu, MenuItem, withBreakpoints, Icon } from 'cozy-ui/react'
+import { Menu, MenuItem, Icon } from 'cozy-ui/react'
 
 import UploadButton from '../../../components/UploadButton'
 import { MoreButton } from 'components/Button'
 
 import CheckboxIcon from 'photos/assets/icons/icon-checkbox.svg'
-const { BarRight } = cozy.bar
 
 const MoreMenu = ({ t, disabled, uploadPhotos, selectItems }) => (
   <Menu
@@ -45,10 +43,13 @@ MoreMenu.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-const Toolbar = (
-  { disabled = false, uploadPhotos, selectItems, breakpoints: { isMobile } },
-  { t }
-) => (
+const Toolbar = ({
+  t,
+  disabled = false,
+  uploadPhotos,
+  selectItems,
+  breakpoints: { isMobile }
+}) => (
   <div className={styles['pho-toolbar']} role="toolbar">
     <UploadButton
       className={styles['u-hide--mob']}
@@ -56,23 +57,12 @@ const Toolbar = (
       disabled={disabled}
       label={t('Toolbar.photo_upload')}
     />
-    {isMobile ? (
-      <BarRight>
-        <MoreMenu
-          t={t}
-          disabled={disabled}
-          uploadPhotos={uploadPhotos}
-          selectItems={selectItems}
-        />
-      </BarRight>
-    ) : (
-      <MoreMenu
-        t={t}
-        disabled={disabled}
-        uploadPhotos={uploadPhotos}
-        selectItems={selectItems}
-      />
-    )}
+    <MoreMenu
+      t={t}
+      disabled={disabled}
+      uploadPhotos={uploadPhotos}
+      selectItems={selectItems}
+    />
   </div>
 )
 
@@ -83,4 +73,4 @@ Toolbar.propTypes = {
   breakpoints: PropTypes.node
 }
 
-export default withBreakpoints()(Toolbar)
+export default Toolbar

--- a/src/photos/ducks/timeline/components/Toolbar.jsx
+++ b/src/photos/ducks/timeline/components/Toolbar.jsx
@@ -43,13 +43,7 @@ MoreMenu.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-const Toolbar = ({
-  t,
-  disabled = false,
-  uploadPhotos,
-  selectItems,
-  breakpoints: { isMobile }
-}) => (
+const Toolbar = ({ t, disabled = false, uploadPhotos, selectItems }) => (
   <div className={styles['pho-toolbar']} role="toolbar">
     <UploadButton
       className={styles['u-hide--mob']}
@@ -70,7 +64,7 @@ Toolbar.propTypes = {
   disabled: PropTypes.bool,
   uploadPhotos: PropTypes.func.isRequired,
   selectItems: PropTypes.func.isRequired,
-  breakpoints: PropTypes.node
+  t: PropTypes.func.isRequired
 }
 
 export default Toolbar

--- a/src/photos/ducks/timeline/components/Toolbar.jsx
+++ b/src/photos/ducks/timeline/components/Toolbar.jsx
@@ -3,13 +3,51 @@ import styles from '../../../styles/toolbar'
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { translate } from 'cozy-ui/react/I18n'
+import { Menu, MenuItem, withBreakpoints, Icon } from 'cozy-ui/react'
+const { BarRight } = cozy.bar
 
 import UploadButton from '../../../components/UploadButton'
-import Menu, { Item } from 'components/Menu'
 import { MoreButton } from 'components/Button'
 
-const Toolbar = ({ t, disabled = false, uploadPhotos, selectItems }) => (
+import CheckboxIcon from 'photos/assets/icons/icon-checkbox.svg'
+
+const MoreMenu = ({ t, disabled, uploadPhotos, selectItems }) => (
+  <Menu
+    disabled={disabled}
+    position="right"
+    className={styles['pho-toolbar-menu']}
+    component={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+  >
+    <MenuItem icon={<Icon icon="upload" />} className={styles['u-hide--desk']}>
+      <UploadButton
+        onUpload={uploadPhotos}
+        disabled={disabled}
+        label={t('Toolbar.menu.photo_upload')}
+        inMenu
+        className={classNames(
+          styles['u-hide--tablet'],
+          styles['pho-action-upload']
+        )}
+      />
+    </MenuItem>
+    <hr className={styles['u-hide--desk']} />
+    <MenuItem onSelect={selectItems} icon={<Icon icon={CheckboxIcon} />}>
+      {t('Toolbar.menu.select_items')}
+    </MenuItem>
+  </Menu>
+)
+
+MoreMenu.propTypes = {
+  disabled: PropTypes.bool,
+  uploadPhotos: PropTypes.func.isRequired,
+  selectItems: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired
+}
+
+const Toolbar = (
+  { disabled = false, uploadPhotos, selectItems, breakpoints: { isMobile } },
+  { t }
+) => (
   <div className={styles['pho-toolbar']} role="toolbar">
     <UploadButton
       className={styles['u-hide--mob']}
@@ -17,38 +55,30 @@ const Toolbar = ({ t, disabled = false, uploadPhotos, selectItems }) => (
       disabled={disabled}
       label={t('Toolbar.photo_upload')}
     />
-    <Menu
-      disabled={disabled}
-      className={styles['pho-toolbar-menu']}
-      button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
-    >
-      <Item>
-        <UploadButton
-          onUpload={uploadPhotos}
+    {isMobile ? (
+      <BarRight>
+        <MoreMenu
+          t={t}
           disabled={disabled}
-          label={t('Toolbar.menu.photo_upload')}
-          type="menu-item"
-          className={classNames(
-            styles['u-hide--tablet'],
-            styles['pho-action-upload']
-          )}
+          uploadPhotos={uploadPhotos}
+          selectItems={selectItems}
         />
-      </Item>
-      <hr className={styles['u-hide--desk']} />
-      <Item>
-        <a className={styles['pho-action-select']} onClick={selectItems}>
-          {t('Toolbar.menu.select_items')}
-        </a>
-      </Item>
-    </Menu>
+      </BarRight>
+    ) : (
+      <MoreMenu
+        t={t}
+        disabled={disabled}
+        uploadPhotos={uploadPhotos}
+        selectItems={selectItems}
+      />
+    )}
   </div>
 )
 
 Toolbar.propTypes = {
   disabled: PropTypes.bool,
   uploadPhotos: PropTypes.func.isRequired,
-  selectItems: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired
+  selectItems: PropTypes.func.isRequired
 }
 
-export default translate()(Toolbar)
+export default withBreakpoints()(Toolbar)

--- a/src/photos/ducks/timeline/components/Toolbar.jsx
+++ b/src/photos/ducks/timeline/components/Toolbar.jsx
@@ -1,15 +1,16 @@
+/* global cozy */
 import styles from '../../../styles/toolbar'
 
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { Menu, MenuItem, withBreakpoints, Icon } from 'cozy-ui/react'
-const { BarRight } = cozy.bar
 
 import UploadButton from '../../../components/UploadButton'
 import { MoreButton } from 'components/Button'
 
 import CheckboxIcon from 'photos/assets/icons/icon-checkbox.svg'
+const { BarRight } = cozy.bar
 
 const MoreMenu = ({ t, disabled, uploadPhotos, selectItems }) => (
   <Menu
@@ -78,7 +79,8 @@ const Toolbar = (
 Toolbar.propTypes = {
   disabled: PropTypes.bool,
   uploadPhotos: PropTypes.func.isRequired,
-  selectItems: PropTypes.func.isRequired
+  selectItems: PropTypes.func.isRequired,
+  breakpoints: PropTypes.node
 }
 
 export default withBreakpoints()(Toolbar)

--- a/src/photos/reducers/index.js
+++ b/src/photos/reducers/index.js
@@ -1,5 +1,7 @@
 import upload from '../ducks/upload'
+import uiReducer from 'react-cozy-helpers'
 
 export default {
-  upload
+  upload,
+  ui: uiReducer
 }

--- a/src/photos/styles/toolbar.styl
+++ b/src/photos/styles/toolbar.styl
@@ -34,8 +34,6 @@
 
         &.pho-action-newalbum
             background embedurl("../assets/icons/icon-album-add.svg") 1rem center no-repeat
-        &.pho-action-select
-            background embedurl("../assets/icons/icon-checkbox.svg") 1rem center no-repeat
         &.pho-action-rename
             background embedurl("../assets/icons/icon-pen.svg") 1rem center no-repeat
         &.pho-action-addphotos
@@ -48,10 +46,6 @@
             color pomegranate
             background embedurl("../assets/icons/icon-trash-red.svg") 1rem center no-repeat
 
-    +medium-screen()
-        .pho-action-upload
-            display inline-flex
-            padding-left 1rem
-
-            svg
-                margin-right .5rem
+.pho-action-upload[role=button]
+    display inline-flex
+    padding .3rem 0

--- a/src/photos/styles/toolbar.styl
+++ b/src/photos/styles/toolbar.styl
@@ -30,21 +30,8 @@
     display flex
     margin-left auto
 
-    a
-
-        &.pho-action-newalbum
-            background embedurl("../assets/icons/icon-album-add.svg") 1rem center no-repeat
-        &.pho-action-rename
-            background embedurl("../assets/icons/icon-pen.svg") 1rem center no-repeat
-        &.pho-action-addphotos
-            background embedurl("../assets/icons/icon-album-add.svg") 1rem center no-repeat
-        &.pho-action-share
-            background embedurl("../assets/icons/icon-share.svg") 1rem center no-repeat
-        &.pho-action-download
-            background embedurl("../assets/icons/icon-download-16.svg") 1rem center no-repeat
-        &.pho-action-delete
-            color pomegranate
-            background embedurl("../assets/icons/icon-trash-red.svg") 1rem center no-repeat
+    .pho-action-delete
+        color pomegranate
 
 .pho-action-upload[role=button]
     display inline-flex

--- a/src/photos/styles/topbar.styl
+++ b/src/photos/styles/topbar.styl
@@ -47,6 +47,8 @@ $coz-bar-size = 3rem
 
     +small-screen()
        font-size 1.25rem
+       display flex
+       align-items center
 
     +tiny-screen()
        white-space   nowrap

--- a/yarn.lock
+++ b/yarn.lock
@@ -2673,11 +2673,11 @@ cozy-client-js@^0.3.19:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
 
-cozy-client@1.0.0-beta.29:
-  version "1.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-1.0.0-beta.29.tgz#53245784127aebb31c31777be50c52ffbd55cf93"
+cozy-client@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-2.7.0.tgz#21d47c9fb71ccc2032edccabfcc236b0e84baa2f"
   dependencies:
-    cozy-stack-client "^1.0.0-beta.29"
+    cozy-stack-client "^2.5.1"
     lodash "^4.17.5"
     prop-types "^15.6.0"
     react "^16.2.0"
@@ -2688,9 +2688,9 @@ cozy-realtime@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-1.1.0.tgz#6370ba7e1197ca267e0793c9dd7f2d871d359698"
 
-cozy-stack-client@^1.0.0-beta.29:
-  version "1.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-1.0.0-beta.29.tgz#94c7e274c5c2db6b31734a4cb8f3293fcd103be6"
+cozy-stack-client@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-2.5.1.tgz#ccd8257940e230b052ad6e499c38a935f088e1ef"
   dependencies:
     mime-types "^2.1.18"
 
@@ -8528,7 +8528,6 @@ pouchdb-abstract-mapreduce@6.4.3:
 
 "pouchdb-adapter-cordova-sqlite@https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
   version "2.0.2"
-  uid f3ee23009b70209c611435d57491aa77fb88802a
   resolved "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
   dependencies:
     pouchdb-adapter-websql-core "^6.1.1"


### PR DESCRIPTION
Don't merge until we have https://github.com/cozy/cozy-client/pull/116 and a new version of cozy-client!

- I moved the title of the pages to the cozy-bar on mobile view, that was relatively easy.
- I also moved all the menus toolbar there
- The toolbar menus now use cozy-ui menu's
- Once renderer inside the cozy-bar, the components get the cozy-bar contact, so any HOC that relies on context won't work. To workaround this, I had to pass the Toolbars instance of `t`, `router`, and move some sharing code around