### PR TITLE
fix: Prepare should also rm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "testcafe:photos": "node testcafe/runner-photos.js",
     "test": "cozy-scripts test --verbose --coverage --config=jest.config.json",
     "genicon:drive:mobile": "(cd src/drive/targets/mobile && rm -Rf ./res/icons ./res/screens && splashicon-generator --imagespath='./res/model' && cp res/model/splash.png res/screens/ios/Default@2x~universal~anyany.png)",
-    "prepare:drive:mobile": "(cd src/drive/targets/mobile && rm -rf platforms && rm -rf plugins && cordova prepare)",
+    "prepare:drive:mobile": "(cd src/drive/targets/mobile && rm -rf platforms && rm -rf plugins && rm package.json || true && rm package-lock.json || true && cordova prepare)",
     "run:drive:android": "(cd src/drive/targets/mobile && cordova run android --device)",
     "run:drive:android:emulator": "(cd src/drive/targets/mobile && cordova run android --emulator)",
     "build:drive:android": "(cd src/drive/targets/mobile && cordova build android --release)",


### PR DESCRIPTION
As `cordova` prefers our package.json instead of our config.xml, we need to remove it during the clean