### PR TITLE
feat: Do not query auto albums

### DIFF
--- a/src/photos/ducks/albums/index.js
+++ b/src/photos/ducks/albums/index.js
@@ -13,6 +13,10 @@ export const DOCTYPE = 'io.cozy.photos.albums'
 const ALBUMS_QUERY = client =>
   client
     .find(DOCTYPE, { created_at: { $gt: null } })
+    .where({
+      auto: { $exists: false }
+    })
+    .indexFields(['created_at'])
     .include(['photos'])
     .sortBy([{ created_at: 'desc' }])
 


### PR DESCRIPTION
Filter the albums on the `auto` fields to anticipate the ones created as clusters.
The `indexFields` is useful to avoid the `auto` field to be automatically indexed, which would prevent the albums without this field to enter the index.