### PR TITLE
fix: Remove double / in paths (root directory)

### DIFF
--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -204,7 +204,7 @@ const uploadFile = async (client, file, dirID) => {
 export const getFileFullpath = async (client, file, dirID) => {
   const resp = await client.collection('io.cozy.files').get(dirID)
   const parentDirectory = resp.data
-  return `${parentDirectory.path}/${file.name}`
+  return `${parentDirectory.path}/${file.name}`.replace('//', '/')
 }
 
 /*

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -523,6 +523,17 @@ describe('getFileFullpath function', () => {
     const result = await getFileFullpath(fakeClient, file, 'parent')
     expect(result).toEqual('/GrandParent/Parent/mydoc.odt')
   })
+
+  it('should return the full path of a file in root directory', async () => {
+    getSpy.mockResolvedValue({
+      data: {
+        path: '/'
+      }
+    })
+    const file = new File([''], 'mydoc.odt')
+    const result = await getFileFullpath(fakeClient, file, 'parent')
+    expect(result).toEqual('/mydoc.odt')
+  })
 })
 
 describe('overwriteFile function', () => {


### PR DESCRIPTION
When `mydoc.odt` was in the root folder, the calculated path was `//mydoc.odt` and thus, we did not detect that the file was shared