### PR TITLE
fix(Sharings): Remove underline on path on hover

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -353,6 +353,11 @@ mime-types('fil-file-', '../assets/icons/')
     .fil-file-infos
         display block
 
+    .fil-file-path
+        &:hover,
+        &:focus
+            text-decoration none
+
 
 .fil-content-file-action
     opacity 1


### PR DESCRIPTION
I use `+small-screen()` selector, it seems to match mobile resolutions