### PR TITLE
fix: add --disable-dev-shm-usage option to chrome

### DIFF
--- a/testcafe/runner-drive.js
+++ b/testcafe/runner-drive.js
@@ -20,7 +20,9 @@ async function runRunner() {
       'testcafe/tests/drive/public-viewer-feature.js'
     ])
     //emulation:cdpPort=9222 is used to set the download folder in headless mode
-    .browsers(['chrome:headless:emulation:cdpPort=9222 --start-maximized'])
+    .browsers([
+      'chrome:headless:emulation:cdpPort=9222 --start-maximized --disable-dev-shm-usage'
+    ])
 
     .screenshots(
       'reports/',

--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -21,7 +21,9 @@ async function runRunner() {
       'testcafe/tests/photos/photos_end_delete_all_data.js'
     ])
     //emulation:cdpPort=9222 is used to set the download folder in headless mode
-    .browsers(['chrome:headless:emulation:cdpPort=9222 --start-maximized'])
+    .browsers([
+      'chrome:headless:emulation:cdpPort=9222 --start-maximized --disable-dev-shm-usage'
+    ])
 
     .screenshots(
       'reports/',


### PR DESCRIPTION
`ClientFunction execution was interrupted by page unload. This
      problem may appear if you trigger page navigation from
      ClientFunction code.` 
This issue seems to be relative to temporary path, and memory on the CI
https://github.com/DevExpress/testcafe-react-selectors/issues/109
Some seems to have solve this issue by using ` --disable-dev-shm-usage` on chrome (https://github.com/DevExpress/testcafe/issues/3608), so let's try it out