### PR TITLE
chore: Remove eslint warning by removing console or disable-next-line

### DIFF
--- a/src/authentication/src/LinkManager.jsx
+++ b/src/authentication/src/LinkManager.jsx
@@ -13,6 +13,7 @@ export const nativeLinkOpen = async ({ url }) => {
         }
       },
       error => {
+        // eslint-disable-next-line no-console
         console.warn(error)
         window.SafariViewController.hide()
       }

--- a/src/authentication/src/Revoked.jsx
+++ b/src/authentication/src/Revoked.jsx
@@ -26,6 +26,7 @@ class Revoked extends Component {
         router: this.props.router
       })
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.warn(e)
     }
   }

--- a/src/authentication/src/steps/SelectServer.jsx
+++ b/src/authentication/src/steps/SelectServer.jsx
@@ -39,6 +39,7 @@ export class SelectServer extends Component {
     if (window.Keyboard && window.Keyboard.shrinkView) {
       window.Keyboard.shrinkView(true)
     } else {
+      // eslint-disable-next-line no-console
       console.warn(
         'Cozy-Authentication needs a cozy/cordova-plugin-keyboard plugin to work better.'
       )

--- a/src/components/Image/ImageLoader.jsx
+++ b/src/components/Image/ImageLoader.jsx
@@ -38,6 +38,7 @@ class ImageLoader extends React.Component {
     if (status === PENDING) this.loadLink()
     else if (status === LOADING_LINK) this.loadFallback()
     else if (status === LOADING_FALLBACK) {
+      // eslint-disable-next-line no-console
       console.warn('failed loading thumbnail', lastError)
       this.setState({ status: FAILED })
       this.props.onError(lastError)

--- a/src/drive/lib/reporter.js
+++ b/src/drive/lib/reporter.js
@@ -47,7 +47,9 @@ export const configureReporter = () => {
 export const logException = (err, extraContext = null, fingerprint = null) => {
   return new Promise(resolve => {
     Raven.captureException(err, { extra: extraContext, fingerprint })
+    // eslint-disable-next-line no-console
     console.warn('Raven is recording exception')
+    // eslint-disable-next-line no-console
     console.error(err)
     resolve()
   })

--- a/src/drive/lib/upgradePouchDatabase.js
+++ b/src/drive/lib/upgradePouchDatabase.js
@@ -11,6 +11,7 @@ export const upgradePouchDatabase = async dbName => {
       await cozy.client.offline.migrateDatabase(dbName)
       return true
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.warn(err)
       return false
     }

--- a/src/drive/mobile/lib/background.js
+++ b/src/drive/mobile/lib/background.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 import configureStore from 'drive/store/configureStore'
 import { loadState } from 'drive/store/persistedState'
 import { startMediaBackup } from 'drive/mobile/modules/mediaBackup/duck'

--- a/src/drive/mobile/lib/intents.js
+++ b/src/drive/mobile/lib/intents.js
@@ -35,6 +35,7 @@ const getFile = (dirEntry, type = '') =>
 const resolveNativePath = path =>
   new Promise((resolve, reject) => {
     window.FilePath.resolveNativePath(path, resolve, err => {
+      // eslint-disable-next-line no-console
       console.error(
         `${path} could not be resolved by the plugin: ${err.message}`
       )
@@ -51,6 +52,7 @@ const getFiles = contentFiles =>
         return file
       } catch (err) {
         try {
+          // eslint-disable-next-line no-console
           console.warn(
             `Unable to get files with their real filename, let's try another way: ${
               err.message
@@ -60,6 +62,7 @@ const getFiles = contentFiles =>
           const file = await getFile(dirEntry)
           return file
         } catch (err) {
+          // eslint-disable-next-line no-console
           console.error(err)
           throw new Error(`Unable to get files: ${err.message}`)
         }

--- a/src/drive/mobile/lib/media.js
+++ b/src/drive/mobile/lib/media.js
@@ -30,7 +30,6 @@ export const requestAuthorization = async () => {
       () => resolve(true),
       error => {
         if (!error.startsWith('Permission')) {
-          console.warn(error)
           logException('requestAuthorization error:', error)
         }
         resolve(false)
@@ -132,6 +131,7 @@ export const getPhotos = async () => {
         false, // includePictures, includeVideos, includeCloud
         response => resolve(response.library),
         err => {
+          // eslint-disable-next-line no-console
           console.warn(err)
           resolve(defaultReturn)
         }

--- a/src/drive/mobile/lib/replication.js
+++ b/src/drive/mobile/lib/replication.js
@@ -16,8 +16,10 @@ export const startReplication = async (
 
     if (!hasFinishedFirstReplication) {
       await startFirstReplication()
+      // eslint-disable-next-line no-console
       console.log('End of first replication, warming up indexes')
       await warmUpIndexes(indexes)
+      // eslint-disable-next-line no-console
       console.log('indexes ready')
       firstReplicationFinished()
     }
@@ -37,11 +39,14 @@ export const startReplication = async (
       err.message === clientRevokedMsg ||
       err.error === 'code=400, message=Invalid JWT token'
     ) {
+      // eslint-disable-next-line no-console
       console.warn('The device is not connected to your server anymore')
       revokeClient()
     } else if (err.message === 'ETIMEDOUT') {
+      // eslint-disable-next-line no-console
       console.log('replication timed out')
     } else {
+      // eslint-disable-next-line no-console
       console.warn(err)
     }
   }
@@ -128,6 +133,7 @@ const startRepeatedReplication = ({ afterReplication }) => {
   return new Promise((resolve, reject) => {
     const options = {
       onError: error => {
+        // eslint-disable-next-line no-console
         console.warn(error)
         reject(error)
       },

--- a/src/drive/mobile/modules/mediaBackup/duck/checkCorruptedFiles.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/checkCorruptedFiles.js
@@ -42,6 +42,7 @@ export const checkCorruptedFiles = async (photosOnDevice, dispatch) => {
               await localforage.setItem('CORRUPTED_FILES', newObj)
               return memo.push(photoOnDevice.id)
             } catch (error) {
+              // eslint-disable-next-line no-console
               console.log('error on CORRUPTED FILES', error)
             }
           }
@@ -50,6 +51,7 @@ export const checkCorruptedFiles = async (photosOnDevice, dispatch) => {
       return memo
     }, [])
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.log('error globale', error)
   }
 }

--- a/src/drive/mobile/modules/mediaBackup/duck/index.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/index.js
@@ -178,6 +178,7 @@ const uploadPhoto = (dirName, dirID, photo) => async dispatch => {
   const MINUTE = 60 * SECOND
   const maxBackupTime = 5 * MINUTE
   const timeout = setTimeout(() => {
+    // eslint-disable-next-line no-console
     console.info(JSON.stringify(photo))
     logException(`Backup duration exceeded ${maxBackupTime} milliseconds`)
   }, maxBackupTime)
@@ -201,6 +202,7 @@ const uploadPhoto = (dirName, dirID, photo) => async dispatch => {
       clearTimeout(timeout)
       dispatch({ type: MEDIA_UPLOAD_QUOTA })
     } else {
+      /* eslint-disable no-console */
       console.warn('startMediaBackup upload item error')
       console.warn(JSON.stringify(err))
       console.info(JSON.stringify(photo))

--- a/src/drive/mobile/modules/offline/duck.js
+++ b/src/drive/mobile/modules/offline/duck.js
@@ -74,9 +74,11 @@ const saveOfflineFileCopy = async file => {
 
 export const openLocalFile = file => async (dispatch, getState) => {
   if (!isAvailableOffline(getState(), file.id)) {
+    // eslint-disable-next-line no-console
     console.error('openLocalFile: this file is not available offline')
   }
   openOfflineFile(file).catch(error => {
+    // eslint-disable-next-line no-console
     console.error('openLocalFile', error)
     Alerter.error('mobile.error.make_available_offline.noapp')
   })

--- a/src/drive/mobile/modules/replication/sagas.js
+++ b/src/drive/mobile/modules/replication/sagas.js
@@ -23,6 +23,7 @@ import {
 } from './duck'
 
 export const startReplication = () => async (dispatch, getState) => {
+  // eslint-disable-next-line no-console
   console.info('Starting replication...')
 
   const firstReplication = isFirstReplicationDone(getState())

--- a/src/drive/mobile/modules/settings/duck/reducers.js
+++ b/src/drive/mobile/modules/settings/duck/reducers.js
@@ -44,7 +44,6 @@ const getSetting = (state, key) => {
   ) {
     return state.mobile.settings[key]
   }
-  console.warn(`Not found mobile setting ${key}`)
   return undefined
 }
 

--- a/src/drive/store/persistedState.js
+++ b/src/drive/store/persistedState.js
@@ -38,6 +38,7 @@ const migrateSettings = async prevState => {
     availableOffline: prevState.availableOffline
   }
   await localforage.setItem('state', newState)
+  /* eslint-disable no-console */
   console.info('Migrated persisted settings')
   console.info('Previously persisted state: ', prevState)
   console.info('New persisted state: ', newState)
@@ -51,12 +52,14 @@ export const loadState = async () => {
       return undefined
     }
     if (shouldMigrateSettings(persistedState)) {
+      // eslint-disable-next-line no-console
       console.warn('Migrating persisted settings')
       const newState = await migrateSettings(persistedState)
       return newState
     }
     return persistedState
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.warn(err)
     return undefined
   }
@@ -66,6 +69,7 @@ export const saveState = async state => {
   try {
     await localforage.setItem('state', state)
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.warn(err)
   }
 }

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -99,6 +99,7 @@ const init = async () => {
       root
     )
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn(e)
     initCozyBar(dataset)
     renderError(lang, root)

--- a/src/drive/web/modules/drive/rename.js
+++ b/src/drive/web/modules/drive/rename.js
@@ -75,6 +75,7 @@ export const rename = () => async (dispatch, getState) => {
     )
     dispatch(renamed(extractFileAttributes(updated)))
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn(e)
   }
 }

--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -55,6 +55,7 @@ class MoveModal extends React.Component {
       )
       this.trackEvent(entries.length)
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.warn(e)
       Alerter.error(t('Move.error', { smart_count: entries.length }))
     } finally {
@@ -79,6 +80,7 @@ class MoveModal extends React.Component {
         })
       )
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.warn(e)
       Alerter.error(t('Move.cancelled_error', { smart_count: entries.length }))
     }

--- a/src/drive/web/modules/navigation/RealtimeFiles.jsx
+++ b/src/drive/web/modules/navigation/RealtimeFiles.jsx
@@ -45,6 +45,7 @@ class RealtimeFiles extends React.Component {
           else this.onDocumentChange(change.doc)
         })
         .on('error', err => {
+          // eslint-disable-next-line no-console
           console.warn('Pouch changefeed error', err)
         })
     }

--- a/src/drive/web/modules/navigation/duck/actions.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.jsx
@@ -451,13 +451,11 @@ export const openFileWith = (id, filename) => {
     if (isMobileApp() && window.cordova.plugins.fileOpener2) {
       dispatch({ type: OPEN_FILE_WITH, id })
       const response = await cozy.client.files.downloadById(id).catch(error => {
-        console.error('downloadById', error)
         Alerter.error(openFileDownloadError(error))
         throw error
       })
       const blob = await response.blob()
-      await saveAndOpenWithCordova(blob, filename).catch(error => {
-        console.error('openFileWithCordova', error)
+      await saveAndOpenWithCordova(blob, filename).catch(() => {
         Alerter.error('mobile.error.open_with.noapp')
       })
     } else {

--- a/src/drive/web/modules/navigation/duck/async.js
+++ b/src/drive/web/modules/navigation/duck/async.js
@@ -20,6 +20,7 @@ class Stack {
       !!parentId &&
       (await cozy.client.files.statById(parentId, false).catch(ex => {
         if (ex.status === 403) {
+          // eslint-disable-next-line no-console
           console.warn("User don't have access to parent folder")
         } else {
           throw ex
@@ -233,6 +234,7 @@ class PouchDB {
     const index = this.indexes[sortAttribute]
 
     if (!index)
+      // eslint-disable-next-line no-console
       console.warn(
         `No suitable index found for atribute ${sortAttribute}. This might be slow.`
       )

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -166,6 +166,7 @@ class PublicToolbar extends React.Component {
         .getDiscoveryLink(sharingId, sharecode)
       this.setState({ discoveryLink: link })
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.warn('Failed to load sharing discovery link', err)
     }
   }

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -86,6 +86,7 @@ const processNextFile = (
     }
     dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file })
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.warn(error)
     const statusError = {
       409: CONFLICT,

--- a/src/drive/web/modules/viewer/FilesViewer.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.jsx
@@ -44,6 +44,7 @@ class FilesViewer extends Component {
         }))
       })
       .catch(() => {
+        // eslint-disable-next-line no-console
         console.warn("can't find the file")
         this.onClose()
       })

--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -101,7 +101,6 @@ const ALBUMS_MUTATIONS = client => ({
       })
       return resp.data
     } catch (error) {
-      console.log({ error })
       Alerter.error('Albums.create.error.generic')
     }
   }

--- a/src/photos/ducks/upload/index.js
+++ b/src/photos/ducks/upload/index.js
@@ -68,6 +68,7 @@ const processNextFile = callback => async (dispatch, getState) => {
     await callback(file)
     dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file })
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.log(error)
     dispatch({
       type: RECEIVE_UPLOAD_ERROR,

--- a/src/sharing/components/ShareByEmail.jsx
+++ b/src/sharing/components/ShareByEmail.jsx
@@ -129,6 +129,7 @@ ShareTypeSelect.propTypes = {
 }
 
 ShareTypeSelect.defaultProps = {
+  // eslint-disable-next-line no-console
   onChange: console.log,
   value: ''
 }

--- a/src/sharing/components/ShareByLink.jsx
+++ b/src/sharing/components/ShareByLink.jsx
@@ -31,6 +31,7 @@ class ShareByLink extends React.Component {
       await this.props.onEnable(this.props.document)
     } catch (e) {
       Alerter.error(`${this.props.documentType}.share.error.generic`)
+      // eslint-disable-next-line no-console
       console.log(e)
     } finally {
       this.setState(state => ({ ...state, loading: false }))
@@ -43,6 +44,7 @@ class ShareByLink extends React.Component {
       await this.props.onDisable(this.props.document)
     } catch (e) {
       Alerter.error(`${this.props.documentType}.share.error.revoke`)
+      // eslint-disable-next-line no-console
       console.log(e)
     } finally {
       this.setState(state => ({ ...state, loading: false }))

--- a/src/viewer/TextViewer.jsx
+++ b/src/viewer/TextViewer.jsx
@@ -58,6 +58,7 @@ class TextViewer extends React.Component {
         loading: false
       })
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.warn(error)
       this.setState({
         loading: false,


### PR DESCRIPTION
I'm tired of seeing so much warnings when linting ;).

I removed some, for others I just disable the check since I think they can be useful on Sentry.

What do you think? 