### PR TITLE
WIP Testcafe/clientfunction

### DIFF
--- a/testcafe/runner-drive.js
+++ b/testcafe/runner-drive.js
@@ -20,9 +20,7 @@ async function runRunner() {
       'testcafe/tests/drive/public-viewer-feature.js'
     ])
     //emulation:cdpPort=9222 is used to set the download folder in headless mode
-    .browsers([
-      'chrome:headless:emulation:cdpPort=9222 --start-maximized --disable-dev-shm-usage'
-    ])
+    .browsers(['chrome:headless:emulation:cdpPort=9222 --start-maximized'])
 
     .screenshots(
       'reports/',

--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -21,9 +21,7 @@ async function runRunner() {
       'testcafe/tests/photos/photos_end_delete_all_data.js'
     ])
     //emulation:cdpPort=9222 is used to set the download folder in headless mode
-    .browsers([
-      'chrome:headless:emulation:cdpPort=9222 --start-maximized --disable-dev-shm-usage'
-    ])
+    .browsers(['chrome:headless:emulation:cdpPort=9222 --start-maximized'])
 
     .screenshots(
       'reports/',


### PR DESCRIPTION
Erreur testcafé :
`ClientFunction execution was interrupted by page unload. This
      problem may appear if you trigger page navigation from
      ClientFunction code.`

`ClientFunction()` was needed to do xhr request, and was failing (even after trying the `await Promise.all(statuses) ` and other changes we talk about)
So instead I remove the clientFunction and use `request` instead of `xhr.status` to get the image status