### PR TITLE
fix: Use email if public_name and name are not available

### DIFF
--- a/src/models/Contact.js
+++ b/src/models/Contact.js
@@ -5,7 +5,10 @@ class Contact extends DoctypeContact {
     if (Contact.isContact(contactOrRecipient)) {
       return DoctypeContact.getInitials(contactOrRecipient)
     } else {
-      const s = contactOrRecipient.public_name || contactOrRecipient.name
+      const s =
+        contactOrRecipient.public_name ||
+        contactOrRecipient.name ||
+        contactOrRecipient.email
       return (s && s[0].toUpperCase()) || ''
     }
   }

--- a/src/models/Contact.spec.js
+++ b/src/models/Contact.spec.js
@@ -19,6 +19,16 @@ describe('Contact model', () => {
       expect(result).toEqual('J')
     })
 
+    it('should return the first letter of email if it is a recipient and name/public_name are not defined', () => {
+      const recipient = {
+        name: undefined,
+        public_name: undefined,
+        email: 'janedoe@example.com'
+      }
+      const result = Contact.getInitials(recipient)
+      expect(result).toEqual('J')
+    })
+
     it('should return an empty string if name/public_name are undefined', () => {
       const recipient = {}
       const result = Contact.getInitials(recipient)


### PR DESCRIPTION
When Bob shares a document to Alice and Alice look at this document's sharings in her cozy's, Alice's cozy may only have the recipient's emails to display the avatar of the recipients. This PR fixes this use case.