### PR TITLE
Fix bar usage on mobile

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -8,14 +8,6 @@ const pkg = require(path.resolve(__dirname, '../package.json'))
 module.exports = {
   devtool: 'cheap-module-source-map',
   externals: ['cozy'],
-  module: {
-    rules: [
-      {
-        test: require.resolve('cozy-bar/dist/cozy-bar.js'),
-        loader: 'imports-loader?css=./cozy-bar.css'
-      }
-    ]
-  },
   plugins: [
     new DefinePlugin({
       __STACK_ASSETS__: false,

--- a/config/webpack.target.browser.js
+++ b/config/webpack.target.browser.js
@@ -73,8 +73,16 @@ module.exports = function(production, app) {
     )
   }
 
+  const devBrowserRules = [
+    {
+      test: require.resolve('cozy-bar/dist/cozy-bar.js'),
+      loader: 'imports-loader?css=./cozy-bar.css'
+    }
+  ]
+
   return {
     entry: entry,
+    module: { rules: production ? devBrowserRules : [] },
     output: {
       path: path.resolve(__dirname, `../build/${app}`),
       filename: '[name].js'

--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -7,7 +7,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 module.exports = function(production, app) {
   return {
     entry: {
-      app: [path.resolve(__dirname, `../targets/${app}/mobile/main`)]
+      app: [path.resolve(__dirname, 'expose-react.js'), path.resolve(__dirname, `../targets/${app}/mobile/main`)]
     },
     output: {
       path: path.resolve(__dirname, `../targets/${app}/mobile/www`),

--- a/targets/drive/mobile/main.jsx
+++ b/targets/drive/mobile/main.jsx
@@ -111,7 +111,7 @@ const startApplication = async function(store, client, polyglot) {
       shouldInitBar = true
     }
   } finally {
-    if (shouldInitBar) initBar(client)
+    if (shouldInitBar) await initBar(client)
   }
 
   useHistoryForTracker(hashHistory)


### PR DESCRIPTION
* The commit https://github.com/cozy/cozy-drive/commit/b9fa2bb714204c7d602b8ad24bfc6e73e03a48e7 avoids linking the cozy-bar since the build will look for the `cozy-bar.js` and the `cozy-bar.mobile.js` files but it needs only `cozy-bar.mobile.js`.
* The bar initialisation is async so we need to use `await` here
* We need to expose Preact for the bar to be able to use Preact instead of React (breaking the API)