### PR TITLE
fix: Don't crash when album is not found

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -6,6 +6,7 @@
     ".svg$": "<rootDir>/jestHelpers/mocks/iconMock.js",
     "styles": "identity-obj-proxy",
     "^drive/(.*)": "<rootDir>/src/drive/$1",
+    "^photos/(.*)": "<rootDir>/src/photos/$1",
     "^sharing(.*)": "<rootDir>/src/sharing$1",
     "^react-cozy-helpers(.*)": "<rootDir>/src/lib/react-cozy-helpers$1",
     "^components(.*)": "<rootDir>/src/components$1",

--- a/src/photos/ducks/albums/__snapshots__/index.spec.js.snap
+++ b/src/photos/ducks/albums/__snapshots__/index.spec.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Album view should show a loader 1`] = `
+<Wrapper
+  loadingType="photos_fetching"
+  middle={true}
+  size="xxlarge"
+/>
+`;
+
+exports[`Album view should show a spinner when no album can be loaded 1`] = `
+<Wrapper
+  loadingType="photos_fetching"
+  middle={true}
+  size="xxlarge"
+/>
+`;
+
+exports[`Album view should show an album when loaded 1`] = `
+<Wrapper
+  album={
+    Object {
+      "photos": Object {
+        "data": Array [],
+        "fetchMore": [MockFunction],
+        "hasMore": false,
+      },
+    }
+  }
+  fetchMore={[Function]}
+  hasMore={false}
+  photos={Array []}
+/>
+`;

--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -146,7 +146,6 @@ export const ConnectedAlbumPhotos = withRouter(props => (
             removePhotos={removePhotos}
             hasMore={album.photos.hasMore}
             fetchMore={album.photos.fetchMore.bind(album.photos)}
-            {...props}
           />
         )
       } else {

--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -130,34 +130,32 @@ const ConnectedAddToAlbumModal = props => (
   </Query>
 )
 
+export const AlbumPhotosWithLoader = (
+  { data: album, fetchStatus },
+  { updateAlbum, deleteAlbum, removePhotos }
+) => {
+  if (album && fetchStatus === 'loaded') {
+    return (
+      <AlbumPhotos
+        album={album}
+        photos={album.photos.data}
+        updateAlbum={updateAlbum}
+        deleteAlbum={deleteAlbum}
+        removePhotos={removePhotos}
+        hasMore={album.photos.hasMore}
+        fetchMore={album.photos.fetchMore.bind(album.photos)}
+      />
+    )
+  } else {
+    return (
+      <Loading size={'xxlarge'} loadingType={'photos_fetching'} middle={true} />
+    )
+  }
+}
+
 export const ConnectedAlbumPhotos = withRouter(props => (
   <Query query={ALBUM_QUERY} {...props} mutations={ALBUM_MUTATIONS}>
-    {(
-      { data: album, fetchStatus },
-      { updateAlbum, deleteAlbum, removePhotos }
-    ) => {
-      if (fetchStatus === 'loaded') {
-        return (
-          <AlbumPhotos
-            album={album}
-            photos={album.photos.data}
-            updateAlbum={updateAlbum}
-            deleteAlbum={deleteAlbum}
-            removePhotos={removePhotos}
-            hasMore={album.photos.hasMore}
-            fetchMore={album.photos.fetchMore.bind(album.photos)}
-          />
-        )
-      } else {
-        return (
-          <Loading
-            size={'xxlarge'}
-            loadingType={'photos_fetching'}
-            middle={true}
-          />
-        )
-      }
-    }}
+    {AlbumPhotosWithLoader}
   </Query>
 ))
 

--- a/src/photos/ducks/albums/index.spec.js
+++ b/src/photos/ducks/albums/index.spec.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { AlbumPhotosWithLoader } from './index'
+
+describe('Album view', () => {
+  it('should show a loader', () => {
+    const component = shallow(
+      <AlbumPhotosWithLoader data={[]} fetchStatus="loading" />
+    )
+    expect(component).toMatchSnapshot()
+  })
+
+  it('should show an album when loaded', () => {
+    const component = shallow(
+      <AlbumPhotosWithLoader
+        data={{
+          photos: {
+            data: [],
+            hasMore: false,
+            fetchMore: jest.fn()
+          }
+        }}
+        fetchStatus="loaded"
+      />
+    )
+    expect(component).toMatchSnapshot()
+  })
+
+  it('should show a spinner when no album can be loaded', () => {
+    const component = shallow(
+      <AlbumPhotosWithLoader data={null} fetchStatus="loaded" />
+    )
+    expect(component).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
When the request album is not found (because it has been deleted, or the id is wrong, or some other reason), we don't want to render it.