### PR TITLE
Add appMetadata and contacts doctype version to CozyClient

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -21,7 +21,8 @@
   },
   "snapshotSerializers": ["enzyme-to-json/serializer"],
   "transform": {
-    "^.+\\.(js|jsx)?$": "<rootDir>/test/jestLib/babel-transformer.js"
+    "^.+\\.(js|jsx)?$": "<rootDir>/test/jestLib/babel-transformer.js",
+    "^.+\\.webapp$": "<rootDir>/test/jestLib/json-transformer.js"
   },
   "transformIgnorePatterns": ["node_modules/(?!cozy-ui)/"],
   "testMatch": ["**/(*.)(spec|test).js?(x)"],

--- a/src/drive/appMetadata.js
+++ b/src/drive/appMetadata.js
@@ -1,0 +1,8 @@
+import manifest from 'drive/targets/manifest.webapp'
+
+const appMetadata = {
+  slug: manifest.name,
+  version: manifest.version
+}
+
+export default appMetadata

--- a/src/drive/lib/doctypes.js
+++ b/src/drive/lib/doctypes.js
@@ -4,6 +4,7 @@ export const DOCTYPE_FILES = 'io.cozy.files'
 export const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 export const DOCTYPE_PHOTOS_SETTINGS = 'io.cozy.photos.settings'
 export const DOCTYPE_APPS = 'io.cozy.apps'
+const DOCTYPE_CONTACTS_VERSION = 2
 
 export const schema = {
   files: { doctype: DOCTYPE_FILES },

--- a/src/drive/lib/doctypes.js
+++ b/src/drive/lib/doctypes.js
@@ -4,10 +4,13 @@ export const DOCTYPE_FILES = 'io.cozy.files'
 export const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 export const DOCTYPE_PHOTOS_SETTINGS = 'io.cozy.photos.settings'
 export const DOCTYPE_APPS = 'io.cozy.apps'
-const DOCTYPE_CONTACTS_VERSION = 2
+export const DOCTYPE_CONTACTS_VERSION = 2
 
 export const schema = {
   files: { doctype: DOCTYPE_FILES },
-  contacts: { doctype: Contact.doctype },
+  contacts: {
+    doctype: Contact.doctype,
+    doctypeVersion: DOCTYPE_CONTACTS_VERSION
+  },
   groups: { doctype: Group.doctype }
 }

--- a/src/drive/lib/reporter.js
+++ b/src/drive/lib/reporter.js
@@ -1,5 +1,6 @@
-/* global __SENTRY_URL__, __DEVELOPMENT__, __APP_VERSION__ */
+/* global __SENTRY_URL__, __DEVELOPMENT__ */
 import Raven from 'raven-js'
+import appMetadata from 'drive/appMetadata'
 
 export const ANALYTICS_URL =
   typeof __SENTRY_URL__ === 'undefined' ? '' : __SENTRY_URL__
@@ -35,7 +36,7 @@ export const normalizeData = data => {
 export const getReporterConfiguration = () => ({
   shouldSendCallback: true,
   environment: __DEVELOPMENT__ ? 'development' : 'production',
-  release: __APP_VERSION__,
+  release: appMetadata.version,
   allowSecretKey: true,
   dataCallback: normalizeData
 })

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -7,6 +7,8 @@ import { schema, DOCTYPE_FILES } from 'drive/lib/doctypes'
 export const getLang = () =>
   navigator && navigator.language ? navigator.language.slice(0, 2) : 'en'
 import { isMobileApp, getDeviceName } from 'cozy-device-helper'
+import appMetadata from 'drive/appMetadata'
+
 export const getOauthOptions = () => {
   return {
     redirectURI: isMobileApp() ? 'cozydrive://auth' : 'http://localhost',
@@ -36,6 +38,7 @@ export const initClient = url => {
     scope: permissions,
     oauth: getOauthOptions(),
     offline: { doctypes: [DOCTYPE_FILES] },
+    appMetadata,
     schema
   })
 }

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -1,4 +1,4 @@
-/* global cozy, document, __APP_VERSION__, */
+/* global cozy, document */
 import { LocalStorage as Storage } from 'cozy-client-js'
 import CozyClient from 'cozy-client'
 import { SOFTWARE_ID, SOFTWARE_NAME } from './constants'
@@ -14,7 +14,7 @@ export const getOauthOptions = () => {
     redirectURI: isMobileApp() ? 'cozydrive://auth' : 'http://localhost',
     softwareID: SOFTWARE_ID,
     clientName: `${SOFTWARE_NAME} (${getDeviceName()})`,
-    softwareVersion: __APP_VERSION__,
+    softwareVersion: appMetadata.version,
     clientKind: 'mobile',
     clientURI: 'https://github.com/cozy/cozy-drive/',
     logoURI:

--- a/src/drive/mobile/modules/settings/components/FeedbackForm.jsx
+++ b/src/drive/mobile/modules/settings/components/FeedbackForm.jsx
@@ -1,4 +1,4 @@
-/* global cozy __APP_VERSION__ */
+/* global cozy */
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
@@ -7,6 +7,7 @@ import { Button } from 'cozy-ui/react/Button'
 
 import styles from '../styles.styl'
 import { logInfo } from 'drive/lib/reporter'
+import appMetadata from 'drive/appMetadata'
 
 const FEEDBACK_EMAIL = 'contact@cozycloud.cc'
 
@@ -22,7 +23,7 @@ class FeedbackForm extends Component {
     e.preventDefault()
     const { t } = this.context
     const envInfo =
-      `Cozy Drive Mobile v${__APP_VERSION__}` +
+      `Cozy Drive Mobile v${appMetadata.version}` +
       `\nOn ${navigator.platform}` +
       `\nFrom ${navigator.vendor}` +
       `\n${navigator.userAgent}`

--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -11,7 +11,7 @@ import CozyClient, { CozyProvider } from 'cozy-client'
 import { shouldEnableTracking, getTracker } from 'cozy-ui/react/helpers/tracker'
 import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
 
-import manifest from 'drive/targets/manifest.webapp'
+import appMetadata from 'drive/appMetadata'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
 import configureStore from 'drive/store/configureStore'
 import { schema } from 'drive/lib/doctypes'
@@ -29,10 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const client = new CozyClient({
     uri: cozyUrl,
     token: data.cozyToken,
-    appMetadata: {
-      slug: manifest.name,
-      version: manifest.version
-    },
+    appMetadata,
     schema
   })
 

--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -11,6 +11,7 @@ import CozyClient, { CozyProvider } from 'cozy-client'
 import { shouldEnableTracking, getTracker } from 'cozy-ui/react/helpers/tracker'
 import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
 
+import manifest from 'drive/targets/manifest.webapp'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
 import configureStore from 'drive/store/configureStore'
 import { schema } from 'drive/lib/doctypes'
@@ -28,6 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const client = new CozyClient({
     uri: cozyUrl,
     token: data.cozyToken,
+    appMetadata: {
+      slug: manifest.name,
+      version: manifest.version
+    },
     schema
   })
 

--- a/src/drive/targets/intents/index.jsx
+++ b/src/drive/targets/intents/index.jsx
@@ -9,6 +9,7 @@ import IntentHandler from 'drive/web/modules/services'
 import CozyClient, { CozyProvider } from 'cozy-client'
 import { I18n } from 'cozy-ui/react/I18n'
 import { getQueryParameter } from 'react-cozy-helpers'
+import appMetadata from 'drive/appMetadata'
 import { schema } from 'drive/lib/doctypes'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -23,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const client = new CozyClient({
     uri: cozyUrl,
     token: data.cozyToken,
+    appMetadata,
     schema
   })
 

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -17,6 +17,7 @@ import LightFileViewer from 'drive/web/modules/public/LightFileViewer'
 import ErrorShare from 'components/Error/ErrorShare'
 import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
 import getSharedDocument from 'sharing/getSharedDocument'
+import appMetadata from 'drive/appMetadata'
 
 const initCozyBar = (data, client) => {
   if (
@@ -57,6 +58,7 @@ const init = async () => {
   const client = new CozyClient({
     uri: cozyUrl,
     token: sharecode,
+    appMetadata,
     schema
   })
   configureReporter()

--- a/src/photos/appMetadata.js
+++ b/src/photos/appMetadata.js
@@ -1,0 +1,8 @@
+import manifest from 'photos/targets/manifest.webapp'
+
+const appMetadata = {
+  slug: manifest.name,
+  version: manifest.version
+}
+
+export default appMetadata

--- a/src/photos/targets/browser/index.jsx
+++ b/src/photos/targets/browser/index.jsx
@@ -20,7 +20,7 @@ import {
 } from 'cozy-ui/react/helpers/tracker'
 
 import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
-
+import appMetadata from 'photos/appMetadata'
 import doctypes from './doctypes'
 const loggerMiddleware = createLogger()
 
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const client = new CozyClient({
     uri: cozyUrl,
     token: data.cozyToken,
+    appMetadata,
     schema: doctypes
   })
 

--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -12,6 +12,7 @@ import getSharedDocument from 'sharing/getSharedDocument'
 import ErrorUnsharedComponent from 'photos/components/ErrorUnshared'
 import { IconSprite } from 'cozy-ui/transpiled/react'
 
+import appMetadata from 'photos/appMetadata'
 import doctypes from '../browser/doctypes'
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'photos/styles/main.styl'
@@ -32,6 +33,7 @@ async function init() {
   const client = new CozyClient({
     uri: cozyUrl,
     token: sharecode,
+    appMetadata,
     schema: doctypes
   })
 

--- a/test/jestLib/json-transformer.js
+++ b/test/jestLib/json-transformer.js
@@ -1,0 +1,3 @@
+module.exports = {
+  process: src => `module.exports = ${src};`
+}


### PR DESCRIPTION
So that `CozyClient` can use those infos to add `cozyMetadata` on contacts it creates.

There are several `CozyClient` instantiations in cozy-drive (mobile, photos, public, ...), we probably need to add those infos everywhere?