### PR TITLE
fix: Dates timezone

### DIFF
--- a/src/photos/ducks/timeline-clusters/dates.js
+++ b/src/photos/ducks/timeline-clusters/dates.js
@@ -1,17 +1,71 @@
-import { isThisYear } from 'date-fns'
+import {
+  isThisYear,
+  differenceInCalendarMonths,
+  differenceInCalendarDays,
+  differenceInHours,
+  compareAsc
+} from 'date-fns'
+
+/**
+ *  Format the date as specified by the formatter parameter.
+ *  The extraction of year, day, etc is needed because the Date(string) constructor use the local timezone.
+ *  Yet, the photos' dates are saved with the stack's locale (GMT+0 in production environment),
+ *  because the timezone is mostly not specified in the EXIF metadata.
+ *  So, to avoid a date offset in case the user timezone is not the stack's one, we use the Date(numbers) constructor instead.
+ *  See https://github.com/date-fns/date-fns/issues/489 for more insights.
+ * @param {function} f - date-fns format function
+ * @param {string} date - date passed as string
+ * @param {string} formatter - The wanted format. See https://date-fns.org/v1.30.1/docs/format
+ * @returns {string} The formatted date
+ */
+const formatDate = (f, date, formatter) => {
+  const [year, month, day] = date.substr(0, 10).split('-')
+  const [hours, minutes, seconds] = date.substr(11, 8).split(':')
+  return f(new Date(year, month - 1, day, hours, minutes, seconds), formatter)
+}
 
 export const formatH = (f, date) => {
-  return f(date, 'HH')
+  return formatDate(f, date, 'HH')
 }
 
 export const formatD = (f, date) => {
-  return f(date, 'DD')
+  return formatDate(f, date, 'DD')
 }
 
 export const formatDMY = (f, date) => {
-  return f(date, 'DD MMMM') + addYear(f, date)
+  return formatDate(f, date, 'DD MMMM') + addYear(f, date)
+}
+
+export const formatYMD = (f, date) => {
+  return formatDate(f, date, 'YYYY-MM-DD')
 }
 
 const addYear = (f, date) => {
-  return isThisYear(date) ? '' : f(date, ' YYYY')
+  return isThisYear(date) ? '' : formatDate(f, date, ' YYYY')
+}
+
+export const isSameMonth = (f, newerDate, olderDate) => {
+  const newer = formatDate(f, newerDate)
+  const older = formatDate(f, olderDate)
+  return differenceInCalendarMonths(older, newer) < 1
+}
+
+export const isSameDay = (f, newerDate, olderDate) => {
+  const newer = formatDate(f, newerDate)
+  const older = formatDate(f, olderDate)
+  return differenceInCalendarDays(newer, older) < 1
+}
+
+export const isSameHour = (f, newerDate, olderDate) => {
+  const newer = formatDate(f, newerDate)
+  const older = formatDate(f, olderDate)
+  return differenceInHours(newer, older) < 1
+}
+
+export const isEqualOrNewer = (newerDate, olderDate) => {
+  return compareAsc(newerDate, olderDate) >= 0
+}
+
+export const isEqualOrOlder = (newerDate, olderDate) => {
+  return compareAsc(newerDate, olderDate) <= 0
 }

--- a/src/photos/ducks/timeline-clusters/index.jsx
+++ b/src/photos/ducks/timeline-clusters/index.jsx
@@ -3,11 +3,16 @@ import { Query } from 'cozy-client'
 import Timeline from '../timeline/components/Timeline'
 import PhotoBoard from '../../components/PhotoBoard'
 import {
-  differenceInCalendarDays,
-  differenceInCalendarMonths,
-  differenceInHours
-} from 'date-fns'
-import { formatDMY, formatD, formatH } from './dates'
+  formatDMY,
+  formatD,
+  formatH,
+  formatYMD,
+  isSameDay,
+  isSameMonth,
+  isSameHour,
+  isEqualOrOlder,
+  isEqualOrNewer
+} from './dates'
 import { translate } from 'cozy-ui/react/I18n'
 
 // constants
@@ -52,18 +57,18 @@ const TIMELINE_MUTATIONS = client => ({
  */
 const getSectionTitle = (album, f) => {
   if (album.period) {
-    const startPeriod = new Date(album.period.start)
-    const endPeriod = new Date(album.period.end)
+    const startPeriod = album.period.start
+    const endPeriod = album.period.end
 
-    if (differenceInCalendarMonths(endPeriod, startPeriod) > 0) {
+    if (!isSameMonth(f, endPeriod, startPeriod)) {
       return formatDMY(f, startPeriod) + ' - ' + formatDMY(f, endPeriod)
     }
-    if (differenceInCalendarDays(endPeriod, startPeriod) > 0) {
+    if (!isSameDay(f, endPeriod, startPeriod)) {
       return formatD(f, startPeriod) + '-' + formatDMY(f, endPeriod)
     }
     return formatDMY(f, startPeriod)
   }
-  return formatDMY(f, new Date(album.name))
+  return formatDMY(f, album.name)
 }
 
 /**
@@ -75,17 +80,15 @@ const getSectionTitle = (album, f) => {
 const getSectionTitleHours = (dates, index, section, f) => {
   if (section.album) {
     if (
-      (index > 0 &&
-        differenceInCalendarDays(dates[index - 1], dates[index]) < 1) ||
-      (index < dates.length - 1 &&
-        differenceInCalendarDays(dates[index], dates[index + 1]) < 1)
+      (index > 0 && isSameDay(f, dates[index - 1], dates[index])) ||
+      (index < dates.length - 1 && isSameDay(f, dates[index], dates[index + 1]))
     ) {
       // Several sections for this day: add the hours
-      const startPeriod = new Date(section.album.period.start)
-      const endPeriod = new Date(section.album.period.end)
+      const startPeriod = section.album.period.start
+      const endPeriod = section.album.period.end
 
       let titleWithHours = section.title + ' ⠂' + formatH(f, startPeriod) + 'h'
-      if (differenceInHours(endPeriod, startPeriod) > 0) {
+      if (!isSameHour(f, endPeriod, startPeriod)) {
         titleWithHours += '-' + formatH(f, endPeriod) + 'h'
       }
       return titleWithHours
@@ -95,22 +98,21 @@ const getSectionTitleHours = (dates, index, section, f) => {
 }
 
 /**
- * A section matches if:
- * - The datetime is inside the period.
- * - The section has no period (not a cluster) and is the datetime's day.
+ * A section matches if a not-clustered photo's datetime:
+ * - Is inside its period, or the same day
  */
-const getMatchingSection = (sections, datetime) => {
+const getMatchingSection = (sections, datetime, f) => {
   return Object.keys(sections).find(date => {
     if (sections[date].album) {
-      const startPeriod = new Date(sections[date].album.period.start)
-      const endPeriod = new Date(sections[date].album.period.end)
-      return (
-        (datetime >= startPeriod && datetime <= endPeriod) ||
-        differenceInCalendarDays(datetime, endPeriod) === 0
-      )
+      const startPeriod = sections[date].album.period.start
+      const endPeriod = sections[date].album.period.end
+      const isInsidePeriod =
+        isEqualOrNewer(datetime, startPeriod) &&
+        isEqualOrOlder(datetime, endPeriod)
+      return isInsidePeriod || isSameDay(f, datetime, endPeriod)
     } else {
       // If the section has no album, it is not a cluster but a daily section
-      return differenceInCalendarDays(datetime, new Date(date)) === 0
+      return isSameDay(f, datetime, date)
     }
   })
 }
@@ -156,15 +158,14 @@ const getPhotosByClusters = (photos, f) => {
         ? photo.metadata.datetime
         : photo.created_at
 
-    const sectionDate = getMatchingSection(sections, new Date(datetime))
+    const sectionDate = getMatchingSection(sections, datetime, f)
     if (sectionDate) {
       sections[sectionDate].photos.push(photo)
     } else {
       // Create a new section for this day, without a period, to differentiate from clusters' sections
-      const date = new Date(datetime)
-      const day = f(date, 'YYYY-MM-DD') // Match the albums's format
+      const day = formatYMD(f, datetime) // Match the albums's format
       sections[day] = {
-        title: formatDMY(f, date),
+        title: formatDMY(f, datetime),
         photos: [photo]
       }
     }


### PR DESCRIPTION
**Context**: the stack stores photos' datetime with its own timezone, UTC+00 for our infra.
However, this creates an offset if the user's locale is not the same. Typically with a UTC+02 timezone, 2 hours will be "added" to all photos on the front side when we create the date with `new Date(date)`.
This is particularly obvious when there are several cluster for the same day, as we show the hour. 

This PR fixes this behavior by using the constructor `new dates(year, month ...)`, as the arguments are interpreted as the local time, as stated [here](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Date#Param%C3%A8tres) 