### PR TITLE
fix(PublicLink): Translate button label

### DIFF
--- a/src/components/Button/CozyHomeLink.jsx
+++ b/src/components/Button/CozyHomeLink.jsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { translate } from 'cozy-ui/react/I18n'
 import { ButtonLink } from 'cozy-ui/react'
 import styles from './index.styl'
 
-const CozyHomeLink = ({ from, embedInCozyBar = false }, { t }) => (
+const CozyHomeLink = ({ from, embedInCozyBar = false, t }) => (
   <ButtonLink
     subtle
     label={t('Share.create-cozy')}
@@ -16,7 +15,8 @@ const CozyHomeLink = ({ from, embedInCozyBar = false }, { t }) => (
 
 CozyHomeLink.propTypes = {
   from: PropTypes.string,
-  embedInCozyBar: PropTypes.bool
+  embedInCozyBar: PropTypes.bool,
+  t: PropTypes.func.isRequired
 }
 
 CozyHomeLink.defaultProps = {
@@ -28,4 +28,4 @@ export const getHomeLinkHref = from =>
     from ? `?pk_campaign=${encodeURIComponent(from)}` : ''
   }`
 
-export default translate()(CozyHomeLink)
+export default CozyHomeLink

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -76,7 +76,7 @@ const CozybarToolbar = ({ onDownload, discoveryLink }, { t }) => (
       {discoveryLink ? (
         <OpenInCozyButton href={discoveryLink} t={t} size="small" />
       ) : (
-        <CozyHomeLink from="sharing-drive" />
+        <CozyHomeLink from="sharing-drive" t={t} />
       )}
       <DownloadFilesButton t={t} onDownload={onDownload} size="small" />
     </div>


### PR DESCRIPTION
The button is rendered in the cozy bar, so it still doesn't have the right context.
See https://github.com/cozy/cozy-bar/issues/144 for discussions on a long term solution.