### PR TITLE
fix: move creation button to menu on mobile

### DIFF
--- a/src/components/Button/CozyHomeLink.jsx
+++ b/src/components/Button/CozyHomeLink.jsx
@@ -2,29 +2,28 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ButtonLink } from 'cozy-ui/react'
 import styles from './index.styl'
+import getHomeLinkHref from './getHomeLinkHref'
 
-const CozyHomeLink = ({ from, embedInCozyBar = false, t }) => (
+const CozyHomeLink = ({ from, embedInCozyBar = false, t, size, className }) => (
   <ButtonLink
     label={t('Share.create-cozy')}
     icon="cozy-negative"
-    className={embedInCozyBar ? styles['bar-homelink'] : ''}
+    className={embedInCozyBar ? styles['bar-homelink'] : className}
     href={getHomeLinkHref(from)}
+    size={size}
   />
 )
 
 CozyHomeLink.propTypes = {
   from: PropTypes.string,
   embedInCozyBar: PropTypes.bool,
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
+  size: PropTypes.oneOf(['tiny', 'small', 'large', 'normal'])
 }
 
 CozyHomeLink.defaultProps = {
-  from: ''
+  from: '',
+  size: 'normal'
 }
-
-export const getHomeLinkHref = from =>
-  `https://manager.cozycloud.cc/cozy/create${
-    from ? `?pk_campaign=${encodeURIComponent(from)}` : ''
-  }`
 
 export default CozyHomeLink

--- a/src/components/Button/getHomeLinkHref.jsx
+++ b/src/components/Button/getHomeLinkHref.jsx
@@ -1,0 +1,6 @@
+const getHomeLinkHref = from =>
+  `https://manager.cozycloud.cc/cozy/create${
+    from ? `?pk_campaign=${encodeURIComponent(from)}` : ''
+  }`
+
+export default getHomeLinkHref

--- a/src/components/Button/getHomeLinkHref.spec.js
+++ b/src/components/Button/getHomeLinkHref.spec.js
@@ -1,0 +1,14 @@
+import getHomeLinkHref from './getHomeLinkHref'
+
+describe('getHomeLinkHref', () => {
+  it('Should add the origin parameter', () => {
+    expect(getHomeLinkHref('cozy.io')).toEqual(
+      'https://manager.cozycloud.cc/cozy/create?pk_campaign=cozy.io'
+    )
+  })
+  it('Should not add the origin parameter', () => {
+    expect(getHomeLinkHref('')).toEqual(
+      'https://manager.cozycloud.cc/cozy/create'
+    )
+  })
+})

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -10,7 +10,8 @@ import DownloadButton from './DownloadButton'
 import { downloadFiles } from 'drive/web/modules/navigation/duck'
 import toolbarstyles from 'drive/styles/toolbar'
 import { getQueryParameter } from 'react-cozy-helpers'
-import CozyHomeLink, { getHomeLinkHref } from 'components/Button/CozyHomeLink'
+import CozyHomeLink from 'components/Button/CozyHomeLink'
+import getHomeLinkHref from 'components/Button/getHomeLinkHref'
 import OpenInCozyButton from './OpenInCozyButton'
 
 import CloudIcon from 'drive/assets/icons/icon-cloud-open.svg'
@@ -108,7 +109,7 @@ const CozybarToolbar = ({ onDownload, discoveryLink, isFile }, { t }) => (
       {discoveryLink ? (
         <OpenInCozyButton href={discoveryLink} t={t} size="small" />
       ) : (
-        <CozyHomeLink from="sharing-drive" t={t} />
+        <CozyHomeLink from="sharing-drive" t={t} size="small" />
       )}
       <DownloadFilesButton
         t={t}

--- a/src/photos/targets/public/App.jsx
+++ b/src/photos/targets/public/App.jsx
@@ -9,6 +9,7 @@ import { Main } from 'cozy-ui/react/Layout'
 
 import Selection from 'photos/ducks/selection'
 import { MoreButton, CozyHomeLink } from 'components/Button'
+import getHomeLinkHref from 'components/Button/getHomeLinkHref'
 import PhotoBoard from 'photos/components/PhotoBoard'
 import styles from './index.styl'
 import { ALBUM_QUERY } from '../../../../src/photos/ducks/albums/index'
@@ -73,7 +74,11 @@ export class App extends Component {
                 >
                   <h2 className={styles['pho-content-title']}>{album.name}</h2>
                   <div className={styles['pho-toolbar']} role="toolbar">
-                    <CozyHomeLink from="sharing-photos" t={t} />
+                    <CozyHomeLink
+                      from="sharing-photos"
+                      t={t}
+                      className={styles['pho-public-mycozy']}
+                    />
                     <Button
                       theme="secondary"
                       className={styles['pho-public-download']}
@@ -89,6 +94,14 @@ export class App extends Component {
                       position="right"
                       className="u-hide--desk"
                     >
+                      <MenuItem
+                        onSelect={() =>
+                          (window.location = getHomeLinkHref('sharing-photos'))
+                        }
+                        icon={<Icon icon="cozy-negative" />}
+                      >
+                        {t('Share.create-cozy')}
+                      </MenuItem>
                       <MenuItem
                         onSelect={() => this.onDownload(selected)}
                         icon={<Icon icon="download" />}

--- a/src/photos/targets/public/__snapshots__/App.spec.jsx.snap
+++ b/src/photos/targets/public/__snapshots__/App.spec.jsx.snap
@@ -15,6 +15,7 @@ exports[`Public view should render children when they are present 1`] = `
         >
           <CozyHomeLink
             from="sharing-photos"
+            size="normal"
             t={
               [MockFunction] {
                 "calls": Array [
@@ -25,6 +26,9 @@ exports[`Public view should render children when they are present 1`] = `
                     "Toolbar.more",
                   ],
                   Array [
+                    "Share.create-cozy",
+                  ],
+                  Array [
                     "Toolbar.album_download",
                   ],
                   Array [
@@ -34,10 +38,21 @@ exports[`Public view should render children when they are present 1`] = `
                     "Toolbar.more",
                   ],
                   Array [
+                    "Share.create-cozy",
+                  ],
+                  Array [
                     "Toolbar.album_download",
                   ],
                 ],
                 "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
                   Object {
                     "isThrow": false,
                     "value": undefined,
@@ -84,6 +99,15 @@ exports[`Public view should render children when they are present 1`] = `
             popover={false}
             position="right"
           >
+            <MenuItem
+              icon={
+                <Icon
+                  icon="cozy-negative"
+                  spin={false}
+                />
+              }
+              onSelect={[Function]}
+            />
             <MenuItem
               icon={
                 <Icon
@@ -147,6 +171,7 @@ exports[`Public view should render the album 1`] = `
         >
           <CozyHomeLink
             from="sharing-photos"
+            size="normal"
             t={
               [MockFunction] {
                 "calls": Array [
@@ -157,10 +182,17 @@ exports[`Public view should render the album 1`] = `
                     "Toolbar.more",
                   ],
                   Array [
+                    "Share.create-cozy",
+                  ],
+                  Array [
                     "Toolbar.album_download",
                   ],
                 ],
                 "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
                   Object {
                     "isThrow": false,
                     "value": undefined,
@@ -195,6 +227,15 @@ exports[`Public view should render the album 1`] = `
             popover={false}
             position="right"
           >
+            <MenuItem
+              icon={
+                <Icon
+                  icon="cozy-negative"
+                  spin={false}
+                />
+              }
+              onSelect={[Function]}
+            />
             <MenuItem
               icon={
                 <Icon

--- a/src/photos/targets/public/index.styl
+++ b/src/photos/targets/public/index.styl
@@ -26,6 +26,7 @@
 
 +small-screen()
     .pho-public-download
+    .pho-public-mycozy
         display none
 
 +small-screen('min')


### PR DESCRIPTION
I should have seen it… That was too easy.

Here, now the button is hidden on mobile and a new `MenuItem` with the same action is added on Album sharing and the button is properly displayed when in cozy-bar on Drive as well.

NB: `getHomeLinkHref` function has been extracted to be properly called in any other context.