### PR TITLE
feat: Set statusbar to black when fullscreen viewer

### DIFF
--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -1,3 +1,4 @@
+/* global StatusBar */
 import React, { Component } from 'react'
 import cx from 'classnames'
 
@@ -44,6 +45,10 @@ export default class Viewer extends Component {
 
   componentWillUnmount() {
     document.removeEventListener('keyup', this.onKeyUp, false)
+    if (isMobileApp) {
+      StatusBar.styleDefault()
+      StatusBar.backgroundColorByName('white')
+    }
   }
 
   onKeyUp = e => {
@@ -101,6 +106,10 @@ export default class Viewer extends Component {
     const hasNext = currentIndex < fileCount - 1
     // this `expanded` property makes the next/previous controls cover the displayed image
     const expanded = currentFile && currentFile.class === 'image'
+    if (isMobileApp) {
+      StatusBar.styleBlackOpaque()
+      StatusBar.backgroundColorByName('black')
+    }
     return (
       <ViewerWrapper
         style={style}


### PR DESCRIPTION
We already had cordova-status-bar installed 

Didn't test on android yet

before : 
![IMG_1D3714DA0F16-1](https://user-images.githubusercontent.com/1107936/56431172-334acf00-62c9-11e9-918d-e7d0377cae64.jpeg)

after
![IMG_40F282EAA03A-1](https://user-images.githubusercontent.com/1107936/56431176-35ad2900-62c9-11e9-8d5b-15d41e9f878a.jpeg)

