### PR TITLE
fix: Update RealTime when context token change

### DIFF
--- a/src/drive/web/modules/navigation/RealtimeFiles.jsx
+++ b/src/drive/web/modules/navigation/RealtimeFiles.jsx
@@ -14,16 +14,15 @@ import {
 } from 'drive/web/modules/navigation/duck'
 import { updateOfflineFileCopyIfNecessary } from 'drive/mobile/modules/offline/duck'
 
-class RealtimeFiles extends React.Component {
+export class RealtimeFiles extends React.Component {
   realtimeListener = null
   pouchListener = null
   static contextTypes = {
     client: PropTypes.object.isRequired
   }
-  async componentWillMount() {
+  componentWillMount() {
     const { stackClient: client } = this.context.client
     const { token, uri } = client
-
     this.realtimeListener = realtime
       .subscribe(
         {
@@ -35,7 +34,6 @@ class RealtimeFiles extends React.Component {
       .onCreate(this.onDocumentChange)
       .onUpdate(this.onDocumentChange)
       .onDelete(this.onDocumentDeletion)
-
     const db = cozy.client.offline.getDatabase('io.cozy.files')
     if (db) {
       this.pouchListener = db.changes({
@@ -54,7 +52,32 @@ class RealtimeFiles extends React.Component {
         })
     }
   }
-
+  /* 
+  I know, willReceiveProps is deprecated but we use the old API context
+  */
+  componentWillReceiveProps(nextProps, nextContext) {
+    const { stackClient: client } = nextContext.client
+    const { token, uri } = client
+    if (token !== this.context.client.stackClient.token) {
+      // eslint-disable-next-line no-console
+      console.log('Update realtime token')
+      if (this.realtimeListener) {
+        this.realtimeListener.unsubscribe()
+        this.realtimeListener = null
+      }
+      this.realtimeListener = realtime
+        .subscribe(
+          {
+            token: token.token || token.accessToken,
+            url: uri
+          },
+          'io.cozy.files'
+        )
+        .onCreate(this.onDocumentChange)
+        .onUpdate(this.onDocumentChange)
+        .onDelete(this.onDocumentDeletion)
+    }
+  }
   onDocumentChange = rawDoc => {
     const doc = this.normalizeId(rawDoc)
     const previousDoc = this.props.files.find(f => f.id === doc.id)
@@ -96,7 +119,7 @@ class RealtimeFiles extends React.Component {
   }
 
   render() {
-    return this.props.children
+    return this.props.children ? this.props.children : null
   }
 }
 
@@ -113,7 +136,9 @@ const mapDispatchToProps = dispatch => ({
     dispatch(updateOfflineFileCopyIfNecessary(file, prevFile))
 })
 
-export default connect(
+const RealtimeFilesConnected = connect(
   mapStateToProps,
   mapDispatchToProps
 )(withRouter(RealtimeFiles))
+
+export default RealtimeFilesConnected

--- a/src/drive/web/modules/navigation/RealtimeFiles.spec.jsx
+++ b/src/drive/web/modules/navigation/RealtimeFiles.spec.jsx
@@ -1,0 +1,113 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import realtime from 'cozy-realtime'
+import { RealtimeFiles } from './RealtimeFiles'
+global.cozy = {
+  client: {
+    offline: {
+      getDatabase: jest.fn()
+    }
+  }
+}
+
+jest.mock('cozy-realtime', () => {
+  const mockReturn = {
+    onCreate: jest.fn(() => mockReturn),
+    onUpdate: jest.fn(() => mockReturn),
+    onDelete: jest.fn(() => mockReturn),
+    unsubscribe: jest.fn(() => mockReturn)
+  }
+  return {
+    ...require.requireActual('cozy-realtime'),
+    subscribe: jest.fn(() => mockReturn)
+  }
+})
+
+describe('RealTimeFiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should instanciate Realtime', () => {
+    const context = {
+      client: {
+        stackClient: {
+          token: {
+            token: '1'
+          },
+          uri: 'http://mycozy.cloud'
+        }
+      }
+    }
+    //eslint-disable-next-line
+    const component = mount(<RealtimeFiles />, { context })
+    expect(realtime.subscribe).toHaveBeenCalledWith(
+      {
+        token: '1',
+        url: 'http://mycozy.cloud'
+      },
+      'io.cozy.files'
+    )
+  })
+
+  it('should instanciate Realtime and update when context change', () => {
+    const context = {
+      client: {
+        stackClient: {
+          token: {
+            token: '1'
+          },
+          uri: 'http://mycozy.cloud'
+        }
+      }
+    }
+    const component = mount(<RealtimeFiles />, { context })
+    // jest.spyOn(realtime, 'subscribe')
+    expect(realtime.subscribe).toHaveBeenCalledWith(
+      {
+        token: '1',
+        url: 'http://mycozy.cloud'
+      },
+      'io.cozy.files'
+    )
+
+    component.setContext({
+      client: {
+        stackClient: {
+          token: {
+            token: '2'
+          },
+          uri: 'http://mycozy.cloud'
+        }
+      }
+    })
+    expect(realtime.subscribe).toHaveBeenCalledWith(
+      {
+        token: '2',
+        url: 'http://mycozy.cloud'
+      },
+      'io.cozy.files'
+    )
+  })
+
+  it('should instanciate Realtime even with accessToken ', () => {
+    const context = {
+      client: {
+        stackClient: {
+          token: {
+            accessToken: '1'
+          },
+          uri: 'http://mycozy.cloud'
+        }
+      }
+    }
+    const component = mount(<RealtimeFiles />, { context })
+    // jest.spyOn(realtime, 'subscribe')
+    expect(realtime.subscribe).toHaveBeenCalledWith(
+      {
+        token: '1',
+        url: 'http://mycozy.cloud'
+      },
+      'io.cozy.files'
+    )
+  })
+})


### PR DESCRIPTION
If the context has a change, we unsuscribe the socket and registrer it again with the new information 