### PR TITLE
Compute reachabilities between photos

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -2,9 +2,10 @@ export const THRESHOLD = 314
 export const DEFAULT_PERIOD = 'all'
 export const DEFAULT_MODE = 'default'
 export const SETTING_TYPE = 'clustering'
-export const DEFAULT_MAX_BOUND = 24
-export const DEFAULT_EPS_TEMPORAL = 12
-export const DEFAULT_EPS_SPATIAL = 2
+export const DEFAULT_MAX_BOUND = 48
+export const MIN_EPS_TEMPORAL = 3
+export const MIN_EPS_SPATIAL = 3
+export const PERCENTILE = 99.5
 
 export const DEFAULT_SETTING = {
   type: SETTING_TYPE,

--- a/src/photos/ducks/clustering/metrics.js
+++ b/src/photos/ducks/clustering/metrics.js
@@ -15,6 +15,21 @@ export const temporal = (point1, point2) => {
 }
 
 /**
+ * Metric giving a spatio-temporal distance by converting the spatial distance
+ * into a temporal equivalent.
+ * The conversion is done by using the caracteristic time and distance.
+ */
+export const spatioTemporalScaled = (
+  point1,
+  point2,
+  epsTemporal,
+  epsSpatial
+) => {
+  const r = epsTemporal / epsSpatial
+  return (temporal(point1, point2) + spatial(point1, point2) * r) / 2
+}
+
+/**
  *  Compute the geodesic distance between (point1, point2) coordinates
  *  See https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
  */

--- a/src/photos/ducks/clustering/service.js
+++ b/src/photos/ducks/clustering/service.js
@@ -1,12 +1,38 @@
 import KNN from './knn'
 import { temporal, spatial } from './metrics'
+import { MIN_EPS_TEMPORAL, MIN_EPS_SPATIAL } from './consts'
+
+/**
+* Compute the distance bewteen adjacents points in the dataset.
+* This is a very simplified version of the OPTICS [1] algorithm, taking
+* advantage of the temporal property for our context (all points are already
+* sorted by time).
+* The reachabilites are used later to determine how to clusterize the points.
+
+* [1] Ankerst, M., Breunig, M. M., Kriegel, H. P., & Sander, J. (1999, June).
+* OPTICS: ordering points to identify the clustering structure.
+* In ACM Sigmod record (Vol. 28, No. 2, pp. 49-60). ACM.
+*/
+export const reachabilities = (dataset, metric, params) => {
+  const reachabilities = [null]
+  for (let i = 1; i < dataset.length; i++) {
+    const point1 = dataset[i - 1]
+    const point2 = dataset[i]
+    const dist = metric(point1, point2, params.epsTemporal, params.epsSpatial)
+    const reach = dist < params.maxBound ? dist : null
+    reachabilities.push(reach)
+  }
+  return reachabilities
+}
 
 export const computeEpsTemporal = (dataset, percentile) => {
-  return computeEps(dataset, temporal, ['date'], percentile)
+  const epsTemporal = computeEps(dataset, temporal, ['date'], percentile)
+  return epsTemporal >= MIN_EPS_TEMPORAL ? epsTemporal : MIN_EPS_TEMPORAL
 }
 
 export const computeEpsSpatial = (dataset, percentile) => {
-  return computeEps(dataset, spatial, ['lat', 'lon'], percentile)
+  const epsSpatial = computeEps(dataset, spatial, ['lat', 'lon'], percentile)
+  return epsSpatial >= MIN_EPS_SPATIAL ? epsSpatial : MIN_EPS_SPATIAL
 }
 
 /**

--- a/src/photos/ducks/clustering/service.spec.js
+++ b/src/photos/ducks/clustering/service.spec.js
@@ -1,5 +1,10 @@
-import { computeEpsTemporal, computeEpsSpatial } from './service'
+import {
+  computeEpsTemporal,
+  computeEpsSpatial,
+  reachabilities
+} from './service'
 import { quantile, mean, standardDeviation } from './maths'
+import { temporal, spatial, spatioTemporalScaled } from './metrics'
 
 const N_DIGITS = 4
 const dataset = [
@@ -34,6 +39,8 @@ const dataset = [
     lon: 20
   }
 ]
+
+const maxBound = 500
 
 describe('maths', () => {
   let random_data = [
@@ -73,5 +80,45 @@ describe('knn', () => {
   })
   it('Should compute spatial eps', () => {
     expect(computeEpsSpatial(dataset)).toBeCloseTo(386.7568, N_DIGITS)
+  })
+})
+
+describe('clustering', () => {
+  it('Should cluster data with temporal metric', () => {
+    const expectedReach = [null, 2, 3, 45, 20, 30]
+
+    const reachs = reachabilities(dataset, temporal, { maxBound: maxBound })
+    expect(reachs).toEqual(expect.arrayContaining(expectedReach))
+  })
+
+  it('Should cluster data with spatial metric', () => {
+    const expectedReach = [
+      11.119492664456596,
+      401.5003434905605,
+      386.7568104542309,
+      68.80809741870237
+    ]
+
+    const reachs = reachabilities(dataset, spatial, { maxBound: maxBound })
+    expect(reachs).toEqual(expect.arrayContaining(expectedReach))
+  })
+
+  it('Should cluster data with spatio temporal scaled metric', () => {
+    const expectedReach = [
+      null,
+      6.559746332228298,
+      202.25017174528026,
+      215.87840522711545,
+      44.40404870935119,
+      null
+    ]
+
+    const params = {
+      epsTemporal: maxBound / 2,
+      epsSpatial: maxBound / 2,
+      maxBound: maxBound
+    }
+    const reachs = reachabilities(dataset, spatioTemporalScaled, params)
+    expect(reachs).toEqual(expect.arrayContaining(expectedReach))
   })
 })

--- a/targets/photos/services/onPhotoUpload.js
+++ b/targets/photos/services/onPhotoUpload.js
@@ -6,7 +6,13 @@ import {
   defaultParameters,
   createDefaultSetting
 } from 'photos/ducks/clustering/settings'
-import { computeEpsTemporal, computeEpsSpatial } from 'photos/ducks/clustering/services'
+import {
+  computeEpsTemporal,
+  computeEpsSpatial,
+  reachabilities
+} from 'photos/ducks/clustering/services'
+import { PERCENTILE, DEFAULT_MAX_BOUND } from 'photos/ducks/clustering/consts'
+import { spatioTemporalScaled } from 'photos/ducks/clustering/metrics'
 
 // Returns the photos metadata sorted by date
 const extractInfo = photos => {
@@ -41,14 +47,20 @@ const clusterizePhotos = async (setting, photos) => {
   }
 
   if (!params.epsTemporal) {
-    params.epsTemporal = computeEpsTemporal(dataset)
+    params.epsTemporal = computeEpsTemporal(dataset, PERCENTILE)
   }
   if (!params.epsSpatial) {
-    params.epsSpatial = computeEpsSpatial(dataset)
+    params.epsSpatial = computeEpsSpatial(dataset, PERCENTILE)
   }
+  const epsMax = Math.max(params.epsTemporal, params.epsSpatial)
+  params.maxBound =
+    epsMax * 2 < DEFAULT_MAX_BOUND ? epsMax * 2 : DEFAULT_MAX_BOUND
 
-  // TODO compute spatio temporal
+  reachabilities(dataset, spatioTemporalScaled, params)
+
+  // TODO gradient clustering
   // TODO save params
+  // TODO adapt percentiles for large datasets
 
   return dataset
 }


### PR DESCRIPTION
The reachabilities are the distance between 2 photos temporally adjacent. This will be useful later to determine how to clusterize the photos.