### PR TITLE
chore(travis) : Add firefox for testing photos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
       env:
         - COZY_APP_SLUG=drive
       addons:
+        firefox: latest
         apt:
           sources:
             - google-chrome


### PR DESCRIPTION
no need to 'install' firefox, just adding it in option was enough before (and that's what the [testcafe-travis tutorial](https://devexpress.github.io/testcafe/documentation/continuous-integration/travis.html) recommend)