### PR TITLE
fix: Safer way to check if auth should start

### DIFF
--- a/src/authentication/MobileRouter.spec.jsx
+++ b/src/authentication/MobileRouter.spec.jsx
@@ -21,6 +21,23 @@ describe('MobileRouter', () => {
     expect(app).toMatchSnapshot()
   })
 
+  it('should render the appRoutes when no onboarding informations are present', () => {
+    const app = shallow(
+      <MobileRouter
+        appRoutes={<div />}
+        isAuthenticated={true}
+        isRevoked={false}
+        onboarding={{}}
+        onboardingInformations={undefined}
+        history={{}}
+        onAuthenticated={jest.fn()}
+        onLogout={jest.fn()}
+        appIcon={''}
+      />
+    )
+    expect(app).toMatchSnapshot()
+  })
+
   it('should render the revoked view', () => {
     const app = shallow(
       <MobileRouter

--- a/src/authentication/__snapshots__/MobileRouter.spec.jsx.snap
+++ b/src/authentication/__snapshots__/MobileRouter.spec.jsx.snap
@@ -11,6 +11,15 @@ exports[`MobileRouter should render the appRoutes when all is well 1`] = `
 </Router>
 `;
 
+exports[`MobileRouter should render the appRoutes when no onboarding informations are present 1`] = `
+<Router
+  history={Object {}}
+  render={[Function]}
+>
+  <div />
+</Router>
+`;
+
 exports[`MobileRouter should render the auth screen when the onboarding has not started 1`] = `
 <Authentication
   appIcon=""

--- a/src/authentication/src/utils/onboarding.js
+++ b/src/authentication/src/utils/onboarding.js
@@ -1,4 +1,5 @@
 import localforage from 'localforage'
+import get from 'lodash/get'
 
 const ONBOARDING_SECRET_KEY = 'onboarding_secret'
 const ONBOARDING_STATE = 'onboarding_state'
@@ -38,7 +39,7 @@ const generateSecret = () => {
   return generateRandomString()
 }
 export const checkIfOnboardingLogin = onboardingInformations => {
-  return onboardingInformations.code !== null
+  return get(onboardingInformations, 'code')
 }
 
 export const generateOAuthForUrl = async ({


### PR DESCRIPTION
I'm not sure why, but in some cases the redux store does not have the default `onboardingInformations` set, and when that happens the auth module crashed.