### PR TITLE
feat: Display real new recipients count in toast

### DIFF
--- a/src/sharing/components/ShareByEmail.jsx
+++ b/src/sharing/components/ShareByEmail.jsx
@@ -98,6 +98,18 @@ ShareSubmit.defaultProps = {
   loading: false
 }
 
+export const countNewRecipients = (currentRecipients, newRecipients) => {
+  return newRecipients.filter(contact => {
+    const email = Contact.getPrimaryEmail(contact)
+    const cozyUrl = Contact.getPrimaryCozy(contact)
+    return !currentRecipients.find(
+      r =>
+        (email && r.email && r.email === email) ||
+        (cozyUrl && r.instance && r.instance === cozyUrl)
+    )
+  }).length
+}
+
 class ShareByEmail extends Component {
   static contextTypes = {
     t: PropTypes.func.isRequired,
@@ -192,7 +204,7 @@ class ShareByEmail extends Component {
   }
 
   getSuccessMessage = () => {
-    const { documentType } = this.props
+    const { currentRecipients, documentType } = this.props
     const { recipients } = this.state
     if (recipients.length === 1) {
       const recipient = recipients[0]
@@ -227,7 +239,7 @@ class ShareByEmail extends Component {
       return [
         `${documentType}.share.shareByEmail.genericSuccess`,
         {
-          count: recipients.length
+          count: countNewRecipients(currentRecipients, recipients)
         }
       ]
     }
@@ -305,6 +317,7 @@ class ShareByEmail extends Component {
 }
 
 ShareByEmail.propTypes = {
+  currentRecipients: PropTypes.arrayOf(PropTypes.object),
   contacts: contactsResponseType.isRequired,
   groups: groupsResponseType.isRequired,
   document: PropTypes.object.isRequired,

--- a/src/sharing/components/ShareByEmail.spec.jsx
+++ b/src/sharing/components/ShareByEmail.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import ShareByEmail from './ShareByEmail'
+import ShareByEmail, { countNewRecipients } from './ShareByEmail'
 
 const fakeDoc = {
   _id: 'c0455ddf-5f4c',
@@ -30,6 +30,7 @@ describe('ShareByEmail component', () => {
         hasMore: false,
         fetchStatus: 'loaded'
       },
+      currentRecipients: [{ email: 'sansa.stark@winterfell.westeros' }],
       document: fakeDoc,
       documentType: 'Files',
       sharingDesc: 'fake-doc.odt',
@@ -47,7 +48,8 @@ describe('ShareByEmail component', () => {
       component.setState({
         recipients: [
           { email: 'jon.snow@thewall.westeros' },
-          { email: 'arya.stark@winterfell.westeros' }
+          { email: 'arya.stark@winterfell.westeros' },
+          { email: 'sansa.stark@winterfell.westeros' }
         ]
       })
       const [message, params] = component.instance().getSuccessMessage()
@@ -118,5 +120,128 @@ describe('ShareByEmail component', () => {
       expect(message).toEqual('Files.share.shareByEmail.genericSuccess')
       expect(params).toEqual({ count: 1 })
     })
+  })
+})
+
+describe('countNewRecipients function', () => {
+  const currentRecipients = [
+    {
+      email: 'arya.stark@winterfell.westeros'
+    },
+    {
+      email: 'sansa.stark@winterfell.westeros'
+    },
+    {
+      email: 'jon.snow@thewall.westeros'
+    }
+  ]
+  const addedRecipients = [
+    {
+      id: '5d4916fa-e193',
+      email: [
+        {
+          address: 'jon.snow@thewall.westeros',
+          type: 'primary'
+        }
+      ]
+    },
+    {
+      id: '4df64228-ce84',
+      email: [
+        {
+          address: 'sansa.stark@winterfell.westeros',
+          type: 'primary'
+        }
+      ]
+    },
+    {
+      id: 'ff955bb1-f696',
+      email: [
+        {
+          address: 'bran.stark@winterfell.westeros',
+          type: 'primary'
+        }
+      ]
+    }
+  ]
+
+  it('should count only the new recipients using email', () => {
+    const result = countNewRecipients(currentRecipients, addedRecipients)
+    expect(result).toEqual(1)
+  })
+
+  it('should count the new recipients when there are no current recipients', () => {
+    const result = countNewRecipients([], addedRecipients)
+    expect(result).toEqual(3)
+  })
+
+  it('should return 0 if there is no new recipients', () => {
+    const currentRecipients = [
+      {
+        email: 'arya.stark@winterfell.westeros'
+      },
+      {
+        email: 'sansa.stark@winterfell.westeros'
+      },
+      {
+        email: 'jon.snow@thewall.westeros'
+      },
+      {
+        email: 'bran.stark@winterfell.westeros'
+      }
+    ]
+    const result = countNewRecipients(currentRecipients, addedRecipients)
+    expect(result).toEqual(0)
+  })
+
+  it('should count the new recipients using cozy url', () => {
+    const currentRecipients = [
+      {
+        instance: 'https://bran.mycozy.cloud'
+      },
+      {
+        instance: 'https://jon.mycozy.cloud'
+      }
+    ]
+    const addedRecipients = [
+      {
+        id: '5d4916fa-e193',
+        cozy: [
+          {
+            url: 'https://jon.mycozy.cloud',
+            type: 'primary'
+          }
+        ]
+      },
+      {
+        id: '4df64228-ce84',
+        cozy: [
+          {
+            url: 'https://sansa.mycozy.cloud',
+            type: 'primary'
+          }
+        ]
+      },
+      {
+        id: 'ff955bb1-f696',
+        cozy: [
+          {
+            url: 'https://bran.mycozy.cloud',
+            type: 'primary'
+          }
+        ]
+      },
+      {
+        id: '0761944a-c740',
+        cozy: [
+          {
+            url: 'https://arya.mycozy.cloud',
+            type: 'primary'
+          }
+        ]
+      }
+    ]
+    const result = countNewRecipients(currentRecipients, addedRecipients)
+    expect(result).toEqual(2)
   })
 })

--- a/src/sharing/components/ShareModal.jsx
+++ b/src/sharing/components/ShareModal.jsx
@@ -74,6 +74,7 @@ export default class ShareModal extends Component {
             !hasSharedParent &&
             !hasSharedChild && (
               <DumbShareByEmail
+                currentRecipients={recipients}
                 document={document}
                 documentType={documentType}
                 sharingDesc={sharingDesc}


### PR DESCRIPTION
Compare new recipients email/cozy to the current recipients email/cozy to display the number of new recipients in the toast