### PR TITLE
fix: Query albums without created_at

### DIFF
--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -10,16 +10,15 @@ import { Alerter } from 'cozy-ui/react/'
 import Loading from '../../components/Loading'
 
 import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
-
 const ALBUMS_QUERY = client =>
   client
-    .find(DOCTYPE_ALBUMS, { created_at: { $gt: null } })
+    .find(DOCTYPE_ALBUMS)
     .where({
       auto: { $exists: false }
     })
-    .indexFields(['created_at'])
+    .indexFields(['name'])
     .include(['photos'])
-    .sortBy([{ created_at: 'desc' }])
+    .sortBy([{ name: 'desc' }])
 
 export const ALBUM_QUERY = (client, ownProps) =>
   client.get(DOCTYPE_ALBUMS, ownProps.router.params.albumId).include(['photos'])


### PR DESCRIPTION
The current albums query use an index on `created_at`.
However, some albums don't have this field, making them disappear from the user perspective. 
As a workaround, this PR uses an index on the name (which always exists), but does not change the UX, as the sort on the `created_at` is already [performed later](https://github.com/cozy/cozy-drive/blob/master/src/photos/ducks/albums/components/AlbumsList.jsx#L11-L17) . This is a bit sub-optimal, but should not have a big impact, as we do not expect thousands of manual albums.