### PR TITLE
fix: add hover on arrow in viewer navigation

### DIFF
--- a/testcafe/tests/pages/viewer/viewer-model.js
+++ b/testcafe/tests/pages/viewer/viewer-model.js
@@ -62,6 +62,11 @@ export default class Viewer {
     )
     for (let i = startIndex; i < startIndex + numberOfNavigation; i++) {
       await this.navigateToNextFile(i)
+      //navigateToNextFile brings you on the next file, so we are sure there is a Previous Button on this image
+      await t.hover(selectors.btnViewerNavPrevious, {
+        offsetX: 0,
+        offsetY: 0
+      })
       if (t.fixtureCtx.isVR)
         await t.fixtureCtx.vr.takeScreenshotAndUpload(
           `${screenshotPath}-${i}-next`
@@ -72,6 +77,10 @@ export default class Viewer {
       console.log(` i : ${i} `)
 
       await this.navigateToPrevFile(i)
+      await t.hover(selectors.btnViewerNavNext, {
+        offsetX: 0,
+        offsetY: 0
+      })
       if (t.fixtureCtx.isVR)
         await t.fixtureCtx.vr.takeScreenshotAndUpload(
           `${screenshotPath}-${i}-prev`


### PR DESCRIPTION
For now, there a no specific hover when navigating in the viewer.
Now, it happens like this : 
- choosing a starting file/photos
- open the viewer, and check there is a next file
- navigate to next file
- hover the **previous** button (which brings us back to the file we opened)
- take screenshots

Same thing when navigating to previous image, we will hover the **next** button.
So 1st screenshots will fail as for now, there were no arrow
