### PR TITLE
fix: Make FileList props explicit

### DIFF
--- a/src/drive/web/modules/filelist/FileList.jsx
+++ b/src/drive/web/modules/filelist/FileList.jsx
@@ -12,7 +12,14 @@ const FileList = ({
   fileActions,
   withSelectionCheckbox = true,
   children,
-  ...rest
+  files,
+  displayedFolder,
+  onFolderOpen,
+  onFileOpen,
+  withFilePath,
+  withSharedBadge,
+  isRenaming,
+  renamingFile
 }) => (
   <div className={styles['fil-content-table']} role="table">
     <MobileFileListHeader canSort={canSort} />
@@ -23,7 +30,14 @@ const FileList = ({
       <FileListBody
         fileActions={fileActions}
         withSelectionCheckbox={withSelectionCheckbox}
-        {...rest}
+        files={files}
+        displayedFolder={displayedFolder}
+        onFolderOpen={onFolderOpen}
+        onFileOpen={onFileOpen}
+        withFilePath={withFilePath}
+        withSharedBadge={withSharedBadge}
+        isRenaming={isRenaming}
+        renamingFile={renamingFile}
       />
     )}
   </div>

--- a/src/drive/web/modules/layout/FolderView.jsx
+++ b/src/drive/web/modules/layout/FolderView.jsx
@@ -68,9 +68,16 @@ class FolderView extends Component {
           )}
           <SelectionBar actions={actions.selection} />
           <FileList
-            {...this.props}
             canSort={canSort}
             fileActions={actions.selection}
+            files={this.props.files}
+            displayedFolder={this.props.displayedFolder}
+            onFolderOpen={this.props.onFolderOpen}
+            onFileOpen={this.props.onFileOpen}
+            withFilePath={this.props.withFilePath}
+            withSharedBadge={this.props.withSharedBadge}
+            isRenaming={this.props.isRenaming}
+            renamingFile={this.props.renamingFile}
           />
           {this.renderViewer(children)}
         </Dropzone>


### PR DESCRIPTION
Because of our router, the `FilesViewer` is considered a child of `FolderView`. And since we were blanket-props forwarding, the `children` prop (and a lot of other props) ended up being passed down to components that don't need them.