### PR TITLE
Embeded viewer without router

### DIFF
--- a/src/drive/web/modules/drive/FileOpenerExternal.jsx
+++ b/src/drive/web/modules/drive/FileOpenerExternal.jsx
@@ -27,10 +27,11 @@ export class FileOpener extends Component {
     file: null
   }
   componentWillMount() {
+    const routerFileId = get(this.props, 'routeParams.fileId')
     if (this.props.fileId) {
       this.loadFileInfo(this.props.fileId)
-    } else if (this.props.routeParams.fileId) {
-      this.loadFileInfo(this.props.routeParams.fileId)
+    } else if (routerFileId) {
+      this.loadFileInfo(routerFileId)
     }
   }
 
@@ -38,8 +39,10 @@ export class FileOpener extends Component {
     if (prevProps.fileId !== this.props.fileId) {
       return this.loadFileInfo(this.props.fileId)
     }
-    if (prevProps.routeParams.fileId !== this.props.routeParams.fileId) {
-      return this.loadFileInfo(this.props.routeParams.fileId)
+    const previousRouterFileId = get(prevProps, 'routeParams.fileId')
+    const routerFileId = get(this.props, 'routeParams.fileId')
+    if (previousRouterFileId !== routerFileId) {
+      return this.loadFileInfo(routerFileId)
     }
   }
   async loadFileInfo(id) {

--- a/src/drive/web/modules/drive/FileOpenerExternal.jsx
+++ b/src/drive/web/modules/drive/FileOpenerExternal.jsx
@@ -82,14 +82,17 @@ export class FileOpener extends Component {
   }
 }
 
-FileOpener.PropTypes = {
+FileOpener.propTypes = {
   router: PropTypes.shape({
     push: PropTypes.func.isRequired,
     params: PropTypes.shape({
       fileId: PropTypes.string.isRequired
     }).isRequired
-  }).isRequired,
-  fileId: PropTypes.number,
+  }),
+  routeParams: PropTypes.shape({
+    fileId: PropTypes.string
+  }),
+  fileId: PropTypes.string,
   withCloseButtton: PropTypes.bool
 }
 


### PR DESCRIPTION
The `FileOpenerExternal` isn't wrapper in a `Router` component when used as an interapp service. 