### PR TITLE
Visual Review : Upload screenshots, and get testcafe to fail if not accepted

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,9 +91,8 @@
     "stylint": "1.5.9",
     "tar": "4.4.8",
     "testcafe": "0.23.3",
-    "unzipper": "0.9.11"
-    "visualreview-client": "git+https://github.com/cozy/VisualReview-node-client.git"
-
+    "unzipper": "0.9.11",
+    "visualreview-client": "git+https://github.com/cozy/VisualReview-node-client.git#v0.0.2"
   },
   "dependencies": {
     "babel-preset-cozy-app": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "tar": "4.4.8",
     "testcafe": "0.23.3",
     "unzipper": "0.9.11"
+    "visualreview-client": "git+https://github.com/cozy/VisualReview-node-client.git"
+
   },
   "dependencies": {
     "babel-preset-cozy-app": "1.2.2",

--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -1,6 +1,10 @@
 const createTestCafe = require('testcafe')
+const postCommentToGithub = require('./tests/helpers/comment-on-github.js')
 
 async function runRunner() {
+  //init vrErrorMsg
+  process.env.vrErrorMsg = ''
+
   const tc = await createTestCafe()
   const runner = await tc.createRunner()
   const response = await runner
@@ -8,10 +12,10 @@ async function runRunner() {
       //Scenario that just upload photos, so we don't need to do it in every test.
       'testcafe/tests/photos/photos_start_upload_photos.js',
 
-      'testcafe/tests/photos/photos_crud.js',
-      'testcafe/tests/photos/create_full_album_scenario.js',
-      'testcafe/tests/photos/create_empty_album_scenario.js',
-
+      // 'testcafe/tests/photos/photos_crud.js',
+      // 'testcafe/tests/photos/create_full_album_scenario.js',
+      // 'testcafe/tests/photos/create_empty_album_scenario.js',
+      //
       //Scenario that just delete photos, so we don't need to do it in every test.
       'testcafe/tests/photos/photos_end_delete_all_data.js'
     ])
@@ -24,6 +28,8 @@ async function runRunner() {
     )
     .run({ assertionTimeout: 6000 }, { pageLoadTimeout: 6000 })
   tc.close()
+
+  await postCommentToGithub()
 
   if (response > 0) throw Error(response)
 }

--- a/testcafe/tests/helpers/comment-on-github.js
+++ b/testcafe/tests/helpers/comment-on-github.js
@@ -1,0 +1,18 @@
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+
+module.exports = async function() {
+  if (process.env.vrErrorMsg != '') {
+    const message = `Visual Review - Please review screenshots, then restart build. ${
+      process.env.vrErrorMsg
+    }`
+    console.log(message)
+    //do not try to post to git when using locally
+    if (
+      typeof process.env.TRAVIS_PULL_REQUEST !== 'undefined' &&
+      process.env.TRAVIS_PULL_REQUEST
+    ) {
+      await exec(`yarn run cozy-ci-github "${message}"`)
+    }
+  }
+}

--- a/testcafe/tests/helpers/utils.js
+++ b/testcafe/tests/helpers/utils.js
@@ -29,6 +29,21 @@ export const getPageUrl = ClientFunction(() => window.location.href)
 
 export const goBack = ClientFunction(() => window.history.back())
 
+export const getNavigatorOs = ClientFunction(() => navigator.platform)
+
+//User Agent is needed for VisualReview, but we don't need the all string
+export const getNavigatorName = ClientFunction(() => {
+  const navigatorKey = ['MSIE', 'Firefox', 'Safari', 'Chrome', 'Opera'],
+    userAgent = navigator.userAgent
+  return navigatorKey.find(
+    navigatorName => userAgent.indexOf(navigatorName) !== -1
+  )
+})
+
+export const getResolution = ClientFunction(
+  () => `${window.screen.width} x ${window.screen.height}`
+)
+
 export const getElementWithTestId = Selector(
   id => document.querySelectorAll(`[data-test-id='${id}']`)
   //getElementsByAttribute is not part of W3C DOM, while querySelectorAll is.

--- a/testcafe/tests/helpers/visualreview-utils.js
+++ b/testcafe/tests/helpers/visualreview-utils.js
@@ -1,0 +1,20 @@
+import VisualReview from 'visualreview-client'
+import { t } from 'testcafe'
+
+//Put this const in travis after POC
+const VISUALREVIEW_INSTANCE = 'visualreview.cozycloud.cc'
+
+export class VisualReviewTestcafe extends VisualReview {
+  constructor(options) {
+    super(options)
+    this.options.protocol = 'https'
+    this.options.hostname = VISUALREVIEW_INSTANCE
+  }
+
+  async takeScreenshotAndReview(imageName) {
+    await t.takeScreenshot(imageName)
+
+    //the path needs to be in const but i need to define the screenshots tree 1st
+    this.uploadScreenshot('./reports/screenshots/' + imageName)
+  }
+}

--- a/testcafe/tests/helpers/visualreview-utils.js
+++ b/testcafe/tests/helpers/visualreview-utils.js
@@ -1,5 +1,6 @@
 import VisualReview from 'visualreview-client'
 import { t } from 'testcafe'
+import { getNavigatorOs, getNavigatorName, getResolution } from './utils'
 
 //Put this const in travis after POC
 const VISUALREVIEW_INSTANCE = 'visualreview.cozycloud.cc'
@@ -9,33 +10,46 @@ export class VisualReviewTestcafe extends VisualReview {
     super(options)
     this.options.protocol = 'https'
     this.options.hostname = VISUALREVIEW_INSTANCE
+    this.options.compareSettings = {
+      precision: 4
+    }
   }
 
-  async takeScreenshotAndReview(imageName) {
+  async takeScreenshotAndUpload(imageName) {
     await t.takeScreenshot(imageName)
+
+    this.options.properties.os = await getNavigatorOs()
+    this.options.properties.browser = await getNavigatorName()
+    this.options.properties.resolution = await getResolution()
 
     //the path needs to be in const but i need to define the screenshots tree 1st
     this.uploadScreenshot('./reports/screenshots/' + imageName)
   }
 
-  async checkVr() {
-    let runAnalysis = await this.getJsonStatusForCurrentRun()
-    let runStatus = 'accepted'
+  async checkRunStatus() {
+    //this function is called in .after, so we cannot use t.wait(5000)
+    //Needs modifications on server side to avoid delay
+    const delay = ms => new Promise(res => setTimeout(res, ms))
+    await delay(3000)
 
-    for (let imgDiff in runAnalysis.diffs) {
-      if (runAnalysis.diffs[imgDiff].status != 'accepted') {
-        runStatus = runAnalysis.diffs[imgDiff].status
-        throw new Error(
-          `❌ Screenshots changes  in image ID ${
-            runAnalysis.diffs[imgDiff].id
-          } (${runAnalysis.diffs[imgDiff].status}), please Review :  ${
-            this.options.protocol
-          }://${this.options.hostname}/#/${runAnalysis.analysis.projectId}/${
-            runAnalysis.analysis.suiteId
-          }/${runAnalysis.analysis.runId}`
-        )
-      }
+    let runAnalysis = await this.getJsonStatusForCurrentRun()
+    if (
+      runAnalysis.diffs.filter(element => element.status != 'accepted').length >
+      0
+    ) {
+      const vrMessageUrl = `❌ ${runAnalysis.analysis.projectName} : ${
+        runAnalysis.analysis.suiteName
+      } :  ${this.options.protocol}://${this.options.hostname}/#/${
+        runAnalysis.analysis.projectId
+      }/${runAnalysis.analysis.suiteId}/${runAnalysis.analysis.runId}`
+
+      process.env.vrErrorMsg = `${
+        process.env.vrErrorMsg
+      } <li>${vrMessageUrl}</li>`
+
+      throw new Error(vrMessageUrl)
+    } else {
+      console.log(`Screenshots status : accepted`)
     }
-    console.log(`Screenshots status : ${runStatus}`)
   }
 }

--- a/testcafe/tests/helpers/visualreview-utils.js
+++ b/testcafe/tests/helpers/visualreview-utils.js
@@ -17,4 +17,25 @@ export class VisualReviewTestcafe extends VisualReview {
     //the path needs to be in const but i need to define the screenshots tree 1st
     this.uploadScreenshot('./reports/screenshots/' + imageName)
   }
+
+  async checkVr() {
+    let runAnalysis = await this.getJsonStatusForCurrentRun()
+    let runStatus = 'accepted'
+
+    for (let imgDiff in runAnalysis.diffs) {
+      if (runAnalysis.diffs[imgDiff].status != 'accepted') {
+        runStatus = runAnalysis.diffs[imgDiff].status
+        throw new Error(
+          `❌ Screenshots changes  in image ID ${
+            runAnalysis.diffs[imgDiff].id
+          } (${runAnalysis.diffs[imgDiff].status}), please Review :  ${
+            this.options.protocol
+          }://${this.options.hostname}/#/${runAnalysis.analysis.projectId}/${
+            runAnalysis.analysis.suiteId
+          }/${runAnalysis.analysis.runId}`
+        )
+      }
+    }
+    console.log(`Screenshots status : ${runStatus}`)
+  }
 }

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -1,24 +1,37 @@
-import { photosUser } from '../helpers/roles' //import roles for login
+import { photosUser } from '../helpers/roles' 
 import { TESTCAFE_PHOTOS_URL } from '../helpers/utils'
 import Page from '../pages/photos-model'
 import { IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
+import { VisualReviewTestcafe } from '../helpers/visualreview-utils'
 
 const page = new Page()
 
-fixture`Delete all photos`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
-  await t.useRole(photosUser)
-  await page.waitForLoading()
-  await page.initPhotosCount()
-})
+fixture`Delete all photos`.page`${TESTCAFE_PHOTOS_URL}/`
+  .before(async ctx => {
+    ctx.vr = new VisualReviewTestcafe({
+      projectName: 'PHOTOS',
+      suiteName: `fixture : delete photos`
+    })
+    await ctx.vr.start()
+  })
+  .beforeEach(async t => {
+    await t.useRole(photosUser)
+    await page.waitForLoading()
+    await page.initPhotosCount()
+  })
 
 test('Deleting 1st pic on Timeline : Open up a modal, and confirm', async () => {
   await page.selectPhotosByName([IMG0])
   //pic is removed
   await page.deletePhotos(1)
+
+  await t.fixtureCtx.vr.takeScreenshotAndReview('delete-1-pic.png')
 })
 
 test('Deleting 4 pics on Timeline : Open up a modal, and confirm', async () => {
   await page.selectPhotosByName([IMG1, IMG2, IMG3, IMG4])
   //pics are removed, there are no more pictures on  page
   await page.deletePhotos(4, true)
+
+  await t.fixtureCtx.vr.takeScreenshotAndReview('delete-4-pics.png')
 })

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -19,6 +19,9 @@ fixture`Delete all photos`.page`${TESTCAFE_PHOTOS_URL}/`
     await page.waitForLoading()
     await page.initPhotosCount()
   })
+  .after(async ctx => {
+    await ctx.vr.checkVr()
+  })
 
 test('Deleting 1st pic on Timeline : Open up a modal, and confirm', async () => {
   await page.selectPhotosByName([IMG0])

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -1,4 +1,4 @@
-import { photosUser } from '../helpers/roles' 
+import { photosUser } from '../helpers/roles'
 import { TESTCAFE_PHOTOS_URL } from '../helpers/utils'
 import Page from '../pages/photos-model'
 import { IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
@@ -20,21 +20,21 @@ fixture`Delete all photos`.page`${TESTCAFE_PHOTOS_URL}/`
     await page.initPhotosCount()
   })
   .after(async ctx => {
-    await ctx.vr.checkVr()
+    await ctx.vr.checkRunStatus()
   })
 
-test('Deleting 1st pic on Timeline : Open up a modal, and confirm', async () => {
+test('Deleting 1st pic on Timeline : Open up a modal, and confirm', async t => {
   await page.selectPhotosByName([IMG0])
   //pic is removed
   await page.deletePhotos(1)
 
-  await t.fixtureCtx.vr.takeScreenshotAndReview('delete-1-pic.png')
+  await t.fixtureCtx.vr.takeScreenshotAndUpload('delete-1-pic.png')
 })
 
-test('Deleting 4 pics on Timeline : Open up a modal, and confirm', async () => {
+test('Deleting 4 pics on Timeline : Open up a modal, and confirm', async t => {
   await page.selectPhotosByName([IMG1, IMG2, IMG3, IMG4])
   //pics are removed, there are no more pictures on  page
   await page.deletePhotos(4, true)
 
-  await t.fixtureCtx.vr.takeScreenshotAndReview('delete-4-pics.png')
+  await t.fixtureCtx.vr.takeScreenshotAndUpload('delete-4-pics.png')
 })

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -18,6 +18,9 @@ fixture`Upload photos`.page`${TESTCAFE_PHOTOS_URL}/`
     await t.useRole(photosUser)
     await page.waitForLoading()
   })
+  .after(async ctx => {
+    await ctx.vr.checkVr()
+  })
 
 test('Uploading 1 pic from Photos view', async t => {
   ///there is no photos on page

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -1,4 +1,4 @@
-import { photosUser } from '../helpers/roles' 
+import { photosUser } from '../helpers/roles'
 import { TESTCAFE_PHOTOS_URL } from '../helpers/utils'
 import Page from '../pages/photos-model'
 import { DATA_PATH, IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
@@ -19,7 +19,7 @@ fixture`Upload photos`.page`${TESTCAFE_PHOTOS_URL}/`
     await page.waitForLoading()
   })
   .after(async ctx => {
-    await ctx.vr.checkVr()
+    await ctx.vr.checkRunStatus()
   })
 
 test('Uploading 1 pic from Photos view', async t => {
@@ -27,7 +27,7 @@ test('Uploading 1 pic from Photos view', async t => {
   await page.initPhotoCountZero()
   await page.uploadPhotos([`${DATA_PATH}/${IMG0}`])
 
-  await t.fixtureCtx.vr.takeScreenshotAndReview('Upload-1-pic.png')
+  await t.fixtureCtx.vr.takeScreenshotAndUpload('Upload-1-pic.png')
 })
 
 test('Uploadingt 4 pics from Photos view', async t => {
@@ -39,5 +39,5 @@ test('Uploadingt 4 pics from Photos view', async t => {
     `${DATA_PATH}/${IMG4}`
   ])
 
-  await t.fixtureCtx.vr.takeScreenshotAndReview('Upload-4-pic.png')
+  await t.fixtureCtx.vr.takeScreenshotAndUpload('Upload-4-pic.png')
 })

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -1,22 +1,33 @@
-import { photosUser } from '../helpers/roles' //import roles for login
+import { photosUser } from '../helpers/roles' 
 import { TESTCAFE_PHOTOS_URL } from '../helpers/utils'
 import Page from '../pages/photos-model'
 import { DATA_PATH, IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
+import { VisualReviewTestcafe } from '../helpers/visualreview-utils'
 
 const page = new Page()
 
-fixture`Upload 4 photos`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
-  await t.useRole(photosUser)
-  await page.waitForLoading()
-})
+fixture`Upload photos`.page`${TESTCAFE_PHOTOS_URL}/`
+  .before(async ctx => {
+    ctx.vr = new VisualReviewTestcafe({
+      projectName: 'PHOTOS',
+      suiteName: `fixture : upload photos`
+    })
+    await ctx.vr.start()
+  })
+  .beforeEach(async t => {
+    await t.useRole(photosUser)
+    await page.waitForLoading()
+  })
 
-test('Uploading 1 pic from Photos view', async () => {
+test('Uploading 1 pic from Photos view', async t => {
   ///there is no photos on page
   await page.initPhotoCountZero()
   await page.uploadPhotos([`${DATA_PATH}/${IMG0}`])
+
+  await t.fixtureCtx.vr.takeScreenshotAndReview('Upload-1-pic.png')
 })
 
-test('Uploading 4 pics from Photos view', async () => {
+test('Uploadingt 4 pics from Photos view', async t => {
   await page.initPhotosCount()
   await page.uploadPhotos([
     `${DATA_PATH}/${IMG1}`,
@@ -24,4 +35,6 @@ test('Uploading 4 pics from Photos view', async () => {
     `${DATA_PATH}/${IMG3}`,
     `${DATA_PATH}/${IMG4}`
   ])
+
+  await t.fixtureCtx.vr.takeScreenshotAndReview('Upload-4-pic.png')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -16234,6 +16234,12 @@ vfile@^2.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
+"visualreview-client@git+https://github.com/cozy/VisualReview-node-client.git":
+  version "0.0.2"
+  resolved "git+https://github.com/cozy/VisualReview-node-client.git#c8b0b4c033f6382fd78890c0ce90266f4899ad7d"
+  dependencies:
+    request "^2.60.0"
+
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"


### PR DESCRIPTION
For each fixture in testcafe : I create a new VisualReview Object, so https://visualreview.cozycloud.cc/#/ will have 2 projects (Photos and Drive), and one suite for each fixture.
Each time we launch the test, a new run will be created in the suite.
I only check each run once, when all screenshots are uploaded.

----

Also, I'm using the fixture/tests name quite a lot : 
- to declare the fixture/test
- in console.log to provide infos
- to create the visual review object
- to name my screenshots

testcafe doesn't have a prop like test.name , so I think I'll use const like
`const FIXTURE_UPLOAD= 'Uploads Photos'`
`const TEST_UP_1 = 'Uploads 1 Photos'`
etc... and use those const to name my fixtures/test/screenshots/etc....

What do you think is best : 
declare each const in the scenario file (like `photos_start_upload_photos.js`), or create a `data-name` or something file and put everything here ?