### PR TITLE
fix: Request email permissions for the webapp

### DIFF
--- a/src/drive/mobile/lib/__mocks__/cozy-helper.js
+++ b/src/drive/mobile/lib/__mocks__/cozy-helper.js
@@ -11,8 +11,7 @@ const mock = {
   initBar: jest.fn(),
   restoreCozyClientJs: jest.fn(),
   resetClient: jest.fn(),
-  getOauthOptions: jest.fn(),
-  permissions: []
+  getOauthOptions: jest.fn()
 }
 
 module.exports = mock

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -23,19 +23,9 @@ export const getOauthOptions = () => {
   }
 }
 
-export const permissions = [
-  'io.cozy.files',
-  'io.cozy.apps:GET',
-  'io.cozy.settings:GET',
-  'io.cozy.contacts',
-  'io.cozy.contacts.groups',
-  'io.cozy.jobs:POST:sendmail:worker'
-]
-
 export const initClient = url => {
   return new CozyClient({
     uri: url,
-    scope: permissions,
     oauth: getOauthOptions(),
     offline: { doctypes: [DOCTYPE_FILES] },
     appMetadata,

--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -134,6 +134,13 @@
       "description": "Allow to report unexpected errors to the support team",
       "type": "cc.cozycloud.sentry",
       "verbs": ["POST"]
+    },
+    "mail": {
+      "description": "Send feedback emails to the support team",
+      "type": "io.cozy.jobs:POST",
+      "verbs": ["POST"],
+      "selector": "worker",
+      "values": ["sendmail"]
     }
   }
 }

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -33,8 +33,7 @@ import {
   initBar,
   restoreCozyClientJs,
   resetClient,
-  getOauthOptions,
-  permissions
+  getOauthOptions
 } from 'drive/mobile/lib/cozy-helper'
 import DriveMobileRouter from 'drive/mobile/modules/authorization/DriveMobileRouter'
 import { backupImages } from 'drive/mobile/modules/mediaBackup/duck'
@@ -238,8 +237,7 @@ class InitAppMobile {
     const root = document.querySelector('[role=application]')
     const onboarding = {
       oauth: {
-        ...getOauthOptions(),
-        scope: permissions
+        ...getOauthOptions()
       }
     }
     render(


### PR DESCRIPTION
The mobile app uses the same permissions as the web app, so we need email permissions for both.

Arguably, we don't need the mobile specific code anymore..? Should we remove [this](https://github.com/cozy/cozy-drive/blob/master/src/drive/mobile/lib/cozy-helper.js#L26) and everything that goes with it, or leave it as a backup?