### PR TITLE
fix: Properly display pdf fallback

### DIFF
--- a/src/viewer/PdfJsViewer.jsx
+++ b/src/viewer/PdfJsViewer.jsx
@@ -98,7 +98,7 @@ export class PdfJsViewer extends Component {
   }
 
   render() {
-    const { url } = this.props
+    const { url, file } = this.props
     const {
       loaded,
       errored,
@@ -109,7 +109,7 @@ export class PdfJsViewer extends Component {
       renderAllPages
     } = this.state
 
-    if (errored) return <NoViewer file={url} />
+    if (errored) return <NoViewer file={file} />
     const pageWidth = width ? width * scale : null // newer versions of react-pdf do that automatically
 
     return (
@@ -185,6 +185,7 @@ export class PdfJsViewer extends Component {
 
 PdfJsViewer.propTypes = {
   url: PropTypes.string.isRequired,
+  file: PropTypes.object.isRequired,
   gestures: PropTypes.object
 }
 


### PR DESCRIPTION
We were passing the wrong prop to the fallback component.