### PR TITLE
fix(testcafe): breadcrumb and downloads

### DIFF
--- a/src/photos/components/UploadButton.jsx
+++ b/src/photos/components/UploadButton.jsx
@@ -37,7 +37,7 @@ export const UploadButton = ({
       {!inMenu && <Icon icon="upload" />}
       <span>{label}</span>
       <input
-        data-test-id="uploadButton"
+        data-test-id="upload-btn"
         type="file"
         accept="image/*"
         multiple

--- a/testcafe/tests/drive_sharing.js
+++ b/testcafe/tests/drive_sharing.js
@@ -68,6 +68,7 @@ test('Drive : Access a folder public link (desktop)', async t => {
 
   await publicDrivePage.checkActionMenuPublicDesktop()
   await t
+    .wait(3000) //!FIXME to remove after https://trello.com/c/IZfev6F1/1658-drive-public-share-impossible-de-t%C3%A9l%C3%A9charger-le-fichier is fixed
     .setNativeDialogHandler(() => true)
     .click(publicDrivePage.btnPublicDownload)
     .click(publicDrivePage.btnPublicCreateCozy)
@@ -82,6 +83,7 @@ test('Drive : Access a folder public link (mobile)', async t => {
   await publicDrivePage.waitForLoading()
   await publicDrivePage.checkActionMenuPublicMobile()
   await t
+    .wait(3000) //!FIXME to remove after https://trello.com/c/IZfev6F1/1658-drive-public-share-impossible-de-t%C3%A9l%C3%A9charger-le-fichier is fixed
     .setNativeDialogHandler(() => true)
     .click(publicDrivePage.btnPublicMobileDownload)
     .click(publicDrivePage.btnPublicMoreMenu) //need to re-open the more menu

--- a/testcafe/tests/pages/drive-model.js
+++ b/testcafe/tests/pages/drive-model.js
@@ -96,7 +96,7 @@ export default class DrivePage {
     await t
       .expect(this.contentPlaceHolder.exists)
       .notOk('Content placeholder still displayed')
-    isExistingAndVisibile(this.contentTable, 'content Table')
+    await isExistingAndVisibile(this.contentTable, 'content Table')
   }
 
   //@param {string} when : text for console.log

--- a/testcafe/tests/pages/drive-model.js
+++ b/testcafe/tests/pages/drive-model.js
@@ -52,6 +52,7 @@ export default class DrivePage {
     this.btnRemoveFolder = getElementWithTestId('fil-action-delete')
 
     //Files list
+    this.contentTable = Selector('[class*="fil-content-table"]')
     this.content_rows = Selector(
       `[class*="fil-content-row"]:not([class*="fil-content-row-head"])`
     )
@@ -90,11 +91,12 @@ export default class DrivePage {
     this.modalDeleteBtnDelete = this.modalDelete.find('button').nth(2) //REMOVE
   }
 
-  //wait for content placeholder to disapered
+  //wait for content placeholder to disapered and contenttable to appear
   async waitForLoading() {
     await t
       .expect(this.contentPlaceHolder.exists)
       .notOk('Content placeholder still displayed')
+    isExistingAndVisibile(this.contentTable, 'content Table')
   }
 
   //@param {string} when : text for console.log
@@ -136,12 +138,16 @@ export default class DrivePage {
     await isExistingAndVisibile(this.breadcrumb, 'breadcrumb')
     const childElCount = await this.breadcrumb.childElementCount
     let breadcrumbTitle = await this.breadcrumb.child(0).innerText
-    if (childElCount > 0) {
+    if (childElCount > 1) {
       for (let i = 1; i < childElCount; i++) {
-        breadcrumbTitle = `${breadcrumbTitle} > ${await this.breadcrumb.child(i)
-          .innerText}`
+        if (await this.breadcrumb.child(i).exists) {
+          breadcrumbTitle = `${breadcrumbTitle} > ${await this.breadcrumb.child(
+            i
+          ).innerText}`
+        }
       }
     }
+    breadcrumbTitle = breadcrumbTitle.replace(/(\r\n|\n|\r)/gm, '') //avoid line break problem
     return breadcrumbTitle
   }
 


### PR DESCRIPTION
- fix(testcafe): remove line break in breadcrumbEnd
When running the original test, breadbrumb was `Drive > folder....` on my computer, but `Drive\n > folder...` on thomas's. So I remove all line break from breadcrumb before using it. => This is a temporary fix, I'll need to check with Thomas to understand where the `\n`is coming from.
Also add more robust waitForLoading, so breadcrumbs don't break

- fix(drive): change Selector (seems I forgot to publish the uploadbutton fix before)

- fix(testcafe) : Add wait(3000) for download 
This fix is need for tests to pass. It will be removed after https://trello.com/c/IZfev6F1/1658-drive-public-share-impossible-de-t%C3%A9l%C3%A9charger-le-fichier is fixed