### PR TITLE
Remove unecessary and error prone bar from intents

### DIFF
--- a/targets/drive/web/services.ejs
+++ b/targets/drive/web/services.ejs
@@ -11,7 +11,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <% if (__STACK_ASSETS__) { %>
   {{.CozyClientJS}}
-  {{.CozyBar}}
   <% } %>
 </head>
 <div


### PR DESCRIPTION
The intents will try to get the bar with the host application React, error prone and unecessarry since we don't use the cozy-bar for the intents.