### PR TITLE
Use existing photos in clustering

### DIFF
--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -5,8 +5,8 @@ import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
  * @param {Object[]} photos - Set of photos
  * @returns {Object[]} The metadata's photos sorted by date
  */
-export const prepareDataset = (photos, albums) => {
-  const albumIds = albums ? albums.map(album => album._id) : []
+export const prepareDataset = (photos, albums = []) => {
+  const albumIds = albums.map(album => album._id)
 
   const info = photos
     .map(file => {

--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -1,9 +1,13 @@
+import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
+
 /**
  * Returns the photos metadata sorted by date
  * @param {Object[]} photos - Set of photos
  * @returns {Object[]} The metadata's photos sorted by date
  */
-export const prepareDataset = photos => {
+export const prepareDataset = (photos, albums) => {
+  const albumIds = albums ? albums.map(album => album._id) : []
+
   const info = photos
     .map(file => {
       const photo = {
@@ -20,6 +24,16 @@ export const prepareDataset = photos => {
       }
       const hours = new Date(photo.datetime).getTime() / 1000 / 3600
       photo.timestamp = hours
+      // For each photo, we need to check the clusterid, i.e. the auto-album
+      // referenced by the file. If there is none, the photo wasn't clustered before
+      if (!photo.clusterId && file.referenced_by) {
+        const ref = file.referenced_by.find(
+          ref => ref.type === DOCTYPE_ALBUMS && albumIds.includes(ref.id)
+        )
+        if (ref) {
+          photo.clusterId = ref.id
+        }
+      }
       return photo
     })
     .sort((pa, pb) => pa.timestamp - pb.timestamp)

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -56,13 +56,11 @@ const createInitialClusters = async (paramsMode, dataset) => {
 }
 
 // Clusterize the given photos, i.e. organize them depending on metrics
-const clusterizePhotos = async (setting, dataset) => {
+const clusterizePhotos = async (setting, dataset, albums) => {
   log('info', `Start clustering on ${dataset.length} photos`)
 
   let clusteredCount = 0
   try {
-    const albums = await findAutoAlbums()
-
     if (albums && albums.length > 0) {
       // Build the clusterize object, based on the dataset and existing photos
       const clusterize = await albumsToClusterize(dataset, albums)
@@ -155,8 +153,9 @@ const runClustering = async setting => {
     log('info', 'No photo found to clusterize')
     return
   }
-  const dataset = prepareDataset(changes.photos)
-  const result = await clusterizePhotos(setting, dataset)
+  const albums = await findAutoAlbums()
+  const dataset = prepareDataset(changes.photos, albums)
+  const result = await clusterizePhotos(setting, dataset, albums)
   if (!result) {
     return
   }


### PR DESCRIPTION
If new photos impact existing clusters, we need to be able to re-compute them efficiently. 
This PR deals with files having a referenced cluster (auto-album) and the building of a Map to associate clusters with existing and new photos. 