### PR TITLE
fix: Stop synchro params

### DIFF
--- a/src/drive/mobile/modules/mediaBackup/duck/index.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/index.js
@@ -260,10 +260,13 @@ const uploadPhoto = (dirName, dirID, photo) => async (dispatch, getState) => {
   }
 }
 
-export const backupImages = backupImages => async (dispatch, getState) => {
+export const backupImages = (backupImages, force = false) => async (
+  dispatch,
+  getState
+) => {
   // TODO: it looks like the media backup is triggered twice at app init, but I couldn't figure why :/
   // This fixes the issue, but we'll need to figure out why it is triggered twice...
-  if (getState().mobile.mediaBackup.running === true) {
+  if (getState().mobile.mediaBackup.running === true && !force) {
     return
   }
   if (backupImages === undefined) {

--- a/src/drive/mobile/modules/settings/components/MediaBackup.jsx
+++ b/src/drive/mobile/modules/settings/components/MediaBackup.jsx
@@ -63,7 +63,14 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  setBackupImages: value => dispatch(backupImages(value)),
+  setBackupImages: value => {
+    if (value === false) {
+      dispatch(cancelMediaBackup())
+      dispatch(backupImages(false, true))
+    } else {
+      dispatch(backupImages(value))
+    }
+  },
   setWifiOnly: async value => {
     await dispatch(setWifiOnly(value))
     dispatch(backupImages())


### PR DESCRIPTION
When switching to `False`, we `cancelMediaBackup` and force settings to be set to `false` by adding a new param to the function. 

This is because of https://github.com/cozy/cozy-drive/blob/master/src/drive/mobile/modules/mediaBackup/duck/index.js#L266