### PR TITLE
fix: remove toast from screenshots

### DIFF
--- a/testcafe/runner-drive.js
+++ b/testcafe/runner-drive.js
@@ -6,8 +6,8 @@ async function runRunner() {
   process.env.vrErrorMsg = ''
   if (!process.env.INSTANCE_TESTCAFE || !process.env.TESTCAFE_USER_PASSWORD) {
     throw Error(
-      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD 
-      Exemple: 
+      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD
+      Exemple:
       export INSTANCE_TESTCAFE="cozy.tools:8080"
       export TESTCAFE_USER_PASSWORD="foo" `
     )
@@ -47,6 +47,4 @@ async function runRunner() {
   if (response > 0) throw Error(response)
 }
 
-runRunner().catch(e => {
-  console.warn('eror', e)
-})
+runRunner()

--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -6,8 +6,8 @@ async function runRunner() {
   process.env.vrErrorMsg = ''
   if (!process.env.INSTANCE_TESTCAFE || !process.env.TESTCAFE_USER_PASSWORD) {
     throw Error(
-      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD 
-      Ex: \n 
+      `You have to provide INSTANCE_TESTCAFE & TESTCAFE_USER_PASSWORD
+      Ex: \n
       export INSTANCE_TESTCAFE="cozy.tools:8080"
       export TESTCAFE_USER_PASSWORD="foo" `
     )
@@ -48,6 +48,4 @@ async function runRunner() {
   if (response > 0) throw Error(response)
 }
 
-runRunner().catch(e => {
-  console.warn('eror', e)
-})
+runRunner()

--- a/testcafe/tests/drive/classification_scenario.js
+++ b/testcafe/tests/drive/classification_scenario.js
@@ -226,7 +226,6 @@ test(`${TEST_MOVE_FILE}`, async t => {
   })
   await privateDrivePage.moveElementTo(`${FEATURE_PREFIX}-Folder1`)
 
-  //Wait for toast alert to disapear before taking screenshot
   await checkToastAppearsAndDisappears('has been moved to')
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
@@ -246,7 +245,6 @@ test(`${TEST_MOVE_FOLDER}`, async t => {
   })
   await privateDrivePage.moveElementTo(`${FEATURE_PREFIX}-Folder1`)
 
-  //Wait for toast alert to disapear before taking screenshot
   await checkToastAppearsAndDisappears('has been moved to')
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
@@ -287,7 +285,7 @@ test(`${TEST_DELETE_FOLDER}`, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-2`,
     withMask: maskDeleteFolder
   })
-  //Wait for toast alert to disapear before taking screenshot
+
   await checkToastAppearsAndDisappears(
     'The selection has been moved to the Trash.'
   )
@@ -314,7 +312,7 @@ test(`${TEST_RESTORE_FOLDER}`, async t => {
     withMask: maskDriveFolderWithDate
   })
   await t.click(selectors.btnRestoreActionMenu)
-  //Wait for toast alert to disapear before taking screenshot
+
   await checkToastAppearsAndDisappears(
     'The selection has been successfully restored.'
   )
@@ -343,7 +341,6 @@ test(`${TEST_DELETE_FOLDER_FROM_DRIVE}`, async t => {
   })
   await t.click(selectors.btnModalSecondButton)
 
-  //Wait for toast alert to disapear before taking screenshot
   await checkToastAppearsAndDisappears(
     'The selection has been moved to the Trash.'
   )
@@ -392,18 +389,33 @@ test(`${TEST_EMPTY_TRASH}`, async t => {
   })
 
   //We cannot use checkToastAppearsAndDisappears here, as both toast might appears at the same time, or the 1st one may disappear before the second one shows up.
-  isExistingAndVisibile(
-    selectors.alertWrapper.withText(
-      'Your trash is being emptied. This might take a few moments.'
+  await Promise.all([
+    await isExistingAndVisibile(
+      selectors.alertWrapper.withText(
+        'Your trash is being emptied. This might take a few moments.'
+      ),
+      'Toast : Your trash is being emptied. This might take a few moments. '
     ),
-    'Toast : Your trash is being emptied. This might take a few moments. '
-  )
-  isExistingAndVisibile(
-    selectors.alertWrapper.withText('The trash has been emptied.'),
-    'Toast : The trash has been emptied.'
-  )
-  //Wait for toast alert to disapear before taking screenshot
-  await t.wait(5000)
+    await isExistingAndVisibile(
+      selectors.alertWrapper.withText('The trash has been emptied.'),
+      'Toast : The trash has been emptied.'
+    )
+  ])
+  await Promise.all([
+    await t
+      .expect(
+        selectors.alertWrapper.withText(
+          'Your trash is being emptied. This might take a few moments.'
+        ).exists
+      )
+      .notOk('Toast still exists'),
+    await t
+      .expect(
+        selectors.alertWrapper.withText('The trash has been emptied.').exists
+      )
+      .notOk('Toast still exists')
+  ])
+
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_EMPTY_TRASH}-2`
   })

--- a/testcafe/tests/drive/classification_scenario.js
+++ b/testcafe/tests/drive/classification_scenario.js
@@ -14,6 +14,7 @@ import {
   maskDeleteFolder,
   maskMoveMoadal
 } from '../helpers/data'
+import { checkToastAppearsAndDisappears } from '../pages/commons'
 import * as selectors from '../pages/selectors'
 import PrivateDrivePage from '../pages/drive/drive-model-private'
 
@@ -201,7 +202,10 @@ test(`${TEST_MOVE_FILE_CANCEL}`, async t => {
   console.log('Show Move Moadal, and Cancel (Cancel button)')
   await privateDrivePage.showMoveModalForElement(FILE_PDF)
   // no need to screenshot again the modal
-  await isExistingAndVisibile(selectors.btnModalFirstButton)
+  await isExistingAndVisibile(
+    selectors.btnModalFirstButton,
+    'Modal button cancel'
+  )
   await t.click(selectors.btnModalFirstButton)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FILE_CANCEL}-5`,
@@ -221,6 +225,10 @@ test(`${TEST_MOVE_FILE}`, async t => {
     withMask: maskMoveMoadal
   })
   await privateDrivePage.moveElementTo(`${FEATURE_PREFIX}-Folder1`)
+
+  //Wait for toast alert to disapear before taking screenshot
+  await checkToastAppearsAndDisappears('has been moved to')
+
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FILE}-2`,
     withMask: maskDriveFolderWithDate
@@ -237,6 +245,10 @@ test(`${TEST_MOVE_FOLDER}`, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FOLDER}-1`
   })
   await privateDrivePage.moveElementTo(`${FEATURE_PREFIX}-Folder1`)
+
+  //Wait for toast alert to disapear before taking screenshot
+  await checkToastAppearsAndDisappears('has been moved to')
+
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FOLDER}-2`,
     withMask: maskDriveFolderWithDate
@@ -275,6 +287,10 @@ test(`${TEST_DELETE_FOLDER}`, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-2`,
     withMask: maskDeleteFolder
   })
+  //Wait for toast alert to disapear before taking screenshot
+  await checkToastAppearsAndDisappears(
+    'The selection has been moved to the Trash.'
+  )
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-3`
   })
@@ -297,7 +313,11 @@ test(`${TEST_RESTORE_FOLDER}`, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_RESTORE_FOLDER}-1`,
     withMask: maskDriveFolderWithDate
   })
-  await t.click(selectors.btnRestoreActionMenu).wait(1000)
+  await t.click(selectors.btnRestoreActionMenu)
+  //Wait for toast alert to disapear before taking screenshot
+  await checkToastAppearsAndDisappears(
+    'The selection has been successfully restored.'
+  )
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_RESTORE_FOLDER}-2`,
     withMask: maskDriveFolderWithDate
@@ -322,11 +342,11 @@ test(`${TEST_DELETE_FOLDER_FROM_DRIVE}`, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER_FROM_DRIVE}-2`
   })
   await t.click(selectors.btnModalSecondButton)
-  await isExistingAndVisibile(
-    selectors.alertWrapper,
-    '"successfull" modal alert'
-  )
 
+  //Wait for toast alert to disapear before taking screenshot
+  await checkToastAppearsAndDisappears(
+    'The selection has been moved to the Trash.'
+  )
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER_FROM_DRIVE}-3`
   })
@@ -371,13 +391,21 @@ test(`${TEST_EMPTY_TRASH}`, async t => {
     withMask: maskDeleteFolder
   })
 
+  //We cannot use checkToastAppearsAndDisappears here, as both toast might appears at the same time, or the 1st one may disappear before the second one shows up.
+  isExistingAndVisibile(
+    selectors.alertWrapper.withText(
+      'Your trash is being emptied. This might take a few moments.'
+    ),
+    'Toast : Your trash is being emptied. This might take a few moments. '
+  )
+  isExistingAndVisibile(
+    selectors.alertWrapper.withText('The trash has been emptied.'),
+    'Toast : The trash has been emptied.'
+  )
+  //Wait for toast alert to disapear before taking screenshot
+  await t.wait(5000)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_EMPTY_TRASH}-2`
-  })
-  //wait for trash to be empty
-  await t.wait(2000)
-  await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: `${FEATURE_PREFIX}/${TEST_EMPTY_TRASH}-3`
   })
   console.groupEnd()
 })

--- a/testcafe/tests/drive/public-viewer-feature.js
+++ b/testcafe/tests/drive/public-viewer-feature.js
@@ -291,7 +291,7 @@ test(`${TEST_DELETE_FOLDER}`, async t => {
   await privateDrivePage.deleteCurrentFolder({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-2`
   })
-  //Wait for toast alert to disapear before taking screenshot
+
   await checkToastAppearsAndDisappears(
     'The selection has been moved to the Trash.'
   )

--- a/testcafe/tests/drive/public-viewer-feature.js
+++ b/testcafe/tests/drive/public-viewer-feature.js
@@ -8,6 +8,7 @@ import {
   deleteLocalFile
 } from '../helpers/utils'
 import { initVR } from '../helpers/visualreview-utils'
+import { checkToastAppearsAndDisappears } from '../pages/commons'
 let data = require('../helpers/data')
 import PrivateDriveVRPage from '../pages/drive/drive-model-private'
 import PublicDrivePage from '../pages/drive/drive-model-public'
@@ -290,6 +291,10 @@ test(`${TEST_DELETE_FOLDER}`, async t => {
   await privateDrivePage.deleteCurrentFolder({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-2`
   })
+  //Wait for toast alert to disapear before taking screenshot
+  await checkToastAppearsAndDisappears(
+    'The selection has been moved to the Trash.'
+  )
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-3`
   })

--- a/testcafe/tests/pages/commons.js
+++ b/testcafe/tests/pages/commons.js
@@ -1,0 +1,17 @@
+import { t } from 'testcafe'
+import * as selectors from './selectors'
+import { isExistingAndVisibile } from '../helpers/utils'
+
+//this files contains function that can be use both in photos and drive
+
+//Check that the alerte toast exist, and wait for it to disappear
+export async function checkToastAppearsAndDisappears(toastText) {
+  await t
+  isExistingAndVisibile(
+    selectors.alertWrapper.withText(toastText),
+    `Toast Alert`
+  )
+  await t
+    .expect(selectors.alertWrapper.withText(toastText).exists)
+    .notOk('Toast still exists')
+}

--- a/testcafe/tests/pages/commons.js
+++ b/testcafe/tests/pages/commons.js
@@ -4,7 +4,7 @@ import { isExistingAndVisibile } from '../helpers/utils'
 
 //this files contains function that can be use both in photos and drive
 
-//Check that the alerte toast exist, and wait for it to disappear
+//Check that the alert toast exist, and wait for it to disappear
 export async function checkToastAppearsAndDisappears(toastText) {
   await t
   isExistingAndVisibile(


### PR DESCRIPTION
Screenshots are not commented.
Now, I check the toast exists, and then that it doesn't exist anymore, and then take the screenshots.

The **ClassicationScenario/3-5 Empty Trash** is a bit different:
Because there are 2 toast when emptying the trash : `Your trash is being emptied. This might take a few moments.'` and `The trash has been emptied.`. Those toast sometimes shows up at the same time, one on top of the other. Sometimes the 1st one appears, then disappear, then the 2nd one appears. So we don't have a fix order of appearance/disappearance.
So I just wait for the 2 toasts to show up, then wait 5s to be sure they both disappear, then take the screenshot.