### PR TITLE
fix: change error screenshots path

### DIFF
--- a/testcafe/runner-drive.js
+++ b/testcafe/runner-drive.js
@@ -32,7 +32,7 @@ async function runRunner() {
     .screenshots(
       'reports/',
       true,
-      '${DATE}_${TIME}/test-${TEST}-${FILE_INDEX}.png'
+      '${DATE}_${TIME}/${FIXTURE}/${TEST_ID}-${TEST}/${FILE_INDEX}.png'
     )
     .run({
       assertionTimeout: 6000,

--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -33,7 +33,7 @@ async function runRunner() {
     .screenshots(
       'reports/',
       true,
-      '${DATE}_${TIME}/test-${TEST}-${FILE_INDEX}.png'
+      '${DATE}_${TIME}/${FIXTURE}/${TEST_ID}-${TEST}/${FILE_INDEX}.png'
     )
     .run({
       assertionTimeout: 6000,


### PR DESCRIPTION
Fix error : 
`The file at
  "/home/travis/build/cozy/cozy-drive/reports/2019-04-16_15-06-05/test-2-1
  Check viewer for zip file-errors/1.png" already exists. It has just been
  rewritten with a recent screenshot. This situation can possibly cause
  issues. To avoid them, make sure that each screenshot has a unique path. If
  a test runs in multiple browsers, consider including the user agent in the
  screenshot path or generate a unique identifier in another way.`