### PR TITLE
Don't display groups in recipients until all contacts are loaded

### DIFF
--- a/src/sharing/components/ShareRecipientsInput.jsx
+++ b/src/sharing/components/ShareRecipientsInput.jsx
@@ -42,18 +42,19 @@ class ShareRecipientsInput extends Component {
     }
   }
 
+  getContactsAndGroups = () => {
+    // we need contacts to be loaded to be able to add all group members to recipients
+    const { contacts, groups } = this.props
+    if (contacts.hasMore || contacts.fetchStatus === 'loading') {
+      return contacts.data
+    } else {
+      return [...contacts.data, ...groups.data]
+    }
+  }
+
   render() {
-    const {
-      contacts,
-      groups,
-      label,
-      onPick,
-      onRemove,
-      placeholder,
-      recipients
-    } = this.props
+    const { label, onPick, onRemove, placeholder, recipients } = this.props
     const { loading } = this.state
-    const contactsAndGroups = [...contacts.data, ...groups.data]
     return (
       <div>
         <label className={styles['coz-form-label']} htmlFor="email">
@@ -61,7 +62,7 @@ class ShareRecipientsInput extends Component {
         </label>
         <ShareAutosuggest
           loading={loading}
-          contactsAndGroups={contactsAndGroups}
+          contactsAndGroups={this.getContactsAndGroups()}
           recipients={recipients}
           onFocus={this.onFocus}
           onPick={onPick}

--- a/src/sharing/components/ShareRecipientsInput.spec.jsx
+++ b/src/sharing/components/ShareRecipientsInput.spec.jsx
@@ -54,4 +54,55 @@ describe('ShareRecipientsInput component', () => {
     const wrapper = shallow(jsx)
     expect(wrapper).toMatchSnapshot()
   })
+
+  it('should include groups only if all contacts are loaded', () => {
+    const props = {
+      label: 'Recipients',
+      contacts: {
+        id: 'contacts',
+        fetchStatus: 'loading',
+        hasMore: false,
+        data: [
+          {
+            id: 'df563cc4-6440',
+            name: {
+              givenName: 'Michale',
+              familyName: 'Russel'
+            }
+          },
+          {
+            id: '5a3b4ccf-c257',
+            name: {
+              givenName: 'Teagan',
+              familyName: 'Wolf'
+            }
+          }
+        ]
+      },
+      groups: {
+        id: 'groups',
+        fetchStatus: 'loaded',
+        hasMore: false,
+        data: [
+          { id: 'fe86af20-c6c5', name: "The Night's Watch" },
+          { id: '3d8193ab-2ce4', name: 'The North' }
+        ]
+      },
+      recipients: [
+        {
+          id: '5a3b4ccf-c257',
+          name: {
+            givenName: 'Teagan',
+            familyName: 'Wolf'
+          }
+        }
+      ],
+      onPick: jest.fn().mockName('onPick'),
+      onRemove: jest.fn().mockName('onRemove'),
+      placeholder: 'Enter recipients here'
+    }
+    const jsx = <ShareRecipientsInput {...props} />
+    const wrapper = shallow(jsx)
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/sharing/components/__snapshots__/ShareRecipientsInput.spec.jsx.snap
+++ b/src/sharing/components/__snapshots__/ShareRecipientsInput.spec.jsx.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ShareRecipientsInput component should include groups only if all contacts are loaded 1`] = `
+<div>
+  <label
+    className="coz-form-label"
+    htmlFor="email"
+  >
+    Recipients
+  </label>
+  <ShareAutocomplete
+    contactsAndGroups={
+      Array [
+        Object {
+          "id": "df563cc4-6440",
+          "name": Object {
+            "familyName": "Russel",
+            "givenName": "Michale",
+          },
+        },
+        Object {
+          "id": "5a3b4ccf-c257",
+          "name": Object {
+            "familyName": "Wolf",
+            "givenName": "Teagan",
+          },
+        },
+      ]
+    }
+    loading={false}
+    onFocus={[Function]}
+    onPick={[MockFunction onPick]}
+    onRemove={[MockFunction onRemove]}
+    placeholder="Enter recipients here"
+    recipients={
+      Array [
+        Object {
+          "id": "5a3b4ccf-c257",
+          "name": Object {
+            "familyName": "Wolf",
+            "givenName": "Teagan",
+          },
+        },
+      ]
+    }
+  />
+</div>
+`;
+
 exports[`ShareRecipientsInput component should match snapshot 1`] = `
 <div>
   <label


### PR DESCRIPTION
We need contacts to be able to display groups correctly and to be able to get the contacts from the group on click.