### PR TITLE
chore: Upgrade cozy-doctypes to 1.44.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "cozy-client": "6.20.0",
     "cozy-client-js": "0.13.0",
     "cozy-device-helper": "1.5.0",
-    "cozy-doctypes": "1.43.0",
+    "cozy-doctypes": "1.44.1",
     "cozy-flags": "1.6.0",
     "cozy-konnector-libs": "4.11.4",
     "cozy-realtime": "2.0.8",


### PR DESCRIPTION
We need `cozy-doctypes==1.44.1` to have the latest Contact/Group models and proptypes