### PR TITLE
chore: Update matomo URL

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -23,7 +23,7 @@ module.exports = {
       __PIWIK_SITEID__: 8,
       __PIWIK_SITEID_MOBILE__: 12,
       __PIWIK_DIMENSION_ID_APP__: 1,
-      __PIWIK_TRACKER_URL__: JSON.stringify('https://piwik.cozycloud.cc'),
+      __PIWIK_TRACKER_URL__: JSON.stringify('https://matomo.cozycloud.cc'),
       __SENTRY_TOKEN__: JSON.stringify('29bd1255b6d544a1b65435a634c9ff67:ba312a96643d4f98aee26c6378c74212'),
       __APP_VERSION__: JSON.stringify(pkg.version)
     }),

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -26,7 +26,7 @@ module.exports = {
       __PIWIK_SITEID__: 8,
       __PIWIK_SITEID_MOBILE__: 12,
       __PIWIK_DIMENSION_ID_APP__: 1,
-      __PIWIK_TRACKER_URL__: JSON.stringify('https://piwik.cozycloud.cc'),
+      __PIWIK_TRACKER_URL__: JSON.stringify('https://matomo.cozycloud.cc'),
       __SENTRY_TOKEN__: JSON.stringify('9259817fbb44484b8b7a0a817d968ae4:171a3bcb3095448484aa3e709ea47e9b'),
       __APP_VERSION__: JSON.stringify(pkg.version)
     })


### PR DESCRIPTION
The variables are still called `piwik`, but I don't think renaming them matters.