### PR TITLE
chore: Removed unused code

### DIFF
--- a/src/sharing/components/Avatar.jsx
+++ b/src/sharing/components/Avatar.jsx
@@ -3,7 +3,6 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { SharingTooltip, TooltipRecipientList } from './Tooltip'
 import styles from './recipient.styl'
-import { Avatar as CozyUIAvatar, Tooltip } from 'cozy-ui/react'
 import ColorHash from './colorhash'
 
 export const Avatar = ({ text, size, textId }) => {
@@ -24,14 +23,6 @@ export const Avatar = ({ text, size, textId }) => {
       <span>{initial}</span>
       <SharingTooltip id={`recipient-avatar-${text}`} />
     </div>
-  )
-}
-
-export const AvatarToUseAfer = props => {
-  return (
-    <Tooltip title={props.textId}>
-      <CozyUIAvatar {...props} className={styles['recipient-avatar']} />
-    </Tooltip>
   )
 }
 


### PR DESCRIPTION
We're not using this avatar at the moment, and it relies on importing `Tooltip` from cozy-ui but that component [doesn't exist yet either](https://github.com/cozy/cozy-ui/pull/648).