### PR TITLE
feat: Add extraDoctypes to ease customization

### DIFF
--- a/src/drive/lib/doctypes.js
+++ b/src/drive/lib/doctypes.js
@@ -1,4 +1,5 @@
 import { Contact, Group } from 'models'
+import extraDoctypes from 'drive/lib/extraDoctypes'
 
 export const DOCTYPE_FILES = 'io.cozy.files'
 export const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
@@ -12,5 +13,6 @@ export const schema = {
     doctype: Contact.doctype,
     doctypeVersion: DOCTYPE_CONTACTS_VERSION
   },
-  groups: { doctype: Group.doctype }
+  groups: { doctype: Group.doctype },
+  ...extraDoctypes
 }

--- a/src/drive/lib/extraDoctypes.js
+++ b/src/drive/lib/extraDoctypes.js
@@ -1,0 +1,1 @@
+export default {}


### PR DESCRIPTION
To be able to customize the client's schema without overriding the `doctypes.js` file, we introduce an empty `extraDoctypes` object. It will allow us to override doctypes in the schema without having to change the customizations schema each time we change something in Drive