### PR TITLE
Share with cozy url

### DIFF
--- a/src/sharing/components/ShareAutosuggest.jsx
+++ b/src/sharing/components/ShareAutosuggest.jsx
@@ -7,34 +7,13 @@ import palette from 'cozy-ui/react/palette'
 import styles from 'sharing/components/autosuggest.styl'
 import BoldCross from 'sharing/assets/icons/icon-cross-bold.svg'
 
-import { Contact, Group } from 'models'
+import { Contact } from 'models'
+import {
+  cozyUrlMatch,
+  emailMatch,
+  groupNameMatch
+} from 'sharing/suggestionMatchers'
 import ContactSuggestion from 'sharing/components/ContactSuggestion'
-
-// TODO: sadly we have different versions of contacts' doctype to handle...
-// A migration tool on the stack side is needed here
-const emailMatch = (input, contact) => {
-  if (!contact.email) return false
-  const emailInput = new RegExp(input, 'i')
-  if (Array.isArray(contact.email)) {
-    return contact.email.some(email => emailInput.test(email.address))
-  }
-  return emailInput.test(contact.email)
-}
-
-const cozyUrlMatch = (input, contact) => {
-  if (!contact.cozy || !contact.url) return false
-  const urlInput = new RegExp(input, 'i')
-  if (contact.cozy && Array.isArray(contact.cozy)) {
-    return contact.cozy.some(cozy => urlInput.test(cozy.url))
-  }
-  return urlInput.test(contact.url)
-}
-
-const groupNameMatch = (input, contactOrGroup) => {
-  if (contactOrGroup._type !== Group.doctype) return false
-  const nameInput = new RegExp(input, 'i')
-  return nameInput.test(contactOrGroup.name)
-}
 
 export default class ShareAutocomplete extends Component {
   state = {

--- a/src/sharing/components/ShareByEmail.jsx
+++ b/src/sharing/components/ShareByEmail.jsx
@@ -168,9 +168,9 @@ class ShareByEmail extends Component {
 
     const filtered = contactsToAdd
       .filter(
-        contact => contact.email && contact.email.length > 0
-        // TODO: uncomment next line when contacts without email can actually be added
-        //  || (contact.cozy && contact.cozy.length > 0)
+        contact =>
+          (contact.email && contact.email.length > 0) ||
+          (contact.cozy && contact.cozy.length > 0)
       )
       .filter(contact => !this.state.recipients.find(r => r === contact))
 

--- a/src/sharing/suggestionMatchers.js
+++ b/src/sharing/suggestionMatchers.js
@@ -1,0 +1,29 @@
+import { Group } from 'cozy-doctypes'
+
+// TODO: sadly we have different versions of contacts' doctype to handle...
+// A migration tool on the stack side is needed here
+const emailMatch = (input, contact) => {
+  if (!contact.email) return false
+  const emailInput = new RegExp(input, 'i')
+  if (Array.isArray(contact.email)) {
+    return contact.email.some(email => emailInput.test(email.address))
+  }
+  return emailInput.test(contact.email)
+}
+
+const cozyUrlMatch = (input, contact) => {
+  if (!contact.cozy || !contact.url) return false
+  const urlInput = new RegExp(input, 'i')
+  if (contact.cozy && Array.isArray(contact.cozy)) {
+    return contact.cozy.some(cozy => urlInput.test(cozy.url))
+  }
+  return urlInput.test(contact.url)
+}
+
+const groupNameMatch = (input, contactOrGroup) => {
+  if (contactOrGroup._type !== Group.doctype) return false
+  const nameInput = new RegExp(input, 'i')
+  return nameInput.test(contactOrGroup.name)
+}
+
+export { emailMatch, cozyUrlMatch, groupNameMatch }

--- a/src/sharing/suggestionMatchers.js
+++ b/src/sharing/suggestionMatchers.js
@@ -12,7 +12,7 @@ const emailMatch = (input, contact) => {
 }
 
 const cozyUrlMatch = (input, contact) => {
-  if (!contact.cozy || !contact.url) return false
+  if (!contact.cozy && !contact.url) return false
   const urlInput = new RegExp(input, 'i')
   if (contact.cozy && Array.isArray(contact.cozy)) {
     return contact.cozy.some(cozy => urlInput.test(cozy.url))

--- a/src/sharing/suggestionMatchers.spec.js
+++ b/src/sharing/suggestionMatchers.spec.js
@@ -1,0 +1,54 @@
+import * as matchers from './suggestionMatchers'
+
+describe('Suggestion matchers', () => {
+  describe('emailMatch', () => {
+    it('should return true if one email matches', () => {
+      const contact = {
+        fullname: 'Jon Snow',
+        email: [
+          {
+            address: 'jon@winterfell.westeros',
+            type: 'Home',
+            primary: true
+          },
+          {
+            address: 'jon.snow@thewall.westeros',
+            type: 'Work',
+            primary: true
+          }
+        ]
+      }
+      const result = matchers.emailMatch('jon.snow@thewall.westeros', contact)
+      expect(result).toBe(true)
+    })
+
+    it('should return false if no email matches', () => {
+      const contact = {
+        fullname: 'Jon Snow',
+        email: [
+          {
+            address: 'jon@winterfell.westeros',
+            type: 'Home',
+            primary: true
+          },
+          {
+            address: 'jon.snow@thewall.westeros',
+            type: 'Work',
+            primary: true
+          }
+        ]
+      }
+      const result = matchers.emailMatch('jon@thewall.westeros', contact)
+      expect(result).toBe(false)
+    })
+
+    it('should return false if contact has no email', () => {
+      const contact = {
+        fullname: 'Jon Snow',
+        email: []
+      }
+      const result = matchers.emailMatch('jon.snow@thewall.westeros', contact)
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/src/sharing/suggestionMatchers.spec.js
+++ b/src/sharing/suggestionMatchers.spec.js
@@ -1,6 +1,49 @@
 import * as matchers from './suggestionMatchers'
 
 describe('Suggestion matchers', () => {
+  describe('cozyUrlMatch', () => {
+    it('should return true if cozy url matches', () => {
+      const contact = {
+        fullname: 'Jon Snow',
+        cozy: [
+          {
+            url: 'https://jon.mycozy.cloud'
+          }
+        ]
+      }
+      const result = matchers.cozyUrlMatch('https://jon.mycozy.cloud', contact)
+      expect(result).toBe(true)
+    })
+
+    it("should return false if cozy url doesn't match", () => {
+      const contact = {
+        fullname: 'Jon Snow',
+        cozy: [
+          {
+            url: 'https://jon.mycozy.cloud'
+          }
+        ]
+      }
+      const result = matchers.emailMatch(
+        'https://jonsnow.mycozy.cloud',
+        contact
+      )
+      expect(result).toBe(false)
+    })
+
+    it('should return false if contact has no cozy', () => {
+      const contact = {
+        fullname: 'Jon Snow',
+        cozy: []
+      }
+      const result = matchers.emailMatch(
+        'https://jonsnow.mycozy.cloud',
+        contact
+      )
+      expect(result).toBe(false)
+    })
+  })
+
   describe('emailMatch', () => {
     it('should return true if one email matches', () => {
       const contact = {


### PR DESCRIPTION
We can use the cozy url to share documents to users with a cozy but without email, The stack will find the email to send the notification. It also handles contacts that have a cozy in groups.