### PR TITLE
fix: Put t.maximizeWindow() at the begining of test

### DIFF
--- a/testcafe/tests/drive/classification_scenario.js
+++ b/testcafe/tests/drive/classification_scenario.js
@@ -50,6 +50,8 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -125,6 +127,8 @@ fixture`${FIXTURE_CLASSIFICATION}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -266,6 +270,8 @@ fixture`${FIXTURE_TRASH}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()

--- a/testcafe/tests/drive/clean-data.js
+++ b/testcafe/tests/drive/clean-data.js
@@ -20,6 +20,7 @@ fixture`${FIXTURE_CLEANUP}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()

--- a/testcafe/tests/drive/file_sharing_scenario.js
+++ b/testcafe/tests/drive/file_sharing_scenario.js
@@ -23,6 +23,8 @@ const publicViewerPage = new PublicViewerPage()
 fixture`File link Sharing Scenario`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -64,10 +66,12 @@ test('Drive : from Drive, go in a folder, upload a file, and share the file', as
 //************************
 fixture`Drive : Access a file public link, download the file, and check the 'create Cozy' link`
   .page`${TESTCAFE_DRIVE_URL}/`
-  .beforeEach(async () => {
+  .beforeEach(async t => {
     console.group(
       `\n↳ ℹ️  no Loggin (anonymous) & DOWNLOAD_PATH initialization`
     )
+    await t.maximizeWindow()
+
     //await t.useRole(Role.anonymous())
     await setDownloadPath(data.DOWNLOAD_PATH)
     console.groupEnd()
@@ -113,7 +117,6 @@ test(`[Mobile] Drive : Access a file public link, download the file, and check t
   await publicDrivePage.checkCreateCozy()
   await publicViewerPage.waitForLoading()
 
-  await t.maximizeWindow() //Back to desktop
   console.groupEnd()
 })
 
@@ -123,6 +126,8 @@ test(`[Mobile] Drive : Access a file public link, download the file, and check t
 fixture`Drive : Unshare public link`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow() //Back to desktop
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -140,8 +145,10 @@ test('Unshare file', async () => {
 // Public (no authentification)
 //************************
 fixture`Drive : No Access to an old file public link`
-  .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async () => {
+  .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
   console.group(`\n↳ ℹ️  no Loggin (anonymous)`)
+  await t.maximizeWindow()
+
   //await t.useRole(Role.anonymous())
   console.groupEnd()
 })
@@ -161,6 +168,8 @@ test('Drive : No Access to an old file public link', async t => {
 fixture`Test clean up : remove files and folders`
   .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
   console.group(`\n↳ ℹ️  Login & Initialization`)
+  await t.maximizeWindow()
+
   await t.useRole(driveUser)
   await privateDrivePage.waitForLoading()
   console.groupEnd()

--- a/testcafe/tests/drive/folder_sharing_scenario.js
+++ b/testcafe/tests/drive/folder_sharing_scenario.js
@@ -21,6 +21,8 @@ const publicDrivePage = new PublicDrivePage()
 fixture`Folder link Sharing Scenario`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -61,10 +63,12 @@ test('Drive : from Drive, go in a folder, upload a file, and share the folder', 
 //************************
 fixture`Drive : Access a folder public link, download the file(s), and check the 'create Cozy' link`
   .page`${TESTCAFE_DRIVE_URL}/`
-  .beforeEach(async () => {
+  .beforeEach(async t => {
     console.group(
       `\n↳ ℹ️  no Loggin (anonymous) & DOWNLOAD_PATH initialization`
     )
+    await t.maximizeWindow()
+
     //await t.useRole(Role.anonymous())
     await setDownloadPath(data.DOWNLOAD_PATH)
     console.groupEnd()
@@ -112,7 +116,6 @@ test(`[Mobile] Drive : Access a folder public link, download the file(s), and ch
   await publicDrivePage.checkCreateCozy()
   await publicDrivePage.waitForLoading({ isNotAvailable: false, isFull: true })
 
-  await t.maximizeWindow() //Back to desktop
   console.groupEnd()
 })
 
@@ -122,6 +125,8 @@ test(`[Mobile] Drive : Access a folder public link, download the file(s), and ch
 fixture`Drive : Unshare public link`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(
   async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow() //Back to desktop
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -139,8 +144,10 @@ test('Unshare folder', async () => {
 // Public (no authentification)
 //************************
 fixture`Drive : No Access to an old folder public link`
-  .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async () => {
+  .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
   console.group(`\n↳ ℹ️  no Loggin (anonymous)`)
+  await t.maximizeWindow()
+
   //await t.useRole(Role.anonymous())
   console.groupEnd()
 })
@@ -160,6 +167,8 @@ test('`Drive : No Access to an old folder public link', async t => {
 fixture`Test clean up : remove files and folders`
   .page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
   console.group(`\n↳ ℹ️  Login & Initialization`)
+  await t.maximizeWindow()
+
   await t.useRole(driveUser)
   await privateDrivePage.waitForLoading()
   console.groupEnd()

--- a/testcafe/tests/drive/init-data.js
+++ b/testcafe/tests/drive/init-data.js
@@ -49,6 +49,8 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()

--- a/testcafe/tests/drive/navigation.js
+++ b/testcafe/tests/drive/navigation.js
@@ -7,6 +7,8 @@ const privateDrivePage = new PrivateDrivePage()
 
 fixture`DRIVE - NAV`.page`${TESTCAFE_DRIVE_URL}/`.beforeEach(async t => {
   console.group(`\n↳ ℹ️  Login & Initialization`)
+  await t.maximizeWindow()
+
   await t.useRole(driveUser)
   await privateDrivePage.waitForLoading()
   console.groupEnd()

--- a/testcafe/tests/drive/public-viewer-feature.js
+++ b/testcafe/tests/drive/public-viewer-feature.js
@@ -42,6 +42,8 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow() //Back to desktop
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()
@@ -84,6 +86,8 @@ fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_DRIVE_URL}/`
       `\n↳ ℹ️  no Login (anonymous), DOWNLOAD_PATH initialization and Navigate to link`
     )
     //await t.useRole(Role.anonymous())
+    await t.maximizeWindow() //Back to desktop
+
     await t.navigateTo(data.sharingLink)
     await publicDrivePage.waitForLoading({ isFull: true })
 

--- a/testcafe/tests/drive/search.js
+++ b/testcafe/tests/drive/search.js
@@ -24,6 +24,8 @@ fixture`${FEATURE_PREFIX}`.page`${TESTCAFE_DRIVE_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     console.groupEnd()

--- a/testcafe/tests/drive/viewer-feature.js
+++ b/testcafe/tests/drive/viewer-feature.js
@@ -33,6 +33,8 @@ fixture`${FIXTURE_PRIVATE_WITH_DL}`.page`${TESTCAFE_DRIVE_URL}/`
     console.group(
       `\n↳ ℹ️  no Login (anonymous), DOWNLOAD_PATH initialization and Navigate to link`
     )
+    await t.maximizeWindow()
+
     await t.useRole(driveUser)
     await privateDrivePage.waitForLoading()
     await privateDrivePage.goToFolder(data.FOLDER_NAME)

--- a/testcafe/tests/pages/drive-viewer/drive-viewer-model-public.js
+++ b/testcafe/tests/pages/drive-viewer/drive-viewer-model-public.js
@@ -83,7 +83,6 @@ export default class PublicViewerPage extends ViewerPage {
     await this.closeViewer({
       exitWithEsc: true
     })
-    await t.maximizeWindow() //Back to desktop
   }
 
   //Temp method to avoid problem with chrome 73
@@ -112,6 +111,5 @@ export default class PublicViewerPage extends ViewerPage {
     await this.closeViewer({
       exitWithEsc: true
     })
-    await t.maximizeWindow() //Back to desktop
   }
 }

--- a/testcafe/tests/photos/album_sharing_scenario.js
+++ b/testcafe/tests/photos/album_sharing_scenario.js
@@ -50,6 +50,8 @@ const TEST_DELETE_ALBUM = `5-1 Delete Album`
 //************************
 fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
   console.group(`\n↳ ℹ️  Login & Initialization`)
+  await t.maximizeWindow()
+
   await t.useRole(photosUser)
   await timelinePage.waitForLoading()
   await timelinePage.initPhotosCount()
@@ -93,6 +95,8 @@ fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_PHOTOS_URL}/`
     console.group(
       `\n↳ ℹ️  no Loggin (anonymous) & DOWNLOAD_PATH initialization`
     )
+    await t.maximizeWindow()
+
     //await t.useRole(Role.anonymous())
     await setDownloadPath(data.DOWNLOAD_PATH)
     await t.navigateTo(data.sharingLink)
@@ -167,7 +171,6 @@ test(TEST_PUBLIC_ALBUM_MOBILE, async t => {
     .click(selectors.btnAlbumPublicCreateCozyMobile)
   await publicPhotoPage.checkCreateCozy()
 
-  await t.maximizeWindow() //Back to desktop
   console.groupEnd()
 })
 
@@ -177,6 +180,8 @@ test(TEST_PUBLIC_ALBUM_MOBILE, async t => {
 fixture`${FIXTURE_UNSHARE}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow() //Back to desktop
+
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()
@@ -196,8 +201,10 @@ test(TEST_UNSHARE_ALBUM, async () => {
 // Public (no authentification)
 //************************
 fixture`${FIXTURE_PUBLIC_NO_ACCESS}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
-  async () => {
+  async t => {
     console.group(`\n↳ ℹ️  no Loggin (anonymous)`)
+    await t.maximizeWindow()
+
     //await t.useRole(Role.anonymous())
     console.groupEnd()
   }
@@ -217,6 +224,8 @@ test(TEST_PUBLIC_NO_ACCESS, async t => {
 fixture`${FIXTURE_CLEANUP}`.page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(
   async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()

--- a/testcafe/tests/photos/create_empty_album_scenario.js
+++ b/testcafe/tests/photos/create_empty_album_scenario.js
@@ -12,6 +12,7 @@ const photoAlbumsPage = new AlbumsPage()
 fixture`Create new empty album and add photos`
   .page`${TESTCAFE_PHOTOS_URL}/`.beforeEach(async t => {
   console.group(`\n↳ ℹ️  Login & Initialization`)
+  await t.maximizeWindow()
 
   await t.useRole(photosUser)
   await timelinePage.waitForLoading()

--- a/testcafe/tests/photos/create_full_album_scenario.js
+++ b/testcafe/tests/photos/create_full_album_scenario.js
@@ -44,6 +44,8 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Loggin & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()

--- a/testcafe/tests/photos/photos_crud.js
+++ b/testcafe/tests/photos/photos_crud.js
@@ -23,6 +23,8 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()

--- a/testcafe/tests/photos/photos_end_delete_all_data.js
+++ b/testcafe/tests/photos/photos_end_delete_all_data.js
@@ -26,6 +26,8 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     await timelinePage.initPhotosCount()

--- a/testcafe/tests/photos/photos_start_upload_photos.js
+++ b/testcafe/tests/photos/photos_start_upload_photos.js
@@ -13,7 +13,6 @@ import {
 import { initVR } from '../helpers/visualreview-utils'
 import TimelinePage from '../pages/photos/photos-timeline-model'
 import * as selectors from '../pages/selectors'
-import logger from '../helpers/logger'
 
 const timelinePage = new TimelinePage()
 
@@ -29,6 +28,8 @@ fixture`${FIXTURE_INIT}`.page`${TESTCAFE_PHOTOS_URL}/`
   })
   .beforeEach(async t => {
     console.group(`\n↳ ℹ️  Login & Initialization`)
+    await t.maximizeWindow()
+
     await t.useRole(photosUser)
     await timelinePage.waitForLoading()
     console.groupEnd()


### PR DESCRIPTION
Now, all resize operations are done at the begining of a test (or in `beforeEach`), so if a mobile view test fail, the risize will still happend