### PR TITLE
chore: Use chrome for photo integration tests

### DIFF
--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -5,7 +5,7 @@ async function runRunner() {
   const runner = await tc.createRunner()
   const response = await runner
     .src(['testcafe/tests/photos_crud.js'])
-    .browsers(['firefox:headless'])
+    .browsers(['chrome:headless:emulation:cdpPort=9222 --start-maximized'])
 
     .screenshots(
       'reports/screenshots/',


### PR DESCRIPTION
Should prevent [this kind](https://travis-ci.org/cozy/cozy-drive/jobs/492082141#L1417) of error. But we should probably use the same configuration for drive and photos?