### PR TITLE
feat(authentication): Add contextTypes

### DIFF
--- a/src/authentication/src/Authentication.jsx
+++ b/src/authentication/src/Authentication.jsx
@@ -19,6 +19,10 @@ class Authentication extends Component {
     this.steps = [STEP_WELCOME]
   }
 
+  static contextTypes = {
+    client: PropTypes.object.isRequired
+  }
+
   nextStep() {
     this.setState(prevState => ({
       currentStepIndex: ++prevState.currentStepIndex

--- a/src/authentication/src/Revoked.jsx
+++ b/src/authentication/src/Revoked.jsx
@@ -6,6 +6,10 @@ import Modal from 'cozy-ui/react/Modal'
 import { translate } from 'cozy-ui/react/I18n'
 
 class Revoked extends Component {
+  static contextTypes = {
+    context: PropTypes.object.isRequired
+  }
+
   logout() {
     this.props.onLogout()
   }

--- a/src/authentication/src/steps/SelectServer.jsx
+++ b/src/authentication/src/steps/SelectServer.jsx
@@ -16,6 +16,10 @@ const ERR_V2 = 'mobile.onboarding.server_selection.wrong_address_v2'
 const ERR_COSY = 'mobile.onboarding.server_selection.wrong_address_cosy'
 
 export class SelectServer extends Component {
+  static contextTypes = {
+    client: PropTypes.object.isRequired
+  }
+
   state = {
     value: '',
     fetching: false,


### PR DESCRIPTION
React requires `contextTypes` to be defined in order to use `context` in a component. That's not the case with Preact, so we didn't define it on every components. But now we encounter some `this.context.something is undefined` errors when we migrate our apps to React. 