### PR TITLE
chore: Replace p by a div since we now have figure child

### DIFF
--- a/src/components/pushClient/Banner.jsx
+++ b/src/components/pushClient/Banner.jsx
@@ -69,7 +69,7 @@ class BannerClient extends Component {
           }}
           label={t('Nav.btn-client-mobile')}
         />
-        <p className={styles['coz-banner-text']}>
+        <div className={styles['coz-banner-text']}>
           <figure>
             <Icon icon="cozy" width="44" height="44" />
           </figure>
@@ -83,7 +83,7 @@ class BannerClient extends Component {
             }}
             label={t('Nav.banner-btn-client')}
           />
-        </p>
+        </div>
         <Button
           theme="close"
           extension="narrow"


### PR DESCRIPTION
`<p>` HTML tag cannot contain block elements like `<figure>`, it triggers a DOM warning in some browsers console, hence the `<div>` replacement.

See #991 

This PR is not about using UI component plz ;) 