### PR TITLE
[WIP] fix: AndroidLaunchMode to singleInstance

### DIFF
--- a/src/drive/targets/mobile/config.xml
+++ b/src/drive/targets/mobile/config.xml
@@ -15,6 +15,7 @@
     <platform name="android">
         <preference name="StatusBarBackgroundColor" value="#D6D8DA" />
         <preference name="AndroidPersistentFileLocation" value="Compatibility" />
+        <preference name="AndroidLaunchMode" value="singleInstance" />
         <allow-intent href="market:*" />
         <custom-config-file parent="./application/activity/[@android:name='MainActivity']" target="AndroidManifest.xml">
             <intent-filter android:label="Cozy Drive">


### PR DESCRIPTION
Il faut que je regarde si on utilise des Intent quelque part car ça va avoir des répercutions. 

Mais ici ça corrige le fait que : 

- Si on partage un fichier vers Drive, alors on utilise une seule et unique instance de Drive. 

