### PR TITLE
Breadcrumb fix

### DIFF
--- a/src/drive/styles/coz-bar-size.styl
+++ b/src/drive/styles/coz-bar-size.styl
@@ -1,0 +1,1 @@
+$coz-bar-size = 3rem

--- a/src/drive/web/modules/navigation/breadcrumb.styl
+++ b/src/drive/web/modules/navigation/breadcrumb.styl
@@ -3,7 +3,7 @@
 @require 'settings/breakpoints.styl'
 @require 'settings/z-index.styl'
 
-@require '../../../styles/topbar.styl'
+$coz-bar-size = 3rem
 
 .fil-path-backdrop
   flex 1 1 auto
@@ -32,7 +32,7 @@
     height     $coz-bar-size
     border     0
     flex-shrink 0
-    background embedurl('../assets/icons/icon-arrow-left.svg') center center no-repeat
+    background embedurl('../../../assets/icons/icon-arrow-left.svg') center center no-repeat
 
 .fil-path-down
     display     none
@@ -40,7 +40,7 @@
     height      .625rem
     margin-left .4375rem
     border      0
-    background  embedurl('../assets/icons/icon-arrow-down.svg') center center no-repeat
+    background  embedurl('../../../assets/icons/icon-arrow-down.svg') center center no-repeat
 
 .fil-path-current-name
     text-overflow  ellipsis

--- a/src/drive/web/modules/navigation/breadcrumb.styl
+++ b/src/drive/web/modules/navigation/breadcrumb.styl
@@ -2,8 +2,7 @@
 @require 'settings/palette.styl'
 @require 'settings/breakpoints.styl'
 @require 'settings/z-index.styl'
-
-$coz-bar-size = 3rem
+@require '../../../styles/coz-bar-size.styl'
 
 .fil-path-backdrop
   flex 1 1 auto

--- a/src/drive/web/modules/upload/styles.styl
+++ b/src/drive/web/modules/upload/styles.styl
@@ -3,7 +3,7 @@
 @require 'settings/icons.styl'
 @require 'settings/breakpoints.styl'
 @require 'settings/z-index.styl'
-
+@require '../../../styles/coz-bar-size.styl'
 
 .upload-queue
     @extend $popover
@@ -119,7 +119,6 @@ progress.upload-queue-progress::-moz-progress-bar
 
 +medium-screen()
     // we need to cover the border-bottom of the cozy-bar
-    $coz-bar-size = 3rem
     $coz-bar-border-size = .0625rem
 
     .upload-queue

--- a/src/drive/web/modules/viewer/barviewer.styl
+++ b/src/drive/web/modules/viewer/barviewer.styl
@@ -1,8 +1,8 @@
 @require 'settings/z-index.styl'
-bar-height = 3rem
+@require '../../../styles/coz-bar-size.styl'
 
 .viewer-wrapper-with-bar
   position absolute
   width 100%
-  height "calc(100% - %s)" % bar-height
+  height "calc(100% - %s)" % $coz-bar-size
   z-index ($bar-index - 2)


### PR DESCRIPTION
I deleted a variable that seemed unused, but the file was `required` elsewhere, and stylus doesn't complain about undefined variables.