### PR TITLE
fix: Stop event propagation on breadcrumb

### DIFF
--- a/src/drive/web/modules/navigation/Breadcrumb.jsx
+++ b/src/drive/web/modules/navigation/Breadcrumb.jsx
@@ -100,7 +100,10 @@ export class Breadcrumb extends Component {
               return (
                 <span
                   className={styles['fil-path-link']}
-                  onClick={() => onBreadcrumbClick(folder)}
+                  onClick={e => {
+                    e.stopPropagation()
+                    onBreadcrumbClick(folder)
+                  }}
                 >
                   <span className={styles['fil-path-link-name']}>
                     {folder.name}


### PR DESCRIPTION
When clicking on a folder, we want to navigate to the folder, but we also need to stop event progation to avoid "opening" the breadcrumb and thus capturing the next click to close it.