### PR TITLE
chore: delete and retry if instance already exists

### DIFF
--- a/scripts/create-deploy-test.sh
+++ b/scripts/create-deploy-test.sh
@@ -20,6 +20,14 @@ getRundeckStatus $INSTANCE_CREATE_EXECUTION_ID
 INSTANCE_CREATE_STATUS=$?
 
 if [ $INSTANCE_CREATE_STATUS == 0 ] ; then
+  if [[ "${LOG_OUTPUT,,}" == *"instance already exists"* ]]; then
+    source ./scripts/delete-instance.sh
+    source ./scripts/create-deploy-test.sh
+  elif [[ "${LOG_OUTPUT,,}" != *"instance already exists"* ]] && [[ "${LOG_OUTPUT,,}" == *"error"* ]]; then
+  # error other than instance already exists
+    exit 1;
+  fi
+
   INSTANCE_TESTCAFE=$(echo $LOG_OUTPUT  | grep -o -P "(?<=instance_fqdn: ).*?(?=' level)")
   echo "↳ ℹ️  Instance $INSTANCE_TESTCAFE"
   echo "export INSTANCE_TESTCAFE=$INSTANCE_TESTCAFE" > setinstance.sh

--- a/scripts/delete-instance.sh
+++ b/scripts/delete-instance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 source ./scripts/rundeck.sh
-source ./setinstance.sh
+INSTANCE_ID=$COZY_APP_SLUG$TRAVIS_PULL_REQUEST
 
 JOB_DELETE_TEST_INSTANCE="c11109ae-6690-4b9f-9471-e8d74e0e0b3c"
 
@@ -19,5 +19,5 @@ getRundeckStatus $INSTANCE_DELETE_EXECUTION_ID
 INSTANCE_DELETE_EXECUTION_STATUS=$?
 echo $INSTANCE_DELETE_EXECUTION_STATUS
 if [ $INSTANCE_DELETE_EXECUTION_STATUS == 0 ] ; then
-  echo "↳ ✅ Instance $INSTANCE_TESTCAFE deleted"
+  echo "↳ ✅ Instance testauto${INSTANCE_ID}.cozy.rocks deleted"
 fi

--- a/scripts/rundeck.sh
+++ b/scripts/rundeck.sh
@@ -58,7 +58,7 @@ function getRundeckStatus {
 
     #The job can be succesfull. but return an error, so we need to check!
     if [[ "${LOG_OUTPUT,,}" == *"error"* ]]; then
-      echo "❌ Execution ${1} returned an error :" && echo $LOG_OUTPUT && exit 1;
+      echo "❌ Execution ${1} returned an error :" && echo $LOG_OUTPUT 
       else
         return 0
     fi


### PR DESCRIPTION
Add a check on `instance already exists` in error log. 
If that case : delete instance, and re-create it.

This should stabilize our build process