### PR TITLE
fix: Remove duplicated lines

### DIFF
--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -1,8 +1,5 @@
 /* global __DEVELOPMENT__ */
 
-import 'drive/styles/main'
-import 'drive/styles/mobile'
-
 import 'whatwg-fetch'
 import React from 'react'
 import { render } from 'react-dom'

--- a/src/drive/targets/mobile/index.jsx
+++ b/src/drive/targets/mobile/index.jsx
@@ -1,4 +1,3 @@
-/* global __DEVELOPMENT__ */
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'drive/styles/main'
 import 'drive/styles/mobile'


### PR DESCRIPTION
The styles are already imported in the other file, and the `__DEVELOPMENT__ ` wasn't used anymore.