### PR TITLE
fix(Breadcrumb): z-index position

### DIFF
--- a/src/drive/web/modules/navigation/breadcrumb.styl
+++ b/src/drive/web/modules/navigation/breadcrumb.styl
@@ -51,7 +51,6 @@
     .fil-path-backdrop
         min-width 0
         width auto
-        z-index $overlay-index
 
     .fil-path-title
         display        flex
@@ -80,6 +79,7 @@
         right    0
         bottom     0
         left       0
+        z-index $overlay-index
 
         &.inlined
             position absolute


### PR DESCRIPTION
The z-index was conflicting with the cozy-bar, but we only need such a high z-index when the breadcrumb menu is open — and when it's open, the cozy-bar is hidden.