### PR TITLE
Websql migration corrections

### DIFF
--- a/src/components/Error/Oops.jsx
+++ b/src/components/Error/Oops.jsx
@@ -2,13 +2,18 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import { Empty, Button } from 'cozy-ui/react'
 import EmptyIcon from '../../drive/assets/icons/icon-folder-broken.svg'
+import styles from './oops.styl'
 
 const reload = () => {
   window.location.reload()
 }
 
 const Oops = ({ t }) => (
-  <Empty title={t('error.open_folder')} icon={EmptyIcon}>
+  <Empty
+    title={t('error.open_folder')}
+    icon={EmptyIcon}
+    className={styles['oops']}
+  >
     <Button onClick={reload} label={t('error.button.reload')} />
   </Empty>
 )

--- a/src/components/Error/oops.styl
+++ b/src/components/Error/oops.styl
@@ -1,0 +1,5 @@
+@require 'settings/breakpoints'
+
++medium-screen()
+  .oops
+    pointer-events auto

--- a/src/drive/lib/upgradePouchDatabase.js
+++ b/src/drive/lib/upgradePouchDatabase.js
@@ -1,13 +1,27 @@
 /* global cozy */
 
-const upgradePouchDatabase = async dbName => {
+const upgradePouchDatabase = async (dbName, existingIndexes = []) => {
   const db = cozy.client.offline.getDatabase(dbName)
 
   const infos = await db.info()
-  if (infos.adapter === 'websql') {
-    await cozy.client.offline.migrateDatabase(dbName)
-    return true
-  } else return false
+  const isAdapterOutdated = infos.adapter === 'websql'
+
+  if (isAdapterOutdated) {
+    try {
+      await cozy.client.offline.migrateDatabase(dbName)
+      return true
+    } catch (err) {
+      console.warn(err)
+      return false
+    }
+  } else {
+    const { indexes } = await db.getIndexes()
+    const missingIndexes = existingIndexes.filter(
+      existingIndex => !indexes.find(index => index.ddoc === existingIndex)
+    )
+
+    return missingIndexes.length > 0 ? true : false
+  }
 }
 
 export default upgradePouchDatabase

--- a/src/drive/lib/upgradePouchDatabase.js
+++ b/src/drive/lib/upgradePouchDatabase.js
@@ -1,10 +1,10 @@
 /* global cozy */
 
-const upgradePouchDatabase = async (dbName, existingIndexes = []) => {
+export const upgradePouchDatabase = async dbName => {
   const db = cozy.client.offline.getDatabase(dbName)
 
   const infos = await db.info()
-  const isAdapterOutdated = infos.adapter === 'websql'
+  const isAdapterOutdated = infos.adapter !== 'idb'
 
   if (isAdapterOutdated) {
     try {
@@ -15,13 +15,17 @@ const upgradePouchDatabase = async (dbName, existingIndexes = []) => {
       return false
     }
   } else {
-    const { indexes } = await db.getIndexes()
-    const missingIndexes = existingIndexes.filter(
-      existingIndex => !indexes.find(index => index.ddoc === existingIndex)
-    )
-
-    return missingIndexes.length > 0
+    return false
   }
 }
 
-export default upgradePouchDatabase
+export const checkMissingIndexes = async (dbName, existingIndexes) => {
+  const db = cozy.client.offline.getDatabase(dbName)
+  const { indexes } = await db.getIndexes()
+
+  const missingIndexes = existingIndexes.filter(
+    existingIndex => !indexes.find(index => index.ddoc === existingIndex)
+  )
+
+  return missingIndexes.length > 0
+}

--- a/src/drive/lib/upgradePouchDatabase.js
+++ b/src/drive/lib/upgradePouchDatabase.js
@@ -20,7 +20,7 @@ const upgradePouchDatabase = async (dbName, existingIndexes = []) => {
       existingIndex => !indexes.find(index => index.ddoc === existingIndex)
     )
 
-    return missingIndexes.length > 0 ? true : false
+    return missingIndexes.length > 0
   }
 }
 

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -2,7 +2,7 @@
 import { LocalStorage as Storage } from 'cozy-client-js'
 import CozyClient from 'cozy-client'
 import { SOFTWARE_ID, SOFTWARE_NAME } from './constants'
-import { getDeviceName, isIos } from './device'
+import { getDeviceName } from './device'
 import { disableBackgroundService } from './background'
 import { schema, DOCTYPE_FILES } from '../../../../targets/drive/doctypes'
 export const getLang = () =>
@@ -58,7 +58,6 @@ export const updateBarAccessToken = accessToken =>
 
 export const restoreCozyClientJs = (uri, clientInfos, token) => {
   const offline = { doctypes: ['io.cozy.files'] }
-  if (isIos()) offline.options = { adapter: 'cordova-sqlite' }
   cozy.client.init({
     cozyURL: uri,
     oauth: {

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -1,6 +1,5 @@
 /* global cozy emit */
 import { ROOT_DIR_ID } from '../../constants/config.js'
-import upgradePouchDatabase from 'drive/lib/upgradePouchDatabase'
 
 const clientRevokedMsg = 'Client has been revoked'
 
@@ -13,18 +12,6 @@ export const startReplication = async (
   indexesCreated
 ) => {
   try {
-    upgradePouchDatabase('io.cozy.files', [
-      existingIndexes.byName,
-      existingIndexes.bySize,
-      existingIndexes.byUpdatedAt
-    ]).then(async didUpgrade => {
-      if (didUpgrade) {
-        indexesCreated({})
-        const indexes = await createIndexes({}, indexesCreated)
-        await warmUpIndexes(indexes)
-      }
-    })
-
     const indexes = await createIndexes(existingIndexes, indexesCreated)
 
     if (!hasFinishedFirstReplication) {
@@ -60,7 +47,7 @@ export const startReplication = async (
   }
 }
 
-const createIndexes = async (existingIndexes, indexesCreated) => {
+export const createIndexes = async (existingIndexes, indexesCreated) => {
   const db = cozy.client.offline.getDatabase('io.cozy.files')
 
   await db.viewCleanup()
@@ -114,7 +101,7 @@ const createIndexes = async (existingIndexes, indexesCreated) => {
   return indexes
 }
 
-const warmUpIndexes = async indexes => {
+export const warmUpIndexes = async indexes => {
   const warmUpIndex = (index, attribute) =>
     db.find({
       selector: {

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -13,7 +13,11 @@ export const startReplication = async (
   indexesCreated
 ) => {
   try {
-    upgradePouchDatabase('io.cozy.files').then(async didUpgrade => {
+    upgradePouchDatabase('io.cozy.files', [
+      existingIndexes.byName,
+      existingIndexes.bySize,
+      existingIndexes.byUpdatedAt
+    ]).then(async didUpgrade => {
       if (didUpgrade) {
         indexesCreated({})
         const indexes = await createIndexes({}, indexesCreated)

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -97,7 +97,7 @@ const startApplication = async function(store, client, polyglot) {
 
     await oauthClient.fetchInformation()
     shouldInitBar = true
-    store.dispatch(startReplication())
+    await store.dispatch(startReplication())
   } catch (e) {
     console.warn(e)
     if (isClientRevoked(e, store.getState())) {


### PR DESCRIPTION
When we're telling PouchDB to use the `sqlite` adapter on iOS, it starts using it right away. The documents are eventually replicated, but the indexes are missing and that's why we're seeing an error.

We now check for missing indexes, and recreate them if they are missing. The good news is it fixes the problem in all cases, even people having only done a partial migration. the problem is that the app will still show an error message the first time it is loaded, and will need a view change or restart to get the new indexes. But I don't see a better way to handle the situation :/