### PR TITLE
fix: Make the textviewer handle less files

### DIFF
--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -33,6 +33,10 @@ const ViewerWrapper = ({ style, className, children, fullscreen, dark }) => (
   </div>
 )
 
+export const isPlainText = (mimeType = '', fileName = '') => {
+  return mimeType ? /^text\//.test(mimeType) : /\.(txt|md)$/.test(fileName)
+}
+
 export default class Viewer extends Component {
   componentDidMount() {
     document.addEventListener('keyup', this.onKeyUp, false)
@@ -140,7 +144,7 @@ export default class Viewer extends Component {
       case 'pdf':
         return isMobileApp() ? NativePdfViewer : PdfViewer
       case 'text':
-        return TextViewer
+        return isPlainText(file.mime, file.name) ? TextViewer : NoViewer
       default:
         return NoViewer
     }

--- a/src/viewer/Viewer.spec.js
+++ b/src/viewer/Viewer.spec.js
@@ -1,0 +1,40 @@
+import { isPlainText } from './Viewer'
+
+describe('Plain text file detection', () => {
+  describe('using mime types', () => {
+    it('should match mime types starting with "text/"', () => {
+      expect(isPlainText('text/plain')).toBe(true)
+      expect(isPlainText('text/markdown')).toBe(true)
+      expect(isPlainText('application/text')).toBe(false)
+      expect(isPlainText('something/text/else')).toBe(false)
+    })
+
+    it('should not match complex text formats', () => {
+      expect(isPlainText('application/msword')).toBe(false)
+      expect(isPlainText('application/vnd.oasis.opendocument.text')).toBe(false)
+      expect(isPlainText('application/x-iwork-pages-sffpages')).toBe(false)
+    })
+
+    it('should not use the filename if a mime type is present', () => {
+      expect(isPlainText('application/msword', 'iswearitstext.txt')).toBe(false)
+    })
+  })
+  describe('using file names', () => {
+    it('should match txt files', () => {
+      expect(isPlainText(undefined, 'iswearitstext.txt')).toBe(true)
+    })
+
+    it('should match md files', () => {
+      expect(isPlainText(undefined, 'markdown.md')).toBe(true)
+    })
+
+    it('should not match anything else', () => {
+      expect(isPlainText(undefined, 'file.doc')).toBe(false)
+      expect(isPlainText(undefined, 'file.docx')).toBe(false)
+      expect(isPlainText(undefined, 'file.pages')).toBe(false)
+      expect(isPlainText(undefined, 'file.odt')).toBe(false)
+      expect(isPlainText(undefined, 'file.csv')).toBe(false)
+      expect(isPlainText(undefined, 'file.vcf')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
The `class` attribute will report `text` even for complex text formats like docx etc. I added mime type detection to narrow the file formats we display using the viewer, even though it can probably handle more than that.