### PR TITLE
[WIP] Do not include trashed contacts in sharing

### DIFF
--- a/src/sharing/index.jsx
+++ b/src/sharing/index.jsx
@@ -363,7 +363,13 @@ const EditableSharingModal = ({ document, ...rest }) => (
       hasSharedParent,
       hasSharedChild
     }) => (
-      <Query query={cozy => cozy.all('io.cozy.contacts')}>
+      <Query
+        query={client =>
+          client.find('io.cozy.contacts').where({
+            trashed: false
+          })
+        }
+      >
         {(
           { data, fetchStatus, lastError },
           { createDocument: createContact }


### PR DESCRIPTION
I tried different queries but I haven't found a way to include contacts that does not have `trashed` field in the results (most contacts). Do you know a "trick" to do this?

Else we can't merge this until we migrate existing contacts and we change the code in contacts and in the connectors so that `trashed` is always here.