### PR TITLE
Fix: Create cozy button not working

### DIFF
--- a/testcafe/tests/drive/file_sharing_scenario.js
+++ b/testcafe/tests/drive/file_sharing_scenario.js
@@ -5,6 +5,7 @@ import {
   deleteLocalFile,
   checkLocalFile,
   setDownloadPath,
+  isExistingAndVisibile,
   TESTCAFE_DRIVE_URL
 } from '../helpers/utils'
 import PrivateDrivePage from '../pages/drive/drive-model-private'
@@ -107,13 +108,17 @@ test(`[Mobile] Drive : Access a file public link, download the file, and check t
   })
   await t.navigateTo(data.sharingLink)
   await publicViewerPage.waitForLoading()
+  await publicDrivePage.checkDesktopElementsNotShowingOnMobile('file')
 
-  await publicDrivePage.checkActionMenuPublicMobile('file')
+  //Download
+  await publicDrivePage.checkDownloadButtonOnMobile()
   await t
     .setNativeDialogHandler(() => true)
     .click(selectors.btnPublicMobileDownload)
-    .click(selectors.btnMoreMenu) //need to re-open the more menu
-    .click(selectors.btnPublicMobileCreateCozy)
+
+  //create my cozy
+  await publicDrivePage.checkCozyCreationButtonOnMobile()
+  await t.click(selectors.btnPublicMobileCreateCozy)
   await publicDrivePage.checkCreateCozy()
   await publicViewerPage.waitForLoading()
 

--- a/testcafe/tests/drive/folder_sharing_scenario.js
+++ b/testcafe/tests/drive/folder_sharing_scenario.js
@@ -5,6 +5,7 @@ import {
   deleteLocalFile,
   checkLocalFile,
   setDownloadPath,
+  isExistingAndVisibile,
   TESTCAFE_DRIVE_URL
 } from '../helpers/utils'
 import * as selectors from '../pages/selectors'
@@ -105,14 +106,18 @@ test(`[Mobile] Drive : Access a folder public link, download the file(s), and ch
   })
   await t.navigateTo(data.sharingLink)
   await publicDrivePage.waitForLoading({ isNotAvailable: false, isFull: true })
+  await publicDrivePage.checkDesktopElementsNotShowingOnMobile('folder')
 
-  await publicDrivePage.checkActionMenuPublicMobile('folder')
+  //Download
+  await publicDrivePage.checkDownloadButtonOnMobile()
   await t
     .wait(3000) //!FIXME to remove after https://trello.com/c/IZfev6F1/1658-drive-public-share-impossible-de-t%C3%A9l%C3%A9charger-le-fichier is fixed
     .setNativeDialogHandler(() => true)
     .click(selectors.btnPublicMobileDownload)
-    .click(selectors.btnMoreMenu) //need to re-open the more menu
-    .click(selectors.btnPublicMobileCreateCozy)
+
+  //create my cozy
+  await publicDrivePage.checkCozyCreationButtonOnMobile()
+  await t.click(selectors.btnPublicMobileCreateCozy)
   await publicDrivePage.checkCreateCozy()
   await publicDrivePage.waitForLoading({ isNotAvailable: false, isFull: true })
 

--- a/testcafe/tests/pages/drive/drive-model-public.js
+++ b/testcafe/tests/pages/drive/drive-model-public.js
@@ -30,7 +30,7 @@ export default class PublicDrivePage extends DrivePage {
   }
 
   // @param {string} type : 'file' or 'folder' : the toolbar is different depending on share type
-  async checkActionMenuPublicMobile(type) {
+  async checkDesktopElementsNotShowingOnMobile(type) {
     const isFile = type === 'file' ? true : false
     await t
       .expect(selectors.btnPublicDownloadDrive.exists)
@@ -45,24 +45,6 @@ export default class PublicDrivePage extends DrivePage {
       .notOk('toolbar_file exists')
       .expect(selectors.btnViewerPublicCreateCozy.exists)
       .notOk('Create Cozy button (desktop) exists')
-
-    await isExistingAndVisibile(
-      isFile ? selectors.btnMoreMenu : selectors.btnMoreMenu,
-      '[...] Button'
-    )
-    await t.click(isFile ? selectors.btnMoreMenu : selectors.btnMoreMenu)
-    await isExistingAndVisibile(
-      selectors.innerPublicMoreMenu,
-      'Innner More Menu'
-    )
-    await isExistingAndVisibile(
-      selectors.btnPublicMobileDownload,
-      'Download Button (mobile)'
-    )
-    await isExistingAndVisibile(
-      selectors.btnPublicMobileCreateCozy,
-      'Create my Cozy Button (mobile)'
-    )
   }
 
   async checkCreateCozy() {
@@ -73,6 +55,30 @@ export default class PublicDrivePage extends DrivePage {
       )
 
     await goBack()
+  }
+  async checkDownloadButtonOnMobile() {
+    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await t.click(selectors.btnMoreMenu, { speed: 0.5 })
+    await isExistingAndVisibile(
+      selectors.innerPublicMoreMenu,
+      'Innner More Menu'
+    )
+    await isExistingAndVisibile(
+      selectors.btnPublicMobileDownload,
+      'Download Button (mobile)'
+    )
+  }
+  async checkCozyCreationButtonOnMobile() {
+    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await t.click(selectors.btnMoreMenu, { speed: 0.5 })
+    await isExistingAndVisibile(
+      selectors.innerPublicMoreMenu,
+      'Innner More Menu'
+    )
+    await isExistingAndVisibile(
+      selectors.btnPublicMobileCreateCozy,
+      'Create my Cozy Button (mobile)'
+    )
   }
 
   async checkNotAvailable() {

--- a/testcafe/tests/pages/photos/photos-model-public.js
+++ b/testcafe/tests/pages/photos/photos-model-public.js
@@ -38,23 +38,29 @@ export default class PublicPhotos extends Photos {
     )
   }
 
-  async checkActionMenuAlbumPublicMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Menu')
-    await t.click(selectors.btnMoreMenu)
+  async checkPhotosDownloadButtonOnMobile() {
+    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await t.click(selectors.btnMoreMenu, { speed: 0.5 })
     await isExistingAndVisibile(
       selectors.innerPublicMoreMenu,
-      'inner [...] Menu'
-    )
-    await isExistingAndVisibile(
-      selectors.btnAlbumPublicCreateCozyMobile,
-      'Create my Cozy Button (Mobile)'
+      'Innner More Menu'
     )
     await isExistingAndVisibile(
       selectors.btnPublicDownloadPhotosMobile,
-      'Mobile download button'
+      'Download Button (mobile)'
     )
-    // Close [...] menu after check
-    await t.click(selectors.btnMoreMenu)
+  }
+  async checkPhotosCozyCreationButtonOnMobile() {
+    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await t.click(selectors.btnMoreMenu, { speed: 0.5 })
+    await isExistingAndVisibile(
+      selectors.innerPublicMoreMenu,
+      'Innner More Menu'
+    )
+    await isExistingAndVisibile(
+      selectors.btnAlbumPublicCreateCozyMobile,
+      'Create my Cozy Button (mobile)'
+    )
   }
 
   async checkNotAvailable() {

--- a/testcafe/tests/photos/album_sharing_scenario.js
+++ b/testcafe/tests/photos/album_sharing_scenario.js
@@ -6,7 +6,8 @@ import {
   SLUG,
   deleteLocalFile,
   checkLocalFile,
-  setDownloadPath
+  setDownloadPath,
+  isExistingAndVisibile
 } from '../helpers/utils'
 import { initVR } from '../helpers/visualreview-utils'
 import * as selectors from '../pages/selectors'
@@ -154,23 +155,23 @@ test(TEST_PUBLIC_ALBUM_MOBILE, async t => {
     portraitOrientation: true
   })
   await publicPhotoPage.waitForLoading()
-  await publicPhotoPage.checkActionMenuAlbumPublicMobile()
-
   //Viewer
   await photosViewer.openPhotoAndCheckViewer({
     index: 0,
     screenshotPath: `${FEATURE_PREFIX}/${TEST_PUBLIC_ALBUM_MOBILE}-1`
   })
 
+  //Download
+  await publicPhotoPage.checkPhotosDownloadButtonOnMobile()
   await t
     .wait(3000) //!FIXME to remove after https://trello.com/c/IZfev6F1/1658-drive-public-share-impossible-de-t%C3%A9l%C3%A9charger-le-fichier is fixed
     .setNativeDialogHandler(() => true)
-    .click(selectors.btnMoreMenu)
     .click(selectors.btnPublicDownloadPhotosMobile)
-    .click(selectors.btnMoreMenu)
-    .click(selectors.btnAlbumPublicCreateCozyMobile)
-  await publicPhotoPage.checkCreateCozy()
 
+  //create my cozy
+  await publicPhotoPage.checkPhotosCozyCreationButtonOnMobile()
+  await t.click(selectors.btnAlbumPublicCreateCozyMobile)
+  await publicPhotoPage.checkCreateCozy()
   console.groupEnd()
 })
 


### PR DESCRIPTION
We have troubles with the `more` menu not opening, or not closing when expected.
Instead of
- opening the menu
- checking all selectors for both buttons
- clicking on 1st button
- re-open more menu without selector checks
- clicking on the 2nd button

I change the script to : 
- open the menu 
- checking selector for 1st button
- clicking on 1st button
- checking the menu is closed
- open the menu 
- checking selector for 2nd button
- clicking on 2nd button

As we cannot reproduce manually the open/close issue, I reduce the 'click speed' while clicking on the more button (https://devexpress.github.io/testcafe/documentation/test-api/actions/action-options.html#click-action-options) to emulate a more 'human' way of clicking.
while running tests locally it really improve stability on theses tests.
