### PR TITLE
fix: Public page link as a button

### DIFF
--- a/src/components/Button/CozyHomeLink.jsx
+++ b/src/components/Button/CozyHomeLink.jsx
@@ -5,7 +5,6 @@ import styles from './index.styl'
 
 const CozyHomeLink = ({ from, embedInCozyBar = false, t }) => (
   <ButtonLink
-    subtle
     label={t('Share.create-cozy')}
     icon="cozy-negative"
     className={embedInCozyBar ? styles['bar-homelink'] : ''}


### PR DESCRIPTION
Changed the link to create a Cozy from the public sharing page to a button style (but it's still a link).

I hope I didn't miss any other link but according to the code it seems like this is it.

That was a very hard task to do for a morning task 😫 *`</sarcasm>`*