### PR TITLE
fix: change screenshots when uploading files (thumb problems)

### DIFF
--- a/testcafe/tests/drive/public-viewer-feature.js
+++ b/testcafe/tests/drive/public-viewer-feature.js
@@ -74,14 +74,13 @@ test(`${TEST_UPLOAD_AND_SHARE}`, async t => {
   )
   await privateDrivePage.uploadFiles(data.filesList)
   //add wait to avoid thumbnail error on screenshots
-  await t.wait(5000)
   await t.fixtureCtx.vr.setMaksCoordonnates({
     height: 935,
     x: 916,
     width: 140,
     y: 248
   })
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+  await privateDrivePage.takeScreenshotsForUpload(
     `${FEATURE_PREFIX}/${TEST_UPLOAD_AND_SHARE}-2`,
     true
   )

--- a/testcafe/tests/helpers/visualreview-utils.js
+++ b/testcafe/tests/helpers/visualreview-utils.js
@@ -29,6 +29,7 @@ export class VisualReviewTestcafe extends VisualReview {
 
   //@param { jsonObject } masK { x, y, width, height } : coordonate for mask. order is the same in gimp rectangle selection
   async setMaksCoordonnates(maskCoordonates) {
+    this.resetMask()
     this.options.mask = {
       excludeZones: [
         {
@@ -50,6 +51,7 @@ export class VisualReviewTestcafe extends VisualReview {
       //re-init mask
       this.resetMask()
     }
+    //always wait for 1s before taking screenshots
     await t.takeScreenshot(`${screenshotsPath}.png`)
 
     this.options.properties.os = await getNavigatorOs()
@@ -57,7 +59,26 @@ export class VisualReviewTestcafe extends VisualReview {
     this.options.properties.resolution = await getResolution()
 
     //the path needs to be in const but i need to define the screenshots tree 1st
-    this.uploadScreenshot(`./reports/${screenshotsPath}.png`)
+    await this.uploadScreenshot(`./reports/${screenshotsPath}.png`)
+  }
+  async takeElementScreenshotAndUpload(
+    selector,
+    screenshotsPath,
+    hasMask = false
+  ) {
+    if (!hasMask) {
+      //re-init mask
+      this.resetMask()
+    }
+    //always wait for 1s before taking screenshots
+    await t.takeElementScreenshot(selector, `${screenshotsPath}.png`)
+
+    this.options.properties.os = await getNavigatorOs()
+    this.options.properties.browser = await getNavigatorName()
+    this.options.properties.resolution = await getResolution()
+
+    //the path needs to be in const but i need to define the screenshots tree 1st
+    await this.uploadScreenshot(`./reports/${screenshotsPath}.png`)
   }
 
   async checkRunStatus() {

--- a/testcafe/tests/pages/drive/drive-model-private.js
+++ b/testcafe/tests/pages/drive/drive-model-private.js
@@ -143,6 +143,20 @@ export default class PrivateDrivePage extends DrivePage {
     }
   }
 
+  async takeScreenshotsForUpload(screenshotsPath, hasMask = false) {
+    await t.fixtureCtx.vr.takeElementScreenshotAndUpload(
+      this.divUpload,
+      `${screenshotsPath}-Divupload`
+    )
+    //add wait to avoid thumbnail error on screenshots
+    await t.wait(5000)
+    //relaod page to load thumbnails
+    await t.eval(() => location.reload(true))
+    await this.waitForLoading()
+
+    await t.fixtureCtx.vr.takeScreenshotAndUpload(screenshotsPath, hasMask)
+  }
+
   async shareFolderPublicLink() {
     await isExistingAndVisibile(this.toolbarFiles, 'toolbarFiles')
     await isExistingAndVisibile(this.btnShare, `Share button`)

--- a/testcafe/tests/pages/drive/drive-model.js
+++ b/testcafe/tests/pages/drive/drive-model.js
@@ -1,7 +1,8 @@
 import { Selector, t } from 'testcafe'
 import {
   getElementWithTestId,
-  isExistingAndVisibile
+  isExistingAndVisibile,
+  checkAllImagesExists
 } from '../../helpers/utils'
 
 export default class DrivePage {
@@ -115,6 +116,7 @@ export default class DrivePage {
         await isExistingAndVisibile(this.folderOrFileName, 'folder list')
       }
     }
+    await checkAllImagesExists()
     console.log('Loading Ok')
   }
 

--- a/testcafe/tests/pages/photos-album/album-model.js
+++ b/testcafe/tests/pages/photos-album/album-model.js
@@ -64,6 +64,7 @@ export default class Page extends PhotoPage {
   async waitForLoading() {
     await t.expect(this.loading.exists).notOk('Page still loading')
     await isExistingAndVisibile(this.albumContentWrapper, 'Content Wrapper')
+    await checkAllImagesExists()
   }
 
   //@param {string} when : text for console.log

--- a/testcafe/tests/pages/photos-albums/albums-model.js
+++ b/testcafe/tests/pages/photos-albums/albums-model.js
@@ -2,7 +2,8 @@ import { t } from 'testcafe'
 import {
   getPageUrl,
   getElementWithTestId,
-  isExistingAndVisibile
+  isExistingAndVisibile,
+  checkAllImagesExists
 } from '../../helpers/utils'
 import AlbumPage from '../photos-album/album-model'
 import PhotoPage from '../photos/photos-model'
@@ -33,6 +34,7 @@ export default class AlbumsPage extends PhotoPage {
   async waitForLoading() {
     await t.expect(this.loading.exists).notOk('Page still loading')
     await isExistingAndVisibile(this.albumContentWrapper, 'Content Wrapper')
+    await checkAllImagesExists()
   }
 
   // check that the albums view is empty

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -1,7 +1,8 @@
 import { t } from 'testcafe'
 import {
   getElementWithTestId,
-  isExistingAndVisibile
+  isExistingAndVisibile,
+  checkAllImagesExists
 } from '../../helpers/utils'
 import Commons from './photos-model'
 
@@ -47,6 +48,20 @@ export default class Timeline extends Commons {
       .eql(t.ctx.allPhotosStartCount + numOfFiles)
   }
 
+  async takeScreenshotsForUpload(screenshotsPath, hasMask = false) {
+    await t.fixtureCtx.vr.takeElementScreenshotAndUpload(
+      this.divUpload,
+      `${screenshotsPath}-Divupload`
+    )
+    //add wait to avoid thumbnail error on screenshots
+    await t.wait(5000)
+    //relaod page to load thumbnails
+    await t.eval(() => location.reload(true))
+    await this.waitForLoading()
+
+    await t.fixtureCtx.vr.takeScreenshotAndUpload(screenshotsPath, hasMask)
+  }
+
   async checkPhotobar() {
     await isExistingAndVisibile(this.barPhoto, 'Selection bar')
     await isExistingAndVisibile(
@@ -64,6 +79,7 @@ export default class Timeline extends Commons {
   async waitForLoading() {
     await t.expect(this.loading.exists).notOk('Page still loading')
     await isExistingAndVisibile(this.contentWrapper, 'Content Wrapper')
+    await checkAllImagesExists()
   }
 
   //@param { number } numOfFiles : number of file to delete

--- a/testcafe/tests/pages/viewer/viewer-model.js
+++ b/testcafe/tests/pages/viewer/viewer-model.js
@@ -1,7 +1,8 @@
 import { t, Selector } from 'testcafe'
 import {
   getElementWithTestId,
-  isExistingAndVisibile
+  isExistingAndVisibile,
+  checkAllImagesExists
 } from '../../helpers/utils'
 
 export default class Viewer {
@@ -34,6 +35,7 @@ export default class Viewer {
     await t.expect(this.spinner.exists).notOk('Spinner still spinning')
     await isExistingAndVisibile(this.viewerWrapper, 'Viewer Wrapper')
     await isExistingAndVisibile(this.viewerControls, 'Viewer Controls')
+    await checkAllImagesExists()
     console.log('Viewer Ok')
   }
 

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -27,11 +27,11 @@ test('Uploading 1 pic from Photos view', async t => {
   await timelinePage.initPhotoCountZero()
   await timelinePage.uploadPhotos([`${DATA_PATH}/${IMG0}`])
 
-  await t.fixtureCtx.vr.takeScreenshotAndUpload('UploadImage/Upload-1-pic')
+  await timelinePage.takeScreenshotsForUpload('UploadImage/Upload-1-pic')
   console.groupEnd()
 })
 
-test('Uploading 4 pics from Photos view', async t => {
+test('Uploading 4 pics from Photos view', async () => {
   console.group('↳ ℹ️  Uploading 4 pics from Photos view')
   await timelinePage.initPhotosCount()
   await timelinePage.uploadPhotos([
@@ -41,6 +41,6 @@ test('Uploading 4 pics from Photos view', async t => {
     `${DATA_PATH}/${IMG4}`
   ])
 
-  await t.fixtureCtx.vr.takeScreenshotAndUpload('UploadImage/Upload-4-pic')
+  await timelinePage.takeScreenshotsForUpload('UploadImage/Upload-4-pic')
   console.groupEnd()
 })


### PR DESCRIPTION
With this PR the screenshots will be a bit different from before so CI will failed until they are set as new baseline, and we have to wait to merge to do that, other wise, other PR will fail because of screenshots! 

New screenshots : 
- When uploading files, now, we wait 10s, then reload to avoid thumbnail problem : https://visualreview.cozycloud.cc/api/image/21707
- Because of this reload, the "upload div" can't be seen, So I added a screenshot on this component only : https://visualreview.cozycloud.cc/api/image/21704
