### PR TITLE
fix: Don't allow user to share to a trashed contact

### DIFF
--- a/src/sharing/components/EditableSharingModal.jsx
+++ b/src/sharing/components/EditableSharingModal.jsx
@@ -60,6 +60,9 @@ const contactsQuery = client =>
       _id: {
         $gt: null
       },
+      trashed: {
+        $or: [{ $eq: false }, { $exists: false }]
+      },
       $or: [
         {
           cozy: {


### PR DESCRIPTION
Takes only contacts that don't have `trashed` attribute or for which `trashed` is `false`