### PR TITLE
fix: add missing mask

### DIFF
--- a/testcafe/tests/drive/public-viewer-feature.js
+++ b/testcafe/tests/drive/public-viewer-feature.js
@@ -287,9 +287,9 @@ test(TEST_DELETE_FOLDER, async t => {
     withMask: data.maskDriveFolderWithDate
   })
 
-  await t.fixtureCtx.vr.setMaksCoordonnates(data.maskDeleteFolder)
   await privateDrivePage.deleteCurrentFolder({
-    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-2`
+    screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER}-2`,
+    withMask: data.maskDeleteFolder
   })
 
   await checkToastAppearsAndDisappears(


### PR DESCRIPTION
I  forgot to add the mask the correct way.
I'll delete the baseline for `drive : PublicViewerFeature 3- Cleanup Data` in order to get the new mask