### PR TITLE
Fix/suggestion menu

### DIFF
--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -211,12 +211,12 @@ export const RecipientPlusX = ({ extraRecipients }, { t }) => (
   </div>
 )
 
-export const Contact = ({ contact }) => {
+export const ContactSuggestion = ({ contact }) => {
   const name = getPrimaryEmail(contact)
   const url = getPrimaryCozy(contact)
   return (
     <div className={styles['recipient']}>
-      <Avatar name={getInitiales(name)} size={'small'} textId={name} />
+      <Avatar text={getInitiales(name)} size={'small'} textId={name} />
       <Identity name={name} url={url} />
     </div>
   )

--- a/src/sharing/components/ShareAutosuggest.jsx
+++ b/src/sharing/components/ShareAutosuggest.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import Autosuggest from 'react-autosuggest'
 
 import styles from './autosuggest.styl'
-import { Contact } from './Recipient'
+import { ContactSuggestion } from './Recipient'
 import { Icon } from 'cozy-ui/react'
 import BoldCross from '../assets/icons/icon-cross-bold.svg'
 
@@ -138,7 +138,7 @@ export default class ShareAutocomplete extends Component {
         getSuggestionValue={contact => contact}
         onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
         onSuggestionsClearRequested={this.onSuggestionsClearRequested}
-        renderSuggestion={contact => <Contact contact={contact} />}
+        renderSuggestion={contact => <ContactSuggestion contact={contact} />}
         renderInputComponent={props => this.renderInput(props)}
         highlightFirstSuggestion
         inputProps={{

--- a/src/sharing/components/autosuggest.styl
+++ b/src/sharing/components/autosuggest.styl
@@ -29,7 +29,7 @@
     list-style none
 
 .suggestion
-    padding .625rem
+    padding 0 .625rem .625rem .625rem
 
 .suggestionHighlighted
     background paleGrey

--- a/src/sharing/components/recipient.styl
+++ b/src/sharing/components/recipient.styl
@@ -6,7 +6,6 @@
     display flex
     flex-direction row
     align-items center
-    margin-top .75rem
 
     +small-screen()
         align-items flex-start


### PR DESCRIPTION
- Renamed `Contact` to `SuggestionContact` as this component is only used inside `SuggestionList`
- Avatar now takes `text` and not `name` 
- 2/3 margins / paddings 