### PR TITLE
fix: Use relative path from src

### DIFF
--- a/src/components/pushClient/Banner.jsx
+++ b/src/components/pushClient/Banner.jsx
@@ -15,7 +15,7 @@ import {
 } from '.'
 import { Button, ButtonLink, Icon } from 'cozy-ui/react'
 
-import Config from '../../drive/config/config.json'
+import Config from 'drive/config/config.json'
 import localforage from 'localforage'
 
 class BannerClient extends Component {

--- a/src/components/pushClient/Button.jsx
+++ b/src/components/pushClient/Button.jsx
@@ -5,7 +5,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import React, { Component } from 'react'
 import localforage from 'localforage'
 import { track, isLinux, isClientAlreadyInstalled, DESKTOP_BANNER } from '.'
-import Config from '../../drive/config/config.json'
+import Config from 'drive/config/config.json'
 
 class ButtonClient extends Component {
   state = {

--- a/src/viewer/NoViewer/CallToAction.jsx
+++ b/src/viewer/NoViewer/CallToAction.jsx
@@ -8,7 +8,7 @@ import {
   NOVIEWER_DESKTOP_CTA
 } from 'components/pushClient'
 import styles from '../styles'
-import Config from '../../drive/config/config.json'
+import Config from 'drive/config/config.json'
 
 export default class CallToAction extends Component {
   state = {


### PR DESCRIPTION
To be able to override a file from webpack, we need to use a relative path from `src` folder. We already have an alias for that : `drive`. 