### PR TITLE
fix: Do not cozy bar refreshToken. Use route expired token

### DIFF
--- a/src/drive/mobile/lib/__mocks__/cozy-helper.js
+++ b/src/drive/mobile/lib/__mocks__/cozy-helper.js
@@ -9,7 +9,6 @@ const mock = {
     getStackClient: jest.fn(() => mockStackClient)
   })),
   initBar: jest.fn(),
-  updateBarAccessToken: jest.fn(),
   restoreCozyClientJs: jest.fn(),
   resetClient: jest.fn(),
   getOauthOptions: jest.fn(),

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -59,9 +59,6 @@ export const initBar = async client => {
   })
 }
 
-export const updateBarAccessToken = accessToken =>
-  cozy.bar.updateAccessToken(accessToken)
-
 export const restoreCozyClientJs = (uri, clientInfos, token) => {
   const offline = { doctypes: ['io.cozy.files'] }
   cozy.client.init({

--- a/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
+++ b/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
@@ -7,11 +7,7 @@ import MobileRouter from 'authentication/MobileRouter'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
 import { setToken } from 'drive/mobile/modules/authorization/duck'
 import { setUrl } from 'drive/mobile/modules/settings/duck'
-import {
-  restoreCozyClientJs,
-  initBar,
-  updateBarAccessToken
-} from 'drive/mobile/lib/cozy-helper'
+import { restoreCozyClientJs, initBar } from 'drive/mobile/lib/cozy-helper'
 import { IconSprite } from 'cozy-ui/transpiled/react/'
 import {
   unlink,
@@ -45,7 +41,6 @@ class DriveMobileRouter extends Component {
     oauthClient.setCredentials(token)
     oauthClient.setUri(url)
     oauthClient.onTokenRefresh = () => {
-      updateBarAccessToken(token.accessToken)
       restoreCozyClientJs(url, clientInfo, token)
       this.props.dispatch(setToken(token))
     }

--- a/src/drive/mobile/modules/authorization/sagas.js
+++ b/src/drive/mobile/modules/authorization/sagas.js
@@ -1,7 +1,4 @@
-import {
-  restoreCozyClientJs,
-  updateBarAccessToken
-} from 'drive/mobile/lib/cozy-helper'
+import { restoreCozyClientJs } from 'drive/mobile/lib/cozy-helper'
 import { setUrl, setOffline } from 'drive/mobile/modules/settings/duck'
 import { startReplication } from 'drive/mobile/modules/replication/sagas'
 import { setClient, setToken } from './duck'
@@ -19,7 +16,6 @@ export const renewAuthorization = client => async dispatch => {
   const url = client.options.uri
   const { infos, token } = await client.renewAuthorization(url)
   restoreCozyClientJs(url, infos, token)
-  updateBarAccessToken(token)
   dispatch(setUrl(url))
   dispatch(saveCredentials(infos, token))
 }

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -204,6 +204,7 @@ class InitAppMobile {
       realOauthOptions =
         clientInfos !== null ? { ...clientInfos, ...getOauthOptions() } : null
       const token = getToken(store.getState())
+
       const stackClient = client.getStackClient()
 
       stackClient.setOAuthOptions(realOauthOptions)
@@ -215,7 +216,7 @@ class InitAppMobile {
         store.dispatch(setToken(token))
       }
       //In order to check if the token is good
-      await stackClient.fetchJSON('GET', '/settings/disk-usage')
+      await stackClient.fetchJSON('GET', '/apps/settings')
       shouldInitBar = true
       await store.dispatch(startReplication())
     } catch (e) {


### PR DESCRIPTION
- Since cozy-client is injected, we do not need to refresh token from the bar 
- /settings/disk-usage doesn't check the expired token... 