### PR TITLE
fix(FileList): leaking default image image preview

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -99,6 +99,7 @@
     user-select none
     background-position 0 center
     background-repeat no-repeat
+    background-size rem(32) rem(32)
 
 .fil-content-header.fil-content-file
     padding-left 0


### PR DESCRIPTION
Force background-image's size so devices with some different screen DPI don't enlarge the icon.

Fixes #1147