### PR TITLE
feat(Drive): Require DevTools during DEV

### DIFF
--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -14,7 +14,7 @@ import { configureReporter } from 'drive/lib/reporter'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
 import configureStore from 'drive/store/configureStore'
 import { schema } from 'drive/lib/doctypes'
-
+require('../../../lib/initHelper')
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset

--- a/src/lib/initHelper.js
+++ b/src/lib/initHelper.js
@@ -1,0 +1,3 @@
+if (process.env.NODE_ENV === 'development') {
+  require('preact/debug')
+}


### PR DESCRIPTION
This is just a POC to have access to the React Dev Tools panel. 

But I want to discuss about a more global subject.

We've several entry points with Drive / Photos and we need to do the same thing several times. 

How can we have some kind pf mutualisation here? Should we create a DriveWrapper to wrap IconSprite / devtools and so on?


PS : If you want to crash your browser, do not hesitate to enable React dev tools highlights :D 