### PR TITLE
feat: use a MAX_DISTANCE for outliers

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -8,6 +8,7 @@ export const DEFAULT_EPS_SPATIAL = 3
 export const MIN_EPS_TEMPORAL = 3
 export const MIN_EPS_SPATIAL = 2.5
 export const PERCENTILE = 99.5
+export const MAX_DISTANCE = 24 * 7
 export const COARSE_COEFFICIENT = 1
 export const EVALUATION_THRESHOLD = 314
 

--- a/src/photos/ducks/clustering/knn.js
+++ b/src/photos/ducks/clustering/knn.js
@@ -1,5 +1,6 @@
 import { kdTree } from 'kd-tree-javascript'
 import { diffPairWise, standardDeviation, mean, quantile } from './maths'
+import { MAX_DISTANCE } from './consts'
 
 export default class KNN {
   /**
@@ -24,8 +25,9 @@ export default class KNN {
   }
 
   excludeOutliers(distances, percentile) {
-    const boundValue = quantile(distances, percentile)
-    return distances.filter(distance => distance <= boundValue)
+    const filtered = distances.filter(d => d < MAX_DISTANCE)
+    const boundValue = quantile(filtered, percentile)
+    return filtered.filter(distance => distance <= boundValue)
   }
 
   /**

--- a/src/photos/ducks/clustering/service.js
+++ b/src/photos/ducks/clustering/service.js
@@ -51,8 +51,8 @@ const computeEps = (dataset, metric, dimensions, percentile) => {
   const neighbors = knn.kNeighbors(dataset)
 
   // Extract the sorted distances and remove outliers
-  const distances = neighbors.map(n => n.distance).sort((a, b) => a - b)
-  knn.excludeOutliers(distances, percentile)
+  let distances = neighbors.map(n => n.distance).sort((a, b) => a - b)
+  distances = knn.excludeOutliers(distances, percentile)
 
   // Compute the optimal eps for the given criterion
   return knn.epsSignificativeSlope(distances)

--- a/src/photos/ducks/clustering/service.js
+++ b/src/photos/ducks/clustering/service.js
@@ -30,7 +30,8 @@ export const computeEpsTemporal = (dataset, percentile) => {
 }
 
 export const computeEpsSpatial = (dataset, percentile) => {
-  const epsSpatial = computeEps(dataset, spatial, ['lat', 'lon'], percentile)
+  const gpsDataset = dataset.filter(d => d.lat && d.lon)
+  const epsSpatial = computeEps(gpsDataset, spatial, ['lat', 'lon'], percentile)
   return epsSpatial >= MIN_EPS_SPATIAL ? epsSpatial : MIN_EPS_SPATIAL
 }
 

--- a/src/photos/ducks/clustering/service.spec.js
+++ b/src/photos/ducks/clustering/service.spec.js
@@ -80,7 +80,7 @@ describe('knn', () => {
     expect(computeEpsTemporal(dataset)).toBeCloseTo(3.0, N_DIGITS)
   })
   it('Should compute spatial eps', () => {
-    expect(computeEpsSpatial(dataset)).toBeCloseTo(244.9352, N_DIGITS)
+    expect(computeEpsSpatial(dataset)).toBeCloseTo(11.11949, N_DIGITS)
   })
 })
 

--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -13,7 +13,8 @@ export const prepareDataset = photos => {
       }
       if (file.metadata) {
         photo.datetime = file.metadata.datetime
-        photo.gps = file.metadata.gps
+        photo.lat = file.metadata.gps ? file.metadata.gps.lat : null
+        photo.lon = file.metadata.gps ? file.metadata.gps.long : null
       } else {
         photo.datetime = file.created_at
       }

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -192,6 +192,12 @@ const onPhotoUpload = async () => {
         ? initParameters(dataset)
         : getDefaultParameters(dataset)
     setting = await createSetting(params)
+    log(
+      'info',
+      `Setting saved with ${JSON.stringify(
+        params.modes
+      )} on period ${JSON.stringify(params.period)}`
+    )
   } else {
     if (setting.evaluationCount > EVALUATION_THRESHOLD) {
       const newParams = await recomputeParameters(setting)
@@ -203,6 +209,7 @@ const onPhotoUpload = async () => {
           evaluationCount: 0
         }
         setting = await updateSetting(setting, newSetting)
+        log('info', `Setting updated with ${JSON.stringify(newParams)}`)
       }
     }
   }


### PR DESCRIPTION
Some large dataset performed badly for the parameters estimation because of noise data (in this context, 2 photos taken in distant dates). 
We fix that by adding a `MAX_DISTANCE` constant, beyond which a distance is not used for the computation.