### PR TITLE
Testcafé Album full : New steps and screenshots

### DIFF
--- a/testcafe/runner-photos.js
+++ b/testcafe/runner-photos.js
@@ -20,9 +20,9 @@ async function runRunner() {
       'testcafe/tests/photos/photos_start_upload_photos.js',
 
       'testcafe/tests/photos/photos_crud.js',
-      'testcafe/tests/photos/create_full_album_scenario.js',
-      'testcafe/tests/photos/create_empty_album_scenario.js',
       'testcafe/tests/photos/album_sharing_scenario.js',
+      'testcafe/tests/photos/create_empty_album_scenario.js',
+      'testcafe/tests/photos/create_full_album_scenario.js',
 
       //Scenario that just delete photos, so we don't need to do it in every test.
       'testcafe/tests/photos/photos_end_delete_all_data.js'

--- a/testcafe/tests/helpers/data.js
+++ b/testcafe/tests/helpers/data.js
@@ -75,3 +75,4 @@ export const maskVideoViewerMobile = { height: 25, x: 12, width: 353, y: 381 }
 export const maskDeleteFolder = { height: 918, x: 916, width: 140, y: 300 }
 export const maskMoveMoadal = { height: 115, x: 905, width: 140, y: 237 }
 export const maskPhotosCluster = { height: 43, x: 242, width: 424, y: 203 }
+export const maskPhotosAddToAlbum = { height: 43, x: 432, width: 249, y: 111 }

--- a/testcafe/tests/pages/photos-album/album-model.js
+++ b/testcafe/tests/pages/photos-album/album-model.js
@@ -8,6 +8,7 @@ import {
   getLastExecutedCommand
 } from '../../helpers/utils'
 import * as selectors from '../selectors'
+import { checkToastAppearsAndDisappears } from '../commons'
 import PhotoPage from '../photos/photos-model'
 
 export default class Page extends PhotoPage {
@@ -147,8 +148,11 @@ export default class Page extends PhotoPage {
   }
 
   // @param { number } photoNumber : Number of photos to remove from the album (
-  async removePhoto(photoNumber) {
-    const photoAlbumStart = await this.getPhotosCount('In album, before')
+  async removePhotoFromAlbum(photoNumber) {
+    let photoAlbumStart
+    if (!t.fixtureCtx.isVR) {
+      photoAlbumStart = await this.getPhotosCount('In album, before')
+    }
     await this.selectPhotos(photoNumber)
     await isExistingAndVisibile(selectors.cozySelectionbar, 'Selection bar')
 
@@ -160,12 +164,13 @@ export default class Page extends PhotoPage {
     await t.click(selectors.btnRemoveFromAlbumCozySelectionBar)
 
     await isExistingAndVisibile(selectors.alertWrapper, 'modal Alert')
-    await t
-      .expect(selectors.alertWrapper.innerText)
-      .contains('The photo has been removed from album') //!FIXME
-
-    const photoAlbumEnd = await this.getPhotosCount('In album, before')
-    await t.expect(photoAlbumEnd).eql(photoAlbumStart - photoNumber)
+    await checkToastAppearsAndDisappears(
+      'The photo has been removed from album'
+    )
+    if (!t.fixtureCtx.isVR) {
+      const photoAlbumEnd = await this.getPhotosCount('In album, after')
+      await t.expect(photoAlbumEnd).eql(photoAlbumStart - photoNumber)
+    }
   }
 
   async deleteAlbum() {

--- a/testcafe/tests/pages/photos-albums/albums-model.js
+++ b/testcafe/tests/pages/photos-albums/albums-model.js
@@ -28,7 +28,12 @@ export default class AlbumsPage extends PhotoPage {
   // @param {String} albumName : Name for the new album
   // @param { number } photoNumber : Number of photos to add to the new album (it will add the first X photos from the timeline)
   // click on new album button, check the new album page, give a name to album and select photos
-  async addNewAlbum(albumName, photoNumber) {
+  async addNewAlbum({
+    albumName: albumName,
+    photoNumber: photoNumber,
+    screenshotPath: screenshotPath,
+    withMask = false
+  }) {
     await this.waitForLoading()
     await isExistingAndVisibile(
       selectors.toolbarAlbumsList,
@@ -56,6 +61,14 @@ export default class AlbumsPage extends PhotoPage {
 
     await t.typeText(selectors.inputAlbumName, albumName)
     await albumPage.selectPhotostoAdd(0, photoNumber)
+
+    if (t.fixtureCtx.isVR && screenshotPath)
+      //dates show up here, so there is a mask for screenshots
+      await t.fixtureCtx.vr.takeScreenshotAndUpload({
+        screenshotPath: screenshotPath,
+        withMask: withMask
+      })
+
     await t.click(selectors.btnValidateAlbum)
   }
 

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -52,7 +52,6 @@ export default class Timeline extends Commons {
   }
 
   //@param { number } numOfFiles : number of file to delete
-  //@param { bool } isRemoveAll: true if all photos are supposed to be remove at the end
   async deletePhotosFromTimeline({
     numOfFiles: numOfFiles,
     screenshotPath: screenshotPath,

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -53,7 +53,11 @@ export default class Timeline extends Commons {
 
   //@param { number } numOfFiles : number of file to delete
   //@param { bool } isRemoveAll: true if all photos are supposed to be remove at the end
-  async deletePhotosFromTimeline(numOfFiles, isRemoveAll) {
+  async deletePhotosFromTimeline({
+    numOfFiles: numOfFiles,
+    screenshotPath: screenshotPath,
+    withMask = false
+  }) {
     await isExistingAndVisibile(selectors.cozySelectionbar, 'Selection bar')
 
     logger.debug('Deleting ' + numOfFiles + ' picture(s)')
@@ -68,18 +72,18 @@ export default class Timeline extends Commons {
       selectors.btnModalSecondButton,
       'Modal delete button Delete'
     )
+    if (t.fixtureCtx.isVR)
+      //dates show up here, so there is a mask for screenshots
+      await t.fixtureCtx.vr.takeScreenshotAndUpload({
+        screenshotPath: screenshotPath,
+        withMask: withMask
+      })
+
     await t.click(selectors.btnModalSecondButton)
-    await t.takeScreenshot()
 
-    let allPhotosEndCount
-    if (isRemoveAll) {
-      await isExistingAndVisibile(selectors.folderEmpty, 'Folder Empty')
-      logger.debug(`Number of pictures on page (Before test): 0`)
-      allPhotosEndCount = 0
-    } else {
-      allPhotosEndCount = await this.getPhotosCount('After')
+    if (!t.fixtureCtx.isVR) {
+      let allPhotosEndCount = await this.getPhotosCount('After')
+      await t.expect(allPhotosEndCount).eql(t.ctx.totalFilesCount - numOfFiles)
     }
-
-    await t.expect(allPhotosEndCount).eql(t.ctx.totalFilesCount - numOfFiles)
   }
 }

--- a/testcafe/tests/photos/album_sharing_scenario.js
+++ b/testcafe/tests/photos/album_sharing_scenario.js
@@ -59,7 +59,10 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
 test(TEST_CREATE_ALBUM, async () => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_CREATE_ALBUM}`)
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.addNewAlbum(FEATURE_PREFIX, 3)
+  await photoAlbumsPage.addNewAlbum({
+    albumName: FEATURE_PREFIX,
+    photoNumber: 3
+  })
   //we need to check the album page, just after the redirection from album creation, hence this step being in this test
   await photoAlbumPage.checkAlbumPage(FEATURE_PREFIX, 3)
   console.groupEnd()

--- a/testcafe/tests/photos/create_empty_album_scenario.js
+++ b/testcafe/tests/photos/create_empty_album_scenario.js
@@ -29,7 +29,10 @@ test('Go into Album view, and check that there is no album', async () => {
 test('Go into Album view, and create new empty album', async () => {
   console.group('↳ ℹ️  Go into Album view, and create new empty album')
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.addNewAlbum(ALBUM_DATE_TIME, 0)
+  await photoAlbumsPage.addNewAlbum({
+    albumName: ALBUM_DATE_TIME,
+    photoNumber: 0
+  })
   await photoAlbumPage.checkAlbumPage(ALBUM_DATE_TIME, 0)
   //we need to check the album page, just after the redirection from album creation, hence this step being in this test
   console.groupEnd()
@@ -81,7 +84,7 @@ test('Go to New2_ALBUM_DATE_TIME, and remove the 1st photos', async () => {
   )
   await timelinePage.goToAlbums()
   await photoAlbumsPage.goToAlbum(`New2_${ALBUM_DATE_TIME}`)
-  await photoAlbumPage.removePhoto(1)
+  await photoAlbumPage.removePhotoFromAlbum(1)
   console.groupEnd()
 })
 

--- a/testcafe/tests/photos/create_full_album_scenario.js
+++ b/testcafe/tests/photos/create_full_album_scenario.js
@@ -10,7 +10,13 @@ import AlbumsPage from '../pages/photos-albums/albums-model'
 import { initVR } from '../helpers/visualreview-utils'
 import * as selectors from '../pages/selectors'
 import { checkToastAppearsAndDisappears } from '../pages/commons'
-import { IMG0, DATA_PATH, THUMBNAIL_DELAY } from '../helpers/data'
+import {
+  IMG0,
+  DATA_PATH,
+  THUMBNAIL_DELAY,
+  maskPhotosCluster,
+  maskPhotosAddToAlbum
+} from '../helpers/data'
 
 const timelinePage = new Timeline()
 const photoAlbumPage = new AlbumPage()
@@ -63,7 +69,8 @@ test(TEST_CREATE_ALBUM, async t => {
   await photoAlbumsPage.addNewAlbum({
     albumName: FEATURE_PREFIX,
     photoNumber: 3,
-    screenshotPath: `${FEATURE_PREFIX}/${TEST_CREATE_ALBUM}-2`
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_CREATE_ALBUM}-2`,
+    withMask: maskPhotosAddToAlbum
   })
   //we need to check the album page, just after the redirection from album creation, hence this step being in this test
   await photoAlbumPage.checkAlbumPage(FEATURE_PREFIX, 3)
@@ -124,7 +131,8 @@ test(TEST_ADD_EXISTING_PHOTOS, async t => {
   await checkAllImagesExists()
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: `${FEATURE_PREFIX}/${TEST_ADD_EXISTING_PHOTOS}-1`
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_ADD_EXISTING_PHOTOS}-1`,
+    withMask: maskPhotosCluster
   })
   await t.click(selectors.album(`New2_${FEATURE_PREFIX}`))
 
@@ -148,12 +156,14 @@ test(TEST_DELETE_PHOTO_FROM_TIMELINE, async t => {
   await timelinePage.selectPhotosByName([IMG0])
   await timelinePage.deletePhotosFromTimeline({
     numOfFiles: 1,
-    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_PHOTO_FROM_TIMELINE}-1`
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_PHOTO_FROM_TIMELINE}-1`,
+    withMask: maskPhotosCluster
   })
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_PHOTO_FROM_TIMELINE}-2`,
     delay: THUMBNAIL_DELAY,
-    pageToWait: timelinePage
+    pageToWait: timelinePage,
+    withMask: maskPhotosCluster
   })
   console.groupEnd()
 })
@@ -194,7 +204,8 @@ test(TEST_CLEAN_UP, async t => {
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_CLEAN_UP}-1`,
     delay: THUMBNAIL_DELAY,
-    pageToWait: timelinePage
+    pageToWait: timelinePage,
+    withMask: maskPhotosCluster
   })
   console.groupEnd()
 })

--- a/testcafe/tests/photos/create_full_album_scenario.js
+++ b/testcafe/tests/photos/create_full_album_scenario.js
@@ -1,96 +1,200 @@
 import { photosUser } from '../helpers/roles'
-import { TESTCAFE_PHOTOS_URL } from '../helpers/utils'
-import { ALBUM_DATE_TIME } from '../helpers/data'
+import {
+  TESTCAFE_PHOTOS_URL,
+  SLUG,
+  checkAllImagesExists
+} from '../helpers/utils'
 import Timeline from '../pages/photos/photos-timeline-model'
 import AlbumPage from '../pages/photos-album/album-model.js'
 import AlbumsPage from '../pages/photos-albums/albums-model'
+import { initVR } from '../helpers/visualreview-utils'
+import * as selectors from '../pages/selectors'
+import { checkToastAppearsAndDisappears } from '../pages/commons'
+import { IMG0, DATA_PATH, THUMBNAIL_DELAY } from '../helpers/data'
 
 const timelinePage = new Timeline()
 const photoAlbumPage = new AlbumPage()
 const photoAlbumsPage = new AlbumsPage()
 
-fixture`Create new album with photos`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
-  async t => {
-    console.group(`\n↳ ℹ️  Login & Initialization`)
+//Scenario const
+const FEATURE_PREFIX = 'CreateFullAlbumScenario'
+
+const FIXTURE_INIT = `${FEATURE_PREFIX} 1- Create Full Album`
+const TEST_CHECK_NO_ALBUM = `1-1 Check there is no album`
+const TEST_CREATE_ALBUM = `1-2 Create Album with 3 photos`
+const TEST_RENAME_ALBUM1 = `1-3 Rename Album (exitWithEnter)`
+const TEST_RENAME_ALBUM2 = `1-4 Rename Album (exitWithClick)`
+const TEST_ADD_MORE_PHOTOS = `1-5 Add 2 more photos`
+const TEST_ADD_EXISTING_PHOTOS = `1-6 Add photos already in Album`
+
+const TEST_REMOVE_PHOTO = `1-7 Remove 1 photo (from album)`
+const TEST_DELETE_PHOTO_FROM_TIMELINE = `1-8 Delete 1 photo in album (from timeline)`
+const TEST_DELETE_ALBUM = `1-9 Delete Album`
+const TEST_CLEAN_UP = `1-10 Clean up - reupload deleted photo`
+
+fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
+  .before(async ctx => {
+    await initVR(ctx, SLUG, FIXTURE_INIT)
+  })
+  .beforeEach(async t => {
+    console.group(`\n↳ ℹ️  Loggin & Initialization`)
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()
     console.groupEnd()
-  }
-)
+  })
+  .after(async ctx => {
+    await ctx.vr.checkRunStatus()
+  })
 
-test('Go into Album view, and check that there is no album', async () => {
-  console.group('↳ ℹ️  Go into Album view, and check that there is no album')
+test(TEST_CHECK_NO_ALBUM, async () => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_CHECK_NO_ALBUM}`)
   await timelinePage.goToAlbums()
   await photoAlbumsPage.checkEmptyAlbum()
   console.groupEnd()
 })
 
-test('Go into Album view, and create new album with 3 photos', async () => {
-  console.group('↳ ℹ️  Go into Album view, and create new album with 3 photos')
+test(TEST_CREATE_ALBUM, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_CREATE_ALBUM}`)
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.addNewAlbum(ALBUM_DATE_TIME, 3)
-  await photoAlbumPage.checkAlbumPage(ALBUM_DATE_TIME, 3)
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_CREATE_ALBUM}-1`
+  })
+  await photoAlbumsPage.addNewAlbum({
+    albumName: FEATURE_PREFIX,
+    photoNumber: 3,
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_CREATE_ALBUM}-2`
+  })
   //we need to check the album page, just after the redirection from album creation, hence this step being in this test
+  await photoAlbumPage.checkAlbumPage(FEATURE_PREFIX, 3)
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_CREATE_ALBUM}-3`
+  })
+  await photoAlbumPage.backToAlbumsList()
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_CREATE_ALBUM}-4`
+  })
   console.groupEnd()
 })
 
-test('Go to ALBUM_DATE_TIME, and rename it (exit by pressing "enter")', async () => {
-  console.group(
-    `↳ ℹ️  Go to New_${ALBUM_DATE_TIME}, and rename it (exit by pressing "enter")`
-  )
+test(TEST_RENAME_ALBUM1, async () => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_RENAME_ALBUM1}`)
+
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.goToAlbum(ALBUM_DATE_TIME)
-  await photoAlbumPage.checkAlbumPage(ALBUM_DATE_TIME, 3)
-  await photoAlbumPage.renameAlbum(ALBUM_DATE_TIME, `New_${ALBUM_DATE_TIME}`, {
+  await photoAlbumsPage.goToAlbum(FEATURE_PREFIX)
+  await photoAlbumPage.checkAlbumPage(FEATURE_PREFIX, 3)
+  await photoAlbumPage.renameAlbum(FEATURE_PREFIX, `New_${FEATURE_PREFIX}`, {
     exitWithEnter: true
   })
-  await photoAlbumPage.checkAlbumPage(`New_${ALBUM_DATE_TIME}`, 3)
+  await photoAlbumPage.checkAlbumPage(`New_${FEATURE_PREFIX}`, 3)
   console.groupEnd()
 })
 
-test('Go to New_ALBUM_DATE_TIME, and rename it (exit by clicking away)', async () => {
-  console.group(
-    `↳ ℹ️  Go to New_${ALBUM_DATE_TIME}, and rename it (exit by clicking away)`
-  )
+test(TEST_RENAME_ALBUM2, async () => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_RENAME_ALBUM2}`)
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.goToAlbum(`New_${ALBUM_DATE_TIME}`)
-  await photoAlbumPage.checkAlbumPage(`New_${ALBUM_DATE_TIME}`, 3)
+  await photoAlbumsPage.goToAlbum(`New_${FEATURE_PREFIX}`)
+  await photoAlbumPage.checkAlbumPage(`New_${FEATURE_PREFIX}`, 3)
   await photoAlbumPage.renameAlbum(
-    `New_${ALBUM_DATE_TIME}`,
-    `New2_${ALBUM_DATE_TIME}`,
+    `New_${FEATURE_PREFIX}`,
+    `New2_${FEATURE_PREFIX}`,
     { exitWithEnter: false }
   )
-  await photoAlbumPage.checkAlbumPage(`New2_${ALBUM_DATE_TIME}`, 3)
+  await photoAlbumPage.checkAlbumPage(`New2_${FEATURE_PREFIX}`, 3)
   console.groupEnd()
 })
 
-test('Go to New2_ALBUM_DATE_TIME, and add 2 more photos', async () => {
-  console.group(`↳ ℹ️  Go to New2_${ALBUM_DATE_TIME}, and add 2 more photos`)
+test(TEST_ADD_MORE_PHOTOS, async () => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_ADD_MORE_PHOTOS}`)
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.goToAlbum(`New2_${ALBUM_DATE_TIME}`)
-  await photoAlbumPage.addPhotosToAlbum(`New2_${ALBUM_DATE_TIME}`, 3, 2)
+  await photoAlbumsPage.goToAlbum(`New2_${FEATURE_PREFIX}`)
+  await photoAlbumPage.addPhotosToAlbum(`New2_${FEATURE_PREFIX}`, 3, 2)
   await photoAlbumPage.backToAlbumsList()
-  await photoAlbumsPage.isAlbumExistsAndVisible(`New2_${ALBUM_DATE_TIME}`, 5)
+  await photoAlbumsPage.isAlbumExistsAndVisible(`New2_${FEATURE_PREFIX}`, 5)
   console.groupEnd()
 })
 
-test('Go to New2_ALBUM_DATE_TIME, and remove the 1st photos', async () => {
-  console.group(
-    `↳ ℹ️  Go to New2_${ALBUM_DATE_TIME}, and remove the 1st photos`
+test(TEST_ADD_EXISTING_PHOTOS, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_ADD_EXISTING_PHOTOS}`)
+  await timelinePage.selectPhotos(1)
+  await timelinePage.checkCozyBarOnTimeline()
+  await t.click(selectors.btnAddToAlbumCozySelectionBar)
+
+  await t.expect(selectors.spinner.exists).notOk('Spinner still spinning')
+  await checkAllImagesExists()
+
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_ADD_EXISTING_PHOTOS}-1`
+  })
+  await t.click(selectors.album(`New2_${FEATURE_PREFIX}`))
+
+  //Wait for toast alert to disapear before taking screenshot
+  await checkToastAppearsAndDisappears(
+    'This album already contains this photo.'
   )
+  //go to album to get the screenshot
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.goToAlbum(`New2_${ALBUM_DATE_TIME}`)
-  await photoAlbumPage.removePhoto(1)
+  await photoAlbumsPage.goToAlbum(`New2_${FEATURE_PREFIX}`)
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_ADD_EXISTING_PHOTOS}-2`,
+    delay: THUMBNAIL_DELAY,
+    pageToWait: photoAlbumPage
+  })
   console.groupEnd()
 })
 
-test('Go to New2_ALBUM_DATE_TIME, and delete it', async () => {
-  console.group(`↳ ℹ️  Go to New2_${ALBUM_DATE_TIME}, and delete it`)
+test(TEST_DELETE_PHOTO_FROM_TIMELINE, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE_PHOTO_FROM_TIMELINE}`)
+  await timelinePage.selectPhotosByName([IMG0])
+  await timelinePage.deletePhotosFromTimeline({
+    numOfFiles: 1,
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_PHOTO_FROM_TIMELINE}-1`
+  })
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_PHOTO_FROM_TIMELINE}-2`,
+    delay: THUMBNAIL_DELAY,
+    pageToWait: timelinePage
+  })
+  console.groupEnd()
+})
+
+test(TEST_REMOVE_PHOTO, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_REMOVE_PHOTO}`)
   await timelinePage.goToAlbums()
-  await photoAlbumsPage.goToAlbum(`New2_${ALBUM_DATE_TIME}`)
+  await photoAlbumsPage.goToAlbum(`New2_${FEATURE_PREFIX}`)
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_REMOVE_PHOTO}-1`,
+    delay: THUMBNAIL_DELAY,
+    pageToWait: photoAlbumPage
+  })
+  await photoAlbumPage.removePhotoFromAlbum(1)
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_REMOVE_PHOTO}-2`,
+    delay: THUMBNAIL_DELAY,
+    pageToWait: photoAlbumPage
+  })
+  console.groupEnd()
+})
+
+test(TEST_DELETE_ALBUM, async () => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE_ALBUM}`)
+  await timelinePage.goToAlbums()
+  await photoAlbumsPage.goToAlbum(`New2_${FEATURE_PREFIX}`)
   await photoAlbumPage.deleteAlbum()
   await photoAlbumPage.waitForLoading()
   await photoAlbumsPage.checkEmptyAlbum() //There is no more album
+  console.groupEnd()
+})
+
+test(TEST_CLEAN_UP, async t => {
+  console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_CLEAN_UP}`)
+  await timelinePage.initPhotosCount()
+  await timelinePage.uploadPhotos([`${DATA_PATH}/${IMG0}`])
+
+  await t.fixtureCtx.vr.takeScreenshotAndUpload({
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_CLEAN_UP}-1`,
+    delay: THUMBNAIL_DELAY,
+    pageToWait: timelinePage
+  })
   console.groupEnd()
 })

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -1,12 +1,13 @@
 import { photosUser } from '../helpers/roles'
 import { TESTCAFE_PHOTOS_URL, SLUG } from '../helpers/utils'
 import {
+  THUMBNAIL_DELAY,
+  maskPhotosCluster,
   IMG0,
   IMG1,
   IMG2,
   IMG3,
-  IMG4,
-  maskPhotosCluster
+  IMG4
 } from '../helpers/data'
 import { initVR } from '../helpers/visualreview-utils'
 import TimelinePage from '../pages/photos/photos-timeline-model'
@@ -38,11 +39,16 @@ test(TEST_DELETE1, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE1}`)
   await timelinePage.selectPhotosByName([IMG0])
   //pic is removed
-  await timelinePage.deletePhotosFromTimeline(1)
+  await timelinePage.deletePhotosFromTimeline({
+    numOfFiles: 1,
+    screenshotPath: 'DeleteImage/delete-1-pic-modal'
+  })
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE1}-1`,
-    withMask: maskPhotosCluster
+    withMask: maskPhotosCluster,
+    delay: THUMBNAIL_DELAY,
+    pageToWait: timelinePage
   })
   console.groupEnd()
 })
@@ -51,10 +57,15 @@ test(TEST_DELETE2, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_DELETE2}`)
   await timelinePage.selectPhotosByName([IMG1, IMG2, IMG3, IMG4])
   //pics are removed, there are no more pictures on  page
-  await timelinePage.deletePhotosFromTimeline(4, true)
+  await timelinePage.deletePhotosFromTimeline({
+    numOfFiles: 4,
+    screenshotPath: 'DeleteImage/delete-4-pic-modal'
+  })
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
-    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE2}-1`
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE2}-1`,
+    delay: THUMBNAIL_DELAY,
+    pageToWait: timelinePage
   })
   console.groupEnd()
 })

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -41,7 +41,8 @@ test(TEST_DELETE1, async t => {
   //pic is removed
   await timelinePage.deletePhotosFromTimeline({
     numOfFiles: 1,
-    screenshotPath: 'DeleteImage/delete-1-pic-modal'
+    screenshotPath: 'DeleteImage/delete-1-pic-modal',
+    withMask: maskPhotosCluster
   })
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
@@ -59,7 +60,8 @@ test(TEST_DELETE2, async t => {
   //pics are removed, there are no more pictures on  page
   await timelinePage.deletePhotosFromTimeline({
     numOfFiles: 4,
-    screenshotPath: 'DeleteImage/delete-4-pic-modal'
+    screenshotPath: 'DeleteImage/delete-4-pic-modal',
+    withMask: maskPhotosCluster
   })
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({


### PR DESCRIPTION
Ready for review (but I close this PR during my holidays)

There are new screenshots (which don't have a baseline yet) in this scenario, you can check VR : photos : **CreateFullAlbumScenario 1- Create Full Album** : https://visualreview.cozycloud.cc/#/8/72/1117
Also, 2 new screens for **photos : PhotosDelete 1- Delete Photos** : https://visualreview.cozycloud.cc/#/8/65/1119

~~Screenshots in **photos : AlbumSharingScenario 2- Go to public link and download files :** https://visualreview.cozycloud.cc/#/8/51/1118 changed because I now remove, then re-upload some photos in the **CreateFullAlbumScenario**, but I can avoid thoses changes by changing the order tests run.~~ Tests order changes to avoid screenshots changes