### PR TITLE
Fix/menutoolbar

### DIFF
--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -66,20 +66,20 @@ export default class Menu extends Component {
           </button>
         )}
         {opened && (
-          <Overlay
-            onClick={this.close}
-            onEscape={this.close}
-            className={styles['cozy-menu-overlay']}
-          />
+          <>
+            <Overlay
+              onClick={this.close}
+              onEscape={this.close}
+              className={styles['cozy-menu-overlay']}
+            />
+            <div
+              data-test-id="coz-menu-inner"
+              className={classNames(styles['coz-menu-inner'], innerClassName)}
+            >
+              {this.renderItems()}
+            </div>
+          </>
         )}
-        <div
-          data-test-id="coz-menu-inner"
-          className={classNames(styles['coz-menu-inner'], innerClassName, {
-            [styles['coz-menu-inner--opened']]: opened
-          })}
-        >
-          {this.renderItems()}
-        </div>
       </div>
     )
   }

--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import classNames from 'classnames'
 import { Overlay } from 'cozy-ui/react'
 
-import styles from './index.styl'
+import styles from 'components/Menu/index.styl'
 
 export const Item = ({ children, onClick }) => (
   <div onClick={onClick} className={styles['coz-menu-item']}>
@@ -30,14 +30,12 @@ export default class Menu extends Component {
   renderItems() {
     return React.Children.map(this.props.children, item => {
       if (!item) return item
-      // ideally here, we should rely on React's type property and verify that
-      // type === Item, but for some reason, preact vnodes don't have this property
-      if (item.nodeName !== 'hr') {
-        return React.cloneElement(item, {
-          onClick: this.handleSelect.bind(this, item)
-        })
+      //if the Item is wrapped in an HOC we should provide a type props
+      if ((item.props && item.props.type === 'hr') || item.type === 'hr') {
+        return item
       }
-      return React.cloneElement(item)
+
+      return <div onClick={this.handleSelect}>{item}</div>
     })
   }
 

--- a/src/components/Menu/index.styl
+++ b/src/components/Menu/index.styl
@@ -7,7 +7,7 @@
     display  inline-block
 
 .coz-menu-inner
-    display    none
+    display    block
     position   absolute
     @extend    $popover
     right      0
@@ -17,8 +17,6 @@
     min-width  13.75rem
     z-index $file-action-menu
 
-.coz-menu-inner--opened
-    display block
 
 .coz-menu-item:hover
 .coz-menu-item:focus

--- a/src/drive/web/modules/drive/Toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar.jsx
@@ -83,7 +83,7 @@ class Toolbar extends Component {
             </a>
           </SelectableItem>
         </Item>
-        <NotRootFolder>
+        <NotRootFolder type="hr">
           <hr />
         </NotRootFolder>
         <NotRootFolder>


### PR DESCRIPTION
- No need to renderItems() if the menu is not opened (better perf and less css) 
- I don't like to cloneElement. So I just wrapped the item in a div only when needed
- No need to wrap the item if we don't add the onclick 
- Sometimes Item is wrapped in an HOC so we can't check the type. The idea is that case is to provide a "type" props. If we don't do that, we'll be able to close the Menu by clicking on the `<hr />`. Good luck with that because hr is pretty small ;)  

edit: formatting by @y-lohse 