### PR TITLE
fix: Use transpiled version of cozy-ui

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -27,7 +27,8 @@ const extraConfig = {
   resolve: {
     modules: ['node_modules', SRC_DIR],
     alias: {
-      'react-cozy-helpers': path.resolve(SRC_DIR, './lib/react-cozy-helpers')
+      'react-cozy-helpers': path.resolve(SRC_DIR, './lib/react-cozy-helpers'),
+      'cozy-ui/react': 'cozy-ui/transpiled/react'
     }
   },
   plugins: [

--- a/src/components/Button/index.styl
+++ b/src/components/Button/index.styl
@@ -14,7 +14,7 @@
         display inline-flex
 
 +small-screen()
-    .dri-btn--more
+    button.dri-btn--more
         border           0
         margin-right     0
         height           3rem

--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -14,6 +14,8 @@ import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
 import configureStore from 'drive/store/configureStore'
 import { schema } from 'drive/lib/doctypes'
+import 'cozy-ui/transpiled/react/stylesheet.css'
+
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset

--- a/src/drive/targets/mobile/index.jsx
+++ b/src/drive/targets/mobile/index.jsx
@@ -1,5 +1,5 @@
 /* global __DEVELOPMENT__ */
-
+import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'drive/styles/main'
 import 'drive/styles/mobile'
 

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -4,6 +4,7 @@ import 'whatwg-fetch'
 import React from 'react'
 import { render } from 'react-dom'
 
+import 'cozy-ui/transpiled/react/stylesheet.css'
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 import CozyClient, { CozyProvider } from 'cozy-client'
 import { I18n, initTranslation } from 'cozy-ui/react/I18n'

--- a/src/photos/targets/browser/index.jsx
+++ b/src/photos/targets/browser/index.jsx
@@ -1,5 +1,5 @@
 /* global cozy __DEVELOPMENT__ */
-
+import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'photos/styles/main'
 
 import React from 'react'

--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -12,6 +12,7 @@ import getSharedDocument from 'sharing/getSharedDocument'
 import ErrorUnsharedComponent from 'photos/components/ErrorUnshared'
 
 import doctypes from '../browser/doctypes'
+import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'photos/styles/main.styl'
 
 import App from './App'


### PR DESCRIPTION
There are some differences in css orders when we build the app for production, but using the transpiled version of cozy-ui solves the problem.

See https://github.com/cozy/cozy-ui/issues/335 for the original issue.