### PR TITLE
fix: Redirect on public pages

### DIFF
--- a/src/drive/web/modules/public/LightFolderView.jsx
+++ b/src/drive/web/modules/public/LightFolderView.jsx
@@ -75,7 +75,7 @@ class DumbFolderView extends React.Component {
       <Main>
         <Topbar>
           <Breadcrumb isPublic />
-          <PublicToolbar files={[this.props.displayedFolder]} />
+          <PublicToolbar files={[this.props.displayedFolder]} isFile={false} />
         </Topbar>
         <Content>
           <FileList

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -19,7 +19,7 @@ import DownloadIcon from 'drive/assets/icons/icon-download-16.svg'
 
 const { BarRight } = cozy.bar
 
-const DownloadFilesButton = ({ t, onDownload, size = 'normal', isFile }) => (
+const DownloadFilesButton = ({ t, onDownload, size, isFile }) => (
   <DownloadButton
     label={
       isFile
@@ -32,6 +32,12 @@ const DownloadFilesButton = ({ t, onDownload, size = 'normal', isFile }) => (
     size={size}
   />
 )
+DownloadFilesButton.propTypes = {
+  t: PropTypes.func.isRequired,
+  onDownload: PropTypes.func.isRequired,
+  isFile: PropTypes.bool.isRequired,
+  size: PropTypes.oneOf(['tiny', 'small', 'large'])
+}
 
 const MoreMenu = ({ t, onDownload, onOpenInCozy, onCreateCozy, isFile }) => (
   <Menu
@@ -61,7 +67,19 @@ const MoreMenu = ({ t, onDownload, onOpenInCozy, onCreateCozy, isFile }) => (
     </MenuItem>
   </Menu>
 )
+MoreMenu.propTypes = {
+  t: PropTypes.func.isRequired,
+  onDownload: PropTypes.func.isRequired,
+  onOpenInCozy: PropTypes.func,
+  onCreateCozy: PropTypes.func,
+  isFile: PropTypes.bool.isRequired
+}
 
+const toolbarProptypes = {
+  onDownload: PropTypes.func.isRequired,
+  discoveryLink: PropTypes.string,
+  isFile: PropTypes.bool.isRequired
+}
 const openExternalLink = url => (window.location = url)
 
 const MobileToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
@@ -81,6 +99,7 @@ const MobileToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
     />
   </BarRight>
 )
+MobileToolbar.propTypes = toolbarProptypes
 
 const CozybarToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
   <BarRight>
@@ -99,6 +118,7 @@ const CozybarToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
     </div>
   </BarRight>
 )
+CozybarToolbar.propTypes = toolbarProptypes
 
 const DesktopToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
   <div className={toolbarstyles['fil-toolbar-files']} role="toolbar">
@@ -113,6 +133,7 @@ const DesktopToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
     </BarRight>
   </div>
 )
+DesktopToolbar.propTypes = toolbarProptypes
 
 class PublicToolbar extends React.Component {
   state = {

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -1,7 +1,6 @@
 /* global cozy */
 import React from 'react'
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
 
@@ -63,20 +62,21 @@ const MoreMenu = ({ t, onDownload, onOpenInCozy, onCreateCozy, isFile }) => (
   </Menu>
 )
 
-const MobileToolbar = (
-  { onDownload, discoveryLink, redirectTo, isFile },
-  { t }
-) => (
+const openExternalLink = url => (window.location = url)
+
+const MobileToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
   <BarRight>
     <MoreMenu
       isFile={isFile}
       t={t}
       onDownload={onDownload}
-      onOpenInCozy={discoveryLink ? () => redirectTo(discoveryLink) : false}
+      onOpenInCozy={
+        discoveryLink ? () => openExternalLink(discoveryLink) : false
+      }
       onCreateCozy={
         discoveryLink
           ? false
-          : () => redirectTo(getHomeLinkHref('sharing-drive'))
+          : () => openExternalLink(getHomeLinkHref('sharing-drive'))
       }
     />
   </BarRight>
@@ -143,10 +143,6 @@ class PublicToolbar extends React.Component {
     }
   }
 
-  redirectTo(url) {
-    this.props.router.push(url)
-  }
-
   downloadFiles = () => {
     this.props.onDownload(this.props.files)
   }
@@ -164,7 +160,6 @@ class PublicToolbar extends React.Component {
         <MobileToolbar
           onDownload={this.downloadFiles}
           discoveryLink={discoveryLink}
-          redirectTo={this.redirectTo}
           isFile={isFile}
         />
       )
@@ -200,4 +195,4 @@ const mapDispatchToProps = dispatch => ({
 export default connect(
   null,
   mapDispatchToProps
-)(withBreakpoints()(withRouter(PublicToolbar)))
+)(withBreakpoints()(PublicToolbar))


### PR DESCRIPTION
We were using the react router to open URLs on the public page, but:

- [we don't always have a router in the public page](https://github.com/y-lohse/cozy-drive/blob/share-redirect/src/drive/targets/public/index.jsx#L93)
- `router.push` is meant for routes that are part of the app, but here we redirect to completely different pages, so `window.location` is more appropriate