### PR TITLE
chore: Remove eslint-config-prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "enzyme-adapter-react-16": "1.12.1",
     "enzyme-to-json": "3.3.5",
     "eslint-config-cozy-app": "1.1.4",
-    "eslint-config-prettier": "4.1.0",
     "husky": "0.14.3",
     "identity-obj-proxy": "3.0.0",
     "npm-run-all": "4.1.5",


### PR DESCRIPTION
I think we do not need this dep anymore since eslint-config-cozy-app has the dep https://github.com/cozy/cozy-libs/blob/master/packages/eslint-config-cozy-app/package.json 