### PR TITLE
fix: Force bar to be in public mode

### DIFF
--- a/targets/drive/web/public/main.jsx
+++ b/targets/drive/web/public/main.jsx
@@ -44,7 +44,8 @@ const initCozyBar = data => {
       appEditor: data.cozyAppEditor,
       iconPath: data.cozyIconPath,
       lang: data.cozyLocale,
-      replaceTitleOnMobile: true
+      replaceTitleOnMobile: true,
+      isPublic: true
     })
   }
 }


### PR DESCRIPTION
It works on some views because the bar automatically goes into public mode when the URL contains `/public`… but not on all the views.