### PR TITLE
fix: Show album photos

### DIFF
--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -130,7 +130,7 @@ const ConnectedAddToAlbumModal = props => (
   </Query>
 )
 
-export const AlbumPhotosWithLoader = (
+export const AlbumPhotosWithLoader = ({ children }) => (
   { data: album, fetchStatus },
   { updateAlbum, deleteAlbum, removePhotos }
 ) => {
@@ -144,7 +144,9 @@ export const AlbumPhotosWithLoader = (
         removePhotos={removePhotos}
         hasMore={album.photos.hasMore}
         fetchMore={album.photos.fetchMore.bind(album.photos)}
-      />
+      >
+        {children}
+      </AlbumPhotos>
     )
   } else {
     return (
@@ -155,7 +157,9 @@ export const AlbumPhotosWithLoader = (
 
 export const ConnectedAlbumPhotos = withRouter(props => (
   <Query query={ALBUM_QUERY} {...props} mutations={ALBUM_MUTATIONS}>
-    {AlbumPhotosWithLoader}
+    {AlbumPhotosWithLoader({
+      children: props.children
+    })}
   </Query>
 ))
 

--- a/src/photos/ducks/albums/index.spec.js
+++ b/src/photos/ducks/albums/index.spec.js
@@ -3,16 +3,16 @@ import { shallow } from 'enzyme'
 import { AlbumPhotosWithLoader } from './index'
 
 describe('Album view', () => {
+  const AlbumPhotos = AlbumPhotosWithLoader({ children: null })
+
   it('should show a loader', () => {
-    const component = shallow(
-      <AlbumPhotosWithLoader data={[]} fetchStatus="loading" />
-    )
+    const component = shallow(<AlbumPhotos data={[]} fetchStatus="loading" />)
     expect(component).toMatchSnapshot()
   })
 
   it('should show an album when loaded', () => {
     const component = shallow(
-      <AlbumPhotosWithLoader
+      <AlbumPhotos
         data={{
           photos: {
             data: [],
@@ -27,9 +27,7 @@ describe('Album view', () => {
   })
 
   it('should show a spinner when no album can be loaded', () => {
-    const component = shallow(
-      <AlbumPhotosWithLoader data={null} fetchStatus="loaded" />
-    )
+    const component = shallow(<AlbumPhotos data={null} fetchStatus="loaded" />)
     expect(component).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
I previously [removed a spreaded `props`](https://github.com/cozy/cozy-drive/pull/1466/commits/c799b9cb0c817ed9a2d3c90fcdfa6d42cc978097#diff-b99860e2348055cdd5e05388380200ddL149) — most of it is react-router stuff that is unnecessary, but the `children` prop is important as it is used to render the photo viewer / photo picker.