### PR TITLE
fix(ModalFileList): Firefox overflow bug in modal

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -3,6 +3,7 @@
 
 .fil-content-table
     @extend $table
+    overflow auto
 
 .fil-content-head
     @extend $table-head


### PR DESCRIPTION
Tagging @GoOz just in case it's of interest to you: in firefox, the file list in a modal was taking up all it's height instead of being scrollable. This change fixes the problem, and I haven't seen any other consequences on desktop or mobile, in Chrome, Firefox or Safari.