### PR TITLE
Fix getDisplayName and getInitials

### DIFF
--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -523,5 +523,10 @@
         "description": "Required to share files with your groups"
       }
     }
+  },
+  "models": {
+    "contact": {
+      "defaultDisplayName": "Anonymous"
+    }
   }
 }

--- a/src/models/Contact.js
+++ b/src/models/Contact.js
@@ -1,7 +1,7 @@
 import { Contact as DoctypeContact } from 'cozy-doctypes'
 
 class Contact extends DoctypeContact {
-  static getInitials(contactOrRecipient) {
+  static getInitials(contactOrRecipient, defaultValue = '') {
     if (Contact.isContact(contactOrRecipient)) {
       return DoctypeContact.getInitials(contactOrRecipient)
     } else {
@@ -9,15 +9,17 @@ class Contact extends DoctypeContact {
         contactOrRecipient.public_name ||
         contactOrRecipient.name ||
         contactOrRecipient.email
-      return (s && s[0].toUpperCase()) || ''
+      return (s && s[0].toUpperCase()) || defaultValue
     }
   }
 
-  static getDisplayName(contact) {
+  static getDisplayName(contact, defaultValue = '') {
     if (Contact.isContact(contact)) {
       return DoctypeContact.getDisplayName(contact)
     } else {
-      return contact.name || contact.email || ''
+      return (
+        contact.public_name || contact.name || contact.email || defaultValue
+      )
     }
   }
 }

--- a/src/models/Contact.spec.js
+++ b/src/models/Contact.spec.js
@@ -35,6 +35,12 @@ describe('Contact model', () => {
       expect(result).toEqual('')
     })
 
+    it('should use a default value if name/public_name are undefined', () => {
+      const recipient = {}
+      const result = Contact.getInitials(recipient, 'A')
+      expect(result).toEqual('A')
+    })
+
     it('should use the original implementation if a contact is given', () => {
       const contact = {
         _id: '46b5d129-0296-4466-8c02-9a6a0c17c4cb',
@@ -64,6 +70,16 @@ describe('Contact model', () => {
       expect(result).toEqual('Arya Stark')
     })
 
+    it('should use public_name if available', () => {
+      const contact = {
+        email: 'arya@winterfell.westeros',
+        name: 'Arya Stark',
+        public_name: 'aryastark'
+      }
+      const result = Contact.getDisplayName(contact)
+      expect(result).toEqual('aryastark')
+    })
+
     it('should use name if a recipient is given', () => {
       const contact = {
         name: 'Arya Stark'
@@ -78,6 +94,18 @@ describe('Contact model', () => {
       }
       const result = Contact.getDisplayName(recipient)
       expect(result).toEqual('arya.stark@winterfell.westeros')
+    })
+
+    it('should use an empty string as default value if nothing is available', () => {
+      const recipient = {}
+      const result = Contact.getDisplayName(recipient)
+      expect(result).toEqual('')
+    })
+
+    it('should use a default value if nothing is available', () => {
+      const recipient = {}
+      const result = Contact.getDisplayName(recipient, 'Anonymous')
+      expect(result).toEqual('Anonymous')
     })
   })
 })

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -49,14 +49,16 @@ export const RecipientsAvatars = ({
           size={size}
         />
       )}
-      {reversedRecipients.slice(0, MAX_DISPLAYED_RECIPIENTS).map(recipient => (
-        <Avatar
-          key={`key_avatar_${recipient.email}`}
-          text={Contact.getInitials(recipient)}
-          size={size}
-          textId={Contact.getDisplayName(recipient)}
-        />
-      ))}
+      {reversedRecipients
+        .slice(0, MAX_DISPLAYED_RECIPIENTS)
+        .map((recipient, idx) => (
+          <Avatar
+            key={idx}
+            text={Contact.getInitials(recipient)}
+            size={size}
+            textId={Contact.getDisplayName(recipient)}
+          />
+        ))}
     </div>
   )
 }

--- a/src/sharing/components/Recipient.jsx
+++ b/src/sharing/components/Recipient.jsx
@@ -17,6 +17,7 @@ import { Contact } from 'models'
 import Identity from 'sharing/components/Identity'
 
 const MAX_DISPLAYED_RECIPIENTS = 3
+const DEFAULT_DISPLAY_NAME = 'models.contact.defaultDisplayName'
 
 export const RecipientsAvatars = ({
   recipients,
@@ -166,11 +167,13 @@ const Recipient = (props, { client, t }) => {
   const { instance, isOwner, status, ...rest } = props
   const isMe =
     (isOwner && status === 'owner') || instance === client.options.uri
-  const name = Contact.getDisplayName(rest)
+  const defaultDisplayName = t(DEFAULT_DISPLAY_NAME)
+  const defaultInitials = defaultDisplayName[0].toUpperCase()
+  const name = Contact.getDisplayName(rest, defaultDisplayName)
   return (
     <div className={classNames(styles['recipient'], 'u-mt-1')}>
       <Avatar
-        text={Contact.getInitials(rest)}
+        text={Contact.getInitials(rest, defaultInitials)}
         size={'small-plus'}
         textId={name}
       />


### PR DESCRIPTION
- if sharing has been done by url, we may only have the member's `public_name`
- also add a default values for initials and display name if name, public_name or email are not available (for sharing members for whom sharing has been done by url and that have not yet accepted the sharing)