### PR TITLE
fix: Android scroll bar issue

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -136,7 +136,8 @@ column-width-thumbnail = 3rem
 .fil-file-thumbnail
   position relative
   flex 0 0 column-width-thumbnail - 1rem //width without padding
-
+  svg  
+    display block
 .fil-file-thumbnail-image
   object-fit cover
 
@@ -188,9 +189,6 @@ column-width-thumbnail = 3rem
 .fil-content-body--selectable
     .fil-content-file-select
         opacity 1
-
-.fil-content-body--mobile
-    overflow hidden
 
 .fil-content-row-actioned
     .fil-content-file-action

--- a/src/drive/web/modules/filelist/FileListBody.jsx
+++ b/src/drive/web/modules/filelist/FileListBody.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import cx from 'classnames'
-import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
 
 import Oops from 'components/Error/Oops'
 import { EmptyDrive, EmptyTrash } from 'components/Error/Empty'
@@ -40,14 +39,12 @@ export const FileListBody = ({
   selectionModeActive,
   isTypingNewFolderName,
   withSelectionCheckbox,
-  breakpoints: { isMobile },
   ...props
 }) => (
   <div
     data-test-id="fil-content-body"
     className={cx(styles['fil-content-body'], {
-      [styles['fil-content-body--selectable']]: selectionModeActive,
-      [styles['fil-content-body--mobile']]: isMobile
+      [styles['fil-content-body--selectable']]: selectionModeActive
     })}
   >
     <AddFolder />
@@ -92,4 +89,4 @@ const mapStateToProps = state => ({
   isTypingNewFolderName: isTypingNewFolderName(state)
 })
 
-export default connect(mapStateToProps)(withBreakpoints()(FileListBody))
+export default connect(mapStateToProps)(FileListBody)


### PR DESCRIPTION
from @GoOz : "sinon le SVG est inline est donc il a une "marge" correspondante à une hauteur de ligne et ça augmente sa taille, et donc ça pousse de 1px les ligne sans que ça se voit."