### PR TITLE
chore: Build on travis for PRs and push on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ node-preset: &node # Used internally to share configuration, ignored by travis.
     yarn: true
     directories:
       - node_modules
+branches:
+  only:
+    - master
 stages:
   - prebuild
   - build


### PR DESCRIPTION
It will skip builds when pushing to other branches as they are building the same things that the pull requests, and slow down the other builds.