### PR TITLE
[POC][WIP] feat(Viewer): Use pdf.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "react-dropzone": "4.3.0",
     "react-markdown": "3.4.1",
     "react-measure": "2.2.4",
+    "react-pdf-js": "^4.0.2",
     "react-redux": "5.0.7",
     "react-router": "3.2.0",
     "react-tooltip": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "react-dropzone": "4.3.0",
     "react-markdown": "3.4.1",
     "react-measure": "2.2.4",
+    "react-pdf": "3.0.6",
     "react-pdf-js": "^4.0.2",
     "react-redux": "5.0.7",
     "react-router": "3.2.0",

--- a/src/viewer/PdfJsViewer.jsx
+++ b/src/viewer/PdfJsViewer.jsx
@@ -1,0 +1,84 @@
+import React, { Component } from 'react'
+import PDF from 'react-pdf-js'
+import withFileUrl from './withFileUrl'
+
+class PdfJsViewer extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {}
+  }
+  onDocumentComplete = pages => {
+    this.setState({ page: 1, pages })
+  }
+
+  handlePrevious = () => {
+    this.setState({ page: this.state.page - 1 })
+  }
+
+  handleNext = () => {
+    this.setState({ page: this.state.page + 1 })
+  }
+
+  renderPagination = (page, pages) => {
+    let previousButton = (
+      <li className="previous" onClick={this.handlePrevious}>
+        <a href="#">
+          <i className="fa fa-arrow-left" /> Previous
+        </a>
+      </li>
+    )
+    if (page === 1) {
+      previousButton = (
+        <li className="previous disabled">
+          <a href="#">
+            <i className="fa fa-arrow-left" /> Previous
+          </a>
+        </li>
+      )
+    }
+    let nextButton = (
+      <li className="next" onClick={this.handleNext}>
+        <a href="#">
+          Next <i className="fa fa-arrow-right" />
+        </a>
+      </li>
+    )
+    if (page === pages) {
+      nextButton = (
+        <li className="next disabled">
+          <a href="#">
+            Next <i className="fa fa-arrow-right" />
+          </a>
+        </li>
+      )
+    }
+    return (
+      <nav>
+        <ul className="pager">
+          {previousButton}
+          {nextButton}
+        </ul>
+      </nav>
+    )
+  }
+
+  render() {
+    const { url } = this.props
+    let pagination = null
+    if (this.state.pages) {
+      pagination = this.renderPagination(this.state.page, this.state.pages)
+    }
+    return (
+      <div>
+        <PDF
+          file={url}
+          onDocumentComplete={this.onDocumentComplete}
+          page={this.state.page}
+        />
+        {pagination}
+      </div>
+    )
+  }
+}
+
+export default withFileUrl(PdfJsViewer)

--- a/src/viewer/PdfJsViewer.jsx
+++ b/src/viewer/PdfJsViewer.jsx
@@ -1,81 +1,89 @@
 import React, { Component } from 'react'
-import PDF from 'react-pdf-js'
+import { Document, Page } from 'react-pdf'
 import withFileUrl from './withFileUrl'
+import Spinner from 'cozy-ui/react/Spinner'
+import styles from './styles'
+import cx from 'classnames'
+import { Button } from 'cozy-ui/react'
 
 class PdfJsViewer extends Component {
   constructor(props) {
     super(props)
-    this.state = {}
-  }
-  onDocumentComplete = pages => {
-    this.setState({ page: 1, pages })
-  }
-
-  handlePrevious = () => {
-    this.setState({ page: this.state.page - 1 })
-  }
-
-  handleNext = () => {
-    this.setState({ page: this.state.page + 1 })
-  }
-
-  renderPagination = (page, pages) => {
-    let previousButton = (
-      <li className="previous" onClick={this.handlePrevious}>
-        <a href="#">
-          <i className="fa fa-arrow-left" /> Previous
-        </a>
-      </li>
-    )
-    if (page === 1) {
-      previousButton = (
-        <li className="previous disabled">
-          <a href="#">
-            <i className="fa fa-arrow-left" /> Previous
-          </a>
-        </li>
-      )
+    this.state = {
+      totalPages: 1,
+      scale: 1,
+      currentPage: 1,
+      loaded: false,
     }
-    let nextButton = (
-      <li className="next" onClick={this.handleNext}>
-        <a href="#">
-          Next <i className="fa fa-arrow-right" />
-        </a>
-      </li>
-    )
-    if (page === pages) {
-      nextButton = (
-        <li className="next disabled">
-          <a href="#">
-            Next <i className="fa fa-arrow-right" />
-          </a>
-        </li>
-      )
-    }
-    return (
-      <nav>
-        <ul className="pager">
-          {previousButton}
-          {nextButton}
-        </ul>
-      </nav>
-    )
+    this.onLoadSuccess = this.onLoadSuccess.bind(this)
+    this.nextPage = this.nextPage.bind(this)
+    this.previousPage = this.previousPage.bind(this)
+    this.scaleUp = this.scaleUp.bind(this)
+    this.scaleDown = this.scaleDown.bind(this)
+  }
+
+  async onLoadSuccess ({ numPages }) {
+    this.setState({
+      totalPages: numPages,
+      loaded: true
+    })
+  }
+
+  nextPage () {
+    this.setState(state => ({
+      currentPage: Math.min(state.currentPage + 1, state.totalPages)
+    }))
+  }
+
+  previousPage () {
+    this.setState(state => ({
+      currentPage: Math.max(state.currentPage - 1, 1)
+    }))
+  }
+
+  scaleUp () {
+    this.setState(state => ({
+      scale: Math.min(state.scale + .25, 3)
+    }))
+  }
+
+  scaleDown () {
+    this.setState(state => ({
+      scale: Math.max(state.scale - .25, .25)
+    }))
   }
 
   render() {
     const { url } = this.props
-    let pagination = null
-    if (this.state.pages) {
-      pagination = this.renderPagination(this.state.page, this.state.pages)
-    }
+    const { loaded, totalPages, currentPage, scale } = this.state
+
     return (
-      <div>
-        <PDF
+      <div
+        data-test-id="viewer-pdf"
+        className={styles['pho-viewer-pdfviewer']}
+      >
+        <Document
           file={url}
-          onDocumentComplete={this.onDocumentComplete}
-          page={this.state.page}
-        />
-        {pagination}
+          onLoadSuccess={this.onLoadSuccess}
+          className={styles['pho-viewer-pdfviewer-pdf']}
+          loading={<Spinner size="xxlarge" middle noMargin color="white" />}
+          error={"error"}
+        >
+          <Page pageNumber={currentPage} scale={scale} />
+        </Document>
+        { loaded &&
+          <div className={cx(styles['pho-viewer-pdfviewer-toolbar'], 'u-p-half')}>
+            <span className="u-mh-1">
+              <Button iconOnly subtle theme="secondary" className="u-p-half u-m-half" icon="top" onClick={this.previousPage} />
+              {currentPage}/{totalPages}
+              <Button iconOnly subtle theme="secondary" className="u-p-half u-m-half" icon="bottom" onClick={this.nextPage} />
+            </span>
+            <span className="u-mh-half">
+              <Button iconOnly subtle theme="secondary" className="u-p-half u-m-half" icon="dash" onClick={this.scaleDown} />
+              <Button iconOnly subtle theme="secondary" className="u-p-half u-m-half" icon="plus" onClick={this.scaleUp} />
+            </span>
+          </div>
+        }
       </div>
     )
   }

--- a/src/viewer/PdfViewer.jsx
+++ b/src/viewer/PdfViewer.jsx
@@ -5,21 +5,23 @@ import withFileUrl from './withFileUrl'
 import styles from './styles'
 import { isIOS } from 'cozy-device-helper'
 
-const PdfViewer = ({ file, url }) => (
-  <div
-    data-test-id="viewer-pdf"
-    className={cx(styles['pho-viewer-pdfviewer'], {
-      [styles['pho-viewer-pdfviewer-ios']]: isIOS()
-    })}
-  >
-    <object
-      data={url}
-      type="application/pdf"
-      className="vui-fileviewer-pdf-native"
+const PdfViewer = ({ file, url }) => {
+  return (
+    <div
+      data-test-id="viewer-pdf"
+      className={cx(styles['pho-viewer-pdfviewer'], {
+        [styles['pho-viewer-pdfviewer-ios']]: isIOS()
+      })}
     >
-      <NoViewer file={file} fallbackUrl={url} />
-    </object>
-  </div>
-)
+      <object
+        data={url}
+        type="application/pdf"
+        className="vui-fileviewer-pdf-native"
+      >
+        <NoViewer file={file} fallbackUrl={url} />
+      </object>
+    </div>
+  )
+}
 
 export default withFileUrl(PdfViewer)

--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -7,6 +7,7 @@ import AudioViewer from './AudioViewer'
 import VideoViewer from './VideoViewer'
 import PdfViewer from './PdfViewer'
 import NativePdfViewer from './NativePdfViewer'
+import TextViewer from './TextViewer'
 import NoViewer from './NoViewer'
 import PdfJsViewer from './PdfJsViewer'
 import Spinner from 'cozy-ui/react/Spinner'
@@ -100,7 +101,8 @@ export default class Viewer extends Component {
     const hasPrevious = currentIndex > 0
     const hasNext = currentIndex < fileCount - 1
     // this `expanded` property makes the next/previous controls cover the displayed image
-    const expanded = currentFile && currentFile.class === 'image'
+    // const expanded = currentFile && currentFile.class === 'image'
+    const expanded = true
     return (
       <ViewerWrapper
         style={style}

--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -7,9 +7,8 @@ import AudioViewer from './AudioViewer'
 import VideoViewer from './VideoViewer'
 import PdfViewer from './PdfViewer'
 import NativePdfViewer from './NativePdfViewer'
-import TextViewer from './TextViewer'
 import NoViewer from './NoViewer'
-
+import PdfJsViewer from './PdfJsViewer'
 import Spinner from 'cozy-ui/react/Spinner'
 
 import styles from './styles'
@@ -143,7 +142,8 @@ export default class Viewer extends Component {
       case 'video':
         return isMobile() ? NoViewer : VideoViewer
       case 'pdf':
-        return isMobileApp() ? NativePdfViewer : PdfViewer
+        return PdfJsViewer
+        // return isMobileApp() ? NativePdfViewer : PdfViewer
       case 'text':
         return isPlainText(file.mime, file.name) ? TextViewer : NoViewer
       default:

--- a/src/viewer/ViewerControls.jsx
+++ b/src/viewer/ViewerControls.jsx
@@ -77,8 +77,6 @@ class ViewerControls extends Component {
     const { hidden } = this.state
     const { client } = this.context
 
-    const isPDF = currentFile.class === 'pdf'
-
     return (
       <div
         data-test-id="pho-viewer-controls"
@@ -107,7 +105,7 @@ class ViewerControls extends Component {
                 styles['pho-viewer-toolbar-actions']
               )}
             >
-              {!isPDF &&
+              {
                 !isMobile && (
                   <Button
                     data-test-id="viewer-toolbar-download"

--- a/src/viewer/styles.styl
+++ b/src/viewer/styles.styl
@@ -3,6 +3,19 @@
 @require 'settings/palette.styl'
 @require 'settings/z-index.styl'
 
+.pho-viewer-pdfviewer
+  position:  relative;
+  height: 100%;
+.pho-viewer-pdfviewer-pdf
+  overflow-y: auto;
+
+.pho-viewer-pdfviewer-toolbar
+  position: absolute;
+  bottom: 2rem;
+  background: charcoalGrey;
+  color: white;
+  z-index: $modal-index + 2
+
 // TODO: this is an overlay, we should use cozy-ui/react/Overlay
 .pho-viewer-wrapper
     position        fixed
@@ -138,10 +151,6 @@
     .pho-viewer-filename
         max-width     90%
         text-overflow ellipsis
-.pho-viewer-pdfviewer-ios
-    object
-        background none
-        background-color #ffffff //needed for PDF only on Safari Mobile
 .pho-viewer-imageviewer
 .pho-viewer-nav + .pho-viewer-pdfviewer
 .pho-viewer-nav + .pho-viewer-noviewer
@@ -185,10 +194,6 @@
 
 .pho-viewer-textviewer:before
   height 2rem
-
-.pho-viewer-pdfviewer .pho-viewer-noviewer
-    background charcoalGrey
-    height 100%
 
 .pho-viewer-canceled
     &:before

--- a/yarn.lock
+++ b/yarn.lock
@@ -9422,7 +9422,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.1:
+loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -10437,6 +10437,11 @@ node-cache@^4.1.1:
   dependencies:
     clone "2.x"
     lodash "4.x"
+
+node-ensure@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
+  integrity sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=
 
 node-fetch-npm@^2.0.2:
   version "2.0.2"
@@ -11567,6 +11572,14 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pdfjs-dist@2.0.943:
+  version "2.0.943"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz#32fb9a2d863df5a1d89521a0b3cd900c16e7edde"
+  integrity sha512-iLhNcm4XceTHRaSU5o22ZGCm4YpuW5+rf4+BJFH/feBhMQLbCGBry+Jet8Q419QDI4qgARaIQzXuiNrsNWS8Yw==
+  dependencies:
+    node-ensure "^0.0.0"
+    worker-loader "^2.0.0"
 
 pdfjs@2.1.0:
   version "2.1.0"
@@ -12805,6 +12818,13 @@ react-measure@2.2.4:
     prop-types "^15.6.2"
     resize-observer-polyfill "^1.5.0"
 
+react-pdf-js@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-pdf-js/-/react-pdf-js-4.0.2.tgz#57cb9294fbdb72eb64c9c2eabd73c53d91b397ca"
+  integrity sha512-6IWHYatHSMfmTc/kwfr7KTNUU+Z/oyztgxoSXQIo4ZBmDhprTRtM+uXEpPEuR+qLFF/StssHN+Oo7vFVdkQIFg==
+  dependencies:
+    pdfjs-dist "2.0.943"
+
 react-redux@5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
@@ -13873,7 +13893,7 @@ scheduler@^0.12.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@^0.4.4:
+schema-utils@^0.4.0, schema-utils@^0.4.4:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -16642,6 +16662,14 @@ worker-farm@^1.5.2:
   integrity sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==
   dependencies:
     errno "~0.1.7"
+
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"
 
 wrap-ansi@^2.0.0, wrap-ansi@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9583,6 +9583,11 @@ lodash.omitby@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
   integrity sha1-XBX/R1StVVAWtTwEExHo8HkgR5E=
 
+lodash.once@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
 lodash.pad@^4.1.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash.pad/-/lodash.pad-4.5.1.tgz#4330949a833a7c8da22cc20f6a26c4d59debba70"
@@ -9899,6 +9904,11 @@ memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
   integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
+merge-class-names@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/merge-class-names/-/merge-class-names-1.1.1.tgz#3bd2f38eb5418c464a0fef615484fdf6c8932256"
+  integrity sha512-+UUWBUoFw9QLY/UlBKU/xk9h6OhyG3BUDDuF2eIJcxmusWb/uedvNpZGkysqMw5b/ds+wkX7NJTDSdUuRsCNyA==
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -11573,6 +11583,14 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pdfjs-dist@2.0.305:
+  version "2.0.305"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.305.tgz#53b0f9805ae101d7ef742d020d03578ee9781b06"
+  integrity sha1-U7D5gFrhAdfvdC0CDQNXjul4GwY=
+  dependencies:
+    node-ensure "^0.0.0"
+    worker-loader "^1.1.0"
+
 pdfjs-dist@2.0.943:
   version "2.0.943"
   resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz#32fb9a2d863df5a1d89521a0b3cd900c16e7edde"
@@ -12824,6 +12842,17 @@ react-pdf-js@^4.0.2:
   integrity sha512-6IWHYatHSMfmTc/kwfr7KTNUU+Z/oyztgxoSXQIo4ZBmDhprTRtM+uXEpPEuR+qLFF/StssHN+Oo7vFVdkQIFg==
   dependencies:
     pdfjs-dist "2.0.943"
+
+react-pdf@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-3.0.6.tgz#399631e05f7057795d273d2b4809b808625b10e0"
+  integrity sha512-xdko6TTQvEfsKawJkXkp/AA6MCsnYpWHKD5JoaKbngjAsPWAw1LH+f5ImBd6yyF02nX58srwFW2Ikw7mRFubJA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    lodash.once "^4.1.1"
+    merge-class-names "^1.1.1"
+    pdfjs-dist "2.0.305"
+    prop-types "^15.6.1"
 
 react-redux@5.0.7:
   version "5.0.7"
@@ -16662,6 +16691,14 @@ worker-farm@^1.5.2:
   integrity sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==
   dependencies:
     errno "~0.1.7"
+
+worker-loader@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-1.1.1.tgz#920d74ddac6816fc635392653ed8b4af1929fd92"
+  integrity sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"
 
 worker-loader@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This branch was used in order to create an APK to test PDF.js on several Android devices. 

I used react-pdf-js, but with this lib we can't specify the worker url so it will not work out of the box on mobile. I had to edit the source to add `https`. There is a PR to expose a props to change that : https://github.com/mikecousins/react-pdf-js/pull/91. 

Also, it seems that we can import : 
https://github.com/mozilla/pdfjs-dist/blob/master/build/pdf.worker.js 

