### PR TITLE
fix: Don't take currentRecipients from props in getSuccessMessage

### DIFF
--- a/src/sharing/components/ShareByEmail.jsx
+++ b/src/sharing/components/ShareByEmail.jsx
@@ -203,8 +203,8 @@ class ShareByEmail extends Component {
     }))
   }
 
-  getSuccessMessage = () => {
-    const { currentRecipients, documentType } = this.props
+  getSuccessMessage = recipientsBefore => {
+    const { documentType } = this.props
     const { recipients } = this.state
     if (recipients.length === 1) {
       const recipient = recipients[0]
@@ -239,7 +239,7 @@ class ShareByEmail extends Component {
       return [
         `${documentType}.share.shareByEmail.genericSuccess`,
         {
-          count: countNewRecipients(currentRecipients, recipients)
+          count: countNewRecipients(recipientsBefore, recipients)
         }
       ]
     }
@@ -251,6 +251,11 @@ class ShareByEmail extends Component {
     if (recipients.length === 0) {
       return
     }
+
+    // we can't use currentRecipients prop in getSuccessMessage because it may use
+    // the updated prop to count the new recipients
+    const recipientsBefore = this.props.currentRecipients
+
     this.setState(state => ({ ...state, loading: true }))
     Promise.all(
       recipients.map(
@@ -266,7 +271,7 @@ class ShareByEmail extends Component {
         onShare(document, recipients, sharingType, sharingDesc)
       )
       .then(() => {
-        Alerter.success(...this.getSuccessMessage())
+        Alerter.success(...this.getSuccessMessage(recipientsBefore))
         this.reset()
       })
       .catch(err => {

--- a/src/sharing/components/ShareByEmail.spec.jsx
+++ b/src/sharing/components/ShareByEmail.spec.jsx
@@ -52,7 +52,29 @@ describe('ShareByEmail component', () => {
           { email: 'sansa.stark@winterfell.westeros' }
         ]
       })
-      const [message, params] = component.instance().getSuccessMessage()
+      const recipientsBefore = props.currentRecipients
+      const [message, params] = component
+        .instance()
+        .getSuccessMessage(recipientsBefore)
+      expect(message).toEqual('Files.share.shareByEmail.genericSuccess')
+      expect(params).toEqual({ count: 2 })
+    })
+
+    // see https://github.com/cozy/cozy-drive/pull/1671
+    it('should work if currentRecipients prop change before it is called', () => {
+      const newRecipients = [
+        { email: 'jon.snow@thewall.westeros' },
+        { email: 'arya.stark@winterfell.westeros' },
+        { email: 'sansa.stark@winterfell.westeros' }
+      ]
+      component.setState({
+        recipients: newRecipients
+      })
+      const recipientsBefore = props.currentRecipients
+      component.setProps({ ...props, currentRecipients: newRecipients })
+      const [message, params] = component
+        .instance()
+        .getSuccessMessage(recipientsBefore)
       expect(message).toEqual('Files.share.shareByEmail.genericSuccess')
       expect(params).toEqual({ count: 2 })
     })
@@ -61,7 +83,10 @@ describe('ShareByEmail component', () => {
       component.setState({
         recipients: [{ email: 'jon.snow@thewall.westeros' }]
       })
-      const [message, params] = component.instance().getSuccessMessage()
+      const recipientsBefore = props.currentRecipients
+      const [message, params] = component
+        .instance()
+        .getSuccessMessage(recipientsBefore)
       expect(message).toEqual('Files.share.shareByEmail.success')
       expect(params).toEqual({ email: 'jon.snow@thewall.westeros' })
     })
@@ -86,7 +111,10 @@ describe('ShareByEmail component', () => {
           }
         ]
       })
-      const [message, params] = component.instance().getSuccessMessage()
+      const recipientsBefore = props.currentRecipients
+      const [message, params] = component
+        .instance()
+        .getSuccessMessage(recipientsBefore)
       expect(message).toEqual('Files.share.shareByEmail.success')
       expect(params).toEqual({ email: 'jon.snow@thewall.westeros' })
     })
@@ -103,7 +131,10 @@ describe('ShareByEmail component', () => {
           }
         ]
       })
-      const [message, params] = component.instance().getSuccessMessage()
+      const recipientsBefore = props.currentRecipients
+      const [message, params] = component
+        .instance()
+        .getSuccessMessage(recipientsBefore)
       expect(message).toEqual('Files.share.shareByEmail.success')
       expect(params).toEqual({ email: 'https://doranmartell.mycozy.cloud' })
     })
@@ -116,7 +147,10 @@ describe('ShareByEmail component', () => {
           }
         ]
       })
-      const [message, params] = component.instance().getSuccessMessage()
+      const recipientsBefore = props.currentRecipients
+      const [message, params] = component
+        .instance()
+        .getSuccessMessage(recipientsBefore)
       expect(message).toEqual('Files.share.shareByEmail.genericSuccess')
       expect(params).toEqual({ count: 1 })
     })


### PR DESCRIPTION
Since https://github.com/cozy/cozy-drive/pull/1652 has been merged, we can't use `this.props.currentRecipients` in `getSuccessMessage` because in this case, it uses the updated prop to count the new recipients. Thus, we "save" the currentRecipients before the promises are resolved and it's all good.