### PR TITLE
fix: add whatwg-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,22 +43,14 @@
     "sign:drive:android": "(cd targets/drive/mobile && apksigner sign --ks keys/android/cozy-drive-release-key.jks --out build/android/cozy-drive.apk platforms/android/build/outputs/apk/release/android-release-unsigned.apk)",
     "buildsigned:drive:android": "npm run build:drive:android && npm run sign:drive:android",
     "publish:drive:android": "(cd targets/drive/mobile && fastlane supply)",
-    "publishbeta:drive:android":
-      "(cd targets/drive/mobile && fastlane android pushbeta)",
-    "run:drive:ios":
-      "(cd targets/drive/mobile && cordova run ios --buildFlag='-UseModernBuildSystem=0' --device)",
-    "run:drive:ios:emulator":
-      "(cd targets/drive/mobile && cordova run ios --buildFlag='-UseModernBuildSystem=0' --emulator)",
-    "publish:drive:ios":
-      "npm run build:drive:mobile && (cd targets/drive/mobile && fastlane ios pushtest)",
-    "sentry:drive:mobile":
-      "sentry-cli releases -o sentry -p cozy-drive-v3 files $npm_package_version upload-sourcemaps ./targets/drive/mobile/www",
-    "version:drive:manifest":
-      "replace '\\d+\\.\\d+\\.\\d+' $npm_package_version ./targets/drive/manifest.webapp",
-    "version:drive:config":
-      "replace 'version=\"\\d+\\.\\d+\\.\\d+\"' 'version=\"'$npm_package_version'\"' ./targets/drive/mobile/config.xml",
-    "version:drive:iosbuild":
-      "replace 'CFBundleVersion=\"\\d+\\.\\d+\\.\\d+.\\d+\"' 'CFBundleVersion=\"'$npm_package_version'.0\"' ./targets/drive/mobile/config.xml",
+    "publishbeta:drive:android": "(cd targets/drive/mobile && fastlane android pushbeta)",
+    "run:drive:ios": "(cd targets/drive/mobile && cordova run ios --buildFlag='-UseModernBuildSystem=0' --device)",
+    "run:drive:ios:emulator": "(cd targets/drive/mobile && cordova run ios --buildFlag='-UseModernBuildSystem=0' --emulator)",
+    "publish:drive:ios": "npm run build:drive:mobile && (cd targets/drive/mobile && fastlane ios pushtest)",
+    "sentry:drive:mobile": "sentry-cli releases -o sentry -p cozy-drive-v3 files $npm_package_version upload-sourcemaps ./targets/drive/mobile/www",
+    "version:drive:manifest": "replace '\\d+\\.\\d+\\.\\d+' $npm_package_version ./targets/drive/manifest.webapp",
+    "version:drive:config": "replace 'version=\"\\d+\\.\\d+\\.\\d+\"' 'version=\"'$npm_package_version'\"' ./targets/drive/mobile/config.xml",
+    "version:drive:iosbuild": "replace 'CFBundleVersion=\"\\d+\\.\\d+\\.\\d+.\\d+\"' 'CFBundleVersion=\"'$npm_package_version'.0\"' ./targets/drive/mobile/config.xml",
     "version:drive:androidbuild": "replace 'android-versionCode=\"\\d+\"' 'android-versionCode=\"'${npm_package_version//\\./}'0\"' ./targets/drive/mobile/config.xml",
     "version:drive:useragent": "replace 'value=\"(.+)\\d+\\.\\d+\\.\\d+\"' 'value=\"$1'$npm_package_version'\"' ./targets/drive/mobile/config.xml",
     "version:drive": "npm-run-all --parallel 'version:drive:*'",
@@ -198,7 +190,8 @@
     "redux-raven-middleware": "1.2.0",
     "redux-thunk": "2.3.0",
     "url-polyfill": "1.1.0",
-    "webpack-node-externals": "1.7.2"
+    "webpack-node-externals": "1.7.2",
+    "whatwg-fetch": "^3.0.0"
   },
   "eslintConfig": {
     "extends": [

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -4,6 +4,7 @@ import 'babel-polyfill'
 import 'drive/styles/main'
 import 'drive/styles/mobile'
 
+import 'whatwg-fetch'
 import React from 'react'
 import { render } from 'react-dom'
 import { hashHistory } from 'react-router'

--- a/targets/drive/web/main.jsx
+++ b/targets/drive/web/main.jsx
@@ -4,6 +4,7 @@ import 'babel-polyfill'
 
 import 'drive/styles/main'
 
+import 'whatwg-fetch'
 import React from 'react'
 import { render } from 'react-dom'
 import { Router, hashHistory } from 'react-router'

--- a/targets/drive/web/public/main.jsx
+++ b/targets/drive/web/public/main.jsx
@@ -1,6 +1,7 @@
 /* global cozy __DEVELOPMENT__ */
 import 'babel-polyfill'
 
+import 'whatwg-fetch'
 import React from 'react'
 import { render } from 'react-dom'
 import { Router, Route, Redirect, hashHistory } from 'react-router'

--- a/targets/drive/web/services.jsx
+++ b/targets/drive/web/services.jsx
@@ -1,6 +1,7 @@
 /* global __DEVELOPMENT__, cozy */
 
 import 'babel-polyfill'
+import 'whatwg-fetch'
 
 import React from 'react'
 import { render } from 'react-dom'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11746,7 +11746,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.23"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
 


### PR DESCRIPTION
fix the issue when fetch was not defined. It's the case at least on iOS 9. 

I don't know why we didn't encountered it before, we certainly had one dependency installing it, and since an update it's not the case anymore.

