### PR TITLE
feature: Add screenshots to photos crud scenario

### DIFF
--- a/testcafe/runner-drive.js
+++ b/testcafe/runner-drive.js
@@ -6,8 +6,8 @@ async function runRunner() {
   process.env.vrErrorMsg = ''
   if (!process.env.INSTANCE_TESTCAFE || !process.env.TESTCAFE_USER_PASSWORD) {
     throw Error(
-      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD 
-      Exemple: 
+      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD
+      Exemple:
       export INSTANCE_TESTCAFE="cozy.tools:8080"
       export TESTCAFE_USER_PASSWORD="foo" `
     )
@@ -47,6 +47,4 @@ async function runRunner() {
   if (response > 0) throw Error(response)
 }
 
-runRunner().catch(e => {
-  console.warn('eror', e)
-})
+runRunner()

--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -6,8 +6,8 @@ async function runRunner() {
   process.env.vrErrorMsg = ''
   if (!process.env.INSTANCE_TESTCAFE || !process.env.TESTCAFE_USER_PASSWORD) {
     throw Error(
-      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD 
-      Ex: \n 
+      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD
+      Ex: \n
       export INSTANCE_TESTCAFE="cozy.tools:8080"
       export TESTCAFE_USER_PASSWORD="foo" `
     )
@@ -48,6 +48,4 @@ async function runRunner() {
   if (response > 0) throw Error(response)
 }
 
-runRunner().catch(e => {
-  console.warn('eror', e)
-})
+runRunner()

--- a/testcafe/tests/drive/classification_scenario.js
+++ b/testcafe/tests/drive/classification_scenario.js
@@ -47,7 +47,7 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_DRIVE_URL}/`
     await initVR(ctx, SLUG, FIXTURE_INIT)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -56,7 +56,7 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_DRIVE_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_CREATE_FOLDER}`, async t => {
+test(TEST_CREATE_FOLDER, async t => {
   await t.maximizeWindow() //Real fullscren for VR
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_CREATE_FOLDER}`)
 
@@ -79,7 +79,7 @@ test(`${TEST_CREATE_FOLDER}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_UPLOAD}`, async t => {
+test(TEST_UPLOAD, async t => {
   console.group(
     `↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UPLOAD} (in "${FEATURE_PREFIX}-Folder2" folder)`
   )
@@ -122,7 +122,7 @@ fixture`${FIXTURE_CLASSIFICATION}`.page`${TESTCAFE_DRIVE_URL}/`
     await initVR(ctx, SLUG, FIXTURE_CLASSIFICATION)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -131,7 +131,7 @@ fixture`${FIXTURE_CLASSIFICATION}`.page`${TESTCAFE_DRIVE_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_RENAME_FILE}`, async t => {
+test(TEST_RENAME_FILE, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_RENAME_FILE}`)
   const [fileName, ext] = FILE_PDF.split('.')
 
@@ -162,7 +162,7 @@ test(`${TEST_RENAME_FILE}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_MOVE_FILE_CANCEL}`, async t => {
+test(TEST_MOVE_FILE_CANCEL, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_MOVE_FILE_CANCEL}`)
   //set mask only once, all screen in this test use the same mask
   await privateDrivePage.goToFolder(`${FEATURE_PREFIX}-Folder2`)
@@ -211,7 +211,7 @@ test(`${TEST_MOVE_FILE_CANCEL}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_MOVE_FILE}`, async t => {
+test(TEST_MOVE_FILE, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_MOVE_FILE}`)
   await privateDrivePage.goToFolder(`${FEATURE_PREFIX}-Folder2`)
 
@@ -228,7 +228,7 @@ test(`${TEST_MOVE_FILE}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_MOVE_FOLDER}`, async t => {
+test(TEST_MOVE_FOLDER, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_MOVE_FOLDER}`)
 
   await privateDrivePage.showMoveModalForElement(`${FEATURE_PREFIX}-Folder2`)
@@ -252,7 +252,7 @@ fixture`${FIXTURE_TRASH}`.page`${TESTCAFE_DRIVE_URL}/`
     await initVR(ctx, SLUG, FIXTURE_TRASH)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -261,7 +261,7 @@ fixture`${FIXTURE_TRASH}`.page`${TESTCAFE_DRIVE_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_DELETE_FOLDER}`, async t => {
+test(TEST_DELETE_FOLDER, async t => {
   console.group(
     `↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE_FOLDER} "${FEATURE_PREFIX}-Folder1"`
   )
@@ -281,7 +281,7 @@ test(`${TEST_DELETE_FOLDER}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_RESTORE_FOLDER}`, async t => {
+test(TEST_RESTORE_FOLDER, async t => {
   console.group(
     `↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_RESTORE_FOLDER} "${FEATURE_PREFIX}-Folder1"`
   )
@@ -305,7 +305,7 @@ test(`${TEST_RESTORE_FOLDER}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_DELETE_FOLDER_FROM_DRIVE}`, async t => {
+test(TEST_DELETE_FOLDER_FROM_DRIVE, async t => {
   console.group(
     `↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE_FOLDER_FROM_DRIVE} "${FEATURE_PREFIX}-Folder1"`
   )
@@ -333,7 +333,7 @@ test(`${TEST_DELETE_FOLDER_FROM_DRIVE}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_NAVIGATE_IN_TRASH}`, async t => {
+test(TEST_NAVIGATE_IN_TRASH, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_NAVIGATE_IN_TRASH}`)
   await privateDrivePage.clickOnSidebarButton(
     selectors.btnNavToTrash,
@@ -359,7 +359,7 @@ test(`${TEST_NAVIGATE_IN_TRASH}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_EMPTY_TRASH}`, async t => {
+test(TEST_EMPTY_TRASH, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_EMPTY_TRASH}`)
   await privateDrivePage.clickOnSidebarButton(
     selectors.btnNavToTrash,

--- a/testcafe/tests/drive/file_sharing_scenario.js
+++ b/testcafe/tests/drive/file_sharing_scenario.js
@@ -21,7 +21,7 @@ const publicViewerPage = new PublicViewerPage()
 //************************
 fixture`File link Sharing Scenario`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -120,7 +120,7 @@ test(`[Mobile] Drive : Access a file public link, download the file, and check t
 //************************
 fixture`Drive : Unshare public link`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -158,7 +158,7 @@ test('Drive : No Access to an old file public link', async t => {
 //************************
 fixture`Test clean up : remove files and folders`
   .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
+  console.group(`\n↳ ℹ️  Login & Initialization`)
   await t.useRole(driveUser)
   await privateDrivePage.waitForLoading()
   console.groupEnd()

--- a/testcafe/tests/drive/folder_sharing_scenario.js
+++ b/testcafe/tests/drive/folder_sharing_scenario.js
@@ -19,7 +19,7 @@ const publicDrivePage = new PublicDrivePage()
 //************************
 fixture`Folder link Sharing Scenario`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -119,7 +119,7 @@ test(`[Mobile] Drive : Access a folder public link, download the file(s), and ch
 //************************
 fixture`Drive : Unshare public link`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -157,7 +157,7 @@ test('`Drive : No Access to an old folder public link', async t => {
 //************************
 fixture`Test clean up : remove files and folders`
   .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
+  console.group(`\n↳ ℹ️  Login & Initialization`)
   await t.useRole(driveUser)
   await privateDrivePage.waitForLoading()
   console.groupEnd()

--- a/testcafe/tests/drive/navigation.js
+++ b/testcafe/tests/drive/navigation.js
@@ -6,7 +6,7 @@ import PrivateDrivePage from '../pages/drive/drive-model-private'
 const privateDrivePage = new PrivateDrivePage()
 
 fixture`DRIVE - NAV`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
+  console.group(`\n↳ ℹ️  Login & Initialization`)
   await t.useRole(driveUser)
   await privateDrivePage.waitForLoading()
   console.groupEnd()

--- a/testcafe/tests/drive/public-viewer-feature.js
+++ b/testcafe/tests/drive/public-viewer-feature.js
@@ -43,7 +43,7 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_DRIVE_URL}/`
     await initVR(ctx, SLUG, FIXTURE_INIT)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -52,7 +52,7 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_DRIVE_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_CREATE_FOLDER}`, async t => {
+test(TEST_CREATE_FOLDER, async t => {
   await t.maximizeWindow() //Real fullscren for VR
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_CREATE_FOLDER}`)
   await privateDrivePage.addNewFolder({
@@ -65,7 +65,7 @@ test(`${TEST_CREATE_FOLDER}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_UPLOAD_AND_SHARE}`, async t => {
+test(TEST_UPLOAD_AND_SHARE, async t => {
   console.group(
     `↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UPLOAD_AND_SHARE} (in "${FEATURE_PREFIX} - ${TEST_CREATE_FOLDER}" folder)`
   )
@@ -109,7 +109,7 @@ fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(
-      `\n↳ ℹ️  no Loggin (anonymous), DOWNLOAD_PATH initialization and Navigate to link`
+      `\n↳ ℹ️  no Login (anonymous), DOWNLOAD_PATH initialization and Navigate to link`
     )
     //await t.useRole(Role.anonymous())
     await t.navigateTo(data.sharingLink)
@@ -135,7 +135,7 @@ fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_DRIVE_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_PUBLIC_VIEWER_ZIP}`, async t => {
+test(TEST_PUBLIC_VIEWER_ZIP, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_VIEWER_ZIP}`)
   //take a general screen for the shared folder :
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
@@ -163,7 +163,7 @@ test(`${TEST_PUBLIC_VIEWER_ZIP}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_PUBLIC_VIEWER_ZIP}`, async t => {
+test(TEST_PUBLIC_VIEWER_ZIP, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_VIEWER_PPTX}`)
   await publicViewerPage.openViewerForFile(data.FILE_PPTX)
   await publicViewerPage.checkNoViewerDownload(data.FILE_PPTX)
@@ -183,7 +183,7 @@ test(`${TEST_PUBLIC_VIEWER_ZIP}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_PUBLIC_VIEWER_IMG}`, async t => {
+test(TEST_PUBLIC_VIEWER_IMG, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_VIEWER_IMG}`)
   await publicViewerPage.openFileAndCheckCommonViewerDownload(data.FILE_IMG)
   t.ctx.fileDownloaded = data.FILE_IMG
@@ -200,7 +200,7 @@ test(`${TEST_PUBLIC_VIEWER_IMG}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_PUBLIC_VIEWER_AUDIO}`, async t => {
+test(TEST_PUBLIC_VIEWER_AUDIO, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_VIEWER_AUDIO}`)
   await publicViewerPage.openFileAndCheckCommonViewerDownload(data.FILE_AUDIO)
   t.ctx.fileDownloaded = data.FILE_AUDIO
@@ -222,7 +222,7 @@ test(`${TEST_PUBLIC_VIEWER_AUDIO}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_PUBLIC_VIEWER_VIDEO}`, async t => {
+test(TEST_PUBLIC_VIEWER_VIDEO, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_VIEWER_VIDEO}`)
   await publicViewerPage.openFileAndCheckCommonViewerDownload(data.FILE_VIDEO)
   t.ctx.fileDownloaded = data.FILE_VIDEO
@@ -244,7 +244,7 @@ test(`${TEST_PUBLIC_VIEWER_VIDEO}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_PUBLIC_VIEWER_TXT}`, async t => {
+test(TEST_PUBLIC_VIEWER_TXT, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_VIEWER_TXT}`)
   await publicViewerPage.openFileAndCheckCommonViewerDownload(data.FILE_TXT)
   t.ctx.fileDownloaded = data.FILE_TXT
@@ -269,7 +269,7 @@ fixture`${FIXTURE_CLEANUP}`.page`${TESTCAFE_DRIVE_URL}/`
     await initVR(ctx, SLUG, FIXTURE_CLEANUP)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -278,7 +278,7 @@ fixture`${FIXTURE_CLEANUP}`.page`${TESTCAFE_DRIVE_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_DELETE_FOLDER}`, async t => {
+test(TEST_DELETE_FOLDER, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE_FOLDER}`)
   await privateDrivePage.goToFolder(TEST_CREATE_FOLDER)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({

--- a/testcafe/tests/drive/viewer-feature.js
+++ b/testcafe/tests/drive/viewer-feature.js
@@ -19,7 +19,7 @@ const viewerPage = new ViewerPage()
 //************************
 fixture`Drive : Viewer features : prepare data`
   .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
+  console.group(`\n↳ ℹ️  Login & Initialization`)
   await t.useRole(driveUser)
   await drivePage.waitForLoading()
   console.groupEnd()
@@ -46,7 +46,7 @@ test('Drive : Go to $test_date_time and upload 26 files', async () => {
 fixture`Drive : Viewer features (and Download)`
   .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
   console.group(
-    `\n↳ ℹ️  Loggin, Page Initialization & data.DOWNLOAD_PATH initialization`
+    `\n↳ ℹ️  Login, Page Initialization & data.DOWNLOAD_PATH initialization`
   )
   await t.useRole(driveUser)
   await drivePage.waitForLoading()
@@ -133,7 +133,7 @@ test('Viewer : no Viewer : other Download', async t => {
 //************************
 fixture`Drive : Viewer features`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin, Page Initialization`)
+    console.group(`\n↳ ℹ️  Login, Page Initialization`)
     await t.useRole(driveUser)
     await drivePage.waitForLoading()
     await drivePage.goToFolder(data.FOLDER_DATE_TIME)
@@ -238,7 +238,7 @@ test('Viewer : text Viewer', async () => {
 //************************
 fixture`Test clean up : remove files and folders`
   .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
+  console.group(`\n↳ ℹ️  Login & Initialization`)
   await t.useRole(driveUser)
   await drivePage.waitForLoading()
   console.groupEnd()

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -31,9 +31,21 @@ export default class Timeline extends Commons {
       )
     await t.takeScreenshot()
     const allPhotosEndCount = await this.getPhotosCount('After')
-    await t
-      .expect(allPhotosEndCount)
-      .eql(t.ctx.totalFilesCount + numOfFiles)
+    await t.expect(allPhotosEndCount).eql(t.ctx.totalFilesCount + numOfFiles)
+  }
+
+  async takeScreenshotsForUpload(screenshotsPath, hasMask = false) {
+    await t.fixtureCtx.vr.takeElementScreenshotAndUpload(
+      selectors.divUpload,
+      `${screenshotsPath}-Divupload`
+    )
+    //add wait to avoid thumbnail error on screenshots
+    await t.wait(THUMBNAIL_DELAY)
+    //relaod page to load thumbnails
+    await t.eval(() => location.reload(true))
+    await this.waitForLoading()
+
+    await t.fixtureCtx.vr.takeScreenshotAndUpload(screenshotsPath, hasMask)
   }
 
   async checkCozyBarOnTimeline() {
@@ -81,8 +93,6 @@ export default class Timeline extends Commons {
       allPhotosEndCount = await this.getPhotosCount('After')
     }
 
-    await t
-      .expect(allPhotosEndCount)
-      .eql(t.ctx.totalFilesCount - numOfFiles)
+    await t.expect(allPhotosEndCount).eql(t.ctx.totalFilesCount - numOfFiles)
   }
 }

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -34,20 +34,6 @@ export default class Timeline extends Commons {
     await t.expect(allPhotosEndCount).eql(t.ctx.totalFilesCount + numOfFiles)
   }
 
-  async takeScreenshotsForUpload(screenshotsPath, hasMask = false) {
-    await t.fixtureCtx.vr.takeElementScreenshotAndUpload(
-      selectors.divUpload,
-      `${screenshotsPath}-Divupload`
-    )
-    //add wait to avoid thumbnail error on screenshots
-    await t.wait(THUMBNAIL_DELAY)
-    //relaod page to load thumbnails
-    await t.eval(() => location.reload(true))
-    await this.waitForLoading()
-
-    await t.fixtureCtx.vr.takeScreenshotAndUpload(screenshotsPath, hasMask)
-  }
-
   async checkCozyBarOnTimeline() {
     await isExistingAndVisibile(selectors.cozySelectionbar, 'Selection bar')
     await isExistingAndVisibile(

--- a/testcafe/tests/photos/album_sharing_scenario.js
+++ b/testcafe/tests/photos/album_sharing_scenario.js
@@ -7,7 +7,7 @@ import {
   checkLocalFile,
   setDownloadPath
 } from '../helpers/utils'
-import { VisualReviewTestcafe } from '../helpers/visualreview-utils'
+import { initVR } from '../helpers/visualreview-utils'
 import * as selectors from '../pages/selectors'
 
 import TimelinePage from '../pages/photos/photos-timeline-model'
@@ -48,14 +48,14 @@ const TEST_DELETE_ALBUM = `5-1 Delete Album`
 //Tests when authentified
 //************************
 fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
+  console.group(`\n↳ ℹ️  Login & Initialization`)
   await t.useRole(photosUser)
   await timelinePage.waitForLoading()
   await timelinePage.initPhotosCount()
   console.groupEnd()
 })
 
-test(`${TEST_CREATE_ALBUM}`, async () => {
+test(TEST_CREATE_ALBUM, async () => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_CREATE_ALBUM}`)
   await timelinePage.goToAlbums()
   await photoAlbumsPage.addNewAlbum(FEATURE_PREFIX, 3)
@@ -64,7 +64,7 @@ test(`${TEST_CREATE_ALBUM}`, async () => {
   console.groupEnd()
 })
 
-test(`${TEST_SHARE_ALBUM}`, async () => {
+test(TEST_SHARE_ALBUM, async () => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_SHARE_ALBUM}`)
   await timelinePage.goToAlbums()
   await photoAlbumsPage.goToAlbum(FEATURE_PREFIX)
@@ -83,11 +83,7 @@ test(`${TEST_SHARE_ALBUM}`, async () => {
 //************************
 fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_PHOTOS_URL}/`
   .before(async ctx => {
-    ctx.vr = new VisualReviewTestcafe({
-      projectName: `${SLUG}`,
-      suiteName: `${FIXTURE_PUBLIC_WITH_DL}`
-    })
-    await ctx.vr.start()
+    await initVR(ctx, SLUG, FIXTURE_PUBLIC_WITH_DL)
   })
   .beforeEach(async t => {
     console.group(
@@ -115,7 +111,7 @@ fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_PHOTOS_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_PUBLIC_ALBUM_DESKTOP}`, async t => {
+test(TEST_PUBLIC_ALBUM_DESKTOP, async t => {
   console.group(
     `↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_ALBUM_DESKTOP} > Access an album public link, check the viewer, download the file(s), and check the 'create Cozy' link`
   )
@@ -142,7 +138,7 @@ test(`${TEST_PUBLIC_ALBUM_DESKTOP}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_PUBLIC_ALBUM_MOBILE}`, async t => {
+test(TEST_PUBLIC_ALBUM_MOBILE, async t => {
   console.group(
     `↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_ALBUM_MOBILE} > Access an album public link, check the viewer, download the file(s), and check the 'create Cozy' link`
   )
@@ -176,7 +172,7 @@ test(`${TEST_PUBLIC_ALBUM_MOBILE}`, async t => {
 //************************
 fixture`${FIXTURE_UNSHARE}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()
@@ -184,7 +180,7 @@ fixture`${FIXTURE_UNSHARE}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   }
 )
 
-test(`${TEST_UNSHARE_ALBUM}`, async () => {
+test(TEST_UNSHARE_ALBUM, async () => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UNSHARE_ALBUM}`)
   await timelinePage.goToAlbums()
   await photoAlbumsPage.goToAlbum(FEATURE_PREFIX)
@@ -203,7 +199,7 @@ fixture`${FIXTURE_PUBLIC_NO_ACCESS}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   }
 )
 
-test(`${TEST_PUBLIC_NO_ACCESS}`, async t => {
+test(TEST_PUBLIC_NO_ACCESS, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_PUBLIC_NO_ACCESS}`)
   await t.navigateTo(data.sharingLink)
   await publicPhotoPage.waitForLoading()
@@ -216,7 +212,7 @@ test(`${TEST_PUBLIC_NO_ACCESS}`, async t => {
 //************************
 fixture`${FIXTURE_CLEANUP}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()
@@ -224,7 +220,7 @@ fixture`${FIXTURE_CLEANUP}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   }
 )
 
-test(`${TEST_DELETE_ALBUM}`, async () => {
+test(TEST_DELETE_ALBUM, async () => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE_ALBUM}`)
   await timelinePage.goToAlbums()
   await photoAlbumsPage.goToAlbum(`${FEATURE_PREFIX}`)

--- a/testcafe/tests/photos/create_empty_album_scenario.js
+++ b/testcafe/tests/photos/create_empty_album_scenario.js
@@ -11,7 +11,7 @@ const photoAlbumsPage = new AlbumsPage()
 
 fixture`Create new empty album and add photos`
   .page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
+  console.group(`\n↳ ℹ️  Login & Initialization`)
 
   await t.useRole(photosUser)
   await timelinePage.waitForLoading()

--- a/testcafe/tests/photos/create_full_album_scenario.js
+++ b/testcafe/tests/photos/create_full_album_scenario.js
@@ -11,7 +11,7 @@ const photoAlbumsPage = new AlbumsPage()
 
 fixture`Create new album with photos`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()

--- a/testcafe/tests/photos/photos_crud.js
+++ b/testcafe/tests/photos/photos_crud.js
@@ -4,13 +4,13 @@ import random from 'lodash/random'
 import { initVR } from '../helpers/visualreview-utils'
 import Viewer from '../pages/photos-viewer/photos-viewer-model'
 import Timeline from '../pages/photos/photos-timeline-model'
-
+import * as selectors from '../pages/selectors'
 const timelinePage = new Timeline()
 const photoViewer = new Viewer()
 
 //Scenario const
 const FEATURE_PREFIX = 'PhotosCrud'
-const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Photos Navigationn`
+const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Photos Navigation`
 const TEST_SELECT1 = `1-1 Select 1 photo`
 const TEST_SELECT2 = `1-2 Select 3 photos`
 const TEST_VIEWER_FIRST = `1-1 Open viewer for 1st photo`
@@ -37,9 +37,9 @@ test(TEST_SELECT1, async t => {
   //Selection bar shows up. It includes AddtoAlbun, Download and Delete buttons
   await timelinePage.selectPhotos(1)
   await timelinePage.checkCozyBarOnTimeline()
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
-    `${FEATURE_PREFIX}/${TEST_SELECT1}-1`
-  )
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_SELECT1}-1`
+  })
   console.groupEnd()
 })
 
@@ -48,9 +48,9 @@ test(TEST_SELECT2, async t => {
   //Selection bar shows up. It includes AddtoAlbun, Download and Delete buttons
   await timelinePage.selectPhotos(3)
   await timelinePage.checkCozyBarOnTimeline()
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
-    `${FEATURE_PREFIX}/${TEST_SELECT2}-1`
-  )
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_SELECT2}-1`
+  })
   console.groupEnd()
 })
 
@@ -58,10 +58,13 @@ test(TEST_VIEWER_FIRST, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_FIRST}`)
   //Right arrow shows up. Navigation to other pics is OK, Closing pic (X or 'esc') is Ok
   await photoViewer.openPhotoFullscreen(0)
-
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
-    `${FEATURE_PREFIX}/${TEST_VIEWER_FIRST}-1`
-  )
+  await t.hover(selectors.viewerControls, {
+    offsetX: 0,
+    offsetY: 0
+  })
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_VIEWER_FIRST}-1`
+  })
   await photoViewer.navigateToNextFile(0)
   await photoViewer.closeViewer({
     exitWithEsc: true
@@ -78,9 +81,13 @@ test(TEST_VIEWER_LAST, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_LAST}`)
   //Left arrow shows up. Navigation to other pics is OK, Closing pic (X or 'esc') is Ok
   await photoViewer.openPhotoFullscreen(t.ctx.totalFilesCount - 1)
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
-    `${FEATURE_PREFIX}/${TEST_VIEWER_LAST}-1`
-  )
+  await t.hover(selectors.viewerControls, {
+    offsetX: 0,
+    offsetY: 0
+  })
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_VIEWER_LAST}-1`
+  })
   await photoViewer.navigateToNextFile(t.ctx.totalFilesCount - 1)
   await photoViewer.closeViewer({
     exitWithEsc: true
@@ -101,9 +108,13 @@ test(TEST_VIEWER_OTHER, async t => {
 
   console.log('Open random pic  > photoIndex ' + photoIndex)
   await photoViewer.openPhotoFullscreen(photoIndex)
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
-    `${FEATURE_PREFIX}/${TEST_VIEWER_OTHER}-1`
-  )
+  await t.hover(selectors.viewerControls, {
+    offsetX: 0,
+    offsetY: 0
+  })
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_VIEWER_OTHER}-1`
+  })
   await photoViewer.navigateToNextFile(photoIndex)
   await photoViewer.closeViewer({
     exitWithEsc: true

--- a/testcafe/tests/photos/photos_crud.js
+++ b/testcafe/tests/photos/photos_crud.js
@@ -1,40 +1,71 @@
 import { photosUser } from '../helpers/roles' //import roles for login
-import { TESTCAFE_PHOTOS_URL } from '../helpers/utils'
+import { TESTCAFE_PHOTOS_URL, SLUG } from '../helpers/utils'
 import random from 'lodash/random'
+import { VisualReviewTestcafe } from '../helpers/visualreview-utils'
 import Viewer from '../pages/photos-viewer/photos-viewer-model'
 import Timeline from '../pages/photos/photos-timeline-model'
 
 const timelinePage = new Timeline()
 const photoViewer = new Viewer()
 
-fixture`PHOTOS - CRUD`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
-  console.group(`\n↳ ℹ️  Loggin & Initialization`)
-  await t.useRole(photosUser)
-  await timelinePage.waitForLoading()
-  await timelinePage.initPhotosCount()
-  console.groupEnd()
-})
+//Scenario const
+const FEATURE_PREFIX = 'PhotosCrud'
+const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Photos Navigation`
+const TEST_SELECT1 = `1-1 Select 1 photo`
+const TEST_SELECT2 = `1-2 Select 3 photos`
+const TEST_VIEWER_FIRST = `1-1 Open viewer for 1st photo`
+const TEST_VIEWER_LAST = `1-1 Open viewer for last photo`
+const TEST_VIEWER_OTHER = `1-1 Open viewer for 2nd photo`
 
-test('Select 1 pic from Photos view', async () => {
-  console.group('↳ ℹ️  Select 1 pic from Photos view')
+fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
+  .before(async ctx => {
+    ctx.vr = new VisualReviewTestcafe({
+      projectName: `${SLUG}`,
+      suiteName: `${FIXTURE_INIT}`
+    })
+    await ctx.vr.start()
+  })
+  .beforeEach(async t => {
+    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    await t.useRole(photosUser)
+    await timelinePage.waitForLoading()
+    await timelinePage.initPhotosCount()
+    console.groupEnd()
+  })
+  .after(async ctx => {
+    await ctx.vr.checkRunStatus()
+  })
+
+test(`${TEST_SELECT1}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_SELECT1}`)
   //Selection bar shows up. It includes AddtoAlbun, Download and Delete buttons
   await timelinePage.selectPhotos(1)
   await timelinePage.checkCozyBarOnTimeline()
+  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+    `${FEATURE_PREFIX}/${TEST_SELECT1}-1`
+  )
   console.groupEnd()
 })
 
-test('Select 3 pic from Photos view', async () => {
-  console.group('↳ ℹ️  Select 3 pic from Photos view')
+test(`${TEST_SELECT2}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_SELECT2}`)
   //Selection bar shows up. It includes AddtoAlbun, Download and Delete buttons
   await timelinePage.selectPhotos(3)
   await timelinePage.checkCozyBarOnTimeline()
+  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+    `${FEATURE_PREFIX}/${TEST_SELECT2}-1`
+  )
   console.groupEnd()
 })
 
-test('Open 1st pic', async () => {
-  console.group('↳ ℹ️  Open 1st pic')
+test(`${TEST_VIEWER_FIRST}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_FIRST}`)
   //Right arrow shows up. Navigatio to other pics is OK, Closing pic (X or 'esc') is Ok
   await photoViewer.openPhotoFullscreen(0)
+
+  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+    `${FEATURE_PREFIX}/${TEST_VIEWER_FIRST}-1`
+  )
   await photoViewer.navigateToNextFile(0)
   await photoViewer.closeViewer({
     exitWithEsc: true
@@ -47,10 +78,13 @@ test('Open 1st pic', async () => {
   console.groupEnd()
 })
 
-test('Open Last pic', async t => {
-  console.group('↳ ℹ️  Open Last pic')
+test(`${TEST_VIEWER_LAST}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_LAST}`)
   //Left arrow shows up. Navigatio to other pics is OK, Closing pic (X or 'esc') is Ok
   await photoViewer.openPhotoFullscreen(t.ctx.totalFilesCount - 1)
+  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+    `${FEATURE_PREFIX}/${TEST_VIEWER_LAST}-1`
+  )
   await photoViewer.navigateToNextFile(t.ctx.totalFilesCount - 1)
   await photoViewer.closeViewer({
     exitWithEsc: true
@@ -63,14 +97,17 @@ test('Open Last pic', async t => {
   console.groupEnd()
 })
 
-test('Open a random pic (not first nor last)', async t => {
-  console.group('↳ ℹ️  Open a random pic (not first nor last)')
+test(`${TEST_VIEWER_OTHER}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_OTHER}`)
   //Both arrows show up. Navigatio to other pics is OK, Closing pic (X or 'esc') is Ok
   // We need at least 3 pics in our cozy for this test to pass
   const photoIndex = random(1, t.ctx.totalFilesCount - 2)
 
   console.log('Open random pic  > photoIndex ' + photoIndex)
   await photoViewer.openPhotoFullscreen(photoIndex)
+  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+    `${FEATURE_PREFIX}/${TEST_VIEWER_OTHER}-1`
+  )
   await photoViewer.navigateToNextFile(photoIndex)
   await photoViewer.closeViewer({
     exitWithEsc: true

--- a/testcafe/tests/photos/photos_crud.js
+++ b/testcafe/tests/photos/photos_crud.js
@@ -1,7 +1,7 @@
 import { photosUser } from '../helpers/roles' //import roles for login
 import { TESTCAFE_PHOTOS_URL, SLUG } from '../helpers/utils'
 import random from 'lodash/random'
-import { VisualReviewTestcafe } from '../helpers/visualreview-utils'
+import { initVR } from '../helpers/visualreview-utils'
 import Viewer from '../pages/photos-viewer/photos-viewer-model'
 import Timeline from '../pages/photos/photos-timeline-model'
 
@@ -10,7 +10,7 @@ const photoViewer = new Viewer()
 
 //Scenario const
 const FEATURE_PREFIX = 'PhotosCrud'
-const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Photos Navigation`
+const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Photos Navigationn`
 const TEST_SELECT1 = `1-1 Select 1 photo`
 const TEST_SELECT2 = `1-2 Select 3 photos`
 const TEST_VIEWER_FIRST = `1-1 Open viewer for 1st photo`
@@ -19,14 +19,10 @@ const TEST_VIEWER_OTHER = `1-1 Open viewer for 2nd photo`
 
 fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   .before(async ctx => {
-    ctx.vr = new VisualReviewTestcafe({
-      projectName: `${SLUG}`,
-      suiteName: `${FIXTURE_INIT}`
-    })
-    await ctx.vr.start()
+    await initVR(ctx, SLUG, FIXTURE_INIT)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()
@@ -36,7 +32,7 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_SELECT1}`, async t => {
+test(TEST_SELECT1, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_SELECT1}`)
   //Selection bar shows up. It includes AddtoAlbun, Download and Delete buttons
   await timelinePage.selectPhotos(1)
@@ -47,7 +43,7 @@ test(`${TEST_SELECT1}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_SELECT2}`, async t => {
+test(TEST_SELECT2, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_SELECT2}`)
   //Selection bar shows up. It includes AddtoAlbun, Download and Delete buttons
   await timelinePage.selectPhotos(3)
@@ -58,9 +54,9 @@ test(`${TEST_SELECT2}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_VIEWER_FIRST}`, async t => {
+test(TEST_VIEWER_FIRST, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_FIRST}`)
-  //Right arrow shows up. Navigatio to other pics is OK, Closing pic (X or 'esc') is Ok
+  //Right arrow shows up. Navigation to other pics is OK, Closing pic (X or 'esc') is Ok
   await photoViewer.openPhotoFullscreen(0)
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload(
@@ -78,9 +74,9 @@ test(`${TEST_VIEWER_FIRST}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_VIEWER_LAST}`, async t => {
+test(TEST_VIEWER_LAST, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_LAST}`)
-  //Left arrow shows up. Navigatio to other pics is OK, Closing pic (X or 'esc') is Ok
+  //Left arrow shows up. Navigation to other pics is OK, Closing pic (X or 'esc') is Ok
   await photoViewer.openPhotoFullscreen(t.ctx.totalFilesCount - 1)
   await t.fixtureCtx.vr.takeScreenshotAndUpload(
     `${FEATURE_PREFIX}/${TEST_VIEWER_LAST}-1`
@@ -97,9 +93,9 @@ test(`${TEST_VIEWER_LAST}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_VIEWER_OTHER}`, async t => {
+test(TEST_VIEWER_OTHER, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_VIEWER_OTHER}`)
-  //Both arrows show up. Navigatio to other pics is OK, Closing pic (X or 'esc') is Ok
+  //Both arrows show up. Navigation to other pics is OK, Closing pic (X or 'esc') is Ok
   // We need at least 3 pics in our cozy for this test to pass
   const photoIndex = random(1, t.ctx.totalFilesCount - 2)
 

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -33,9 +33,9 @@ test(TEST_DELETE1, async t => {
   //pic is removed
   await timelinePage.deletePhotosFromTimeline(1)
 
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
-    `${FEATURE_PREFIX}/${TEST_DELETE1}-1`
-  )
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE1}-1`
+  })
   console.groupEnd()
 })
 
@@ -45,8 +45,8 @@ test(TEST_DELETE2, async t => {
   //pics are removed, there are no more pictures on  page
   await timelinePage.deletePhotosFromTimeline(4, true)
 
-  await t.fixtureCtx.vr.takeScreenshotAndUpload(
-    `${FEATURE_PREFIX}/${TEST_DELETE2}-1`
-  )
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE2}-1`
+  })
   console.groupEnd()
 })

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -1,14 +1,24 @@
 import { photosUser } from '../helpers/roles'
 import { TESTCAFE_PHOTOS_URL, SLUG } from '../helpers/utils'
 import { IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
-import { initVR } from '../helpers/visualreview-utils'
+import { VisualReviewTestcafe } from '../helpers/visualreview-utils'
 import TimelinePage from '../pages/photos/photos-timeline-model'
 
 const timelinePage = new TimelinePage()
 
-fixture`Delete all photos`.page`${TESTCAFE_PHOTOS_URL}/`
+//Scenario const
+const FEATURE_PREFIX = 'PhotosDelete'
+const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Delete Photos`
+const TEST_DELETE1 = `1-1 Delete 1 photo`
+const TEST_DELETE2 = `1-2 Delete 4 photos`
+
+fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   .before(async ctx => {
-    await initVR(ctx, SLUG, `fixture : delete photos`)
+    ctx.vr = new VisualReviewTestcafe({
+      projectName: `${SLUG}`,
+      suiteName: `${FIXTURE_INIT}`
+    })
+    await ctx.vr.start()
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Loggin & Initialization`)
@@ -21,30 +31,26 @@ fixture`Delete all photos`.page`${TESTCAFE_PHOTOS_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test('Deleting 1st pic on Timeline : Open up a modal, and confirm', async t => {
-  console.group(
-    '↳ ℹ️  Deleting 1st pic on Timeline : Open up a modal, and confirm'
-  )
+test(`${TEST_DELETE1}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE1}`)
   await timelinePage.selectPhotosByName([IMG0])
   //pic is removed
   await timelinePage.deletePhotosFromTimeline(1)
 
-  await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: 'DeleteImage/delete-1-pic'
-  })
+  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+    `${FEATURE_PREFIX}/${TEST_DELETE1}-1`
+  )
   console.groupEnd()
 })
 
-test('Deleting the 1st 4 pics on Timeline : Open up a modal, and confirm', async t => {
-  console.group(
-    '↳ ℹ️  Deleting the 1st 4 pics on Timeline : Open up a modal, and confirm'
-  )
+test(`${TEST_DELETE2}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE2}`)
   await timelinePage.selectPhotosByName([IMG1, IMG2, IMG3, IMG4])
   //pics are removed, there are no more pictures on  page
   await timelinePage.deletePhotosFromTimeline(4, true)
 
-  await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: 'DeleteImage/delete-4-pics'
-  })
+  await t.fixtureCtx.vr.takeScreenshotAndUpload(
+    `${FEATURE_PREFIX}/${TEST_DELETE2}-1`
+  )
   console.groupEnd()
 })

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -1,7 +1,7 @@
 import { photosUser } from '../helpers/roles'
 import { TESTCAFE_PHOTOS_URL, SLUG } from '../helpers/utils'
 import { IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
-import { VisualReviewTestcafe } from '../helpers/visualreview-utils'
+import { initVR } from '../helpers/visualreview-utils'
 import TimelinePage from '../pages/photos/photos-timeline-model'
 
 const timelinePage = new TimelinePage()
@@ -14,14 +14,10 @@ const TEST_DELETE2 = `1-2 Delete 4 photos`
 
 fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   .before(async ctx => {
-    ctx.vr = new VisualReviewTestcafe({
-      projectName: `${SLUG}`,
-      suiteName: `${FIXTURE_INIT}`
-    })
-    await ctx.vr.start()
+    await initVR(ctx, SLUG, FIXTURE_INIT)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()
@@ -31,7 +27,7 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_DELETE1}`, async t => {
+test(TEST_DELETE1, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE1}`)
   await timelinePage.selectPhotosByName([IMG0])
   //pic is removed
@@ -43,7 +39,7 @@ test(`${TEST_DELETE1}`, async t => {
   console.groupEnd()
 })
 
-test(`${TEST_DELETE2}`, async t => {
+test(TEST_DELETE2, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE2}`)
   await timelinePage.selectPhotosByName([IMG1, IMG2, IMG3, IMG4])
   //pics are removed, there are no more pictures on  page

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -1,6 +1,14 @@
 import { photosUser } from '../helpers/roles'
 import { TESTCAFE_PHOTOS_URL, SLUG } from '../helpers/utils'
-import { DATA_PATH, IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
+import {
+  DATA_PATH,
+  IMG0,
+  IMG1,
+  IMG2,
+  IMG3,
+  IMG4,
+  THUMBNAIL_DELAY
+} from '../helpers/data'
 import { initVR } from '../helpers/visualreview-utils'
 import TimelinePage from '../pages/photos/photos-timeline-model'
 import * as selectors from '../pages/selectors'
@@ -34,22 +42,20 @@ test(TEST_UPLOAD1, async t => {
   await timelinePage.initPhotoCountZero()
   await timelinePage.uploadPhotos([`${DATA_PATH}/${IMG0}`])
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: `UploadImage/Upload-1-pic-Divupload`,
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_UPLOAD1}-1-Divupload`,
     selector: selectors.divUpload
   })
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: 'UploadImage/Upload-1-pic',
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_UPLOAD1}-1`,
     delay: THUMBNAIL_DELAY,
     pageToWait: timelinePage
   })
-  await timelinePage.takeScreenshotsForUpload(
-    `${FEATURE_PREFIX}/${TEST_UPLOAD1}-1`
-  )
+
   console.groupEnd()
 })
 
-test(TEST_UPLOAD2, async () => {
+test(TEST_UPLOAD2, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UPLOAD2}`)
   await timelinePage.initPhotosCount()
   await timelinePage.uploadPhotos([
@@ -59,15 +65,12 @@ test(TEST_UPLOAD2, async () => {
     `${DATA_PATH}/${IMG4}`
   ])
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: `UploadImage/Upload-4-pic-Divupload`,
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_UPLOAD1}-2-Divupload`,
     selector: selectors.divUpload
   })
 
-  await timelinePage.takeScreenshotsForUpload(
-    `${FEATURE_PREFIX}/${TEST_UPLOAD2}-1`
-  )
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: 'UploadImage/Upload-4-pic',
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_UPLOAD1}-2`,
     delay: THUMBNAIL_DELAY,
     pageToWait: timelinePage
   })

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -15,9 +15,19 @@ import * as selectors from '../pages/selectors'
 
 const timelinePage = new TimelinePage()
 
-fixture`Upload photos`.page`${TESTCAFE_PHOTOS_URL}/`
+//Scenario const
+const FEATURE_PREFIX = 'PhotosUpload'
+const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Upload Photos`
+const TEST_UPLOAD1 = `1-1 Upload 1 photo`
+const TEST_UPLOAD2 = `1-2 Upload 4 photos`
+
+fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   .before(async ctx => {
-    await initVR(ctx, SLUG, `fixture : upload photos`)
+    ctx.vr = new VisualReviewTestcafe({
+      projectName: `${SLUG}`,
+      suiteName: `${FIXTURE_INIT}`
+    })
+    await ctx.vr.start()
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Loggin & Initialization`)
@@ -29,8 +39,8 @@ fixture`Upload photos`.page`${TESTCAFE_PHOTOS_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test('Uploading 1 pic from Photos view', async t => {
-  console.group('↳ ℹ️  Uploading 1 pic from Photos view')
+test(`${TEST_UPLOAD1}`, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UPLOAD1}`)
   await t.maximizeWindow() //Real fullscren for VR
   ///there is no photos on page
   await timelinePage.initPhotoCountZero()
@@ -45,11 +55,16 @@ test('Uploading 1 pic from Photos view', async t => {
     delay: THUMBNAIL_DELAY,
     pageToWait: timelinePage
   })
+  await timelinePage.takeScreenshotsForUpload(
+    `${FEATURE_PREFIX}/${TEST_UPLOAD1}-1`
+  )
   console.groupEnd()
 })
 
 test('Uploading 4 pics from Photos view', async t => {
   console.group('↳ ℹ️  Uploading 4 pics from Photos view')
+test(`${TEST_UPLOAD2}`, async () => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UPLOAD2}`)
   await timelinePage.initPhotosCount()
   await timelinePage.uploadPhotos([
     `${DATA_PATH}/${IMG1}`,
@@ -62,6 +77,9 @@ test('Uploading 4 pics from Photos view', async t => {
     selector: selectors.divUpload
   })
 
+  await timelinePage.takeScreenshotsForUpload(
+    `${FEATURE_PREFIX}/${TEST_UPLOAD2}-1`
+  )
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: 'UploadImage/Upload-4-pic',
     delay: THUMBNAIL_DELAY,

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -1,14 +1,6 @@
 import { photosUser } from '../helpers/roles'
 import { TESTCAFE_PHOTOS_URL, SLUG } from '../helpers/utils'
-import {
-  THUMBNAIL_DELAY,
-  DATA_PATH,
-  IMG0,
-  IMG1,
-  IMG2,
-  IMG3,
-  IMG4
-} from '../helpers/data'
+import { DATA_PATH, IMG0, IMG1, IMG2, IMG3, IMG4 } from '../helpers/data'
 import { initVR } from '../helpers/visualreview-utils'
 import TimelinePage from '../pages/photos/photos-timeline-model'
 import * as selectors from '../pages/selectors'
@@ -23,14 +15,10 @@ const TEST_UPLOAD2 = `1-2 Upload 4 photos`
 
 fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   .before(async ctx => {
-    ctx.vr = new VisualReviewTestcafe({
-      projectName: `${SLUG}`,
-      suiteName: `${FIXTURE_INIT}`
-    })
-    await ctx.vr.start()
+    await initVR(ctx, SLUG, FIXTURE_INIT)
   })
   .beforeEach(async t => {
-    console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    console.group(`\n↳ ℹ️  Login & Initialization`)
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     console.groupEnd()
@@ -39,7 +27,7 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
     await ctx.vr.checkRunStatus()
   })
 
-test(`${TEST_UPLOAD1}`, async t => {
+test(TEST_UPLOAD1, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UPLOAD1}`)
   await t.maximizeWindow() //Real fullscren for VR
   ///there is no photos on page
@@ -61,9 +49,7 @@ test(`${TEST_UPLOAD1}`, async t => {
   console.groupEnd()
 })
 
-test('Uploading 4 pics from Photos view', async t => {
-  console.group('↳ ℹ️  Uploading 4 pics from Photos view')
-test(`${TEST_UPLOAD2}`, async () => {
+test(TEST_UPLOAD2, async () => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_UPLOAD2}`)
   await timelinePage.initPhotosCount()
   await timelinePage.uploadPhotos([


### PR DESCRIPTION
Photos crud scenario was already split into 3 scenario : Upload photos, photos crud, and Delete Photos.
For each one:
- Add const for test names and logs
- change `initVR` to `ctx.vr.start()`
- change name for existing screenshots
- add new screenshots
- move `checkAllImagesExists` to avoid error when reloading page
- change test `open random photos, not 1st nor last` to `open 2nd photo` , beaucse we need to open the same photos each time when taking screenshots