### PR TITLE
Panning the pdf viewer

### DIFF
--- a/src/viewer/ImageViewer.jsx
+++ b/src/viewer/ImageViewer.jsx
@@ -96,7 +96,7 @@ export default class ImageViewer extends Component {
   }
 
   onSwipe = e => {
-    // when a swipa happens while zoomed into an image, it's most likely a pan gesture and not a swipe
+    // when a swipe happens while zoomed into an image, it's most likely a pan gesture and not a swipe
     if (this.state.scale > 1) return
     // a pan event is triggered after the swipe and may trigger a getBoundingClientRect error
     this.gestures.off('pan')

--- a/src/viewer/PdfJsViewer.jsx
+++ b/src/viewer/PdfJsViewer.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Document, Page } from 'react-pdf/dist/entry.webpack'
 import cx from 'classnames'
 import throttle from 'lodash/throttle'
@@ -31,6 +32,12 @@ export class PdfJsViewer extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.resizeListener)
+  }
+
+  toggleGestures(enable) {
+    if (!this.props.gestures) return
+    this.props.gestures.get('swipe').set({ enable })
+    this.props.gestures.get('pan').set({ enable })
   }
 
   setWrapperSize = () => {
@@ -69,15 +76,25 @@ export class PdfJsViewer extends Component {
   }
 
   scaleUp = () => {
-    this.setState(state => ({
-      scale: Math.min(state.scale + 0.25, MAX_SCALE)
-    }))
+    this.setState(state => {
+      const previousScale = state.scale
+      const scale = Math.min(previousScale + 0.25, MAX_SCALE)
+      if (scale > 1 && previousScale <= 1) this.toggleGestures(false)
+      return {
+        scale
+      }
+    })
   }
 
   scaleDown = () => {
-    this.setState(state => ({
-      scale: Math.max(state.scale - 0.25, MIN_SCALE)
-    }))
+    this.setState(state => {
+      const previousScale = state.scale
+      const scale = Math.max(previousScale - 0.25, MIN_SCALE)
+      if (scale <= 1 && previousScale > 1) this.toggleGestures(true)
+      return {
+        scale
+      }
+    })
   }
 
   render() {
@@ -164,6 +181,11 @@ export class PdfJsViewer extends Component {
       </div>
     )
   }
+}
+
+PdfJsViewer.propTypes = {
+  url: PropTypes.string.isRequired,
+  gestures: PropTypes.object
 }
 
 export default withFileUrl(PdfJsViewer)


### PR DESCRIPTION
Most notably on iOS, it was not possible to pan inside a zoomed pdf. This is because somehow, the swipe and pan handlers defined on the ViewerControls kept intercepting regular touch events even though they shouldn't.

The fix I propose is to disable these event handlers when we are zoomed into the pdf.