### PR TITLE
fix: Remove unnecessary style

### DIFF
--- a/src/drive/styles/main.styl
+++ b/src/drive/styles/main.styl
@@ -13,17 +13,3 @@ div:focus
     &.--working
         // we forbid clicks when loading something to avoid concurrent data fetches and consequent flash effects
         pointer-events none
-//!TODO Remove this code after upgrading to cozy-bar@6
-[aria-hidden=true]
-   display: initial
-   visibility: initial
-
-[role=application][aria-hidden=true]
-    display: initial
-    visibility: initial
-
-[role=toolbar] 
-    button
-        svg
-            display: initial
-            visibility: initial


### PR DESCRIPTION
Since we use `cozy-bar` >= 6, we don't need this anymore