### PR TITLE
fix: Init bar isPublic on public page

### DIFF
--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -49,7 +49,8 @@ async function init() {
       cozyClient: client,
       iconPath: data.cozyIconPath,
       lang: data.cozyLocale,
-      replaceTitleOnMobile: true
+      replaceTitleOnMobile: true,
+      isPublic: true
     })
   }
   configureReporter()


### PR DESCRIPTION
As we're on a public page, we should init the bar in public mode