### PR TITLE
fix: Viewer on public album

### DIFF
--- a/src/photos/targets/public/App.jsx
+++ b/src/photos/targets/public/App.jsx
@@ -14,7 +14,7 @@ import styles from './index.styl'
 import { ALBUM_QUERY } from '../../../../src/photos/ducks/albums/index'
 import ErrorUnsharedComponent from 'photos/components/ErrorUnshared'
 
-class App extends Component {
+export class App extends Component {
   onDownload = selected => {
     const photos = selected.length !== 0 ? selected : null
     this.downloadPhotos(photos)
@@ -44,8 +44,18 @@ class App extends Component {
       .downloadArchive(allPhotos.map(({ _id }) => _id), album.name)
   }
 
+  renderViewer(children) {
+    // children are injected by react-router when navigating a photo of the album
+    if (!children) return null
+    return React.Children.map(children, child =>
+      React.cloneElement(child, {
+        photos: this.props.photos
+      })
+    )
+  }
+
   render() {
-    const { album, hasMore, photos, fetchMore } = this.props
+    const { album, hasMore, photos, fetchMore, children } = this.props
 
     const { t } = this.context
     return (
@@ -69,6 +79,7 @@ class App extends Component {
                       className={styles['pho-public-download']}
                       onClick={() => this.onDownload(selected)}
                       icon="download"
+                      size="normal"
                       label={t('Toolbar.album_download')}
                     />
 
@@ -99,6 +110,7 @@ class App extends Component {
                   hasMore={hasMore}
                   fetchMore={fetchMore}
                 />
+                {this.renderViewer(children)}
               </div>
             )}
           </Selection>
@@ -114,6 +126,9 @@ App.propTypes = {
   photos: PropTypes.array.isRequired,
   fetchMore: PropTypes.func.isRequired
 }
+App.contextTypes = {
+  t: PropTypes.func
+}
 const ConnectedApp = props => (
   <Query query={ALBUM_QUERY} {...props}>
     {({ data: album, fetchStatus }) => {
@@ -127,7 +142,9 @@ const ConnectedApp = props => (
             photos={album.photos.data}
             hasMore={album.photos.hasMore}
             fetchMore={album.photos.fetchMore.bind(album.photos)}
-          />
+          >
+            {props.children}
+          </App>
         )
       } else {
         return (

--- a/src/photos/targets/public/App.spec.jsx
+++ b/src/photos/targets/public/App.spec.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { App } from './App'
+
+describe('Public view', () => {
+  const options = {
+    context: {
+      t: jest.fn()
+    }
+  }
+
+  it('should render the album', () => {
+    const app = shallow(
+      <App album={{}} hasMore={false} fetchMore={jest.fn()} photos={[]} />,
+      options
+    )
+    const selection = app.find('Selection')
+    expect(selection.dive()).toMatchSnapshot()
+  })
+
+  it('should render children when they are present', () => {
+    const app = shallow(
+      <App album={{}} hasMore={false} fetchMore={jest.fn()} photos={[1, 2, 3]}>
+        <div />
+      </App>,
+      options
+    )
+    const selection = app.find('Selection')
+    expect(selection.dive()).toMatchSnapshot()
+  })
+})

--- a/src/photos/targets/public/__snapshots__/App.spec.jsx.snap
+++ b/src/photos/targets/public/__snapshots__/App.spec.jsx.snap
@@ -1,0 +1,230 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Public view should render children when they are present 1`] = `
+<Provider
+  value={Array []}
+>
+  <div>
+    <div>
+      <div
+        className=""
+      >
+        <h2 />
+        <div
+          role="toolbar"
+        >
+          <CozyHomeLink
+            from="sharing-photos"
+            t={
+              [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "Toolbar.album_download",
+                  ],
+                  Array [
+                    "Toolbar.more",
+                  ],
+                  Array [
+                    "Toolbar.album_download",
+                  ],
+                  Array [
+                    "Toolbar.album_download",
+                  ],
+                  Array [
+                    "Toolbar.more",
+                  ],
+                  Array [
+                    "Toolbar.album_download",
+                  ],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              }
+            }
+          />
+          <Button
+            icon="download"
+            onClick={[Function]}
+            size="normal"
+            tag="button"
+            theme="secondary"
+            type="submit"
+          />
+          <Menu
+            className="u-hide--desk"
+            component={<Wrapper />}
+            disabled={false}
+            itemsStyle={Object {}}
+            onSelect={null}
+            onSelectDisabled={null}
+            popover={false}
+            position="right"
+          >
+            <MenuItem
+              icon={
+                <Icon
+                  icon="download"
+                  spin={false}
+                />
+              }
+              onSelect={[Function]}
+            />
+          </Menu>
+        </div>
+      </div>
+      <Wrapper
+        fetchMore={[MockFunction]}
+        hasMore={false}
+        lists={
+          Array [
+            Object {
+              "photos": Array [
+                1,
+                2,
+                3,
+              ],
+            },
+          ]
+        }
+        onPhotoToggle={[Function]}
+        onPhotosSelect={[Function]}
+        onPhotosUnselect={[Function]}
+        photosContext="timeline"
+        selected={Array []}
+        showSelection={false}
+      />
+      <div
+        key=".0"
+        photos={
+          Array [
+            1,
+            2,
+            3,
+          ]
+        }
+      />
+    </div>
+  </div>
+</Provider>
+`;
+
+exports[`Public view should render the album 1`] = `
+<Provider
+  value={Array []}
+>
+  <div>
+    <div>
+      <div
+        className=""
+      >
+        <h2 />
+        <div
+          role="toolbar"
+        >
+          <CozyHomeLink
+            from="sharing-photos"
+            t={
+              [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "Toolbar.album_download",
+                  ],
+                  Array [
+                    "Toolbar.more",
+                  ],
+                  Array [
+                    "Toolbar.album_download",
+                  ],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              }
+            }
+          />
+          <Button
+            icon="download"
+            onClick={[Function]}
+            size="normal"
+            tag="button"
+            theme="secondary"
+            type="submit"
+          />
+          <Menu
+            className="u-hide--desk"
+            component={<Wrapper />}
+            disabled={false}
+            itemsStyle={Object {}}
+            onSelect={null}
+            onSelectDisabled={null}
+            popover={false}
+            position="right"
+          >
+            <MenuItem
+              icon={
+                <Icon
+                  icon="download"
+                  spin={false}
+                />
+              }
+              onSelect={[Function]}
+            />
+          </Menu>
+        </div>
+      </div>
+      <Wrapper
+        fetchMore={[MockFunction]}
+        hasMore={false}
+        lists={
+          Array [
+            Object {
+              "photos": Array [],
+            },
+          ]
+        }
+        onPhotoToggle={[Function]}
+        onPhotosSelect={[Function]}
+        onPhotosUnselect={[Function]}
+        photosContext="timeline"
+        selected={Array []}
+        showSelection={false}
+      />
+    </div>
+  </div>
+</Provider>
+`;


### PR DESCRIPTION
Any idea for relevant tests? Shallow-rendering snapshot gives:

```
<div>
  <Main
    className="u-pt-1-half"
  >
    <Selection />
    <IconSprite />
  </Main>
</div>
```

…which is pretty useless. And I don't think deep-rendered snapshot are very useful to catch regressions.