### PR TITLE
Update clustering for new photos

### DIFF
--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -49,12 +49,11 @@ export const findAutoAlbums = async () => {
   ])
   const results = await cozyClient.data.query(autoAlbums, {
     selector: { auto: true },
-    sort: [{ name: 'desc' }]
+    sort: [{ name: 'asc' }]
   })
   return results
 }
 
-// TODO: deal with updates
 export const saveClustering = async (clusters, albums) => {
   for (const photos of clusters) {
     if (photos && photos.length > 0) {
@@ -67,7 +66,7 @@ export const saveClustering = async (clusters, albums) => {
 const findPhotosByAlbum = async album => {
   album._type = DOCTYPE_ALBUMS
   const files = await cozyClient.data.fetchReferencedFiles(album, {})
-  if (files && files.included.length > 0) {
+  if (files && files.included) {
     const attributes = files.included.map(file => {
       const attributes = file.attributes
       attributes.id = file.id
@@ -99,6 +98,7 @@ export const albumsToClusterize = async (photos, albums) => {
   const clusterize = {}
 
   for (const photo of photos) {
+    // Find clusters matching this photo
     const matchingAlbums = matchingClusters(photo, albums)
     if (matchingAlbums.length > 0) {
       const key = matchingAlbums[1]
@@ -107,6 +107,7 @@ export const albumsToClusterize = async (photos, albums) => {
       if (clusterize[key]) {
         clusterize[key].push(photo)
       } else {
+        // Save the photos referenced by the matchig albums
         const photosToClusterize = await findPhotosToClusterize(matchingAlbums)
         photosToClusterize.push(photo)
         clusterize[key] = photosToClusterize

--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -1,5 +1,7 @@
 import { cozyClient, log } from 'cozy-konnector-libs'
 import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
+import { matchingClusters } from './matching'
+import flatten from 'lodash/flatten'
 
 // An auto album name is the date of the first photo
 const albumName = photos => {
@@ -14,17 +16,20 @@ const albumPeriod = photos => {
   return { start: startDate, end: endDate }
 }
 
-const createReferences = async (album, photos) => {
+const createReferences = async (photos, album) => {
   try {
     const ids = photos.map(p => p.id)
-    const result = await cozyClient.data.addReferencedFiles(album, ids)
-    return result
+    await cozyClient.data.addReferencedFiles(album, ids)
+    log(
+      'info',
+      `${photos.length} photos clustered into: ${JSON.stringify(album)}`
+    )
   } catch (e) {
     log('error', e.reason)
   }
 }
 
-const createAutoAlbum = async (albums, photos) => {
+const createAutoAlbum = async (photos, albums) => {
   // Check if an album already exists for these photos. If not, create it
   const name = albumName(photos)
   const album = albums ? albums.find(album => album.name === name) : null
@@ -37,24 +42,112 @@ const createAutoAlbum = async (albums, photos) => {
   }
 }
 
-export const findAllAutoAlbums = async () => {
-  const albums = await cozyClient.data.findAll(DOCTYPE_ALBUMS)
-  return albums.filter(album => album.auto)
+export const findAutoAlbums = async () => {
+  const autoAlbums = await cozyClient.data.defineIndex(DOCTYPE_ALBUMS, [
+    'auto',
+    'name'
+  ])
+  const results = await cozyClient.data.query(autoAlbums, {
+    selector: { auto: true },
+    sort: [{ name: 'desc' }]
+  })
+  return results
 }
 
 // TODO: deal with updates
-export const saveClustering = async clusters => {
-  const albums = await findAllAutoAlbums()
+export const saveClustering = async (clusters, albums) => {
   for (const photos of clusters) {
     if (photos && photos.length > 0) {
-      const album = await createAutoAlbum(albums, photos)
-      const refs = await createReferences(album, photos)
-      if (refs) {
-        log(
-          'info',
-          `${photos.length} photos clustered into: ${JSON.stringify(album)}`
-        )
+      const album = await createAutoAlbum(photos, albums)
+      await createReferences(photos, album)
+    }
+  }
+}
+
+const findPhotosByAlbum = async album => {
+  album._type = DOCTYPE_ALBUMS
+  const files = await cozyClient.data.fetchReferencedFiles(album, {})
+  if (files && files.included.length > 0) {
+    const attributes = files.included.map(file => {
+      const attributes = file.attributes
+      attributes.id = file.id
+      return attributes
+    })
+    return extractPhotosInfo(attributes)
+  }
+  return []
+}
+
+const findPhotosToClusterize = async albums => {
+  const photos = flatten(
+    await Promise.all(
+      albums.map(async album => {
+        return await findPhotosByAlbum(album)
+      })
+    )
+  )
+  return photos
+}
+
+/**
+  Look for existing auto albums to re-clusterize.
+  There are 2 cases for this to occur:
+    - A photo's datetime is inside an album period
+    - A photo's datetime is in a gap between an album and an adjacent one.
+*/
+export const albumsToClusterize = async (photos, albums) => {
+  const clusterize = {}
+
+  for (const photo of photos) {
+    const matchingAlbums = matchingClusters(photo, albums)
+    if (matchingAlbums.length > 0) {
+      const key = matchingAlbums[1]
+        ? matchingAlbums[0]._id + ':' + matchingAlbums[1]._id
+        : matchingAlbums[0]._id
+      if (clusterize[key]) {
+        clusterize[key].push(photo)
+      } else {
+        const photosToClusterize = await findPhotosToClusterize(matchingAlbums)
+        photosToClusterize.push(photo)
+        clusterize[key] = photosToClusterize
       }
     }
   }
+  return clusterize
+}
+
+/**
+ *  Find albums based on the ids
+ */
+export const findAlbumsByIds = (albums, ids) => {
+  return (
+    albums.filter(album => {
+      return ids.find(id => album._id === id)
+    }) || []
+  )
+}
+
+/**
+ * Returns the photos metadata sorted by date
+ */
+export const extractPhotosInfo = photos => {
+  const info = photos
+    .map(file => {
+      const photo = {
+        id: file._id || file.id,
+        name: file.name
+      }
+      if (file.metadata) {
+        photo.datetime = file.metadata.datetime
+        photo.gps = file.metadata.gps
+      } else {
+        photo.datetime = file.created_at
+      }
+      const hours = new Date(photo.datetime).getTime() / 1000 / 3600
+      photo.timestamp = hours
+      return photo
+    })
+    .sort((pa, pb) => pa.timestamp < pb.timestamp)
+
+  return info
 }

--- a/src/photos/ducks/clustering/matching.js
+++ b/src/photos/ducks/clustering/matching.js
@@ -1,0 +1,49 @@
+const outsideClusteringEdges = (photo, newestAlbum, oldestAlbum) => {
+  const photoDate = new Date(photo.datetime)
+  const newestEnd = new Date(newestAlbum.period.end)
+  const oldestStart = new Date(oldestAlbum.period.start)
+
+  if (photoDate > newestEnd) {
+    return newestAlbum
+  } else if (photoDate < oldestStart) {
+    return oldestAlbum
+  }
+  return null
+}
+
+const adjacentToClusters = (photo, newerAlbum, olderAlbum) => {
+  const photoDate = new Date(photo.datetime)
+  const newerStart = new Date(newerAlbum.period.start)
+  const newerEnd = new Date(newerAlbum.period.end)
+  // The olderAlbum might be null if this is the last element
+  const olderEnd = olderAlbum ? new Date(olderAlbum.period.end) : null
+  // Photo inside cluster
+  if (photoDate <= newerEnd && photoDate >= newerStart) {
+    return [newerAlbum]
+  }
+  // Photo between clusters
+  if (olderEnd && photoDate < newerStart && photoDate > olderEnd) {
+    return [newerAlbum, olderAlbum]
+  }
+  return []
+}
+
+/**
+ *  Find the albums in which a photo can be added.
+ *  Albums are sorted by date from newest to oldest.
+ */
+export const matchingClusters = (photo, albums) => {
+  const newestAlbum = albums[0]
+  const oldestAlbum = albums[albums.length - 1]
+  const edge = outsideClusteringEdges(photo, newestAlbum, oldestAlbum)
+  if (edge) {
+    return [edge]
+  }
+  for (let i = 0; i < albums.length; i++) {
+    const matches = adjacentToClusters(photo, albums[i], albums[i + 1])
+    if (matches.length > 0) {
+      return matches
+    }
+  }
+  return []
+}

--- a/src/photos/ducks/clustering/matching.spec.js
+++ b/src/photos/ducks/clustering/matching.spec.js
@@ -1,0 +1,105 @@
+import { matchingClusters } from './matching'
+
+const photos = [
+  {
+    _id: 'photo1',
+    name: 'photo1',
+    datetime: '2018-07-17T15:13:09+02:00',
+    timestamp: 425509.2191666667
+  },
+  {
+    _id: 'photo2',
+    name: 'photo2',
+    datetime: '2018-07-17T15:14:09+02:00',
+    timestamp: 425509.23583333334
+  },
+  {
+    _id: 'photo3',
+    name: 'photo3',
+    datetime: '2018-12-17T15:13:09+02:00',
+    timestamp: 429181.2191666667
+  }
+]
+
+describe('auto albums', () => {
+  it('Should match existing clusters with same date', () => {
+    const existingAlbums = [
+      {
+        _id: 'album1',
+        name: '2018-12-17T15:13:09+02:00',
+        period: {
+          start: '2018-12-17T15:13:09+02:00',
+          end: '2018-12-17T15:13:09+02:00'
+        }
+      },
+      {
+        _id: 'album2',
+        name: '2018-07-17T15:13:09+02:00',
+        period: {
+          start: '2018-07-17T15:13:09+02:00',
+          end: '2018-07-17T15:14:09+02:00'
+        }
+      }
+    ]
+    let matching = matchingClusters(photos[0], existingAlbums)
+    expect(matching.length).toEqual(1)
+    expect(matching[0]).toEqual(existingAlbums[1])
+
+    matching = matchingClusters(photos[1], existingAlbums)
+    expect(matching.length).toEqual(1)
+    expect(matching[0]).toEqual(existingAlbums[1])
+
+    matching = matchingClusters(photos[2], existingAlbums)
+    expect(matching.length).toEqual(1)
+    expect(matching[0]).toEqual(existingAlbums[0])
+  })
+
+  it('Should match existing clusters with different dates', () => {
+    const existingAlbums = [
+      {
+        _id: 'album1',
+        name: '2019-07-17T15:13:09+02:00',
+        period: {
+          start: '2019-07-17T15:13:09+02:00',
+          end: '2019-07-17T15:14:09+02:00'
+        }
+      },
+      {
+        _id: 'album2',
+        name: '2016-12-17T15:13:09+02:00',
+        period: {
+          start: '2016-12-17T15:13:09+02:00',
+          end: '2016-12-17T15:13:09+02:00'
+        }
+      }
+    ]
+    photos.push(
+      {
+        _id: 'photo4',
+        name: 'photo4',
+        datetime: '2014-07-17T15:13:09+02:00',
+        timestamp: 390445.2191666667
+      },
+      {
+        _id: 'photo5',
+        name: 'photo5',
+        datetime: '2020-07-17T15:13:09+02:00',
+        timestamp: 478117.2191666667
+      }
+    )
+    for (let i = 0; i < 3; i++) {
+      let matching = matchingClusters(photos[i], existingAlbums)
+      expect(matching.length).toEqual(2)
+      expect(matching[0]).toEqual(existingAlbums[0])
+      expect(matching[1]).toEqual(existingAlbums[1])
+    }
+
+    let matching = matchingClusters(photos[3], existingAlbums)
+    expect(matching.length).toEqual(1)
+    expect(matching[0]).toEqual(existingAlbums[1])
+
+    matching = matchingClusters(photos[4], existingAlbums)
+    expect(matching.length).toEqual(1)
+    expect(matching[0]).toEqual(existingAlbums[0])
+  })
+})

--- a/targets/photos/services/onPhotoUpload.js
+++ b/targets/photos/services/onPhotoUpload.js
@@ -82,7 +82,7 @@ const clusterizePhotos = async (setting, photos) => {
   const params = clusteringParameters(dataset, setting)
   if (!params) {
     log('warn', 'No default parameters for clustering found')
-    return []
+    return
   }
 
   const albums = await findAutoAlbums()
@@ -90,8 +90,6 @@ const clusterizePhotos = async (setting, photos) => {
 
   // TODO save params
   // TODO adapt percentiles for large datasets
-
-  return dataset
 }
 
 const getNewPhotos = async setting => {

--- a/targets/photos/services/onPhotoUpload.js
+++ b/targets/photos/services/onPhotoUpload.js
@@ -21,40 +21,20 @@ import {
   gradientClustering,
   gradientAngle
 } from 'photos/ducks/clustering/gradient'
-import { saveClustering } from 'photos/ducks/clustering/albums'
+import {
+  saveClustering,
+  findAutoAlbums,
+  albumsToClusterize,
+  findAlbumsByIds,
+  extractPhotosInfo
+} from 'photos/ducks/clustering/albums'
 
-// Returns the photos metadata sorted by date
-const extractInfo = photos => {
-  const info = photos
-    .map(file => {
-      const photo = {
-        id: file._id,
-        name: file.name
-      }
-      if (file.metadata) {
-        photo.datetime = file.metadata.datetime
-        photo.gps = file.metadata.gps
-      } else {
-        photo.datetime = file.created_at
-      }
-      const hours = new Date(photo.datetime).getTime() / 1000 / 3600
-      photo.timestamp = hours
-      return photo
-    })
-    .sort((pa, pb) => pa.timestamp - pb.timestamp)
-
-  return info
-}
-
-// Clusterize the given photos, i.e. organize them depending on metrics
-const clusterizePhotos = async (setting, photos) => {
-  const dataset = extractInfo(photos)
+// Retrieve the parameters used to compute the clustering
+const clusteringParameters = (dataset, setting) => {
   const params = defaultParameters(setting)
   if (!params) {
-    log('warn', 'No default parameters for clustering found')
-    return []
+    return null
   }
-
   if (!params.epsTemporal) {
     params.epsTemporal = computeEpsTemporal(dataset, PERCENTILE)
   }
@@ -69,12 +49,44 @@ const clusterizePhotos = async (setting, photos) => {
   if (!params.cosAngle) {
     params.cosAngle = gradientAngle(epsMax, COARSE_COEFFICIENT)
   }
+  return params
+}
 
-  const reachs = reachabilities(dataset, spatioTemporalScaled, params)
-  const clusters = gradientClustering(dataset, reachs, params)
-  if (clusters.length > 0) {
+// Compute the actual clustering based on the new dataset and the existing albums
+const computeClusters = async (dataset, albums, params) => {
+  if (albums && albums.length > 0) {
+    const clusterize = await albumsToClusterize(dataset, albums)
+    if (clusterize) {
+      for (const [id, photos] of Object.entries(clusterize)) {
+        // TODO adapt params to the period
+        const reachs = reachabilities(photos, spatioTemporalScaled, params)
+        const clusters = gradientClustering(photos, reachs, params)
+        if (clusters.length > 0) {
+          const ids = id.split(':')
+          const albumsToSave = findAlbumsByIds(albums, ids)
+          saveClustering(clusters, albumsToSave)
+        }
+      }
+    }
+  } else {
+    // No album found: this is an initialization
+    const reachs = reachabilities(dataset, spatioTemporalScaled, params)
+    const clusters = gradientClustering(dataset, reachs, params)
     saveClustering(clusters)
   }
+}
+
+// Clusterize the given photos, i.e. organize them depending on metrics
+const clusterizePhotos = async (setting, photos) => {
+  const dataset = extractPhotosInfo(photos)
+  const params = clusteringParameters(dataset, setting)
+  if (!params) {
+    log('warn', 'No default parameters for clustering found')
+    return []
+  }
+
+  const albums = await findAutoAlbums()
+  await computeClusters(dataset, albums, params)
 
   // TODO save params
   // TODO adapt percentiles for large datasets


### PR DESCRIPTION
Each time a set of new photos are uploaded, we have to check theirs dates to determine how the clusters must be updated.
We have 4 cases for each photo : 

* The photo is more recent than the newest cluster.
* The photo is older than the oldest cluster.
* The photo is inside a current cluster.
* The photo is between 2 clusters.

 For each case, we take the relevant cluster(s) and recompute it by retrieving all its photos.