### PR TITLE
Testcafe : add timestamp in log

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "url-polyfill": "1.1.0",
     "webpack-node-externals": "1.7.2",
     "whatwg-fetch": "3.0.0",
-    "minilog": "3.1.0"
+    "minilog": "3.1.0",
+    "log-prefix": "0.1.1"
   }
 }

--- a/testcafe/tests/helpers/logger.js
+++ b/testcafe/tests/helpers/logger.js
@@ -1,3 +1,6 @@
+require('log-prefix')(function() {
+  return '%s [' + new Date().toTimeString() + ']'
+})
 const logger = require('minilog')('testcafe')
 require('minilog').enable()
 require('minilog').suggest.deny('testcafe', 'debug')

--- a/yarn.lock
+++ b/yarn.lock
@@ -9903,6 +9903,11 @@ lodash@^3.3.1, lodash@^3.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
+log-prefix@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/log-prefix/-/log-prefix-0.1.1.tgz#3ec492138c8044c9f9732298492dca87850cac90"
+  integrity sha512-aP1Lst8OCdZKATqzXDN0JBissNVZuiKLyo6hOXDBxaQ1jHDsaxh2J1i5Pp0zMy6ayTKDWfUlLMXyLaQe1PJ48g==
+
 log-update-async-hook@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/log-update-async-hook/-/log-update-async-hook-2.0.2.tgz#6eba89dbe67fa12d0b20ac47df7942947af1fcd1"


### PR DESCRIPTION
Using log-prefix to add timestamp to testcafé log. 

I choose to use `toTimeString` to display the date-time in format ` [14:23:45 GMT+0200 (CEST)]`
This can be [change to any date format ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Conversion_getter)
Maybe `toISOString` is better because more precise (`[2019-05-09T08:58:50.487Z]`), but I think it's less readable