### PR TITLE
fix(drive/Mobile): IOS utf8 issue

### DIFF
--- a/src/drive/targets/mobile/config.xml
+++ b/src/drive/targets/mobile/config.xml
@@ -93,7 +93,7 @@
     <plugin name="cordova-plugin-customurlscheme" spec="~4.3.0">
         <variable name="URL_SCHEME" value="cozydrive" />
     </plugin>
-    <plugin name="cordova-plugin-localization-strings" spec="https://github.com/kelvinhokk/cordova-plugin-localization-strings.git" />
+    <plugin name="cordova-plugin-localization-strings" spec="https://github.com/cozy/cordova-plugin-localization-strings.git" />
     <plugin name="cordova-custom-config" spec="~5.0.2" />
     <plugin name="cordova-plugin-filepath" spec="1.3.0" />
     <plugin name="cordova-android-support-gradle-release" spec="2.0.1">


### PR DESCRIPTION
When reseting our iOS App, we have some encoding issues (cf https://github.com/kelvinhokk/cordova-plugin-localization-strings/issues/34) 

So we use our fork with the fix 