### PR TITLE
fix: fix error 'ClientFunction execution was interrupted by page unload'

### DIFF
--- a/testcafe/tests/pages/photos-album/album-model.js
+++ b/testcafe/tests/pages/photos-album/album-model.js
@@ -64,7 +64,6 @@ export default class Page extends PhotoPage {
   async waitForLoading() {
     await t.expect(this.loading.exists).notOk('Page still loading')
     await isExistingAndVisibile(this.albumContentWrapper, 'Content Wrapper')
-    await checkAllImagesExists()
   }
 
   //@param {string} when : text for console.log

--- a/testcafe/tests/pages/photos-albums/albums-model.js
+++ b/testcafe/tests/pages/photos-albums/albums-model.js
@@ -2,8 +2,7 @@ import { t } from 'testcafe'
 import {
   getPageUrl,
   getElementWithTestId,
-  isExistingAndVisibile,
-  checkAllImagesExists
+  isExistingAndVisibile
 } from '../../helpers/utils'
 import AlbumPage from '../photos-album/album-model'
 import PhotoPage from '../photos/photos-model'
@@ -34,7 +33,6 @@ export default class AlbumsPage extends PhotoPage {
   async waitForLoading() {
     await t.expect(this.loading.exists).notOk('Page still loading')
     await isExistingAndVisibile(this.albumContentWrapper, 'Content Wrapper')
-    await checkAllImagesExists()
   }
 
   // check that the albums view is empty

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -1,8 +1,7 @@
 import { t } from 'testcafe'
 import {
   getElementWithTestId,
-  isExistingAndVisibile,
-  checkAllImagesExists
+  isExistingAndVisibile
 } from '../../helpers/utils'
 import Commons from './photos-model'
 
@@ -79,7 +78,6 @@ export default class Timeline extends Commons {
   async waitForLoading() {
     await t.expect(this.loading.exists).notOk('Page still loading')
     await isExistingAndVisibile(this.contentWrapper, 'Content Wrapper')
-    await checkAllImagesExists()
   }
 
   //@param { number } numOfFiles : number of file to delete

--- a/testcafe/tests/pages/viewer/viewer-model.js
+++ b/testcafe/tests/pages/viewer/viewer-model.js
@@ -1,8 +1,7 @@
 import { t, Selector } from 'testcafe'
 import {
   getElementWithTestId,
-  isExistingAndVisibile,
-  checkAllImagesExists
+  isExistingAndVisibile
 } from '../../helpers/utils'
 
 export default class Viewer {
@@ -35,7 +34,6 @@ export default class Viewer {
     await t.expect(this.spinner.exists).notOk('Spinner still spinning')
     await isExistingAndVisibile(this.viewerWrapper, 'Viewer Wrapper')
     await isExistingAndVisibile(this.viewerControls, 'Viewer Controls')
-    await checkAllImagesExists()
     console.log('Viewer Ok')
   }
 


### PR DESCRIPTION
fix error : 

```
ClientFunction execution was interrupted by page unload. This
      problem may appear if you trigger page navigation from
      ClientFunction code.
```
