### PR TITLE
fix: Fetch file when props have changed

### DIFF
--- a/src/drive/web/modules/drive/FileOpenerExternal.jsx
+++ b/src/drive/web/modules/drive/FileOpenerExternal.jsx
@@ -27,16 +27,25 @@ class FileOpener extends Component {
     file: null
   }
   componentWillMount() {
-    this.loadFileInfo()
+    if (this.props.fileId) {
+      this.loadFileInfo(this.props.fileId)
+    } else if (this.props.routeParams.fileId) {
+      this.loadFileInfo(this.props.routeParams.fileId)
+    }
   }
 
-  async loadFileInfo() {
+  componentDidUpdate(prevProps) {
+    if (prevProps.fileId !== this.props.fileId) {
+      return this.loadFileInfo(this.props.fileId)
+    }
+    if (prevProps.routeParams.fileId !== this.props.routeParams.fileId) {
+      return this.loadFileInfo(this.props.routeParams.fileId)
+    }
+  }
+  async loadFileInfo(id) {
     try {
       this.setState({ fileNotFound: false })
-      const resp = await cozy.client.files.statById(
-        getFileId(this.props),
-        false
-      )
+      const resp = await cozy.client.files.statById(id, false)
       const file = { ...resp, ...resp.attributes, id: resp._id }
       this.setState({ file, loading: false })
     } catch (e) {
@@ -71,10 +80,6 @@ class FileOpener extends Component {
       </div>
     )
   }
-}
-
-const getFileId = ownProps => {
-  return ownProps.fileId || ownProps.router.params.fileId
 }
 
 FileOpener.PropTypes = {

--- a/src/drive/web/modules/drive/FileOpenerExternal.jsx
+++ b/src/drive/web/modules/drive/FileOpenerExternal.jsx
@@ -21,7 +21,7 @@ const FileNotFoundError = translate()(({ t }) => (
   <pre className="u-error">{t('FileOpenerExternal.fileNotFoundError')}</pre>
 ))
 
-class FileOpener extends Component {
+export class FileOpener extends Component {
   state = {
     loading: true,
     file: null

--- a/src/drive/web/modules/drive/FileOpenerExternal.spec.jsx
+++ b/src/drive/web/modules/drive/FileOpenerExternal.spec.jsx
@@ -1,0 +1,68 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import { FileOpener } from './FileOpenerExternal'
+global.cozy = {
+  client: {
+    files: {
+      statById: jest.fn()
+    }
+  }
+}
+const routerMock = {
+  push: () => {},
+  params: {
+    fileId: 1
+  }
+}
+describe('FileOpenerExternal', () => {
+  it('should set the id in state', async () => {
+    const wrapper = shallow(
+      <FileOpener
+        router={routerMock}
+        fileId={123}
+        routeParams={{
+          fileId: 123
+        }}
+      />,
+      {
+        disableLifecycleMethods: true
+      }
+    )
+    global.cozy.client.files.statById.mockResolvedValue({
+      _id: '123'
+    })
+    await wrapper.instance().loadFileInfo('123')
+    expect(wrapper.state().file.id).toBe('123')
+  })
+
+  it('should set the id in state even after a props update', async () => {
+    const wrapper = shallow(
+      <FileOpener
+        router={routerMock}
+        fileId={123}
+        routeParams={{
+          fileId: 123
+        }}
+      />,
+      {
+        disableLifecycleMethods: true
+      }
+    )
+    global.cozy.client.files.statById.mockResolvedValue({
+      _id: '123'
+    })
+    await wrapper.instance().loadFileInfo('123')
+    expect(wrapper.state().file.id).toBe('123')
+    wrapper.setProps({
+      routeParams: {
+        fileId: 456
+      }
+    })
+    global.cozy.client.files.statById.mockResolvedValue({
+      _id: '456'
+    })
+    await wrapper.instance().loadFileInfo('456')
+    expect(wrapper.state().file.id).toBe('456')
+  })
+})


### PR DESCRIPTION
- Component is not unmounted when switching back to other app 
- it's better to use `routeParams` than `router.params` since it's an abstraction and is up to date even if something went wrong 
- react-router v3 doesn't expose render props, right? I wanted to have only props.fileId but... 

- Is there a way to mock   `await cozy.client.files.statById(id, false)` in a test? 
