### PR TITLE
fix(OfflineFile): Upgrade fileOpener2 and remove encodeURIComponent

### DIFF
--- a/src/drive/mobile/lib/filesystem.js
+++ b/src/drive/mobile/lib/filesystem.js
@@ -22,6 +22,7 @@ export const getCozyPath = () => COZY_PATH + '/' + COZY_FILES_PATH + '/'
 export const getEntry = path =>
   new Promise((resolve, reject) => {
     window.resolveLocalFileSystemURL(path, resolve, err => {
+      // eslint-disable-next-line
       console.error(`${path} could not be resolved: ${err.message}`)
       reject(err)
     })
@@ -40,7 +41,9 @@ export const createCozyPath = () =>
 export const getDirectory = (rootDirEntry, folderName) =>
   new Promise((resolve, reject) => {
     rootDirEntry.getDirectory(folderName, { create: true }, resolve, error => {
+      // eslint-disable-next-line
       console.warn(ERROR_GET_DIRECTORY, folderName)
+      // eslint-disable-next-line
       console.warn(error)
       reject(ERROR_GET_DIRECTORY)
     })
@@ -53,7 +56,9 @@ export const writeFile = (fileEntry, dataObj) =>
         resolve(fileEntry)
       }
       fileWriter.onerror = error => {
+        // eslint-disable-next-line
         console.warn(ERROR_WRITE_FILE)
+        // eslint-disable-next-line
         console.warn(error)
         reject(ERROR_WRITE_FILE)
       }
@@ -74,7 +79,9 @@ const saveFile = (dirEntry, fileData, fileName) =>
           .catch(reject)
       },
       error => {
+        // eslint-disable-next-line
         console.warn(ERROR_GET_FILE)
+        // eslint-disable-next-line
         console.warn(error)
         reject(ERROR_GET_FILE)
       }
@@ -83,12 +90,11 @@ const saveFile = (dirEntry, fileData, fileName) =>
 
 export const openFileWithCordova = (URI, mimetype) =>
   new Promise((resolve, reject) => {
-    const decodedURI = decodeURIComponent(URI)
     const callbacks = {
       error: reject,
       success: resolve
     }
-    window.cordova.plugins.fileOpener2.open(decodedURI, mimetype, callbacks)
+    window.cordova.plugins.fileOpener2.open(URI, mimetype, callbacks)
   })
 
 export const deleteOfflineFile = async filename => {

--- a/src/drive/targets/mobile/config.xml
+++ b/src/drive/targets/mobile/config.xml
@@ -73,8 +73,8 @@
     </platform>
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="AutoHideSplashScreen" value="false" />
-    <engine name="ios" spec="^4.5.5" />
-    <engine name="android" spec="~7.1.4" />
+    <engine name="ios" spec="~4.5.5" />
+    <engine name="android" spec="^7.1.4" />
     <plugin name="cordova-plugin-splashscreen" spec="https://github.com/cozy/cordova-plugin-splashscreen#e10cadcd07b613f745370ba023ac0c52cf415648" />
     <plugin name="cordova-plugin-whitelist" spec="1.3.2" />
     <plugin name="cordova-plugin-statusbar" spec="https://github.com/cozy/cordova-plugin-statusbar#c7c7011608c9b8a1d3b0d788879198c5ad46e199" />
@@ -109,7 +109,7 @@
     <plugin name="com.lampa.startapp" spec="^0.1.4" />
     <plugin name="cordova-plugin-queries-schemes" spec="https://github.com/cozy/cordova-plugin-queries-schemes.git#f7cc50ec542d7eeab6857e366dceb2f039f5dcd9" />
     <plugin name="cordova-plugin-keyboard" spec="https://github.com/cozy/cordova-plugin-keyboard.git#4fa4850e6f0ea78e1e2ce573ccde5531a2353edb" />
-    <plugin name="cordova-plugin-file-opener2" spec="^2.1.4">
+    <plugin name="cordova-plugin-file-opener2" spec="^2.2.0">
         <variable name="ANDROID_SUPPORT_V4_VERSION" value="27.+" />
     </plugin>
 </widget>


### PR DESCRIPTION
It should fix the problem with have on iOS with our offline files. 

We don't need to `encodeURIComponent` anymore. 

See https://github.com/pwlin/cordova-plugin-file-opener2/issues/14

