### PR TITLE
fix: Provide full context to bar components

### DIFF
--- a/src/drive/web/modules/drive/Toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar.jsx
@@ -1,15 +1,16 @@
 /* global cozy */
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import SharingProvider, { SharedDocument } from 'sharing'
 
 import { translate } from 'cozy-ui/react/I18n'
 import { withBreakpoints } from 'cozy-ui/react'
+import { BarContextProvider } from 'react-cozy-helpers'
 
 import { MoreButton } from 'components/Button'
 import Menu, { Item } from 'components/Menu'
 
 import { isSelectionBarVisible } from 'drive/web/modules/selection/duck'
-import { SharedDocument } from 'sharing'
 
 import styles from 'drive/styles/toolbar'
 
@@ -100,7 +101,21 @@ class Toolbar extends Component {
           <ShareButton isDisabled={isDisabled} />
         </NotRootFolder>
 
-        {isMobile ? <BarRight>{MoreMenu}</BarRight> : MoreMenu}
+        {isMobile ? (
+          <BarRight>
+            <BarContextProvider
+              client={this.context.client}
+              store={this.context.store}
+              t={this.context.t}
+            >
+              <SharingProvider doctype="io.cozy.files" documentType="Files">
+                {MoreMenu}
+              </SharingProvider>
+            </BarContextProvider>
+          </BarRight>
+        ) : (
+          MoreMenu
+        )}
       </div>
     )
   }

--- a/src/lib/react-cozy-helpers/BarContextProvider.jsx
+++ b/src/lib/react-cozy-helpers/BarContextProvider.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+class BarContextProvider extends React.Component {
+  getChildContext() {
+    return this.props
+  }
+
+  render() {
+    if (!this.props.children) return null
+    if (!Array.isArray(this.props.children)) return this.props.children
+    return this.props.children[0]
+  }
+}
+
+export default BarContextProvider

--- a/src/lib/react-cozy-helpers/index.js
+++ b/src/lib/react-cozy-helpers/index.js
@@ -7,3 +7,4 @@ export default combineReducers({ modal: modalReducer })
 export { ModalManager, showModal } from './ModalManager'
 
 export { default as getQueryParameter } from './QueryParameter'
+export { default as BarContextProvider } from './BarContextProvider'


### PR DESCRIPTION
This fixes our problem of components not showing up in the cozy-bar — more context can be found here : https://github.com/cozy/cozy-bar/issues/144#issuecomment-425138507