### PR TITLE
fix: add TRAVIS_BUILD_ID to version number

### DIFF
--- a/scripts/downcloud.js
+++ b/scripts/downcloud.js
@@ -28,6 +28,7 @@ const launchCmd = (cmd, params, options) => {
 const updateVersion = async folderName => {
   const buildCommit = process.env.TRAVIS_COMMIT
   const TRAVIS_BUILD_DIR = process.env.TRAVIS_BUILD_DIR
+  const TRAVIS_BUILD_ID = process.env.TRAVIS_BUILD_ID
 
   const pathToManifest = path.join(
     TRAVIS_BUILD_DIR,
@@ -35,7 +36,9 @@ const updateVersion = async folderName => {
     'manifest.webapp'
   )
   const appManifestObj = fs.readJSONSync(pathToManifest)
-  const appVersion = `${appManifestObj.version}-dev.${buildCommit}`
+  const appVersion = `${
+    appManifestObj.version
+  }-dev.${buildCommit}-${TRAVIS_BUILD_ID}`
   appManifestObj.version = appVersion
   console.warn(`↳ ℹ️  Updating manifest version to ${appVersion}`)
 


### PR DESCRIPTION
 add TRAVIS_BUILD_ID to version number to help our friend in infra to know why the stack failed to deploy ou zip sometimes