### PR TITLE
fix: 🐛 Updating UI to v11 and fixing button bugs accordingly

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "cozy-client": "2.19.2",
     "cozy-client-js": "0.13.0",
     "cozy-realtime": "1.1.0",
-    "cozy-ui": "10.8.1",
+    "cozy-ui": "11.0.0",
     "create-react-context": "0.2.2",
     "date-fns": "1.29.0",
     "diacritics": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "cozy-bar": "5.0.8",
-    "cozy-client": "2.19.2",
+    "cozy-client": "2.22.1",
     "cozy-client-js": "0.13.0",
     "cozy-realtime": "1.1.0",
     "cozy-ui": "11.0.0",

--- a/src/components/Button/MoreButton.jsx
+++ b/src/components/Button/MoreButton.jsx
@@ -4,7 +4,7 @@ import { Button } from 'cozy-ui/react'
 
 import styles from './index.styl'
 
-const MoreButton = ({ t, disabled, onClick, children }) => (
+const MoreButton = ({ t, disabled, onClick }) => (
   <Button
     className={styles['dri-btn--more']}
     theme="secondary"
@@ -12,9 +12,9 @@ const MoreButton = ({ t, disabled, onClick, children }) => (
     onClick={onClick}
     extension="narrow"
     icon="dots"
-  >
-    <span className={styles['u-visuallyhidden']}>{children}</span>
-  </Button>
+    iconOnly
+    label={t('Toolbar.more')}
+  />
 )
 
 export default translate()(MoreButton)

--- a/src/components/pushClient/Banner.jsx
+++ b/src/components/pushClient/Banner.jsx
@@ -80,6 +80,8 @@ class BannerClient extends Component {
             this.markAsSeen('close')
           }}
           icon={<Icon icon="cross" width="24" height="24" />}
+          iconOnly
+          label={t('SelectionBar.close')}
         />
       </div>
     )

--- a/src/drive/web/modules/drive/Toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar.jsx
@@ -47,7 +47,7 @@ class Toolbar extends Component {
         disabled={isDisabled}
         className={styles['fil-toolbar-menu']}
         innerClassName={styles['fil-toolbar-inner-menu']}
-        button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+        button={<MoreButton />}
       >
         <NotRootFolder>
           <Item>

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -218,7 +218,7 @@ const Status = ({ isAvailableOffline, id }) => (
   </div>
 )
 
-const FileAction = ({ onClick }) => (
+const FileAction = ({ t, onClick }) => (
   <div
     className={classNames(
       styles['fil-content-cell'],
@@ -230,6 +230,8 @@ const FileAction = ({ onClick }) => (
       onClick={onClick}
       extension="narrow"
       icon={<Icon icon="dots" color="charcoalGrey" width="17" height="17" />}
+      iconOnly
+      label={t('Toolbar.more')}
     />
   </div>
 )
@@ -342,6 +344,7 @@ class File extends Component {
         <Status id={attributes.id} isAvailableOffline={isAvailableOffline} />
         {actions && (
           <FileAction
+            t={t}
             ref={toggle => {
               this.filerowMenuToggle = toggle
             }}

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -36,7 +36,7 @@ const MoreMenu = ({ t, onDownload, onOpenInCozy, onCreateCozy }) => (
       toolbarstyles['fil-toolbar-menu--public']
     )}
     buttonClassName={toolbarstyles['fil-toolbar-more-btn']}
-    component={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+    component={<MoreButton />}
     position="right"
   >
     {onOpenInCozy && (

--- a/src/drive/web/modules/trash/Toolbar.jsx
+++ b/src/drive/web/modules/trash/Toolbar.jsx
@@ -31,7 +31,7 @@ const Toolbar = ({
       title={t('toolbar.item_more')}
       disabled={disabled || selectionModeActive}
       className={styles['fil-toolbar-menu']}
-      button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+      button={<MoreButton />}
     >
       <Item>
         <a className={styles['fil-action-delete']} onClick={() => emptyTrash()}>

--- a/src/drive/web/modules/upload/UploadButton.jsx
+++ b/src/drive/web/modules/upload/UploadButton.jsx
@@ -33,7 +33,7 @@ const UploadButton = ({ label, disabled, onUpload, className }) => (
       }}
     >
       <Icon icon="upload" />
-      {label}
+      <span>{label}</span>
       <input
         type="file"
         multiple

--- a/src/drive/web/modules/upload/UploadButton.jsx
+++ b/src/drive/web/modules/upload/UploadButton.jsx
@@ -4,8 +4,7 @@ import { Icon } from 'cozy-ui/react'
 const styles = {
   parent: {
     position: 'relative',
-    width: '100%',
-    boxSizing: 'border-box'
+    overflow: 'hidden'
   },
   input: {
     position: 'absolute',
@@ -14,8 +13,7 @@ const styles = {
     opacity: 0,
     width: '100%',
     height: '100%',
-    zIndex: 1,
-    cursor: 'pointer'
+    zIndex: 1
   }
 }
 
@@ -26,12 +24,7 @@ const UploadButton = ({ label, disabled, onUpload, className }) => (
     className={className}
     style={styles.parent}
   >
-    <span
-      style={{
-        display: 'flex',
-        alignItems: 'center'
-      }}
-    >
+    <span>
       <Icon icon="upload" />
       <span>{label}</span>
       <input

--- a/src/photos/components/UploadButton.jsx
+++ b/src/photos/components/UploadButton.jsx
@@ -36,7 +36,7 @@ export const UploadButton = ({
   >
     <span>
       {!inMenu && <Icon icon="upload" />}
-      {label}
+      <span>{label}</span>
       <input
         type="file"
         accept="image/*"

--- a/src/photos/ducks/albums/components/AlbumToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumToolbar.jsx
@@ -37,7 +37,7 @@ class AlbumToolbar extends Component {
         <Menu
           disabled={disabled}
           className={styles['pho-toolbar-menu']}
-          component={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+          component={<MoreButton />}
           position="right"
         >
           {!sharedWithMe && (

--- a/src/photos/ducks/albums/components/AlbumsToolbar.jsx
+++ b/src/photos/ducks/albums/components/AlbumsToolbar.jsx
@@ -19,7 +19,7 @@ const AlbumsToolbar = ({ t, router }) => (
     </div>
     <Menu
       className={classNames(styles['pho-toolbar-menu'], styles['u-hide--desk'])}
-      component={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+      component={<MoreButton />}
       position="right"
     >
       <MenuItem

--- a/src/photos/ducks/timeline/components/Toolbar.jsx
+++ b/src/photos/ducks/timeline/components/Toolbar.jsx
@@ -15,7 +15,7 @@ const MoreMenu = ({ t, disabled, uploadPhotos, selectItems }) => (
     disabled={disabled}
     position="right"
     className={styles['pho-toolbar-menu']}
-    component={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+    component={<MoreButton />}
   >
     <MenuItem icon={<Icon icon="upload" />} className={styles['u-hide--desk']}>
       <UploadButton

--- a/src/sharing/components/ShareByEmail.jsx
+++ b/src/sharing/components/ShareByEmail.jsx
@@ -49,6 +49,8 @@ const RequestPermissionPopin = ({ onClose, onAccept }, { t }) => (
       className={styles['permission-required-popin-close']}
       onClick={onClose}
       extension="narrow"
+      iconOnly
+      label={t('SelectionBar.close')}
     >
       <Icon icon="cross" width="14" height="14" color="coolGrey" />
     </Button>

--- a/src/viewer/ViewerControls.jsx
+++ b/src/viewer/ViewerControls.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import Hammer from 'hammerjs'
 
 import { translate } from 'cozy-ui/react/I18n'
+import { Button } from 'cozy-ui/react/Button'
 import { downloadFile } from 'cozy-client'
 
 import styles from './styles'
@@ -96,14 +97,16 @@ class ViewerControls extends Component {
                 styles['pho-viewer-toolbar-actions']
               )}
             >
-              <button
+              <Button
+                theme="secondary"
                 className={styles['coz-action-download']}
                 onClick={() => {
                   downloadFile(currentFile)
                 }}
-              >
-                {t('Viewer.actions.download')}
-              </button>
+                icon="download"
+                label={t('Viewer.actions.download')}
+                subtle
+              />
             </div>
             {onClose && (
               <div
@@ -111,7 +114,14 @@ class ViewerControls extends Component {
                 onClick={onClose}
                 title={t('Viewer.close')}
               >
-                <div className={styles['pho-viewer-toolbar-close-cross']} />
+                <Button
+                  theme="secondary"
+                  icon="cross"
+                  color="white"
+                  label={t('Viewer.close')}
+                  iconOnly
+                  extension="narrow"
+                />
               </div>
             )}
           </div>

--- a/src/viewer/ViewerControls.jsx
+++ b/src/viewer/ViewerControls.jsx
@@ -73,6 +73,9 @@ class ViewerControls extends Component {
       children
     } = this.props
     const { hidden } = this.state
+
+    const isPDF = currentFile.class === 'pdf'
+
     return (
       <div
         className={classNames(styles['pho-viewer-controls'], {
@@ -97,16 +100,17 @@ class ViewerControls extends Component {
                 styles['pho-viewer-toolbar-actions']
               )}
             >
-              <Button
-                theme="secondary"
-                className={styles['coz-action-download']}
-                onClick={() => {
-                  downloadFile(currentFile)
-                }}
-                icon="download"
-                label={t('Viewer.actions.download')}
-                subtle
-              />
+              {!isPDF && (
+                <Button
+                  theme="secondary"
+                  onClick={() => {
+                    downloadFile(currentFile)
+                  }}
+                  icon="download"
+                  label={t('Viewer.actions.download')}
+                  subtle
+                />
+              )}
             </div>
             {onClose && (
               <div

--- a/src/viewer/ViewerControls.jsx
+++ b/src/viewer/ViewerControls.jsx
@@ -73,6 +73,7 @@ class ViewerControls extends Component {
       children
     } = this.props
     const { hidden } = this.state
+    const { client } = this.context
 
     const isPDF = currentFile.class === 'pdf'
 
@@ -104,7 +105,7 @@ class ViewerControls extends Component {
                 <Button
                   theme="secondary"
                   onClick={() => {
-                    downloadFile(currentFile)
+                    client.collection('io.cozy.files').download(currentFile)
                   }}
                   icon="download"
                   label={t('Viewer.actions.download')}

--- a/src/viewer/ViewerControls.jsx
+++ b/src/viewer/ViewerControls.jsx
@@ -4,7 +4,6 @@ import Hammer from 'hammerjs'
 
 import { translate } from 'cozy-ui/react/I18n'
 import { Button } from 'cozy-ui/react/Button'
-import { downloadFile } from 'cozy-client'
 
 import styles from './styles'
 

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -286,15 +286,24 @@
     &--hidden
         opacity 0
 
-.pho-viewer-toolbar-actions
-    position          static
-    z-index           0
-    display           flex
-    align-items       center
-    justify-content   center
-    width             100%
-    height            auto
-    background-color  transparent
+    .pho-viewer-toolbar-actions
+        position          static
+        z-index           0
+        display           flex
+        align-items       center
+        justify-content   center
+        width             100%
+        height            auto
+        background-color  transparent
+
+        button
+            pointer-events   initial
+            color white
+
+            &:hover
+            &:focus
+                color white
+
 
 .pho-viewer-toolbar-close
     position         fixed

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -291,21 +291,10 @@
     z-index           0
     display           flex
     align-items       center
-    justify-content   flex-end
+    justify-content   center
     width             100%
     height            auto
     background-color  transparent
-
-    // here we force the action buttons to not show the label even on desktop
-    button
-        width         5.625rem
-        overflow      hidden
-        text-indent   -312rem
-        padding-left  0
-        color         transparent
-        background-position .75rem
-        pointer-events initial
-
 
 .pho-viewer-toolbar-close
     position         fixed
@@ -320,24 +309,14 @@
     pointer-events   initial
 
 
-.pho-viewer-toolbar-close-cross
-    width  1.5rem
-    height 1.5rem
+    button
+        color white
+        background-color transparent
+        border 0
 
-    &::after, &::before
-        content     ''
-        position         absolute
-        margin-left      .75rem
-        border-radius    .1875rem
-        width            .125rem
-        height           1.5rem
-        background-color white
-
-    &::after
-        transform rotate(-45deg);
-
-    &::before
-        transform rotate(45deg);
+        &:hover
+        &:focus
+            background-color transparent
 
 
 +medium-screen()

--- a/targets/photos/web/doctypes.js
+++ b/targets/photos/web/doctypes.js
@@ -1,4 +1,7 @@
 export default {
+  files: {
+    doctype: 'io.cozy.files'
+  },
   albums: {
     doctype: 'io.cozy.photos.albums',
     attributes: {

--- a/targets/photos/web/public/App.jsx
+++ b/targets/photos/web/public/App.jsx
@@ -79,7 +79,7 @@ class App extends Component {
                   <Menu
                     title={t('Toolbar.more')}
                     className={classNames(styles['pho-toolbar-menu'])}
-                    button={<MoreButton>{t('Toolbar.more')}</MoreButton>}
+                    button={<MoreButton />}
                   >
                     <Item>
                       <a

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,11 +2692,11 @@ cozy-client-js@^0.3.19:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
 
-cozy-client@2.19.2:
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-2.19.2.tgz#4f97346a6f0ef595694be0eeb7a42fcf8fbff62f"
+cozy-client@2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-2.22.1.tgz#69ef4ba27bca57183d436d989dd4c9dfaf5ceffc"
   dependencies:
-    cozy-stack-client "^2.19.2"
+    cozy-stack-client "^2.22.1"
     lodash "^4.17.5"
     prop-types "^15.6.0"
     react "^16.2.0"
@@ -2707,9 +2707,9 @@ cozy-realtime@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-1.1.0.tgz#6370ba7e1197ca267e0793c9dd7f2d871d359698"
 
-cozy-stack-client@^2.19.2:
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-2.19.2.tgz#80a8b639553b38a1138b4c1cf27ca481e19a9339"
+cozy-stack-client@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-2.22.1.tgz#4cd10b636161491368c27156cb0a60a142699d0b"
   dependencies:
     mime-types "^2.1.18"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2713,9 +2713,9 @@ cozy-stack-client@^2.19.2:
   dependencies:
     mime-types "^2.1.18"
 
-cozy-ui@10.8.1:
-  version "10.8.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-10.8.1.tgz#4d7142a95621a4350f8b47e6f47a2c960ffcee79"
+cozy-ui@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-11.0.0.tgz#73b3ac54ebb87424eae162da29796cd13f51d877"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"


### PR DESCRIPTION
Updating UI to v11, fixing the missing required `label` props everywhere and also fixing the rendering of action buttons in viewer selection bar (but the download action is still not working)

ping @y-lohse ^

~~⚠️ Needs cozy-bar to be [merged](https://github.com/cozy/cozy-bar/pull/229) & deployed to avoid some inconvenience.~~ ✅