### PR TITLE
feat: Add dummy trigger declaration

### DIFF
--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -39,6 +39,14 @@
       "public": true
     }
   },
+  "services": {
+    "onPhotoUpload": {
+      "type": "node",
+      "file": "services/onPhotoUpload/photos.js",
+      "trigger": "@event io.cozy.clusters.dummy",
+      "debounce": "1s"
+    }
+  },
   "permissions": {
     "files": {
       "description": "Required for photo access",

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -175,6 +175,8 @@ const recomputeParameters = async setting => {
 }
 
 const onPhotoUpload = async () => {
+  log('info', `Service called with COZY_URL: ${process.env.COZY_URL}`)
+
   let setting = await readSetting()
   const lastSeq = setting ? setting.lastSeq : 0
 


### PR DESCRIPTION
Add a trigger declaration on a fake doctype to be able to manually launch it through the cozy-stack CLI.
This is a temporary workaround to test the clustering without impacting anything else.