### PR TITLE
chore: Match tag branches starting with a "v"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
   only:
     - master
     # tags
-    - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
+    - /^v\d+\.\d+\.\d+(\-beta.\d+)?$/
 stages:
   - prebuild
   - build


### PR DESCRIPTION
Our tags start with a `v`.