### PR TITLE
Revert "refactor: Don't display items if menu is not opened"

### DIFF
--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -64,20 +64,20 @@ export default class Menu extends Component {
           </button>
         )}
         {opened && (
-          <>
-            <Overlay
-              onClick={this.close}
-              onEscape={this.close}
-              className={styles['cozy-menu-overlay']}
-            />
-            <div
-              data-test-id="coz-menu-inner"
-              className={classNames(styles['coz-menu-inner'], innerClassName)}
-            >
-              {this.renderItems()}
-            </div>
-          </>
+          <Overlay
+            onClick={this.close}
+            onEscape={this.close}
+            className={styles['cozy-menu-overlay']}
+          />
         )}
+        <div
+          data-test-id="coz-menu-inner"
+          className={classNames(styles['coz-menu-inner'], innerClassName, {
+            [styles['coz-menu-inner--opened']]: opened
+          })}
+        >
+          {this.renderItems()}
+        </div>
       </div>
     )
   }

--- a/src/components/Menu/index.styl
+++ b/src/components/Menu/index.styl
@@ -7,7 +7,7 @@
     display  inline-block
 
 .coz-menu-inner
-    display    block
+    display    none
     position   absolute
     @extend    $popover
     right      0
@@ -17,6 +17,8 @@
     min-width  13.75rem
     z-index $file-action-menu
 
+.coz-menu-inner--opened
+    display block
 
 .coz-menu-item:hover
 .coz-menu-item:focus


### PR DESCRIPTION
This reverts commit da6707c8000e31c7e6c03adf591c493aff2efdaa.

We need to keep the menu in the DOM so the upload event can fire.