### PR TITLE
fix: Remove wait(DOWNLOAD_DELAY) from checkLocalFile

### DIFF
--- a/testcafe/tests/drive/file_sharing_scenario.js
+++ b/testcafe/tests/drive/file_sharing_scenario.js
@@ -77,8 +77,8 @@ fixture`Drive : Access a file public link, download the file, and check the 'cre
     await setDownloadPath(data.DOWNLOAD_PATH)
     console.groupEnd()
   })
-  .afterEach(async () => {
-    await checkLocalFile(`${data.DOWNLOAD_PATH}/${data.FILE_XLSX}`) //The file is downloaded directly, no zip!
+  .afterEach(async t => {
+    await checkLocalFile(t, `${data.DOWNLOAD_PATH}/${data.FILE_XLSX}`) //The file is downloaded directly, no zip!
     await deleteLocalFile(`${data.DOWNLOAD_PATH}/${data.FILE_XLSX}`)
   })
 test(`[Desktop] Drive : Access a file public link, download the file, and check the 'create Cozy' link`, async t => {

--- a/testcafe/tests/drive/folder_sharing_scenario.js
+++ b/testcafe/tests/drive/folder_sharing_scenario.js
@@ -74,8 +74,8 @@ fixture`Drive : Access a folder public link, download the file(s), and check the
     await setDownloadPath(data.DOWNLOAD_PATH)
     console.groupEnd()
   })
-  .afterEach(async () => {
-    await checkLocalFile(data.DOWNLOAD_FOLDER_PATH)
+  .afterEach(async t => {
+    await checkLocalFile(t, data.DOWNLOAD_FOLDER_PATH)
     await deleteLocalFile(data.DOWNLOAD_FOLDER_PATH)
   })
 test(`[Desktop] Drive : Access a folder public link, download the file(s), and check the 'create Cozy' link`, async t => {

--- a/testcafe/tests/drive/public-viewer-feature.js
+++ b/testcafe/tests/drive/public-viewer-feature.js
@@ -104,7 +104,7 @@ fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_DRIVE_URL}/`
         t.ctx.fileDownloaded
       }`
     )
-    await checkLocalFile(`${data.DOWNLOAD_PATH}/${t.ctx.fileDownloaded}`)
+    await checkLocalFile(t, `${data.DOWNLOAD_PATH}/${t.ctx.fileDownloaded}`)
     await deleteLocalFile(`${data.DOWNLOAD_PATH}/${t.ctx.fileDownloaded}`)
   })
   .after(async ctx => {

--- a/testcafe/tests/drive/viewer-feature.js
+++ b/testcafe/tests/drive/viewer-feature.js
@@ -47,7 +47,7 @@ fixture`${FIXTURE_PRIVATE_WITH_DL}`.page`${TESTCAFE_DRIVE_URL}/`
         t.ctx.fileDownloaded
       }`
     )
-    await checkLocalFile(`${data.DOWNLOAD_PATH}/${t.ctx.fileDownloaded}`)
+    await checkLocalFile(t, `${data.DOWNLOAD_PATH}/${t.ctx.fileDownloaded}`)
     await deleteLocalFile(`${data.DOWNLOAD_PATH}/${t.ctx.fileDownloaded}`)
   })
 

--- a/testcafe/tests/helpers/data.js
+++ b/testcafe/tests/helpers/data.js
@@ -52,7 +52,7 @@ export const allSpecialFilesExt = pdfFilesExt
 export const THUMBNAIL_DELAY = 3000
 export const VR_STATUS_DELAY = 3000
 export const VR_UPLOAD_DELAY = 5000
-export const DOWNLOAD_DELAY = 5000
+export const DOWNLOAD_CHECK_RETRIES = 15000
 
 //Mask Coordonnates
 export const maskDriveFolderWithDate = {

--- a/testcafe/tests/helpers/utils.js
+++ b/testcafe/tests/helpers/utils.js
@@ -92,11 +92,26 @@ export const getLastExecutedCommand = ClientFunction(
 )
 
 //@param{string} filepath : Expected full path to file
-export async function checkLocalFile(filepath) {
-  await t.wait(data.DOWNLOAD_DELAY)
-  await t.expect(fs.existsSync(filepath)).ok(`${filepath} doesn't exist`)
-  logger.debug(`${filepath} exists on local drive`)
+export async function checkLocalFile(t, filepath) {
+  for (var i = 0; i < data.DOWNLOAD_CHECK_RETRIES; i++) {
+    await t.wait(10)
+    if (fs.existsSync(filepath)) {
+      logger.info(
+        `${filepath} exists on local drive. Waited for a total of ${i.toString()} milliseconds`
+      )
+      break
+    }
+  }
+  //Will throw error if file was not download
+  await t
+    .expect(fs.existsSync(filepath))
+    .ok(
+      `${filepath} doesn't exist after ${
+        data.DOWNLOAD_CHECK_RETRIES
+      } milliseconds`
+    )
 }
+
 //@param{string} filepath : Expected full path to file
 export async function deleteLocalFile(filepath) {
   fs.unlink(filepath, function(err) {

--- a/testcafe/tests/photos/album_sharing_scenario.js
+++ b/testcafe/tests/photos/album_sharing_scenario.js
@@ -105,11 +105,12 @@ fixture`${FIXTURE_PUBLIC_WITH_DL}`.page`${TESTCAFE_PHOTOS_URL}/`
     t.ctx.totalFilesCount = await publicPhotoPage.getPhotosCount('Before')
     console.groupEnd()
   })
-  .afterEach(async () => {
+  .afterEach(async t => {
     logger.info(
       `↳ ℹ️  ${FEATURE_PREFIX} - Checking downloaded file for ${FEATURE_PREFIX.toLowerCase()}.zip`
     )
     await checkLocalFile(
+      t,
       `${data.DOWNLOAD_PATH}/${FEATURE_PREFIX.toLowerCase()}.zip`
     )
     await deleteLocalFile(


### PR DESCRIPTION
- Remove delay before checking for downloads.
- Add a loop to check for file every 10ms. Error will be throw if the file still not exist after `DOWNLOAD_DELAY`
- increase `DOWNLOAD_DELAY` to avoid false error as we don't have to wait the whole delay anymore
