### PR TITLE
fix: Photo scales in viewer

### DIFF
--- a/src/viewer/controls.styl
+++ b/src/viewer/controls.styl
@@ -4,7 +4,7 @@
 
 .pho-viewer-controls
     display         flex
-    flex-direction  row
+    flex-direction  column
     justify-content center
     align-items center
     width           100%


### PR DESCRIPTION
This fixes a regression that I introduced while refactoring the viewer's css. Most viewers were using a flex direction of `row` so I kept it like that, but I missed the fact that the `ImageViewer` used `column` to make sure the image inside doesn't overflow.

With the new layout, it doesn't actually matter for the other viewers whether the direction is `row` or `column` since there's only one child element anyway. So we can now use `column` everywhere 🏛