### PR TITLE
Fix delete album action color

### DIFF
--- a/src/photos/styles/toolbar.styl
+++ b/src/photos/styles/toolbar.styl
@@ -1,4 +1,5 @@
 @require 'settings/breakpoints.styl'
+@require 'settings/palette.styl'
 @require 'components/button.styl'
 @require 'utilities/display.styl'
 


### PR DESCRIPTION
Delete album action should be red, importing the palette in `toolbar.styl` does the trick

Same as in https://github.com/cozy/cozy-drive/pull/1572