### PR TITLE
Public viewer fix

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -24,6 +24,19 @@ if (isDrive && target === 'mobile')
 if (target !== 'mobile')
   configurationFiles.push(require('./webpack/appicon.config.js'))
 const extraConfig = {
+  module: {
+    rules: [
+      {
+        test: /\.worker(\.entry)\.js$/,
+        use: [{
+          loader: 'worker-loader',
+          options: {
+            name: 'public/[name].[hash].worker.js'
+          }
+        }]
+      },
+    ]
+  },
   resolve: {
     modules: ['node_modules', SRC_DIR],
     alias: {

--- a/jest.config.json
+++ b/jest.config.json
@@ -17,7 +17,7 @@
     "^react-cozy-helpers(.*)": "<rootDir>/src/lib/react-cozy-helpers$1",
     "^components(.*)": "<rootDir>/src/components$1",
     "^folder-references(.*)": "<rootDir>/src/folder-references$1",
-    "react-pdf/dist/entry.webpack": "react-pdf"
+    "react-pdf/dist/pdf.worker.entry.js": "<rootDir>/jestHelpers/mocks/pdfjsWorkerMock.js"
   },
   "snapshotSerializers": ["enzyme-to-json/serializer"],
   "transform": {

--- a/jestHelpers/mocks/pdfjsWorkerMock.js
+++ b/jestHelpers/mocks/pdfjsWorkerMock.js
@@ -1,0 +1,1 @@
+module.exports = () => {};

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "react-dropzone": "5.1.1",
     "react-markdown": "3.4.1",
     "react-measure": "2.2.4",
-    "react-pdf": "3.0.6",
+    "react-pdf": "4.0.5",
     "react-redux": "5.0.7",
     "react-router": "3.2.0",
     "react-tooltip": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "tar": "4.4.8",
     "testcafe": "1.1.2",
     "unzipper": "0.9.11",
-    "visualreview-client": "git+https://github.com/cozy/VisualReview-node-client.git#v0.0.4"
+    "visualreview-client": "git+https://github.com/cozy/VisualReview-node-client.git#v0.0.4",
+    "worker-loader": "2.0.0"
   },
   "dependencies": {
     "babel-preset-cozy-app": "1.2.2",

--- a/src/viewer/PdfJsViewer.jsx
+++ b/src/viewer/PdfJsViewer.jsx
@@ -110,7 +110,6 @@ export class PdfJsViewer extends Component {
     } = this.state
 
     if (errored) return <NoViewer file={file} />
-    const pageWidth = width ? width * scale : null // newer versions of react-pdf do that automatically
 
     return (
       <div
@@ -130,7 +129,8 @@ export class PdfJsViewer extends Component {
               <Page
                 key={page}
                 pageNumber={page + 1}
-                width={pageWidth}
+                width={width}
+                scale={scale}
                 renderAnnotations={false}
                 className={cx('u-mv-1', styles['pho-viewer-pdfviewer-page'])}
               />
@@ -138,7 +138,8 @@ export class PdfJsViewer extends Component {
           ) : (
             <Page
               pageNumber={currentPage}
-              width={pageWidth}
+              width={width}
+              scale={scale}
               renderAnnotations={false}
               className={styles['pho-viewer-pdfviewer-page']}
             />

--- a/src/viewer/PdfJsViewer.jsx
+++ b/src/viewer/PdfJsViewer.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Document, Page } from 'react-pdf/dist/entry.webpack'
+import { Document, Page, pdfjs } from 'react-pdf'
+import createWorker from 'react-pdf/dist/pdf.worker.entry.js'
 import cx from 'classnames'
 import throttle from 'lodash/throttle'
 import { Spinner } from 'cozy-ui/react'
@@ -8,6 +9,8 @@ import withFileUrl from './withFileUrl'
 import ToolbarButton from './PdfToolbarButton'
 import NoViewer from './NoViewer'
 import styles from './styles.styl'
+
+pdfjs.GlobalWorkerOptions.workerPort = createWorker()
 
 export const MIN_SCALE = 0.25
 export const MAX_SCALE = 3

--- a/src/viewer/PdfJsViewer.spec.jsx
+++ b/src/viewer/PdfJsViewer.spec.jsx
@@ -1,6 +1,6 @@
-import { PdfJsViewer, MIN_SCALE, MAX_SCALE, MAX_PAGES } from './PdfJsViewer'
 import React from 'react'
 import { shallow } from 'enzyme'
+import { PdfJsViewer, MIN_SCALE, MAX_SCALE, MAX_PAGES } from './PdfJsViewer'
 
 describe('PDFViewer', () => {
   let component

--- a/yarn.lock
+++ b/yarn.lock
@@ -17112,7 +17112,7 @@ worker-farm@^1.5.2:
   dependencies:
     errno "~0.1.7"
 
-worker-loader@^2.0.0:
+worker-loader@2.0.0, worker-loader@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
   integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,6 +880,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.0.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.3.1":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
@@ -9997,6 +10004,11 @@ make-dir@^2.0.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-event-props@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/make-event-props/-/make-event-props-1.2.0.tgz#96b87d88919533b8f8934b58b4c3d5679459a0cf"
+  integrity sha512-BmWFkm/jZzVH9A0tEBdkjAARUz/eha+5IRyfOndeSMKRadkgR5DawoBHoRwLxkYmjJOI5bHkXKpaZocxj+dKgg==
+
 make-fetch-happen@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz#141497cb878f243ba93136c83d8aba12c216c083"
@@ -10152,9 +10164,9 @@ memorystream@^0.3.1:
   integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 merge-class-names@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/merge-class-names/-/merge-class-names-1.1.1.tgz#3bd2f38eb5418c464a0fef615484fdf6c8932256"
-  integrity sha512-+UUWBUoFw9QLY/UlBKU/xk9h6OhyG3BUDDuF2eIJcxmusWb/uedvNpZGkysqMw5b/ds+wkX7NJTDSdUuRsCNyA==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/merge-class-names/-/merge-class-names-1.2.0.tgz#cb30ecfc3bdbd96b6f76d0a98777907e5fbb3462"
+  integrity sha512-ifHxhC8DojHT1rG3PHCaJYInUqPd0WO+PxsaYDMkgy7RzfyOFtnlpr/hbhki+m/3R/ujIRVnZkD/AHjgjb5uhg==
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -11906,13 +11918,13 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfjs-dist@2.0.305:
-  version "2.0.305"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.305.tgz#53b0f9805ae101d7ef742d020d03578ee9781b06"
-  integrity sha1-U7D5gFrhAdfvdC0CDQNXjul4GwY=
+pdfjs-dist@2.1.266:
+  version "2.1.266"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.1.266.tgz#cded02268b389559e807f410d2a729db62160026"
+  integrity sha512-Jy7o1wE3NezPxozexSbq4ltuLT0Z21ew/qrEiAEeUZzHxMHGk4DUV1D7RuCXg5vJDvHmjX1YssN+we9QfRRgXQ==
   dependencies:
     node-ensure "^0.0.0"
-    worker-loader "^1.1.0"
+    worker-loader "^2.0.0"
 
 pdfjs@2.1.0:
   version "2.1.0"
@@ -13180,16 +13192,17 @@ react-measure@2.2.4:
     prop-types "^15.6.2"
     resize-observer-polyfill "^1.5.0"
 
-react-pdf@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-3.0.6.tgz#399631e05f7057795d273d2b4809b808625b10e0"
-  integrity sha512-xdko6TTQvEfsKawJkXkp/AA6MCsnYpWHKD5JoaKbngjAsPWAw1LH+f5ImBd6yyF02nX58srwFW2Ikw7mRFubJA==
+react-pdf@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-4.0.5.tgz#4f5584005a504cb7941b01670b40355f4706b726"
+  integrity sha512-hoIL08qU5pU1fNEx6NnLl3omD08LAUc+UkmxGXEql/PXiNWjMZHWlu8MSVg9pwSTN6dXtfky0gehrisWvSOrCg==
   dependencies:
-    babel-runtime "^6.26.0"
+    "@babel/runtime" "^7.0.0"
     lodash.once "^4.1.1"
+    make-event-props "^1.1.0"
     merge-class-names "^1.1.1"
-    pdfjs-dist "2.0.305"
-    prop-types "^15.6.1"
+    pdfjs-dist "2.1.266"
+    prop-types "^15.6.2"
 
 react-redux@5.0.7:
   version "5.0.7"
@@ -17099,10 +17112,10 @@ worker-farm@^1.5.2:
   dependencies:
     errno "~0.1.7"
 
-worker-loader@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-1.1.1.tgz#920d74ddac6816fc635392653ed8b4af1929fd92"
-  integrity sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
   dependencies:
     loader-utils "^1.0.0"
     schema-utils "^0.4.0"


### PR DESCRIPTION
The first commit is self-explanatory i think.

For the second one: when importing from `react-pdf/dist/entry.webpack`, react-pdf loads a webworker that it creates through a webpack configuration. This worker is created at the root of the webpack output, and because this file is already transpiled, we can't change that (or at least I didn't manage to).

So the solution is to load the worker through *our* webpack configuration, so we can change the output directory.