### PR TITLE
Upload conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "cozy-client-js": "0.13.0",
     "cozy-device-helper": "1.5.0",
     "cozy-doctypes": "1.44.1",
-    "cozy-flags": "1.6.0",
+    "cozy-flags": "1.6.1",
     "cozy-konnector-libs": "4.11.4",
     "cozy-realtime": "2.0.8",
     "cozy-scripts": "1.13.0",
@@ -119,7 +119,9 @@
     "kd-tree-javascript": "1.0.3",
     "localforage": "1.7.3",
     "lodash": "4.17.11",
+    "log-prefix": "0.1.1",
     "mime-types": "2.1.19",
+    "minilog": "3.1.0",
     "node-polyglot": "2.3.0",
     "node-uuid": "1.4.8",
     "piwik-react-router": "0.8.2",
@@ -145,8 +147,6 @@
     "redux-thunk": "2.3.0",
     "url-polyfill": "1.1.0",
     "webpack-node-externals": "1.7.2",
-    "whatwg-fetch": "3.0.0",
-    "minilog": "3.1.0",
-    "log-prefix": "0.1.1"
+    "whatwg-fetch": "3.0.0"
   }
 }

--- a/src/authentication/src/steps/ButtonLinkRegistration.jsx
+++ b/src/authentication/src/steps/ButtonLinkRegistration.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { getPlatform } from 'cozy-device-helper'
 import { Button } from 'cozy-ui/react'
-//import flag from 'cozy-flags'
 
 import { nativeLinkOpen } from '../LinkManager'
 

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -444,6 +444,8 @@
     "alert": {
       "success": "%{smart_count} file uploaded with success. |||| %{smart_count} files uploaded with success.",
       "success_conflicts": "%{smart_count} file uploaded with %{conflictNumber} conflict(s). |||| %{smart_count} files uploaded with %{conflictNumber} conflict(s).",
+      "success_updated": "%{smart_count} file uploaded and %{updatedCount} updated(s). |||| %{smart_count} files uploaded and %{updatedCount} file(s) updated.",
+      "updated": "%{smart_count} file updated. |||| %{smart_count} files updated.",
       "errors": "Errors occurred during the file upload.",
       "network": "You are currenly offline. Please try again once you're connected."
     }

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -444,7 +444,7 @@
     "alert": {
       "success": "%{smart_count} file uploaded with success. |||| %{smart_count} files uploaded with success.",
       "success_conflicts": "%{smart_count} file uploaded with %{conflictNumber} conflict(s). |||| %{smart_count} files uploaded with %{conflictNumber} conflict(s).",
-      "success_updated": "%{smart_count} file uploaded and %{updatedCount} updated(s). |||| %{smart_count} files uploaded and %{updatedCount} file(s) updated.",
+      "success_updated": "%{smart_count} file uploaded and %{updatedCount} updated(s). |||| %{smart_count} files uploaded and %{updatedCount} updated.",
       "updated": "%{smart_count} file updated. |||| %{smart_count} files updated.",
       "errors": "Errors occurred during the file upload.",
       "network": "You are currenly offline. Please try again once you're connected."

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -444,8 +444,10 @@
     "alert": {
       "success": "%{smart_count} file uploaded with success. |||| %{smart_count} files uploaded with success.",
       "success_conflicts": "%{smart_count} file uploaded with %{conflictNumber} conflict(s). |||| %{smart_count} files uploaded with %{conflictNumber} conflict(s).",
-      "success_updated": "%{smart_count} file uploaded and %{updatedCount} updated(s). |||| %{smart_count} files uploaded and %{updatedCount} updated.",
+      "success_updated": "%{smart_count} file uploaded and %{updatedCount} updated. |||| %{smart_count} files uploaded and %{updatedCount} updated.",
+      "success_updated_conflicts": "%{smart_count} file uploaded, %{updatedCount} updated and %{conflictCount} conflict(s). |||| %{smart_count} files uploaded, %{updatedCount} updated and %{conflictCount} conflict(s).",
       "updated": "%{smart_count} file updated. |||| %{smart_count} files updated.",
+      "updated_conflicts": "%{smart_count} file updated with %{conflictCount} conflict(s). |||| %{smart_count} files updated with %{conflictCount} conflict(s).",
       "errors": "Errors occurred during the file upload.",
       "network": "You are currenly offline. Please try again once you're connected."
     }

--- a/src/drive/web/modules/drive/Toolbar/components/UploadItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/UploadItem.jsx
@@ -10,14 +10,18 @@ const UploadItem = translate()(
   ({ t, displayedFolder, insideMoreMenu, isDisabled, uploadFiles }) =>
     insideMoreMenu ? (
       <UploadButton
-        onUpload={files => uploadFiles(files, displayedFolder)}
+        onUpload={(files, sharingState) =>
+          uploadFiles(files, displayedFolder, sharingState)
+        }
         label={t('toolbar.menu_upload')}
         className={styles['fil-action-upload']}
       />
     ) : (
       <UploadButton
         disabled={isDisabled}
-        onUpload={files => uploadFiles(files, displayedFolder)}
+        onUpload={(files, sharingState) =>
+          uploadFiles(files, displayedFolder, sharingState)
+        }
         label={t('toolbar.item_upload')}
         className={classNames(styles['c-btn'], styles['u-hide--mob'])}
       />

--- a/src/drive/web/modules/drive/Toolbar/components/UploadItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/UploadItem.jsx
@@ -7,21 +7,17 @@ import styles from 'drive/styles/toolbar.styl'
 import toolbarContainer from '../toolbar'
 
 const UploadItem = translate()(
-  ({ t, displayedFolder, insideMoreMenu, isDisabled, uploadFiles }) =>
+  ({ t, displayedFolder, insideMoreMenu, isDisabled }) =>
     insideMoreMenu ? (
       <UploadButton
-        onUpload={(files, sharingState) =>
-          uploadFiles(files, displayedFolder, sharingState)
-        }
+        displayedFolder={displayedFolder}
         label={t('toolbar.menu_upload')}
         className={styles['fil-action-upload']}
       />
     ) : (
       <UploadButton
         disabled={isDisabled}
-        onUpload={(files, sharingState) =>
-          uploadFiles(files, displayedFolder, sharingState)
-        }
+        displayedFolder={displayedFolder}
         label={t('toolbar.item_upload')}
         className={classNames(styles['c-btn'], styles['u-hide--mob'])}
       />

--- a/src/drive/web/modules/drive/Toolbar/toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar/toolbar.jsx
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 import { ROOT_DIR_ID } from 'drive/constants/config'
 
 import { isSelectionBarVisible } from 'drive/web/modules/selection/duck'
-import { uploadFiles } from 'drive/web/modules/navigation/duck'
 
 const mapStateToProps = state => ({
   displayedFolder: state.view.displayedFolder,
@@ -11,16 +10,6 @@ const mapStateToProps = state => ({
   selectionModeActive: isSelectionBarVisible(state)
 })
 
-const mapDispatchToProps = dispatch => ({
-  uploadFiles: (files, displayedFolder, sharingState) => {
-    dispatch(uploadFiles(files, displayedFolder.id, sharingState))
-  }
-})
-
-const toolbarContainer = component =>
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(component)
+const toolbarContainer = component => connect(mapStateToProps)(component)
 
 export default toolbarContainer

--- a/src/drive/web/modules/drive/Toolbar/toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar/toolbar.jsx
@@ -12,8 +12,8 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  uploadFiles: (files, displayedFolder) => {
-    dispatch(uploadFiles(files, displayedFolder.id))
+  uploadFiles: (files, displayedFolder, sharingState) => {
+    dispatch(uploadFiles(files, displayedFolder.id, sharingState))
   }
 })
 

--- a/src/drive/web/modules/layout/Layout.jsx
+++ b/src/drive/web/modules/layout/Layout.jsx
@@ -4,15 +4,20 @@ import { translate } from 'cozy-ui/react/I18n'
 import { Layout as LayoutUI } from 'cozy-ui/react/Layout'
 import Sidebar from 'cozy-ui/react/Sidebar'
 import Alerter from 'cozy-ui/react/Alerter'
+import flag, { FlagSwitcher } from 'cozy-flags'
 
+import { initFlags } from 'lib/flags'
 import Nav from 'drive/web/modules/navigation/Nav'
 import ButtonClient from 'components/pushClient/Button'
 import { UploadQueue } from 'drive/web/modules/upload'
 import UserActionRequired from 'drive/mobile/modules/authorization/UserActionRequired'
 import { IconSprite } from 'cozy-ui/transpiled/react'
 
+initFlags()
+
 const Layout = ({ t, children }) => (
   <LayoutUI>
+    {flag('switcher') && <FlagSwitcher />}
     <Sidebar className="u-flex-justify-between">
       <Nav />
       <ButtonClient />

--- a/src/drive/web/modules/navigation/duck/actions.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.jsx
@@ -255,37 +255,51 @@ export const uploadFiles = (files, dirId, sharingState) => dispatch => {
 }
 
 const uploadQueueProcessed = (
-  loaded,
+  created,
   quotas,
   conflicts,
   networkErrors,
   errors,
   updated
 ) => dispatch => {
+  const conflictCount = conflicts.length
+  const createdCount = created.length
+  const updatedCount = updated.length
   if (quotas.length > 0) {
     // quota errors have their own modal instead of a notification
     dispatch(showModal(<QuotaAlert />))
-  } else if (conflicts.length > 0) {
-    Alerter.info('upload.alert.success_conflicts', {
-      smart_count: loaded.length,
-      conflictNumber: conflicts.length
-    })
   } else if (networkErrors.length > 0) {
     Alerter.info('upload.alert.network')
   } else if (errors.length > 0) {
     Alerter.info('upload.alert.errors')
-  } else if (updated.length > 0 && loaded.length === 0) {
-    Alerter.success('upload.alert.updated', {
-      smart_count: updated.length
+  } else if (updatedCount > 0 && createdCount > 0 && conflictCount > 0) {
+    Alerter.success('upload.alert.success_updated_conflicts', {
+      smart_count: createdCount,
+      updatedCount,
+      conflictCount
     })
-  } else if (updated.length > 0 && loaded.length > 0) {
+  } else if (updatedCount > 0 && createdCount > 0) {
     Alerter.success('upload.alert.success_updated', {
-      smart_count: loaded.length,
-      updatedCount: updated.length
+      smart_count: createdCount,
+      updatedCount
+    })
+  } else if (updatedCount > 0 && conflictCount > 0) {
+    Alerter.success('upload.alert.updated_conflicts', {
+      smart_count: updatedCount,
+      conflictCount
+    })
+  } else if (conflictCount > 0) {
+    Alerter.info('upload.alert.success_conflicts', {
+      smart_count: createdCount,
+      conflictNumber: conflictCount
+    })
+  } else if (updatedCount > 0 && createdCount === 0) {
+    Alerter.success('upload.alert.updated', {
+      smart_count: updatedCount
     })
   } else {
     Alerter.success('upload.alert.success', {
-      smart_count: loaded.length
+      smart_count: createdCount
     })
   }
 }

--- a/src/drive/web/modules/navigation/duck/actions.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.jsx
@@ -225,11 +225,12 @@ export const getFileDownloadUrl = async id => {
   return `${cozy.client._url}${link}`
 }
 
-export const uploadFiles = (files, dirId) => dispatch => {
+export const uploadFiles = (files, dirId, sharingState) => dispatch => {
   dispatch(
     addToUploadQueue(
       files,
       dirId,
+      sharingState,
       () => null,
       (loaded, quotas, conflicts, networkErrors, errors, updated) =>
         dispatch(

--- a/src/drive/web/modules/navigation/duck/actions.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.jsx
@@ -231,9 +231,16 @@ export const uploadFiles = (files, dirId) => dispatch => {
       files,
       dirId,
       () => null,
-      (loaded, quotas, conflicts, networkErrors, errors) =>
+      (loaded, quotas, conflicts, networkErrors, errors, updated) =>
         dispatch(
-          uploadQueueProcessed(loaded, quotas, conflicts, networkErrors, errors)
+          uploadQueueProcessed(
+            loaded,
+            quotas,
+            conflicts,
+            networkErrors,
+            errors,
+            updated
+          )
         )
     )
   )
@@ -244,7 +251,8 @@ const uploadQueueProcessed = (
   quotas,
   conflicts,
   networkErrors,
-  errors
+  errors,
+  updated
 ) => dispatch => {
   if (quotas.length > 0) {
     // quota errors have their own modal instead of a notification
@@ -258,6 +266,15 @@ const uploadQueueProcessed = (
     Alerter.info('upload.alert.network')
   } else if (errors.length > 0) {
     Alerter.info('upload.alert.errors')
+  } else if (updated.length > 0 && loaded.length === 0) {
+    Alerter.success('upload.alert.updated', {
+      smart_count: updated.length
+    })
+  } else if (updated.length > 0 && loaded.length > 0) {
+    Alerter.success('upload.alert.success_updated', {
+      smart_count: loaded.length,
+      updatedCount: updated.length
+    })
   } else {
     Alerter.success('upload.alert.success', {
       smart_count: loaded.length

--- a/src/drive/web/modules/navigation/duck/actions.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.jsx
@@ -225,12 +225,19 @@ export const getFileDownloadUrl = async id => {
   return `${cozy.client._url}${link}`
 }
 
+/*
+ * @function
+ * @param {Array} files - The list of File objects to upload
+ * @param {string} dirId - The id of the directory in which we upload the files
+ * @param {Object} sharingState - The sharing context (provided by SharingContext.Provider)
+ * @returns {function} - A function that dispatches addToUploadQueue action
+ */
 export const uploadFiles = (files, dirId, sharingState) => dispatch => {
   dispatch(
     addToUploadQueue(
       files,
       dirId,
-      sharingState,
+      sharingState, // used to know if files are shared for conflicts management
       () => null,
       (loaded, quotas, conflicts, networkErrors, errors, updated) =>
         dispatch(

--- a/src/drive/web/modules/upload/Dropzone.jsx
+++ b/src/drive/web/modules/upload/Dropzone.jsx
@@ -23,12 +23,11 @@ class StatefulDropzone extends Component {
     this.setState(state => ({ ...state, dropzoneActive: false }))
 
   onDrop = async (files, _, evt) => {
-    const { displayedFolder, sharingState, uploadFiles } = this.props
-    const folderId = displayedFolder.id
+    const { uploadFiles } = this.props
     this.setState(state => ({ ...state, dropzoneActive: false }))
     if (!canDrop(evt)) return
     const filesToUpload = canHandleFolders(evt) ? evt.dataTransfer.items : files
-    uploadFiles(filesToUpload, folderId, sharingState)
+    uploadFiles(filesToUpload)
   }
 
   render() {
@@ -73,9 +72,10 @@ const canDrop = evt => {
   return true
 }
 
-const mapDispatchToProps = {
-  uploadFiles
-}
+const mapDispatchToProps = (dispatch, { displayedFolder, sharingState }) => ({
+  uploadFiles: files =>
+    dispatch(uploadFiles(files, displayedFolder.id, sharingState))
+})
 
 export default compose(
   withSharingState,

--- a/src/drive/web/modules/upload/UploadButton.jsx
+++ b/src/drive/web/modules/upload/UploadButton.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Icon } from 'cozy-ui/react'
 
+import SharingContext from 'sharing/context'
+
 const styles = {
   parent: {
     position: 'relative',
@@ -18,29 +20,33 @@ const styles = {
 }
 
 const UploadButton = ({ label, disabled, onUpload, className }) => (
-  <label
-    role="button"
-    disabled={disabled}
-    className={className}
-    style={styles.parent}
-  >
-    <span className="u-flex u-flex-items-center">
-      <Icon icon="upload" />
-      <span>{label}</span>
-      <input
-        data-test-id="upload-btn"
-        type="file"
-        multiple
-        style={styles.input}
+  <SharingContext.Consumer>
+    {sharingState => (
+      <label
+        role="button"
         disabled={disabled}
-        onChange={e => {
-          if (e.target.files) {
-            onUpload(Array.from(e.target.files))
-          }
-        }}
-      />
-    </span>
-  </label>
+        className={className}
+        style={styles.parent}
+      >
+        <span className="u-flex u-flex-items-center">
+          <Icon icon="upload" />
+          <span>{label}</span>
+          <input
+            data-test-id="upload-btn"
+            type="file"
+            multiple
+            style={styles.input}
+            disabled={disabled}
+            onChange={e => {
+              if (e.target.files) {
+                onUpload(Array.from(e.target.files), sharingState)
+              }
+            }}
+          />
+        </span>
+      </label>
+    )}
+  </SharingContext.Consumer>
 )
 
 export default UploadButton

--- a/src/drive/web/modules/upload/UploadButton.jsx
+++ b/src/drive/web/modules/upload/UploadButton.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
+import { connect } from 'react-redux'
+import { compose } from 'redux'
 import { Icon } from 'cozy-ui/react'
 
-import SharingContext from 'sharing/context'
+import withSharingState from 'sharing/hoc/withSharingState'
+import { uploadFiles } from 'drive/web/modules/navigation/duck'
 
 const styles = {
   parent: {
@@ -20,33 +23,41 @@ const styles = {
 }
 
 const UploadButton = ({ label, disabled, onUpload, className }) => (
-  <SharingContext.Consumer>
-    {sharingState => (
-      <label
-        role="button"
+  <label
+    role="button"
+    disabled={disabled}
+    className={className}
+    style={styles.parent}
+  >
+    <span className="u-flex u-flex-items-center">
+      <Icon icon="upload" />
+      <span>{label}</span>
+      <input
+        data-test-id="upload-btn"
+        type="file"
+        multiple
+        style={styles.input}
         disabled={disabled}
-        className={className}
-        style={styles.parent}
-      >
-        <span className="u-flex u-flex-items-center">
-          <Icon icon="upload" />
-          <span>{label}</span>
-          <input
-            data-test-id="upload-btn"
-            type="file"
-            multiple
-            style={styles.input}
-            disabled={disabled}
-            onChange={e => {
-              if (e.target.files) {
-                onUpload(Array.from(e.target.files), sharingState)
-              }
-            }}
-          />
-        </span>
-      </label>
-    )}
-  </SharingContext.Consumer>
+        onChange={e => {
+          if (e.target.files) {
+            onUpload(Array.from(e.target.files))
+          }
+        }}
+      />
+    </span>
+  </label>
 )
 
-export default UploadButton
+const mapDispatchToProps = (dispatch, { displayedFolder, sharingState }) => ({
+  onUpload: files => {
+    dispatch(uploadFiles(files, displayedFolder.id, sharingState))
+  }
+})
+
+export default compose(
+  withSharingState,
+  connect(
+    null,
+    mapDispatchToProps
+  )
+)(UploadButton)

--- a/src/drive/web/modules/upload/UploadButton.jsx
+++ b/src/drive/web/modules/upload/UploadButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { Icon } from 'cozy-ui/react'
@@ -47,6 +48,20 @@ const UploadButton = ({ label, disabled, onUpload, className }) => (
     </span>
   </label>
 )
+
+UploadButton.propTypes = {
+  label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  onUpload: PropTypes.func.isRequired,
+  className: PropTypes.string.isRequired,
+  displayedFolder: PropTypes.object.isRequired, // io.cozy.files
+  // in case of upload conflicts, shared files are not overridden
+  sharingState: PropTypes.object.isRequired
+}
+
+UploadButton.defaultProps = {
+  disabled: false
+}
 
 const mapDispatchToProps = (dispatch, { displayedFolder, sharingState }) => ({
   onUpload: files => {

--- a/src/drive/web/modules/upload/UploadQueue.jsx
+++ b/src/drive/web/modules/upload/UploadQueue.jsx
@@ -8,6 +8,7 @@ import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
 
 import styles from './styles.styl'
 import {
+  status as uploadStatus,
   getUploadQueue,
   getProcessed,
   getSuccessful,
@@ -29,45 +30,41 @@ const Pending = translate()(props => (
 ))
 
 const Item = translate()(({ file, status, isDirectory }) => {
+  const { CANCEL, LOADING, DONE_STATUSES, ERROR_STATUSES } = uploadStatus
   const { filename, extension } = splitFilename(file.name)
   let statusIcon
-  switch (status) {
-    case 'loading':
-      statusIcon = <Spinner class="u-ml-half" color={palette['dodgerBlue']} />
-      break
-    case 'cancel':
-      statusIcon = (
-        <Icon class="u-ml-half" icon="cross" color={palette['monza']} />
-      )
-      break
-    case 'failed':
-    case 'conflict':
-    case 'network':
-      statusIcon = (
-        <Icon class="u-ml-half" icon="warning" color={palette['monza']} />
-      )
-      break
-    case 'loaded':
-      statusIcon = (
-        <Icon
-          class="u-ml-half"
-          icon="check-circleless"
-          color={palette['emerald']}
-        />
-      )
-      break
-    case 'pending':
-    default:
-      statusIcon = <Pending />
-      break
+  let done = false
+  let error = false
+  if (status === LOADING) {
+    statusIcon = <Spinner class="u-ml-half" color={palette['dodgerBlue']} />
+  } else if (status === CANCEL) {
+    statusIcon = (
+      <Icon class="u-ml-half" icon="cross" color={palette['monza']} />
+    )
+  } else if (ERROR_STATUSES.includes(status)) {
+    error = true
+    statusIcon = (
+      <Icon class="u-ml-half" icon="warning" color={palette['monza']} />
+    )
+  } else if (DONE_STATUSES.includes(status)) {
+    done = true
+    statusIcon = (
+      <Icon
+        class="u-ml-half"
+        icon="check-circleless"
+        color={palette['emerald']}
+      />
+    )
+  } else {
+    statusIcon = <Pending />
   }
+
   return (
     <div
       data-test-id="upload-queue-item"
       className={classNames(styles['upload-queue-item'], {
-        [styles['upload-queue-item--done']]: status === 'loaded',
-        [styles['upload-queue-item--error']]:
-          status === 'failed' || status === 'conflict' || status === 'network'
+        [styles['upload-queue-item--done']]: done,
+        [styles['upload-queue-item--error']]: error
       })}
     >
       <div

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -47,7 +47,7 @@ const item = (state, action = { isUpdate: false }) => ({
   status: getStatus(action)
 })
 
-const queue = (state = [], action) => {
+export const queue = (state = [], action) => {
   switch (action.type) {
     case ADD_TO_UPLOAD_QUEUE:
       return [

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -17,7 +17,7 @@ const PURGE_UPLOAD_QUEUE = 'PURGE_UPLOAD_QUEUE'
 
 const PENDING = 'pending'
 const LOADING = 'loading'
-const LOADED = 'loaded'
+const CREATED = 'created'
 const UPDATED = 'updated'
 const FAILED = 'failed'
 const CONFLICT = 'conflict'
@@ -36,7 +36,7 @@ const getStatus = action => {
     case UPLOAD_FILE:
       return LOADING
     case RECEIVE_UPLOAD_SUCCESS:
-      return action.isUpdate ? UPDATED : LOADED
+      return action.isUpdate ? UPDATED : CREATED
     case RECEIVE_UPLOAD_ERROR:
       return action.status
   }
@@ -51,7 +51,7 @@ const queue = (state = [], action) => {
   switch (action.type) {
     case ADD_TO_UPLOAD_QUEUE:
       return [
-        ...state.filter(i => i.status !== LOADED),
+        ...state.filter(i => i.status !== CREATED),
         ...action.files.map(f => itemInitialState(f))
       ]
     case PURGE_UPLOAD_QUEUE:
@@ -218,14 +218,14 @@ export const purgeUploadQueue = () => ({ type: PURGE_UPLOAD_QUEUE })
 
 export const onQueueEmpty = callback => (dispatch, getState) => {
   const queue = getUploadQueue(getState())
-  const uploaded = getUploaded(queue)
   const quotas = getQuotaErrors(queue)
   const conflicts = getConflicts(queue)
+  const created = getCreated(queue)
   const updated = getUpdated(queue)
   const networkErrors = getNetworkErrors(queue)
   const errors = getErrors(queue)
 
-  return callback(uploaded, quotas, conflicts, networkErrors, errors, updated)
+  return callback(created, quotas, conflicts, networkErrors, errors, updated)
 }
 
 // selectors
@@ -234,7 +234,7 @@ const getConflicts = queue => filterByStatus(queue, CONFLICT)
 const getErrors = queue => filterByStatus(queue, FAILED)
 const getQuotaErrors = queue => filterByStatus(queue, QUOTA)
 const getNetworkErrors = queue => filterByStatus(queue, NETWORK)
-const getUploaded = queue => filterByStatus(queue, LOADED)
+const getCreated = queue => filterByStatus(queue, CREATED)
 const getUpdated = queue => filterByStatus(queue, UPDATED)
 
 export const getUploadQueue = state => state[SLUG].queue
@@ -244,7 +244,7 @@ export const getProcessed = state =>
 
 export const getSuccessful = state => {
   const queue = getUploadQueue(state)
-  return queue.filter(f => [LOADED, UPDATED].includes(f.status))
+  return queue.filter(f => [CREATED, UPDATED].includes(f.status))
 }
 
 export const selectors = {
@@ -252,7 +252,7 @@ export const selectors = {
   getErrors,
   getQuotaErrors,
   getNetworkErrors,
-  getUploaded,
+  getCreated,
   getUpdated,
   getProcessed,
   getSuccessful

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -105,7 +105,7 @@ export const processNextFile = (
           !isShared(sharingState, { path }) &&
           !hasSharedParent(sharingState, { path })
         ) {
-          const uploadedFile = await overwriteFile(client, file, path, dirID)
+          const uploadedFile = await overwriteFile(client, file, path)
           fileUploadedCallback(uploadedFile)
           dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file, isUpdate: true })
           error = null
@@ -182,12 +182,12 @@ export const getFilePath = async (client, file, dirID) => {
   return `${parentDirectory.path}/${file.name}`
 }
 
-export const overwriteFile = async (client, file, path, dirID) => {
+export const overwriteFile = async (client, file, path) => {
   const statResp = await client.collection('io.cozy.files').statByPath(path)
-  const fileId = statResp.data.id
+  const { id: fileId, dir_id: dirId } = statResp.data
   const resp = await client
     .collection('io.cozy.files')
-    .updateFile(file, { dirId: dirID, fileId })
+    .updateFile(file, { dirId, fileId })
 
   return resp.data
 }

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -41,11 +41,11 @@ const status = action => {
   }
 }
 
-const item = (state, action = { isUpdate: false }) =>
-  Object.assign({}, state, {
-    isUpdate: action.isUpdate,
-    status: status(action)
-  })
+const item = (state, action = { isUpdate: false }) => ({
+  ...state,
+  isUpdate: action.isUpdate,
+  status: status(action)
+})
 
 const queue = (state = [], action) => {
   switch (action.type) {

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -177,12 +177,26 @@ const uploadFile = async (client, file, dirID) => {
   return resp.data
 }
 
+/*
+ * @function
+ * @param {Object} client - A CozyClient instance
+ * @param {Object} file - The uploaded javascript File object
+ * @param {string} dirID - The id of the parent directory
+ * @return {Object} - The full path of the file in the cozy
+ */
 export const getFileFullpath = async (client, file, dirID) => {
   const resp = await client.collection('io.cozy.files').get(dirID)
   const parentDirectory = resp.data
   return `${parentDirectory.path}/${file.name}`
 }
 
+/*
+ * @function
+ * @param {Object} client - A CozyClient instance
+ * @param {Object} file - The uploaded javascript File object
+ * @param {string} path - The file's path in the cozy
+ * @return {Object} - The updated io.cozy.files
+ */
 export const overwriteFile = async (client, file, path) => {
   const statResp = await client.collection('io.cozy.files').statByPath(path)
   const { id: fileId, dir_id: dirId } = statResp.data

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -15,6 +15,7 @@ const RECEIVE_UPLOAD_SUCCESS = 'RECEIVE_UPLOAD_SUCCESS'
 const RECEIVE_UPLOAD_ERROR = 'RECEIVE_UPLOAD_ERROR'
 const PURGE_UPLOAD_QUEUE = 'PURGE_UPLOAD_QUEUE'
 
+const CANCEL = 'cancel'
 const PENDING = 'pending'
 const LOADING = 'loading'
 const CREATED = 'created'
@@ -23,6 +24,22 @@ const FAILED = 'failed'
 const CONFLICT = 'conflict'
 const QUOTA = 'quota'
 const NETWORK = 'network'
+const DONE_STATUSES = [CREATED, UPDATED]
+const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA]
+
+export const status = {
+  CANCEL,
+  PENDING,
+  LOADING,
+  CREATED,
+  UPDATED,
+  FAILED,
+  CONFLICT,
+  QUOTA,
+  NETWORK,
+  DONE_STATUSES,
+  ERROR_STATUSES
+}
 
 const CONFLICT_ERROR = 409
 

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -100,7 +100,7 @@ export const processNextFile = (
     if (uploadError.status === CONFLICT_ERROR) {
       try {
         error = uploadError
-        const path = await getFilePath(client, file, dirID)
+        const path = await getFileFullpath(client, file, dirID)
         if (
           flag('handle-conflicts') &&
           !isShared(sharingState, { path }) &&
@@ -177,7 +177,7 @@ const uploadFile = async (client, file, dirID) => {
   return resp.data
 }
 
-export const getFilePath = async (client, file, dirID) => {
+export const getFileFullpath = async (client, file, dirID) => {
   const resp = await client.collection('io.cozy.files').get(dirID)
   const parentDirectory = resp.data
   return `${parentDirectory.path}/${file.name}`

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -1,5 +1,7 @@
 import { combineReducers } from 'redux'
 
+import flag from 'cozy-flags'
+
 import { hasSharedParent, isShared } from 'sharing/state'
 import UploadQueue from './UploadQueue'
 
@@ -99,6 +101,7 @@ export const processNextFile = (
         error = uploadError
         const path = await getFilePath(client, file, dirID)
         if (
+          flag('handle-conflicts') &&
           !isShared(sharingState, { path }) &&
           !hasSharedParent(sharingState, { path })
         ) {

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -188,13 +188,14 @@ export const purgeUploadQueue = () => ({ type: PURGE_UPLOAD_QUEUE })
 
 export const onQueueEmpty = callback => (dispatch, getState) => {
   const queue = getUploadQueue(getState())
-  const loaded = getLoaded(queue)
+  const uploaded = getUploaded(queue)
   const quotas = getQuotaErrors(queue)
   const conflicts = getConflicts(queue)
+  const updated = getUpdated(queue)
   const networkErrors = getNetworkErrors(queue)
   const errors = getErrors(queue)
 
-  return callback(loaded, quotas, conflicts, networkErrors, errors)
+  return callback(uploaded, quotas, conflicts, networkErrors, errors, updated)
 }
 
 // selectors
@@ -204,11 +205,25 @@ const getErrors = queue => filterByStatus(queue, FAILED)
 const getQuotaErrors = queue => filterByStatus(queue, QUOTA)
 const getNetworkErrors = queue => filterByStatus(queue, NETWORK)
 const getLoaded = queue => filterByStatus(queue, LOADED)
+const getUploaded = queue => getLoaded(queue).filter(f => !f.isUpdate)
+const getUpdated = queue => getLoaded(queue).filter(f => f.isUpdate)
 
 export const getUploadQueue = state => state[SLUG].queue
 export const getProcessed = state =>
   getUploadQueue(state).filter(f => f.status !== PENDING)
 export const getSuccessful = state => getLoaded(getUploadQueue(state))
+
+export const selectors = {
+  getConflicts,
+  getErrors,
+  getQuotaErrors,
+  getNetworkErrors,
+  getLoaded,
+  getUploaded,
+  getUpdated,
+  getProcessed,
+  getSuccessful
+}
 
 // DOM helpers
 const extractFilesEntries = items => {

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -60,7 +60,7 @@ const queue = (state = [], action) => {
 }
 export default combineReducers({ queue })
 
-const processNextFile = (
+export const processNextFile = (
   fileUploadedCallback,
   queueCompletedCallback,
   dirID

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -247,7 +247,6 @@ export const selectors = {
   getErrors,
   getQuotaErrors,
   getNetworkErrors,
-  getLoaded,
   getUploaded,
   getUpdated,
   getProcessed,

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -276,7 +276,7 @@ describe('processNextFile function', () => {
 
 describe('selectors', () => {
   const queue = [
-    { status: 'loaded' },
+    { status: 'created' },
     { status: 'updated' },
     { status: 'conflict' },
     { status: 'failed' },
@@ -284,32 +284,13 @@ describe('selectors', () => {
     { status: 'network' },
     { status: 'pending' }
   ]
-  const state = {
-    upload: {
-      queue
-    }
-  }
 
-  describe('getSuccessful selector', () => {
-    it('should return all successful items', () => {
-      const result = selectors.getSuccessful(state)
-      expect(result).toEqual([
-        {
-          status: 'loaded'
-        },
-        {
-          status: 'updated'
-        }
-      ])
-    })
-  })
-
-  describe('getUploaded selector', () => {
+  describe('getCreated selector', () => {
     it('should return all uploaded items', () => {
-      const result = selectors.getUploaded(queue)
+      const result = selectors.getCreated(queue)
       expect(result).toEqual([
         {
-          status: 'loaded'
+          status: 'created'
         }
       ])
     })
@@ -329,7 +310,7 @@ describe('selectors', () => {
   describe('getSuccessful selector', () => {
     it('should return all successful items', () => {
       const queue = [
-        { id: '1', status: 'updated' },
+        { id: '1', status: 'created' },
         { id: '2', status: 'quota' },
         { id: '3', status: 'conflict' },
         { id: '4', status: 'updated' },
@@ -343,7 +324,7 @@ describe('selectors', () => {
       }
       const result = selectors.getSuccessful(state)
       expect(result).toEqual([
-        { id: '1', status: 'updated' },
+        { id: '1', status: 'created' },
         { id: '4', status: 'updated' },
         { id: '6', status: 'updated' }
       ])

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -1,0 +1,109 @@
+import { processNextFile } from './index'
+
+describe('processNextFile function', () => {
+  const fileUploadedCallbackSpy = jest.fn()
+  const queueCompletedCallbackSpy = jest.fn()
+  const dirId = 'my-dir'
+  const dispatchSpy = jest.fn(x => x)
+  const createFileSpy = jest.fn()
+  const fakeClient = {
+    collection: () => ({
+      createFile: createFileSpy
+    })
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should handle an empty queue', async () => {
+    const getState = () => ({
+      upload: {
+        queue: []
+      }
+    })
+    const asyncProcess = processNextFile(
+      fileUploadedCallbackSpy,
+      queueCompletedCallbackSpy,
+      dirId
+    )
+    const result = await asyncProcess(dispatchSpy, getState, {
+      client: fakeClient
+    })
+    result(dispatchSpy, getState)
+    expect(queueCompletedCallbackSpy).toHaveBeenCalledWith([], [], [], [], [])
+  })
+
+  it('should process files in the queue', async () => {
+    const getState = () => ({
+      upload: {
+        queue: [
+          {
+            status: 'pending',
+            file: 'my-doc.odt',
+            entry: '',
+            isDirectory: false
+          }
+        ]
+      }
+    })
+    createFileSpy.mockResolvedValue({
+      data: {
+        file: 'my-doc.odt'
+      }
+    })
+    const asyncProcess = processNextFile(
+      fileUploadedCallbackSpy,
+      queueCompletedCallbackSpy,
+      dirId
+    )
+    await asyncProcess(dispatchSpy, getState, { client: fakeClient })
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'UPLOAD_FILE',
+      file: 'my-doc.odt'
+    })
+    expect(createFileSpy).toHaveBeenCalledWith('my-doc.odt', {
+      dirId: 'my-dir'
+    })
+  })
+
+  it('should process a file in conflict', async () => {
+    const getState = () => ({
+      upload: {
+        queue: [
+          {
+            status: 'pending',
+            file: 'my-doc.odt',
+            entry: '',
+            isDirectory: false
+          }
+        ]
+      }
+    })
+    createFileSpy.mockRejectedValue({
+      status: 409,
+      title: 'Conflict',
+      detail: 'file already exists',
+      source: {}
+    })
+    const asyncProcess = processNextFile(
+      fileUploadedCallbackSpy,
+      queueCompletedCallbackSpy,
+      dirId
+    )
+    await asyncProcess(dispatchSpy, getState, { client: fakeClient })
+
+    expect(dispatchSpy).toHaveBeenNthCalledWith(1, {
+      type: 'UPLOAD_FILE',
+      file: 'my-doc.odt'
+    })
+    expect(createFileSpy).toHaveBeenCalledWith('my-doc.odt', {
+      dirId: 'my-dir'
+    })
+    expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
+      type: 'RECEIVE_UPLOAD_ERROR',
+      file: 'my-doc.odt',
+      status: 'conflict'
+    })
+  })
+})

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -1,4 +1,4 @@
-import { processNextFile } from './index'
+import { processNextFile, selectors } from './index'
 
 describe('processNextFile function', () => {
   const fileUploadedCallbackSpy = jest.fn()
@@ -38,7 +38,14 @@ describe('processNextFile function', () => {
       client: fakeClient
     })
     result(dispatchSpy, getState)
-    expect(queueCompletedCallbackSpy).toHaveBeenCalledWith([], [], [], [], [])
+    expect(queueCompletedCallbackSpy).toHaveBeenCalledWith(
+      [],
+      [],
+      [],
+      [],
+      [],
+      []
+    )
   })
 
   it('should process files in the queue', async () => {
@@ -184,6 +191,61 @@ describe('processNextFile function', () => {
       file,
       status: 'quota',
       type: 'RECEIVE_UPLOAD_ERROR'
+    })
+  })
+})
+
+describe('selectors', () => {
+  const queue = [
+    { status: 'loaded' },
+    { status: 'loaded', isUpdate: true },
+    { status: 'conflict' },
+    { status: 'failed' },
+    { status: 'quota' },
+    { status: 'network' },
+    { status: 'pending' }
+  ]
+  const state = {
+    upload: {
+      queue
+    }
+  }
+
+  describe('getSuccessful selector', () => {
+    it('should return all successful items', () => {
+      const result = selectors.getSuccessful(state)
+      expect(result).toEqual([
+        {
+          status: 'loaded'
+        },
+        {
+          status: 'loaded',
+          isUpdate: true
+        }
+      ])
+    })
+  })
+
+  describe('getUploaded selector', () => {
+    it('should return all uploaded items', () => {
+      const result = selectors.getUploaded(queue)
+      expect(result).toEqual([
+        {
+          status: 'loaded'
+        }
+      ])
+    })
+  })
+
+  describe('getUpdated selector', () => {
+    it('should return all updated items', () => {
+      const result = selectors.getUpdated(queue)
+      expect(result).toEqual([
+        {
+          status: 'loaded',
+          isUpdate: true
+        }
+      ])
     })
   })
 })

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -6,11 +6,18 @@ describe('processNextFile function', () => {
   const dirId = 'my-dir'
   const dispatchSpy = jest.fn(x => x)
   const createFileSpy = jest.fn()
+  const getSpy = jest.fn()
+  const statByPathSpy = jest.fn()
+  const updateFileSpy = jest.fn()
   const fakeClient = {
     collection: () => ({
-      createFile: createFileSpy
+      createFile: createFileSpy,
+      get: getSpy,
+      statByPath: statByPathSpy,
+      updateFile: updateFileSpy
     })
   }
+  const file = new File(['foo'], 'my-doc.odt')
 
   afterEach(() => {
     jest.clearAllMocks()
@@ -40,7 +47,7 @@ describe('processNextFile function', () => {
         queue: [
           {
             status: 'pending',
-            file: 'my-doc.odt',
+            file,
             entry: '',
             isDirectory: false
           }
@@ -49,7 +56,7 @@ describe('processNextFile function', () => {
     })
     createFileSpy.mockResolvedValue({
       data: {
-        file: 'my-doc.odt'
+        file
       }
     })
     const asyncProcess = processNextFile(
@@ -60,9 +67,9 @@ describe('processNextFile function', () => {
     await asyncProcess(dispatchSpy, getState, { client: fakeClient })
     expect(dispatchSpy).toHaveBeenCalledWith({
       type: 'UPLOAD_FILE',
-      file: 'my-doc.odt'
+      file
     })
-    expect(createFileSpy).toHaveBeenCalledWith('my-doc.odt', {
+    expect(createFileSpy).toHaveBeenCalledWith(file, {
       dirId: 'my-dir'
     })
   })
@@ -73,7 +80,7 @@ describe('processNextFile function', () => {
         queue: [
           {
             status: 'pending',
-            file: 'my-doc.odt',
+            file,
             entry: '',
             isDirectory: false
           }
@@ -86,6 +93,21 @@ describe('processNextFile function', () => {
       detail: 'file already exists',
       source: {}
     })
+
+    getSpy.mockResolvedValue({
+      data: {
+        path: '/my-dir'
+      }
+    })
+
+    statByPathSpy.mockResolvedValue({
+      data: {
+        id: 'b552a167-1aa4'
+      }
+    })
+
+    updateFileSpy.mockResolvedValue({ data: file })
+
     const asyncProcess = processNextFile(
       fileUploadedCallbackSpy,
       queueCompletedCallbackSpy,
@@ -95,15 +117,73 @@ describe('processNextFile function', () => {
 
     expect(dispatchSpy).toHaveBeenNthCalledWith(1, {
       type: 'UPLOAD_FILE',
-      file: 'my-doc.odt'
+      file
     })
-    expect(createFileSpy).toHaveBeenCalledWith('my-doc.odt', {
+    expect(createFileSpy).toHaveBeenCalledWith(file, {
       dirId: 'my-dir'
     })
+
+    expect(updateFileSpy).toHaveBeenCalledWith(file, {
+      dirId: 'my-dir',
+      fileId: 'b552a167-1aa4'
+    })
+
+    expect(fileUploadedCallbackSpy).toHaveBeenCalledWith(file)
+
     expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
-      type: 'RECEIVE_UPLOAD_ERROR',
-      file: 'my-doc.odt',
-      status: 'conflict'
+      type: 'RECEIVE_UPLOAD_SUCCESS',
+      file,
+      isUpdate: true
+    })
+  })
+
+  it('should handle an error during overwrite', async () => {
+    const getState = () => ({
+      upload: {
+        queue: [
+          {
+            status: 'pending',
+            file,
+            entry: '',
+            isDirectory: false
+          }
+        ]
+      }
+    })
+    createFileSpy.mockRejectedValue({
+      status: 409,
+      title: 'Conflict',
+      detail: 'file already exists',
+      source: {}
+    })
+
+    getSpy.mockResolvedValue({
+      data: {
+        path: '/my-dir'
+      }
+    })
+
+    statByPathSpy.mockResolvedValue({
+      data: {
+        id: 'b552a167-1aa4'
+      }
+    })
+
+    updateFileSpy.mockRejectedValue({ status: 413 })
+
+    const asyncProcess = processNextFile(
+      fileUploadedCallbackSpy,
+      queueCompletedCallbackSpy,
+      dirId
+    )
+    await asyncProcess(dispatchSpy, getState, { client: fakeClient })
+
+    expect(fileUploadedCallbackSpy).not.toHaveBeenCalled()
+
+    expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
+      file,
+      status: 'quota',
+      type: 'RECEIVE_UPLOAD_ERROR'
     })
   })
 })

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -1,0 +1,22 @@
+import flag from 'cozy-flags'
+
+export const initFlags = () => {
+  let activateFlags = flag('switcher') === true ? true : false
+  if (process.env.NODE_ENV !== 'production' && flag('switcher') === null) {
+    activateFlags = true
+  }
+
+  const searchParams = new URL(window.location).searchParams
+  if (!activateFlags && searchParams.get('flags') !== null) {
+    activateFlags = true
+  }
+
+  if (activateFlags) {
+    flagsList()
+  }
+}
+
+const flagsList = () => {
+  flag('switcher', true)
+  flag('handle-conflicts', false)
+}

--- a/src/sharing/hoc/withSharingState.jsx
+++ b/src/sharing/hoc/withSharingState.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import SharingContext from 'sharing/context'
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
+const withSharingState = Wrapped => {
+  const WithSharingState = props => {
+    return (
+      <SharingContext.Consumer>
+        {sharingState => <Wrapped sharingState={sharingState} {...props} />}
+      </SharingContext.Consumer>
+    )
+  }
+
+  WithSharingState.displayName = `WithSharingState(${getDisplayName(Wrapped)})`
+  return WithSharingState
+}
+
+export default withSharingState

--- a/src/sharing/state.js
+++ b/src/sharing/state.js
@@ -321,6 +321,9 @@ export const hasSharedChild = (state, document) => {
   return ret
 }
 
+export const isShared = (state, document) =>
+  state.sharedPaths.some(path => path === document.path)
+
 // helpers
 const getSharedDocIds = doc =>
   doc.type === 'io.cozy.sharings'

--- a/src/sharing/state.spec.js
+++ b/src/sharing/state.spec.js
@@ -7,7 +7,9 @@ import reducer, {
   revokeRecipient,
   revokeSelf,
   matchingInstanceName,
-  getSharingLink
+  getSharingLink,
+  hasSharedParent,
+  isShared
 } from './state'
 
 import {
@@ -309,5 +311,53 @@ describe('generating a sharing link', () => {
     expect(getSharingLink(state, 'folder_2', 'Document')).toBe(
       'https://drive.cozy.tools/public?sharecode=shortcode'
     )
+  })
+})
+
+describe('hasSharedParent helper', () => {
+  it("should return true if one of the document's parents is shared", () => {
+    const state = {
+      sharedPaths: ['/dir0/doc0', '/dir1', '/dir2/doc1']
+    }
+    const document = {
+      path: '/dir1/subdir0/doc2'
+    }
+    const result = hasSharedParent(state, document)
+    expect(result).toBe(true)
+  })
+
+  it("should return true if one of the document's parents is shared", () => {
+    const state = {
+      sharedPaths: ['/dir0/doc0', '/dir1', '/dir2/doc1']
+    }
+    const document = {
+      path: '/dir3/doc3'
+    }
+    const result = hasSharedParent(state, document)
+    expect(result).toBe(false)
+  })
+})
+
+describe('isShared helper', () => {
+  it('should return true if document is shared', () => {
+    const state = {
+      sharedPaths: ['/dir0/doc0', '/dir1/doc1']
+    }
+    const document = {
+      path: '/dir1/doc1'
+    }
+    const result = isShared(state, document)
+    expect(result).toBe(true)
+  })
+
+  it('should return true if document is shared', () => {
+    const state = {
+      sharedPaths: ['/dir0/doc0', '/dir1/doc1']
+    }
+    const document = {
+      path: '/dir1/doc2'
+    }
+    const result = isShared(state, document)
+    expect(result).toBe(false)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4504,10 +4504,10 @@ cozy-doctypes@1.44.1:
     lodash "4.17.11"
     prop-types "^15.7.2"
 
-cozy-flags@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.6.0.tgz#dcbadf075279e9db2f24df99dc541392d9994b5b"
-  integrity sha512-fFg6H0NmZyom6kJvBGRdIPBwT3qKzCR8UzeLcpIoLcx8uqlcbMqpA+uphcVyJNbSUiPyR1I9qUqOEuGx7s9MFg==
+cozy-flags@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.6.1.tgz#27e8bed076f0676e512beda0f4532548862df0f4"
+  integrity sha512-L0Nh8DdgqRBAu4UkSWTbfJZAlcVYQPX2G09nSiOgsgBzr002txXRz1899r9jHoLJPFFR+Ep9zkSmnOnPzMHUwA==
   dependencies:
     detect-node "2.0.4"
     microee "^0.0.6"


### PR DESCRIPTION
Handle conflicts when we upload a file via :
- Import files button in toolbar
- Import files action in action menu
- dropzone

Uses `handle-conflicts` flag to activate the feature.

Note that we need `sharingState` to be able to know if a file is shared (if a file is shared, user can't update it). To do this, we use a `withSharingState` HOC and pass the `sharingState` directly to the `uploadFiles` action creator. We could use the same `mapDispatchToProps` in `UploadButton` and in `Dropzone` or even the whole `compose(...)` function to avoid duplication, WDYT?