### PR TITLE
Upload PR code to artefact server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ jobs:
         - <<: *deploy
           on:
             tags: true
+      after_success:
+        - *downcloud-cert
+        - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then node scripts/downcloud.js build/$COZY_APP_SLUG; fi
     - <<: *build-web
       name: 'Photos web'
       env:

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "replace": "1.0.0",
     "splashicon-generator": "0.2.12",
     "stylint": "1.5.9",
+    "tar": "^4.4.8",
     "testcafe": "^0.23.3"
   },
   "dependencies": {

--- a/scripts/downcloud.js
+++ b/scripts/downcloud.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs-extra')
 const path = require('path')
+const tar = require('tar')
 const { spawn } = require('child_process')
 
 const DOWNCLOUD_UPLOAD_DIR = 'www-upload/'
@@ -25,9 +26,29 @@ const launchCmd = (cmd, params, options) => {
   })
 }
 
-const pushArchive = async (fileName, parentFolder, options) => {
+const createArchive = async (folderName, archiveFileName) => {
+  console.log(`↳ ℹ️  Creating archive ${folderName}/${archiveFileName}`)
+  const fileList = await fs.readdir(folderName)
+  const options = {
+    gzip: true,
+    cwd: folderName,
+    file: folderName + '/' + archiveFileName
+  }
+  try {
+    await tar.c(options, fileList)
+  } catch (error) {
+    console.error(
+      `↳ ❌ Unable to generate app archive. Is tar installed as a dependency ? Error : ${
+        error.message
+      }`
+    )
+    throw new Error('Unable to generate archive')
+  }
+}
+
+const pushArtifact = async (fileName, parentFolder, options) => {
   const { appSlug, appVersion, buildCommit } = options
-  console.log(`↳ ℹ️  Sending archive to downcloud`)
+  console.log(`↳ ℹ️  Sending artifact to downcloud`)
   const folder = `${appSlug}/mobile/${appVersion}${
     buildCommit ? `-${buildCommit}` : ''
   }/`
@@ -67,34 +88,38 @@ const pushArchive = async (fileName, parentFolder, options) => {
   }
 }
 
+const getUploadTarget = async () => {
+  const uploadTarget = process.argv[2]
+
+  if (!fs.existsSync(uploadTarget)) {
+    throw new Error(`❌ ${uploadTarget} does not exist.`)
+  }
+  else if (fs.lstatSync(uploadTarget).isDirectory()) {
+    const appName = process.env.COZY_APP_SLUG || 'app'
+    const archiveFileName = `${appName.toLowerCase()}.tar.gz`
+    await createArchive(uploadTarget, archiveFileName)
+
+    return [uploadTarget, archiveFileName]
+  }
+  else {
+    const uploadDir = path.dirname(uploadTarget)
+    const uploadFile = path.basename(uploadTarget)
+
+    return [uploadDir, uploadFile]
+  }
+}
+
 const run = (async () => {
   try {
-    const uploadTarget = process.argv[2]
+    const [uploadDir, uploadFile] = await getUploadTarget()
+    const { version } = require('../package.json')
 
-    if (!fs.existsSync(uploadTarget)) {
-      console.error(`↳ ❌ ${uploadTarget} does not exist.`)
-      process.exit(1)
-    }
-    else {
-      if (fs.lstatSync(uploadTarget).isDirectory()) {
-        console.error(`↳ ❌ ${uploadTarget} is a directory.`)
-        //@TODO: turn the directory into an archive and upload it, see https://github.com/cozy/cozy-libs/blob/master/packages/cozy-app-publish/lib/hooks/pre/downcloud.js#L113
-        process.exit(1)
-      }
-      const uploadDir = path.dirname(uploadTarget)
-      const uploadFile = path.basename(uploadTarget)
-
-      const { version } = require('../package.json')
-
-      const { appBuildUrl } = await pushArchive(uploadFile, uploadDir, {
-        appSlug: process.env.COZY_APP_SLUG,
-        appVersion: version,
-        buildCommit: process.env.TRAVIS_COMMIT
-      })
-      console.log(`↳ ✅ Upload complete, APK available at ${appBuildUrl}`)
-
-    }
-
+    const { appBuildUrl } = await pushArtifact(uploadFile, uploadDir, {
+      appSlug: process.env.COZY_APP_SLUG,
+      appVersion: version,
+      buildCommit: process.env.TRAVIS_COMMIT
+    })
+    console.log(`↳ ✅ Upload complete, artifact available at ${appBuildUrl}`)
   }
   catch (error) {
     console.error(`↳ ❌  Error while uploading: ${error.message}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -14601,7 +14601,7 @@ tar@2.2.1, tar@^2.0.0, tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^4:
+tar@^4, tar@^4.4.8:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
   integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==


### PR DESCRIPTION
This PR uploads the app as it is in a pull request to downcloud. Later we'll be able to use the URL of the archive to install the app on a cozy and run tests on it.

It's very similar to what we do in a regular `deploy` step, except we're not creating a release.