### PR TITLE
fix: Use cozy in success message if contact has no email

### DIFF
--- a/src/sharing/components/ShareByEmail.jsx
+++ b/src/sharing/components/ShareByEmail.jsx
@@ -191,14 +191,50 @@ class ShareByEmail extends Component {
     }))
   }
 
+  getSuccessMessage = () => {
+    const { documentType } = this.props
+    const { recipients } = this.state
+    if (recipients.length === 1) {
+      const recipient = recipients[0]
+      const email = Contact.isContact(recipient)
+        ? Contact.getPrimaryEmail(recipient)
+        : recipient.email
+      const cozyUrl = Contact.getPrimaryCozy(recipient)
+
+      if (email) {
+        return [
+          `${documentType}.share.shareByEmail.success`,
+          {
+            email
+          }
+        ]
+      } else if (cozyUrl) {
+        return [
+          `${documentType}.share.shareByEmail.success`,
+          {
+            email: cozyUrl
+          }
+        ]
+      } else {
+        return [
+          `${documentType}.share.shareByEmail.genericSuccess`,
+          {
+            count: 1
+          }
+        ]
+      }
+    } else {
+      return [
+        `${documentType}.share.shareByEmail.genericSuccess`,
+        {
+          count: recipients.length
+        }
+      ]
+    }
+  }
+
   share = () => {
-    const {
-      document,
-      documentType,
-      sharingDesc,
-      onShare,
-      createContact
-    } = this.props
+    const { document, sharingDesc, onShare, createContact } = this.props
     const { recipients, sharingType } = this.state
     if (recipients.length === 0) {
       return
@@ -218,17 +254,7 @@ class ShareByEmail extends Component {
         onShare(document, recipients, sharingType, sharingDesc)
       )
       .then(() => {
-        if (recipients.length === 1) {
-          Alerter.success(`${documentType}.share.shareByEmail.success`, {
-            email: recipients[0].id
-              ? Contact.getPrimaryEmail(recipients[0])
-              : recipients[0].email
-          })
-        } else {
-          Alerter.success(`${documentType}.share.shareByEmail.genericSuccess`, {
-            count: recipients.length
-          })
-        }
+        Alerter.success(...this.getSuccessMessage())
         this.reset()
       })
       .catch(err => {

--- a/src/sharing/components/ShareByEmail.spec.jsx
+++ b/src/sharing/components/ShareByEmail.spec.jsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import ShareByEmail from './ShareByEmail'
+
+const fakeDoc = {
+  _id: 'c0455ddf-5f4c',
+  _type: 'io.cozy.files',
+  name: 'fake-doc.odt'
+}
+
+const fakeContext = {
+  client: {},
+  t: jest.fn()
+}
+
+describe('ShareByEmail component', () => {
+  describe('getSuccessMessage method', () => {
+    let component
+    const props = {
+      contacts: {
+        id: 'contacts',
+        data: [],
+        hasMore: false,
+        fetchStatus: 'loaded'
+      },
+      groups: {
+        id: 'groups',
+        data: [],
+        hasMore: false,
+        fetchStatus: 'loaded'
+      },
+      document: fakeDoc,
+      documentType: 'Files',
+      sharingDesc: 'fake-doc.odt',
+      onShare: jest.fn(),
+      createContact: jest.fn()
+    }
+
+    beforeEach(() => {
+      component = mount(<ShareByEmail {...props} />, {
+        context: fakeContext
+      })
+    })
+
+    it('should return a success message and its params for multiple recipients', () => {
+      component.setState({
+        recipients: [
+          { email: 'jon.snow@thewall.westeros' },
+          { email: 'arya.stark@winterfell.westeros' }
+        ]
+      })
+      const [message, params] = component.instance().getSuccessMessage()
+      expect(message).toEqual('Files.share.shareByEmail.genericSuccess')
+      expect(params).toEqual({ count: 2 })
+    })
+
+    it('should return a success message and its params for one recipient with email', () => {
+      component.setState({
+        recipients: [{ email: 'jon.snow@thewall.westeros' }]
+      })
+      const [message, params] = component.instance().getSuccessMessage()
+      expect(message).toEqual('Files.share.shareByEmail.success')
+      expect(params).toEqual({ email: 'jon.snow@thewall.westeros' })
+    })
+
+    it('should return a success message and its params for one recipient (contact) with email', () => {
+      component.setState({
+        recipients: [
+          {
+            _id: 'e8c0e15f-da7d',
+            _type: 'io.cozy.contacts',
+            fullname: 'Jon Snow',
+            email: [
+              {
+                address: 'jon.snow@thewall.westeros',
+                primary: true
+              },
+              {
+                address: 'jon.snow@winterfell.westeros',
+                primary: false
+              }
+            ]
+          }
+        ]
+      })
+      const [message, params] = component.instance().getSuccessMessage()
+      expect(message).toEqual('Files.share.shareByEmail.success')
+      expect(params).toEqual({ email: 'jon.snow@thewall.westeros' })
+    })
+
+    it('should return a success message and its params for one recipient with cozy', () => {
+      component.setState({
+        recipients: [
+          {
+            cozy: [
+              {
+                url: 'https://doranmartell.mycozy.cloud'
+              }
+            ]
+          }
+        ]
+      })
+      const [message, params] = component.instance().getSuccessMessage()
+      expect(message).toEqual('Files.share.shareByEmail.success')
+      expect(params).toEqual({ email: 'https://doranmartell.mycozy.cloud' })
+    })
+
+    it('should use generic success message if recipient has no email and no cozy', () => {
+      component.setState({
+        recipients: [
+          {
+            _id: 'fcb16b9e-7421'
+          }
+        ]
+      })
+      const [message, params] = component.instance().getSuccessMessage()
+      expect(message).toEqual('Files.share.shareByEmail.genericSuccess')
+      expect(params).toEqual({ count: 1 })
+    })
+  })
+})


### PR DESCRIPTION
If recipient has no email (sharing by cozy url for example), use cozy url. If it has no email and no cozy, use the generic success message.

Refactoring: added a `getSuccessMessage` method and tests.