### PR TITLE
fix: App icon path

### DIFF
--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -5,7 +5,7 @@
   "version": "1.14.0",
   "type": "webapp",
   "licence": "AGPL-3.0",
-  "icon": "public/app-icon.svg",
+  "icon": "app-icon.svg",
   "categories": ["cozy"],
   "source": "https://github.com/cozy/cozy-drive",
   "editor": "Cozy",

--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -5,7 +5,7 @@
   "version": "1.14.0",
   "type": "webapp",
   "licence": "AGPL-3.0",
-  "icon": "public/app-icon.svg",
+  "icon": "app-icon.svg",
   "categories": ["cozy"],
   "source": "https://github.com/cozy/cozy-drive",
   "editor": "Cozy",


### PR DESCRIPTION
With cozy-scrips, the app's icon is at the root of the built folder.