### PR TITLE
Fixed recipient revocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "cozy-bar": "5.0.8",
-    "cozy-client": "2.17.0",
+    "cozy-client": "2.19.2",
     "cozy-client-js": "0.10.0",
     "cozy-realtime": "1.1.0",
     "cozy-ui": "10.8.1",

--- a/src/sharing/__tests__/state.spec.js
+++ b/src/sharing/__tests__/state.spec.js
@@ -111,7 +111,7 @@ describe('Sharing state', () => {
           sharings: [SHARING_1, SHARING_2]
         })
       ),
-      revokeRecipient(SHARING_1, 'john@doe.com')
+      revokeRecipient(SHARING_1, 1)
     )
     expect(state.sharings[0].attributes.members).toHaveLength(1)
   })
@@ -182,6 +182,8 @@ describe('Sharing state', () => {
           email: 'jane@doe.com',
           instance: 'http://cozy.tools:8080',
           name: 'Jane Doe',
+          sharingId: 'sharing_1',
+          index: 0,
           status: 'owner',
           type: 'two-way'
         },
@@ -189,6 +191,8 @@ describe('Sharing state', () => {
           email: 'john@doe.com',
           instance: 'http://cozy.local:8080',
           name: 'John Doe',
+          sharingId: 'sharing_1',
+          index: 1,
           status: 'ready',
           type: 'two-way'
         },
@@ -196,6 +200,8 @@ describe('Sharing state', () => {
           email: 'johnny@doe.com',
           instance: 'http://cozy.foo:8080',
           name: 'Johnny Doe',
+          sharingId: 'sharing_3',
+          index: 1,
           status: 'pending',
           type: 'two-way'
         }

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -58,9 +58,9 @@ class Status extends Component {
   }
 
   onRevoke = async () => {
-    const { onRevoke, document, email } = this.props
+    const { onRevoke, document, sharingId, index } = this.props
     this.setState(state => ({ revoking: true }))
-    await onRevoke(document, email)
+    await onRevoke(document, sharingId, index)
     this.setState(state => ({ revoking: false }))
   }
 

--- a/src/sharing/index.jsx
+++ b/src/sharing/index.jsx
@@ -16,7 +16,7 @@ import reducer, {
   canReshare,
   getOwner,
   getRecipients,
-  getSharingForRecipient,
+  getSharingById,
   getSharingForSelf,
   getSharingType,
   getSharingLink,
@@ -174,19 +174,15 @@ export default class SharingProvider extends Component {
     this.dispatch(updateSharing(resp.data))
   }
 
-  revoke = async (document, recipientEmail) => {
-    const sharing = getSharingForRecipient(
-      this.state,
-      document.id,
-      recipientEmail
-    )
+  revoke = async (document, sharingId, recipientIndex) => {
+    const sharing = getSharingById(this.state, sharingId)
     await this.context.client
       .collection('io.cozy.sharings')
-      .revokeRecipient(sharing, recipientEmail)
+      .revokeRecipient(sharing, recipientIndex)
     this.dispatch(
       revokeRecipient(
         sharing,
-        recipientEmail,
+        recipientIndex,
         document.path || (await this.getFilesPaths([document]))
       )
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,9 +133,9 @@
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.1.tgz#f3a81587ad8d0ef33cdad6f3b4310774fcc1053e"
 
-"@sentry/cli@1.34.0":
-  version "1.34.0"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.34.0.tgz#81aa5e8239efde11148bec5474b08329c36be32a"
+"@sentry/cli@1.35.4":
+  version "1.35.4"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.35.4.tgz#d89bc26a62baa33a8bf4991af04247bfd5093849"
   dependencies:
     https-proxy-agent "^2.2.1"
     node-fetch "^2.1.2"
@@ -561,7 +561,7 @@ attempt-x@^1.1.0, attempt-x@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/attempt-x/-/attempt-x-1.1.3.tgz#9ac844c75bca2c4e9e30d8d5c01f41eeb481a8b7"
 
-attr-accept@^1.0.3:
+attr-accept@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
   dependencies:
@@ -2673,11 +2673,11 @@ cozy-client-js@^0.3.19:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
 
-cozy-client@2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-2.17.0.tgz#fd115654206b561f6ba6b454512321a35cf3ba45"
+cozy-client@2.19.2:
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-2.19.2.tgz#4f97346a6f0ef595694be0eeb7a42fcf8fbff62f"
   dependencies:
-    cozy-stack-client "^2.17.0"
+    cozy-stack-client "^2.19.2"
     lodash "^4.17.5"
     prop-types "^15.6.0"
     react "^16.2.0"
@@ -2688,9 +2688,9 @@ cozy-realtime@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-1.1.0.tgz#6370ba7e1197ca267e0793c9dd7f2d871d359698"
 
-cozy-stack-client@^2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-2.17.0.tgz#80f8df247700fb39e5996db6a8e2f9092e78863b"
+cozy-stack-client@^2.19.2:
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-2.19.2.tgz#80a8b639553b38a1138b4c1cf27ca481e19a9339"
   dependencies:
     mime-types "^2.1.18"
 
@@ -5096,6 +5096,12 @@ immediate@3.0.6, immediate@~3.0.5:
 immutability-helper@^2.1.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.7.1.tgz#5636dbb593e3deb5e572766d42249ea06bae7640"
+  dependencies:
+    invariant "^2.2.0"
+
+immutability-helper@^2.7.1:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.8.0.tgz#f2ade82c23c93dfead3c2c3c4c1753cce47544f6"
   dependencies:
     invariant "^2.2.0"
 
@@ -8187,7 +8193,7 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
-popper.js@^1.14.4:
+popper.js@1.14.4:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
 
@@ -8733,14 +8739,14 @@ pouchdb@6.4.3:
     uuid "3.2.1"
     vuvuzela "1.0.3"
 
-preact-compat@3.18.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.18.0.tgz#ca430cc1f67193fb9feaf7c510832957b2ebe701"
+preact-compat@3.18.4:
+  version "3.18.4"
+  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.18.4.tgz#fbe76ddd30356c68e3ccde608107104946f2cf8d"
   dependencies:
-    immutability-helper "^2.1.2"
-    preact-render-to-string "^3.6.0"
-    preact-transition-group "^1.1.0"
-    prop-types "^15.5.8"
+    immutability-helper "^2.7.1"
+    preact-render-to-string "^3.8.2"
+    preact-transition-group "^1.1.1"
+    prop-types "^15.6.2"
     standalone-react-addons-pure-render-mixin "^0.1.1"
 
 preact-compat@^3.17.0:
@@ -8757,13 +8763,19 @@ preact-portal@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/preact-portal/-/preact-portal-1.1.3.tgz#22cdd3ecf6ad9aaa3f830607a9c6591de90aedb7"
 
-preact-render-to-string@^3.6.0, preact-render-to-string@^3.7.2:
+preact-render-to-string@^3.7.2:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.8.0.tgz#1c62e188dc136b50e5a273dcfaf3e4801c743069"
   dependencies:
     pretty-format "^3.5.1"
 
-preact-transition-group@^1.1.0:
+preact-render-to-string@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz#bd72964d705a57da3a9e72098acaa073dd3ceff9"
+  dependencies:
+    pretty-format "^3.5.1"
+
+preact-transition-group@^1.1.0, preact-transition-group@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
 
@@ -9115,11 +9127,11 @@ react-dom@15.6.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-dropzone@4.2.13:
-  version "4.2.13"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-4.2.13.tgz#31393c079b4e5ddcc176c095cebc3545d1248b9d"
+react-dropzone@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-4.3.0.tgz#facdd7db16509772633c9f5200621ac01aa6706f"
   dependencies:
-    attr-accept "^1.0.3"
+    attr-accept "^1.1.3"
     prop-types "^15.5.7"
 
 react-input-autosize@^2.2.1:
@@ -11409,9 +11421,9 @@ url-parse@^1.1.8, url-parse@~1.4.0:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
-url-polyfill@1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.0.13.tgz#5324c5e6e3d3bafdc93a73c21def21e8b697c910"
+url-polyfill@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.0.tgz#d34e1a596d954b864bc8608f84c592820df422db"
 
 url-slug@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
With this PR, we now rely on the recipient index (from the stack) to revoke a recipient. A cozy-client new version is needed.