### PR TITLE
chore: Only build APK when requested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,7 @@ jobs:
         - yarn autosign:drive:android
       after_success:
         - *downcloud-cert
-        - APK_URL=$(node scripts/downcloud.js src/drive/targets/mobile/build/android/cozy-drive.apk)
-        - scripts/github.sh "🎁 [Click here]($APK_URL) to download the latest Android APK"
+        - if [[ "$(git log -2)" =~ [\[APK\]] ]]; then APK_URL=$(node scripts/downcloud.js src/drive/targets/mobile/build/android/cozy-drive.apk) && scripts/github.sh "🎁 [Click here]($APK_URL) to download the latest Android APK"; fi
 env:
   global:
     - MATTERMOST_CHANNEL=appvengers

--- a/src/drive/targets/mobile/README.md
+++ b/src/drive/targets/mobile/README.md
@@ -112,6 +112,10 @@ You can generate all icons with [splashicon-generator](https://github.com/eberli
 $ yarn genicon:drive:mobile
 ```
 
+## :repeat: CI
+
+Travis CI can automatically build a signed APK for Pull Requests. To trigger a build, simply add the text `[APK]` somewhere in the commit message.
+
 ### Icon
 
 Should be a 1024x1024px.


### PR DESCRIPTION
Only upload an APK when a `[APK]` tag is present in the last commit message.