### PR TITLE
 fix: Don't use color var in stylus func

### DIFF
--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -43,7 +43,7 @@
             width      40%
 
         .pho-viewer-toolbar
-            background linear-gradient(to bottom, alpha(charcoalGrey, .50), alpha(charcoalGrey, .33), alpha(charcoalGrey, 0))
+            background linear-gradient(to bottom, rgba(50, 54, 63, .5), rgba(50, 54, 63, .33), rgba(50, 54, 63, 0))
 
         .pho-viewer-canceled
             height      100%


### PR DESCRIPTION
Some cleaning in preparation for a future [release of Cozy-UI](https://github.com/cozy/cozy-ui/pull/641) with color variables as CSS custom properties.

~I couldn't test it because I could make Photos works.~ It works fine :)

~⚠️ Meanwhile if your Photos apps works well, you should consider testing it locally before merging.~