### PR TITLE
Testcafe/explicit logs

### DIFF
--- a/testcafe/tests/drive/classification_scenario.js
+++ b/testcafe/tests/drive/classification_scenario.js
@@ -190,7 +190,7 @@ test(TEST_MOVE_FILE_CANCEL, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FILE_CANCEL}-2`,
     withMask: maskMoveMoadal
   })
-  await isExistingAndVisibile(selectors.modalClose, 'Modal button close')
+  await isExistingAndVisibile(selectors.modalClose, 'selectors.modalClose')
   await t.click(selectors.modalClose)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FILE_CANCEL}-3`,
@@ -211,7 +211,7 @@ test(TEST_MOVE_FILE_CANCEL, async t => {
   // no need to screenshot again the modal
   await isExistingAndVisibile(
     selectors.btnModalFirstButton,
-    'Modal button cancel'
+    'selectors.btnModalFirstButton'
   )
   await t.click(selectors.btnModalFirstButton)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
@@ -343,7 +343,7 @@ test(TEST_DELETE_FOLDER_FROM_DRIVE, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER_FROM_DRIVE}-1`
   })
   await t.click(selectors.btnRemoveActionMenu)
-  await isExistingAndVisibile(selectors.modalFooter, 'Modal delete')
+  await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER_FROM_DRIVE}-2`
@@ -403,11 +403,11 @@ test(TEST_EMPTY_TRASH, async t => {
       selectors.alertWrapper.withText(
         'Your trash is being emptied. This might take a few moments.'
       ),
-      'Toast : Your trash is being emptied. This might take a few moments. '
+      'selectors.alertWrapper.withText(Your trash is being emptied. This might take a few moments.)'
     ),
     await isExistingAndVisibile(
       selectors.alertWrapper.withText('The trash has been emptied.'),
-      'Toast : The trash has been emptied.'
+      'selectors.alertWrapper.withText(The trash has been emptied.)'
     )
   ])
   await Promise.all([
@@ -417,12 +417,16 @@ test(TEST_EMPTY_TRASH, async t => {
           'Your trash is being emptied. This might take a few moments.'
         ).exists
       )
-      .notOk('Toast still exists'),
+      .notOk(
+        'selectors.alertWrapper.withText(Your trash is being emptied. This might take a few moments.) still exists'
+      ),
     await t
       .expect(
         selectors.alertWrapper.withText('The trash has been emptied.').exists
       )
-      .notOk('Toast still exists')
+      .notOk(
+        'selectors.alertWrapper.withText(The trash has been emptied.) still exists'
+      )
   ])
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({

--- a/testcafe/tests/drive/classification_scenario.js
+++ b/testcafe/tests/drive/classification_scenario.js
@@ -3,7 +3,7 @@ import logger from '../helpers/logger'
 import {
   TESTCAFE_DRIVE_URL,
   SLUG,
-  isExistingAndVisibile
+  isExistingAndVisible
 } from '../helpers/utils'
 import { initVR } from '../helpers/visualreview-utils'
 import {
@@ -190,7 +190,7 @@ test(TEST_MOVE_FILE_CANCEL, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FILE_CANCEL}-2`,
     withMask: maskMoveMoadal
   })
-  await isExistingAndVisibile(selectors.modalClose, 'selectors.modalClose')
+  await isExistingAndVisible('selectors.modalClose')
   await t.click(selectors.modalClose)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FILE_CANCEL}-3`,
@@ -209,10 +209,7 @@ test(TEST_MOVE_FILE_CANCEL, async t => {
   logger.info('Show Move Moadal, and Cancel (Cancel button)')
   await privateDrivePage.showMoveModalForElement(FILE_PDF)
   // no need to screenshot again the modal
-  await isExistingAndVisibile(
-    selectors.btnModalFirstButton,
-    'selectors.btnModalFirstButton'
-  )
+  await isExistingAndVisible('selectors.btnModalFirstButton')
   await t.click(selectors.btnModalFirstButton)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_MOVE_FILE_CANCEL}-5`,
@@ -343,7 +340,7 @@ test(TEST_DELETE_FOLDER_FROM_DRIVE, async t => {
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER_FROM_DRIVE}-1`
   })
   await t.click(selectors.btnRemoveActionMenu)
-  await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
+  await isExistingAndVisible('selectors.modalFooter')
 
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_DELETE_FOLDER_FROM_DRIVE}-2`
@@ -399,15 +396,15 @@ test(TEST_EMPTY_TRASH, async t => {
 
   //We cannot use checkToastAppearsAndDisappears here, as both toast might appears at the same time, or the 1st one may disappear before the second one shows up.
   await Promise.all([
-    await isExistingAndVisibile(
+    await isExistingAndVisible(
+      'selectors.alertWrapper.withText(Your trash is being emptied. This might take a few moments.)',
       selectors.alertWrapper.withText(
         'Your trash is being emptied. This might take a few moments.'
-      ),
-      'selectors.alertWrapper.withText(Your trash is being emptied. This might take a few moments.)'
+      )
     ),
-    await isExistingAndVisibile(
-      selectors.alertWrapper.withText('The trash has been emptied.'),
-      'selectors.alertWrapper.withText(The trash has been emptied.)'
+    await isExistingAndVisible(
+      'selectors.alertWrapper.withText(The trash has been emptied.)',
+      selectors.alertWrapper.withText('The trash has been emptied.')
     )
   ])
   await Promise.all([

--- a/testcafe/tests/drive/file_sharing_scenario.js
+++ b/testcafe/tests/drive/file_sharing_scenario.js
@@ -5,7 +5,6 @@ import {
   deleteLocalFile,
   checkLocalFile,
   setDownloadPath,
-  isExistingAndVisibile,
   TESTCAFE_DRIVE_URL
 } from '../helpers/utils'
 import PrivateDrivePage from '../pages/drive/drive-model-private'

--- a/testcafe/tests/drive/folder_sharing_scenario.js
+++ b/testcafe/tests/drive/folder_sharing_scenario.js
@@ -5,7 +5,6 @@ import {
   deleteLocalFile,
   checkLocalFile,
   setDownloadPath,
-  isExistingAndVisibile,
   TESTCAFE_DRIVE_URL
 } from '../helpers/utils'
 import * as selectors from '../pages/selectors'

--- a/testcafe/tests/drive/navigation.js
+++ b/testcafe/tests/drive/navigation.js
@@ -19,13 +19,13 @@ test('Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash', async
     '↳ ℹ️  Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash'
   )
   //Check Menu and links. Go to page. Check main menu on each page
-  await isExistingAndVisibile(selectors.sidebar, 'Sidebar')
+  await isExistingAndVisibile(selectors.sidebar, 'selectors.sidebar')
 
   //!FIXME change params to use key/keyword
   await privateDrivePage.isSidebarButton(
     selectors.btnNavToRecent,
     '#/recent',
-    'Recent'
+    'selectors.btnNavToRecent'
   )
   await privateDrivePage.clickOnSidebarButton(
     selectors.btnNavToRecent,
@@ -37,7 +37,7 @@ test('Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash', async
   await privateDrivePage.isSidebarButton(
     selectors.btnNavToFolder,
     '#/folder',
-    'Drive'
+    'selectors.btnNavToFolder'
   )
   await privateDrivePage.clickOnSidebarButton(
     selectors.btnNavToFolder,
@@ -49,7 +49,7 @@ test('Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash', async
   await privateDrivePage.isSidebarButton(
     selectors.btnNavToSharing,
     '#/sharings',
-    'Sharing'
+    'electors.btnNavToSharing'
   )
   await privateDrivePage.clickOnSidebarButton(
     selectors.btnNavToSharing,
@@ -61,7 +61,7 @@ test('Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash', async
   await privateDrivePage.isSidebarButton(
     selectors.btnNavToTrash,
     '#/trash',
-    'Trash'
+    'selectors.btnNavToTrash'
   )
   await privateDrivePage.clickOnSidebarButton(
     selectors.btnNavToTrash,

--- a/testcafe/tests/drive/navigation.js
+++ b/testcafe/tests/drive/navigation.js
@@ -1,5 +1,5 @@
 import { driveUser } from '../helpers/roles'
-import { TESTCAFE_DRIVE_URL, isExistingAndVisibile } from '../helpers/utils'
+import { TESTCAFE_DRIVE_URL, isExistingAndVisible } from '../helpers/utils'
 import * as selectors from '../pages/selectors'
 import PrivateDrivePage from '../pages/drive/drive-model-private'
 
@@ -19,7 +19,7 @@ test('Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash', async
     '↳ ℹ️  Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash'
   )
   //Check Menu and links. Go to page. Check main menu on each page
-  await isExistingAndVisibile(selectors.sidebar, 'selectors.sidebar')
+  await isExistingAndVisible('selectors.sidebar')
 
   //!FIXME change params to use key/keyword
   await privateDrivePage.isSidebarButton(

--- a/testcafe/tests/drive/navigation.js
+++ b/testcafe/tests/drive/navigation.js
@@ -49,7 +49,7 @@ test('Drive Navigation Desktop Resolution: Drive, Recent, Sharing, Trash', async
   await privateDrivePage.isSidebarButton(
     selectors.btnNavToSharing,
     '#/sharings',
-    'electors.btnNavToSharing'
+    'selectors.btnNavToSharing'
   )
   await privateDrivePage.clickOnSidebarButton(
     selectors.btnNavToSharing,

--- a/testcafe/tests/drive/search.js
+++ b/testcafe/tests/drive/search.js
@@ -2,7 +2,7 @@ import { driveUser } from '../helpers/roles'
 import {
   TESTCAFE_DRIVE_URL,
   SLUG,
-  isExistingAndVisibile
+  isExistingAndVisible
 } from '../helpers/utils'
 import { initVR } from '../helpers/visualreview-utils'
 import { FOLDER_NAME, maskDriveFolderWithDate } from '../helpers/data'
@@ -112,10 +112,7 @@ test(TEST_SEARCH3, async t => {
 test(TEST_SEARCH_NO_RESULT, async t => {
   console.group(`↳ ℹ️  ${FEATURE_PREFIX} : ${TEST_SEARCH_NO_RESULT}`)
   await privateDrivePage.typeInSearchInput('qwerty')
-  await isExistingAndVisibile(
-    selectors.searchNoResult,
-    `selectors.searchNoResult`
-  )
+  await isExistingAndVisible(`selectors.searchNoResult`)
   await t.fixtureCtx.vr.takeScreenshotAndUpload({
     screenshotPath: `${FEATURE_PREFIX}/${TEST_SEARCH3}-Qwerty`,
     withMask: maskDriveFolderWithDate

--- a/testcafe/tests/helpers/utils.js
+++ b/testcafe/tests/helpers/utils.js
@@ -68,9 +68,13 @@ export const getElementWithTestItem = Selector(
 export async function isExistingAndVisibile(selector, selectorName) {
   await t
     .expect(selector.exists)
-    .ok(`'${selectorName}' doesnt exist`)
+    .ok(
+      `'${selectorName}' doesnt exist - please check its definition in testcafe/tests/pages/selectors`
+    )
     .expect(selector.visible)
-    .ok(`'${selectorName}' is not visible`)
+    .ok(
+      `'${selectorName}' exists, but is not visible - please check its definition in testcafe/tests/pages/selectors`
+    )
   logger.debug(` - '${selectorName}' exists and is visible!`)
 }
 

--- a/testcafe/tests/helpers/utils.js
+++ b/testcafe/tests/helpers/utils.js
@@ -1,12 +1,15 @@
 import { ClientFunction, Selector, t } from 'testcafe'
 import logger from './logger'
-
+import get from 'lodash/get'
 import fs from 'fs-extra'
 import path from 'path'
 import unzipper from 'unzipper'
 import request from 'request'
 import CDP from 'chrome-remote-interface'
 let data = require('../helpers/data')
+let selectors = require('../pages/selectors')
+
+//import * as selectors from '../pages/selectors'
 
 const INSTANCE_TESTCAFE = process.env.INSTANCE_TESTCAFE
 
@@ -55,17 +58,12 @@ export const getResolution = ClientFunction(
   () => `${window.innerWidth} x ${window.innerHeight}`
 )
 
-export const getElementWithTestId = Selector(
-  id => document.querySelectorAll(`[data-test-id='${id}']`)
-  //getElementsByAttribute is not part of W3C DOM, while querySelectorAll is.
-)
-export const getElementWithTestItem = Selector(
-  id => document.querySelectorAll(`[data-test-item='${id}']`)
-  //getElementsByAttribute is not part of W3C DOM, while querySelectorAll is.
-)
-
 //It's best practice to check both exist and visible for an element
-export async function isExistingAndVisibile(selector, selectorName) {
+export async function isExistingAndVisible(selectorName, selector = false) {
+  if (!selector) {
+    const selectorNameShort = selectorName.replace('selectors.', '')
+    selector = get(selectors, selectorNameShort)
+  }
   await t
     .expect(selector.exists)
     .ok(

--- a/testcafe/tests/helpers/utils.js
+++ b/testcafe/tests/helpers/utils.js
@@ -9,8 +9,6 @@ import CDP from 'chrome-remote-interface'
 let data = require('../helpers/data')
 let selectors = require('../pages/selectors')
 
-//import * as selectors from '../pages/selectors'
-
 const INSTANCE_TESTCAFE = process.env.INSTANCE_TESTCAFE
 
 export let TESTCAFE_PHOTOS_URL = ''

--- a/testcafe/tests/pages/commons.js
+++ b/testcafe/tests/pages/commons.js
@@ -9,9 +9,9 @@ export async function checkToastAppearsAndDisappears(toastText) {
   await t
   isExistingAndVisibile(
     selectors.alertWrapper.withText(toastText),
-    `Toast Alert`
+    `selectors.alertWrapper.withText(${toastText})`
   )
   await t
     .expect(selectors.alertWrapper.withText(toastText).exists)
-    .notOk('Toast still exists')
+    .notOk(`selectors.alertWrapper.withText(${toastText}) still exists`)
 }

--- a/testcafe/tests/pages/commons.js
+++ b/testcafe/tests/pages/commons.js
@@ -1,15 +1,15 @@
 import { t } from 'testcafe'
 import * as selectors from './selectors'
-import { isExistingAndVisibile } from '../helpers/utils'
+import { isExistingAndVisible } from '../helpers/utils'
 
 //this files contains function that can be use both in photos and drive
 
 //Check that the alert toast exist, and wait for it to disappear
 export async function checkToastAppearsAndDisappears(toastText) {
   await t
-  isExistingAndVisibile(
-    selectors.alertWrapper.withText(toastText),
-    `selectors.alertWrapper.withText(${toastText})`
+  isExistingAndVisible(
+    `selectors.alertWrapper.withText(${toastText})`,
+    selectors.alertWrapper.withText(toastText)
   )
   await t
     .expect(selectors.alertWrapper.withText(toastText).exists)

--- a/testcafe/tests/pages/drive-viewer/drive-viewer-model.js
+++ b/testcafe/tests/pages/drive-viewer/drive-viewer-model.js
@@ -79,10 +79,10 @@ export default class ViewerDrive extends Viewer {
 
   //Specific check for audioViewer
   async checkAudioViewer() {
-    await isExistingAndVisibile(selectors.audioViewer, 'Audio viewer')
+    await isExistingAndVisibile(selectors.audioViewer, 'selectors.audioViewer')
     await isExistingAndVisibile(
       selectors.audioViewerControls,
-      'Audio viewer controls'
+      'selectors.audioViewerControls'
     )
     if (t.fixtureCtx.isVR) {
       //wait for file to load to get a good screenshots
@@ -92,10 +92,10 @@ export default class ViewerDrive extends Viewer {
 
   //Specific check for videoViewer
   async checkVideoViewer() {
-    await isExistingAndVisibile(selectors.videoViewer, 'Video viewer')
+    await isExistingAndVisibile(selectors.videoViewer, 'selectors.videoViewer')
     await isExistingAndVisibile(
       selectors.videoViewerControls,
-      'Video viewer controls'
+      'selectors.videoViewerControls'
     )
     if (t.fixtureCtx.isVR) {
       //wait for file to load to get a good screenshots
@@ -105,23 +105,23 @@ export default class ViewerDrive extends Viewer {
 
   //Specific check for textViewer
   async checkTextViewer() {
-    await isExistingAndVisibile(selectors.txtViewer, 'text viewer')
+    await isExistingAndVisibile(selectors.txtViewer, 'selectors.txtViewer')
     await isExistingAndVisibile(
       selectors.txtViewerContent,
-      'text viewer controls'
+      'selectors.txtViewerContent'
     )
   }
 
   //Specific check for no viewer : other download btn
   async checkNoViewer() {
-    await isExistingAndVisibile(selectors.noViewer, 'no-viewer Viewer')
+    await isExistingAndVisibile(selectors.noViewer, 'selectors.noViewer')
   }
 
   //Specific check for no viewer : other download btn
   async checkNoViewerDownload() {
     await isExistingAndVisibile(
       selectors.btnNoViewerDownload,
-      'no Viewer Download button'
+      'selectors.btnNoViewerDownload'
     )
     await t
       .setNativeDialogHandler(() => true)
@@ -131,6 +131,6 @@ export default class ViewerDrive extends Viewer {
   //Specific check for pdf viewer : download btn
   async checkPdfViewer() {
     await t.takeScreenshot()
-    await isExistingAndVisibile(selectors.pdfViewer, 'Pdf Viewer')
+    await isExistingAndVisibile(selectors.pdfViewer, 'selectors.pdfViewer')
   }
 }

--- a/testcafe/tests/pages/drive-viewer/drive-viewer-model.js
+++ b/testcafe/tests/pages/drive-viewer/drive-viewer-model.js
@@ -1,6 +1,6 @@
 import logger from '../../helpers/logger'
 import { t } from 'testcafe'
-import { isExistingAndVisibile } from '../../helpers/utils'
+import { isExistingAndVisible } from '../../helpers/utils'
 import DrivePage from '../drive/drive-model'
 import Viewer from '../viewer/viewer-model'
 import { THUMBNAIL_DELAY } from '../../helpers/data'
@@ -79,11 +79,8 @@ export default class ViewerDrive extends Viewer {
 
   //Specific check for audioViewer
   async checkAudioViewer() {
-    await isExistingAndVisibile(selectors.audioViewer, 'selectors.audioViewer')
-    await isExistingAndVisibile(
-      selectors.audioViewerControls,
-      'selectors.audioViewerControls'
-    )
+    await isExistingAndVisible('selectors.audioViewer')
+    await isExistingAndVisible('selectors.audioViewerControls')
     if (t.fixtureCtx.isVR) {
       //wait for file to load to get a good screenshots
       await t.wait(THUMBNAIL_DELAY)
@@ -92,11 +89,8 @@ export default class ViewerDrive extends Viewer {
 
   //Specific check for videoViewer
   async checkVideoViewer() {
-    await isExistingAndVisibile(selectors.videoViewer, 'selectors.videoViewer')
-    await isExistingAndVisibile(
-      selectors.videoViewerControls,
-      'selectors.videoViewerControls'
-    )
+    await isExistingAndVisible('selectors.videoViewer')
+    await isExistingAndVisible('selectors.videoViewerControls')
     if (t.fixtureCtx.isVR) {
       //wait for file to load to get a good screenshots
       await t.wait(THUMBNAIL_DELAY)
@@ -105,24 +99,18 @@ export default class ViewerDrive extends Viewer {
 
   //Specific check for textViewer
   async checkTextViewer() {
-    await isExistingAndVisibile(selectors.txtViewer, 'selectors.txtViewer')
-    await isExistingAndVisibile(
-      selectors.txtViewerContent,
-      'selectors.txtViewerContent'
-    )
+    await isExistingAndVisible('selectors.txtViewer')
+    await isExistingAndVisible('selectors.txtViewerContent')
   }
 
   //Specific check for no viewer : other download btn
   async checkNoViewer() {
-    await isExistingAndVisibile(selectors.noViewer, 'selectors.noViewer')
+    await isExistingAndVisible('selectors.noViewer')
   }
 
   //Specific check for no viewer : other download btn
   async checkNoViewerDownload() {
-    await isExistingAndVisibile(
-      selectors.btnNoViewerDownload,
-      'selectors.btnNoViewerDownload'
-    )
+    await isExistingAndVisible('selectors.btnNoViewerDownload')
     await t
       .setNativeDialogHandler(() => true)
       .click(selectors.btnNoViewerDownload)
@@ -131,6 +119,6 @@ export default class ViewerDrive extends Viewer {
   //Specific check for pdf viewer : download btn
   async checkPdfViewer() {
     await t.takeScreenshot()
-    await isExistingAndVisibile(selectors.pdfViewer, 'selectors.pdfViewer')
+    await isExistingAndVisible('selectors.pdfViewer')
   }
 }

--- a/testcafe/tests/pages/drive/drive-model-private.js
+++ b/testcafe/tests/pages/drive/drive-model-private.js
@@ -2,7 +2,7 @@ import { t } from 'testcafe'
 import logger from '../../helpers/logger'
 import {
   getPageUrl,
-  isExistingAndVisibile,
+  isExistingAndVisible,
   overwriteCopyCommand,
   getLastExecutedCommand
 } from '../../helpers/utils'
@@ -14,7 +14,7 @@ export default class privateDrivePage extends DrivePage {
   //@param {text} path : redirection path
   //@param {text} title : text for logger.debug
   async isSidebarButton(btn, path, title) {
-    await isExistingAndVisibile(btn, `${title}`)
+    await isExistingAndVisible(`${title}`, btn)
     await t.expect(btn.getAttribute('href')).eql(path)
   }
 
@@ -37,21 +37,15 @@ export default class privateDrivePage extends DrivePage {
   }
 
   async openCozyBarMenu() {
-    await isExistingAndVisibile(selectors.btnMainApp, 'selectors.btnMainApp')
+    await isExistingAndVisible('selectors.btnMainApp')
     await t.click(selectors.btnMainApp)
-    await isExistingAndVisibile(
-      selectors.cozNavPopContent,
-      'selectors.cozNavPopContent'
-    )
+    await isExistingAndVisible('selectors.cozNavPopContent')
   }
 
   async checkMainMenu() {
-    await isExistingAndVisibile(selectors.cozBar, 'selectors.cozBar')
+    await isExistingAndVisible('selectors.cozBar')
     await this.openCozyBarMenu()
-    await isExistingAndVisibile(
-      selectors.btnCozBarDrive,
-      'selectors.btnCozBarDrive'
-    )
+    await isExistingAndVisible('selectors.btnCozBarDrive')
 
     await t
       .expect(
@@ -61,16 +55,10 @@ export default class privateDrivePage extends DrivePage {
   }
 
   async openActionMenu() {
-    await isExistingAndVisibile(
-      selectors.toolbarDrive,
-      'selectors.toolbarDrive'
-    )
-    await isExistingAndVisibile(selectors.btnMoreMenu, `selectors.btnMoreMenu`)
+    await isExistingAndVisible('selectors.toolbarDrive')
+    await isExistingAndVisible(`selectors.btnMoreMenu`)
     await t.click(selectors.btnMoreMenu)
-    await isExistingAndVisibile(
-      selectors.cozyMenuInner,
-      'selectors.cozyMenuInner'
-    )
+    await isExistingAndVisible('selectors.cozyMenuInner')
   }
 
   //@param {String} newFolderName
@@ -92,10 +80,7 @@ export default class privateDrivePage extends DrivePage {
         withMask: withMask
       })
 
-    await isExistingAndVisibile(
-      selectors.btnAddFolder,
-      'selectors.btnAddFolder'
-    )
+    await isExistingAndVisible('selectors.btnAddFolder')
     await t.click(selectors.btnAddFolder)
 
     if (!t.fixtureCtx.isVR) {
@@ -103,10 +88,7 @@ export default class privateDrivePage extends DrivePage {
       await t.expect(rowCountEnd).eql(rowCountStart + 1) //New content line appears
     }
 
-    await isExistingAndVisibile(
-      selectors.foldersNamesInputs,
-      'selectors.foldersNamesInputs'
-    )
+    await isExistingAndVisible('selectors.foldersNamesInputs')
     await t
       .typeText(selectors.foldersNamesInputs, newFolderName)
       .pressKey('enter')
@@ -133,14 +115,14 @@ export default class privateDrivePage extends DrivePage {
     await t.expect(selectors.btnUpload.exists).ok(`Upload button doesnt exist`)
     await t.setFilesToUpload(selectors.btnUpload, files)
 
-    await isExistingAndVisibile(selectors.divUpload, 'selectors.divUpload')
+    await isExistingAndVisible('selectors.divUpload')
 
     for (let i = 0; i < numOfFiles; i++) {
       const fileNameChunks = files[i].split('/')
       const fileName = fileNameChunks[fileNameChunks.length - 1]
-      await isExistingAndVisibile(
-        selectors.uploadedItem(fileName),
-        `selectors.uploadedItem(${fileName})`
+      await isExistingAndVisible(
+        `selectors.uploadedItem('${fileName}')`,
+        selectors.uploadedItem(fileName)
       )
       await t
         //hasClass doesn't support [class*='upload-queue-item--done'], only full class name, so we cannot use it
@@ -151,15 +133,9 @@ export default class privateDrivePage extends DrivePage {
     if (!t.fixtureCtx.isVR) {
       // When uploading one file, check for the alert wrapper. When there are lots of files to upload, it already disappear once we finish checking each line
       if (numOfFiles == 1) {
-        await isExistingAndVisibile(
-          selectors.alertWrapper,
-          'selectors.alertWrapper'
-        )
+        await isExistingAndVisible('selectors.alertWrapper')
       }
-      await isExistingAndVisibile(
-        selectors.divUploadSuccess,
-        'selectors.divUploadSuccess'
-      )
+      await isExistingAndVisible('selectors.divUploadSuccess')
       await t
         .expect(selectors.divUpload.child('h4').innerText)
         .match(
@@ -173,30 +149,18 @@ export default class privateDrivePage extends DrivePage {
   }
 
   async shareFolderPublicLink() {
-    await isExistingAndVisibile(
-      selectors.toolbarDrive,
-      'selectors.toolbarDrive'
-    )
-    await isExistingAndVisibile(selectors.btnShare, `selectors.btnShare`)
+    await isExistingAndVisible('selectors.toolbarDrive')
+    await isExistingAndVisible(`selectors.btnShare`)
     await t.click(selectors.btnShare)
-    await isExistingAndVisibile(
-      selectors.divShareByLink,
-      'selectors.divShareByLink'
-    )
-    await isExistingAndVisibile(
-      selectors.toggleShareLink,
-      'selectors.toggleShareLink'
-    )
+    await isExistingAndVisible('selectors.divShareByLink')
+    await isExistingAndVisible('selectors.toggleShareLink')
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
       .ok(`selectors.toggleShareLink.find('input') is unchecked`)
       .expect(selectors.spanLinkCreating.exist)
       .notOk('selectors.spanLinkCreating still exists')
-    await isExistingAndVisibile(
-      selectors.btnCopyShareByLink,
-      'selectors.btnCopyShareByLink'
-    )
+    await isExistingAndVisible('selectors.btnCopyShareByLink')
 
     await overwriteCopyCommand()
 
@@ -205,30 +169,15 @@ export default class privateDrivePage extends DrivePage {
       .expect(getLastExecutedCommand())
       .eql('copy') //check link copy actually happens
 
-    await isExistingAndVisibile(
-      selectors.alertWrapper,
-      'selectors.alertWrapper'
-    )
+    await isExistingAndVisible('selectors.alertWrapper')
   }
 
   async unshareFolderPublicLink() {
-    await isExistingAndVisibile(
-      selectors.toolbarDrive,
-      'selectors.toolbarDrive'
-    )
-    await isExistingAndVisibile(
-      selectors.btnShareByMe,
-      `selectors.btnShareByMe`
-    )
+    await isExistingAndVisible('selectors.toolbarDrive')
+    await isExistingAndVisible(`selectors.btnShareByMe`)
     await t.click(selectors.btnShareByMe)
-    await isExistingAndVisibile(
-      selectors.divShareByLink,
-      'selectors.divShareByLink'
-    )
-    await isExistingAndVisibile(
-      selectors.toggleShareLink,
-      'selectors.toggleShareLink'
-    )
+    await isExistingAndVisible('selectors.divShareByLink')
+    await isExistingAndVisible('selectors.toggleShareLink')
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
@@ -239,31 +188,22 @@ export default class privateDrivePage extends DrivePage {
       .expect(selectors.btnShareByMe.exists)
       .notOk('selectors.btnShareByMe.exists still exists')
 
-    await isExistingAndVisibile(selectors.btnShare, `selectors.btnShare`)
+    await isExistingAndVisible(`selectors.btnShare`)
   }
 
   async shareFirstFilePublicLink() {
     await this.selectElements([0])
 
     await t.click(selectors.btnShareCozySelectionBar)
-    await isExistingAndVisibile(
-      selectors.divShareByLink,
-      'selectors.divShareByLink'
-    )
-    await isExistingAndVisibile(
-      selectors.toggleShareLink,
-      'selectors.toggleShareLink'
-    )
+    await isExistingAndVisible('selectors.divShareByLink')
+    await isExistingAndVisible('selectors.toggleShareLink')
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
       .ok(`selectors.toggleShareLink.find('input') is unchecked`)
       .expect(selectors.spanLinkCreating.exist)
       .notOk('selectors.spanLinkCreating still exists')
-    await isExistingAndVisibile(
-      selectors.btnCopyShareByLink,
-      'selectors.btnCopyShareByLink'
-    )
+    await isExistingAndVisible('selectors.btnCopyShareByLink')
 
     await overwriteCopyCommand()
 
@@ -272,33 +212,24 @@ export default class privateDrivePage extends DrivePage {
       .expect(getLastExecutedCommand())
       .eql('copy') //check link copy actually happens
 
-    await isExistingAndVisibile(
-      selectors.alertWrapper,
-      'selectors.alertWrapper'
-    )
-    await isExistingAndVisibile(
-      selectors.shareBadgeForRowindex(0),
-      'selectors.shareBadgeForRowindex(0)'
+    await isExistingAndVisible('selectors.alertWrapper')
+    await isExistingAndVisible(
+      'selectors.shareBadgeForRowindex(0)',
+      selectors.shareBadgeForRowindex(0)
     )
   }
 
   async unshareFirstFilePublicLink() {
     await this.selectElements([0])
-    await isExistingAndVisibile(
-      selectors.shareBadgeForRowindex(0),
-      'selectors.shareBadgeForRowindex(0)'
+    await isExistingAndVisible(
+      'selectors.shareBadgeForRowindex(0)',
+      selectors.shareBadgeForRowindex(0)
     )
-    //check the bagge after selecting the 1st row, as `selectElements` already check await isExistingAndVisibile(1st row)
+    //check the bagge after selecting the 1st row, as `selectElements` already check await isExistingAndVisible(1st row)
 
     await t.click(selectors.btnShareCozySelectionBar)
-    await isExistingAndVisibile(
-      selectors.divShareByLink,
-      'selectors.divShareByLink'
-    )
-    await isExistingAndVisibile(
-      selectors.toggleShareLink,
-      'selectors.toggleShareLink'
-    )
+    await isExistingAndVisible('selectors.divShareByLink')
+    await isExistingAndVisible('selectors.toggleShareLink')
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
@@ -354,7 +285,7 @@ export default class privateDrivePage extends DrivePage {
     }
     await this.openActionMenu()
     await t.click(selectors.btnRemoveFolder)
-    await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
+    await isExistingAndVisible('selectors.modalFooter')
 
     if (t.fixtureCtx.isVR)
       //dates show up here, so there is a mask for screenshots
@@ -364,10 +295,7 @@ export default class privateDrivePage extends DrivePage {
       })
 
     await t.click(selectors.btnModalSecondButton)
-    await isExistingAndVisibile(
-      selectors.alertWrapper,
-      'selectors.alertWrapper'
-    )
+    await isExistingAndVisible('selectors.alertWrapper')
 
     await this.waitForLoading()
     if (!t.fixtureCtx.isVR) {
@@ -390,10 +318,7 @@ export default class privateDrivePage extends DrivePage {
     await this.selectElements([index])
 
     await t.click(selectors.btnRenameCozySelectionBar)
-    await isExistingAndVisibile(
-      selectors.foldersNamesInputs,
-      'selectors.foldersNamesInputs'
-    )
+    await isExistingAndVisible('selectors.foldersNamesInputs')
     //dates shows up here, so there is a mask for screenshots
     await t.fixtureCtx.vr.takeScreenshotAndUpload({
       screenshotPath: `${screenshotPath}-rename1`,
@@ -438,21 +363,18 @@ export default class privateDrivePage extends DrivePage {
 
   //@param { integer } index :  file index
   async clickOnActionMenuforFile(index) {
-    await isExistingAndVisibile(
-      selectors.contentRows.nth(index),
-      `selectors.contentRows.nth(${index})`
+    await isExistingAndVisible(
+      `selectors.contentRows.nth(${index})`,
+      selectors.contentRows.nth(index)
     )
 
-    await isExistingAndVisibile(
-      selectors.elementActionMenuByRowIndex(index),
-      `selectors.elementActionMenuByRowIndex(${index})`
+    await isExistingAndVisible(
+      `selectors.elementActionMenuByRowIndex(${index})`,
+      selectors.elementActionMenuByRowIndex(index)
     )
     await t.click(selectors.elementActionMenuByRowIndex(index))
 
-    await isExistingAndVisibile(
-      selectors.actionMenuInner,
-      'selectors.actionMenuInner'
-    )
+    await isExistingAndVisible('selectors.actionMenuInner')
   }
 
   //@param {string} fileName : file/folder on which to click on action menu
@@ -465,10 +387,7 @@ export default class privateDrivePage extends DrivePage {
   async showMoveModalForElement(elementToMove) {
     await this.clickOnActionMenuforElementName(elementToMove)
     await t.click(selectors.btnMoveToActionMenu)
-    await isExistingAndVisibile(
-      selectors.modalContent,
-      'selectors.modalContent'
-    )
+    await isExistingAndVisible('selectors.modalContent')
     await this.waitForLoading()
   }
 
@@ -477,10 +396,7 @@ export default class privateDrivePage extends DrivePage {
     await this.goToBaseFolder(true)
     await this.goToFolder(destinationFolder, true)
 
-    await isExistingAndVisibile(
-      selectors.btnModalSecondButton,
-      'selectors.btnModalSecondButton'
-    )
+    await isExistingAndVisible('selectors.btnModalSecondButton')
 
     await t.click(selectors.btnModalSecondButton)
   }
@@ -488,14 +404,8 @@ export default class privateDrivePage extends DrivePage {
   //@param {String} screenshotPath : path for screenshots taken in this test
   //@param { mask } withmask for screenshot
   async emptyTrash({ screenshotPath: screenshotPath, withMask = false }) {
-    await isExistingAndVisibile(
-      selectors.toolbarTrash,
-      'selectors.toolbarTrash'
-    )
-    await isExistingAndVisibile(
-      selectors.btnEmptyTrash,
-      'selectors.btnEmptyTrash'
-    )
+    await isExistingAndVisible('selectors.toolbarTrash')
+    await isExistingAndVisible('selectors.btnEmptyTrash')
     await t.click(selectors.btnEmptyTrash)
     await t.fixtureCtx.vr.takeScreenshotAndUpload({
       screenshotPath: `${screenshotPath}-emptyTrash`,
@@ -508,24 +418,21 @@ export default class privateDrivePage extends DrivePage {
   }
 
   async typeInSearchInput(text) {
-    await isExistingAndVisibile(selectors.searchInput, 'selectors.searchInput')
+    await isExistingAndVisible('selectors.searchInput')
     await t.typeText(selectors.searchInput, text, { speed: 0.5 })
   }
 
   async checkSearchResultCount(expectResultsCount) {
-    await isExistingAndVisibile(
-      selectors.searchResult,
-      `selectors.searchResult`
-    )
+    await isExistingAndVisible(`selectors.searchResult`)
     const resultsCount = await selectors.searchResult.count
     logger.debug(`resultsCount : ${resultsCount}`)
     await t.expect(resultsCount).eql(expectResultsCount)
   }
 
   async openSearchResultByIndex(index) {
-    await isExistingAndVisibile(
-      selectors.searchResult.sibling(index),
-      `selectors.searchResult.sibling(${index})`
+    await isExistingAndVisible(
+      `selectors.searchResult.sibling(${index})`,
+      selectors.searchResult.sibling(index)
     )
     await t.click(selectors.searchResult(index))
   }

--- a/testcafe/tests/pages/drive/drive-model-private.js
+++ b/testcafe/tests/pages/drive/drive-model-private.js
@@ -112,7 +112,9 @@ export default class privateDrivePage extends DrivePage {
 
     logger.info(`Uploading ${numOfFiles} file(s)`)
 
-    await t.expect(selectors.btnUpload.exists).ok(`Upload button doesnt exist`)
+    await t
+      .expect(selectors.btnUpload.exists)
+      .ok(`selectors.btnUpload doesnt exist`)
     await t.setFilesToUpload(selectors.btnUpload, files)
 
     await isExistingAndVisible('selectors.divUpload')

--- a/testcafe/tests/pages/drive/drive-model-private.js
+++ b/testcafe/tests/pages/drive/drive-model-private.js
@@ -14,7 +14,7 @@ export default class privateDrivePage extends DrivePage {
   //@param {text} path : redirection path
   //@param {text} title : text for logger.debug
   async isSidebarButton(btn, path, title) {
-    await isExistingAndVisibile(btn, `Button ${title}`)
+    await isExistingAndVisibile(btn, `${title}`)
     await t.expect(btn.getAttribute('href')).eql(path)
   }
 
@@ -33,41 +33,44 @@ export default class privateDrivePage extends DrivePage {
 
     await t.expect(selectors.errorEmpty.exists).notOk('Error shows up')
     await t.expect(selectors.errorOops.exists).notOk('Error shows up')
-    logger.debug(`Navigation using Button ${title} OK!`)
+    logger.debug(`Navigation to ${title} OK!`)
   }
 
   async openCozyBarMenu() {
-    await isExistingAndVisibile(
-      selectors.btnMainApp,
-      'Cozy bar - Main app button'
-    )
+    await isExistingAndVisibile(selectors.btnMainApp, 'selectors.btnMainApp')
     await t.click(selectors.btnMainApp)
     await isExistingAndVisibile(
       selectors.cozNavPopContent,
-      'Cozy bar - App popup'
+      'selectors.cozNavPopContent'
     )
   }
 
   async checkMainMenu() {
-    await isExistingAndVisibile(selectors.cozBar, 'Cozy bar')
+    await isExistingAndVisibile(selectors.cozBar, 'selectors.cozBar')
     await this.openCozyBarMenu()
     await isExistingAndVisibile(
       selectors.btnCozBarDrive,
-      'Cozy bar - Drive button'
+      'selectors.btnCozBarDrive'
     )
 
     await t
       .expect(
         selectors.btnCozBarDrive.parent('li').filter('[class*=current]').exists
       )
-      .ok('Drive is not current app')
+      .ok('selectors.btnCozBarDrive.parent(li).filter([class*=current])')
   }
 
   async openActionMenu() {
-    await isExistingAndVisibile(selectors.toolbarDrive, 'toolbarDrive')
-    await isExistingAndVisibile(selectors.btnMoreMenu, `[...] button`)
+    await isExistingAndVisibile(
+      selectors.toolbarDrive,
+      'selectors.toolbarDrive'
+    )
+    await isExistingAndVisibile(selectors.btnMoreMenu, `selectors.btnMoreMenu`)
     await t.click(selectors.btnMoreMenu)
-    await isExistingAndVisibile(selectors.cozyMenuInner, 'Cozy inner menu')
+    await isExistingAndVisibile(
+      selectors.cozyMenuInner,
+      'selectors.cozyMenuInner'
+    )
   }
 
   //@param {String} newFolderName
@@ -89,7 +92,10 @@ export default class privateDrivePage extends DrivePage {
         withMask: withMask
       })
 
-    await isExistingAndVisibile(selectors.btnAddFolder, 'Add Folder button')
+    await isExistingAndVisibile(
+      selectors.btnAddFolder,
+      'selectors.btnAddFolder'
+    )
     await t.click(selectors.btnAddFolder)
 
     if (!t.fixtureCtx.isVR) {
@@ -99,7 +105,7 @@ export default class privateDrivePage extends DrivePage {
 
     await isExistingAndVisibile(
       selectors.foldersNamesInputs,
-      'Folder Name input'
+      'selectors.foldersNamesInputs'
     )
     await t
       .typeText(selectors.foldersNamesInputs, newFolderName)
@@ -127,14 +133,14 @@ export default class privateDrivePage extends DrivePage {
     await t.expect(selectors.btnUpload.exists).ok(`Upload button doesnt exist`)
     await t.setFilesToUpload(selectors.btnUpload, files)
 
-    await isExistingAndVisibile(selectors.divUpload, 'Upload pop-in')
+    await isExistingAndVisibile(selectors.divUpload, 'selectors.divUpload')
 
     for (let i = 0; i < numOfFiles; i++) {
       const fileNameChunks = files[i].split('/')
       const fileName = fileNameChunks[fileNameChunks.length - 1]
       await isExistingAndVisibile(
         selectors.uploadedItem(fileName),
-        `Item : ${fileName}`
+        `selectors.uploadedItem(${fileName})`
       )
       await t
         //hasClass doesn't support [class*='upload-queue-item--done'], only full class name, so we cannot use it
@@ -147,12 +153,12 @@ export default class privateDrivePage extends DrivePage {
       if (numOfFiles == 1) {
         await isExistingAndVisibile(
           selectors.alertWrapper,
-          '"successfull" modal alert'
+          'selectors.alertWrapper'
         )
       }
       await isExistingAndVisibile(
         selectors.divUploadSuccess,
-        'successfull Upload pop-in'
+        'selectors.divUploadSuccess'
       )
       await t
         .expect(selectors.divUpload.child('h4').innerText)
@@ -167,21 +173,30 @@ export default class privateDrivePage extends DrivePage {
   }
 
   async shareFolderPublicLink() {
-    await isExistingAndVisibile(selectors.toolbarDrive, 'toolbarDrive')
-    await isExistingAndVisibile(selectors.btnShare, `Share button`)
+    await isExistingAndVisibile(
+      selectors.toolbarDrive,
+      'selectors.toolbarDrive'
+    )
+    await isExistingAndVisibile(selectors.btnShare, `selectors.btnShare`)
     await t.click(selectors.btnShare)
-    await isExistingAndVisibile(selectors.divShareByLink, 'div Share by Link')
+    await isExistingAndVisibile(
+      selectors.divShareByLink,
+      'selectors.divShareByLink'
+    )
     await isExistingAndVisibile(
       selectors.toggleShareLink,
-      'Toggle Share by Link'
+      'selectors.toggleShareLink'
     )
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
-      .ok('toggle Link is unchecked')
+      .ok(`selectors.toggleShareLink.find('input') is unchecked`)
       .expect(selectors.spanLinkCreating.exist)
-      .notOk('Still creating Link')
-    await isExistingAndVisibile(selectors.btnCopyShareByLink, 'Copy Link')
+      .notOk('selectors.spanLinkCreating still exists')
+    await isExistingAndVisibile(
+      selectors.btnCopyShareByLink,
+      'selectors.btnCopyShareByLink'
+    )
 
     await overwriteCopyCommand()
 
@@ -192,48 +207,63 @@ export default class privateDrivePage extends DrivePage {
 
     await isExistingAndVisibile(
       selectors.alertWrapper,
-      '"successfull" modal alert'
+      'selectors.alertWrapper'
     )
   }
 
   async unshareFolderPublicLink() {
-    await isExistingAndVisibile(selectors.toolbarDrive, 'toolbarDrive')
-    await isExistingAndVisibile(selectors.btnShareByMe, `Share by Me button`)
+    await isExistingAndVisibile(
+      selectors.toolbarDrive,
+      'selectors.toolbarDrive'
+    )
+    await isExistingAndVisibile(
+      selectors.btnShareByMe,
+      `selectors.btnShareByMe`
+    )
     await t.click(selectors.btnShareByMe)
-    await isExistingAndVisibile(selectors.divShareByLink, 'div Share by Link')
+    await isExistingAndVisibile(
+      selectors.divShareByLink,
+      'selectors.divShareByLink'
+    )
     await isExistingAndVisibile(
       selectors.toggleShareLink,
-      'Toggle Share by Link'
+      'selectors.toggleShareLink'
     )
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
-      .notOk('Toggle Link is checked')
+      .notOk(`selectors.toggleShareLink.find('input') is checked`)
       .expect(selectors.btnCopyShareByLink.exists)
-      .notOk('Copy Link button still exists')
+      .notOk('selectors.btnCopyShareByLink still exists')
       .pressKey('esc')
       .expect(selectors.btnShareByMe.exists)
-      .notOk('Share by Me still exists')
+      .notOk('selectors.btnShareByMe.exists still exists')
 
-    await isExistingAndVisibile(selectors.btnShare, `Share button`)
+    await isExistingAndVisibile(selectors.btnShare, `selectors.btnShare`)
   }
 
   async shareFirstFilePublicLink() {
     await this.selectElements([0])
 
     await t.click(selectors.btnShareCozySelectionBar)
-    await isExistingAndVisibile(selectors.divShareByLink, 'div Share by Link')
+    await isExistingAndVisibile(
+      selectors.divShareByLink,
+      'selectors.divShareByLink'
+    )
     await isExistingAndVisibile(
       selectors.toggleShareLink,
-      'Toggle Share by Link'
+      'selectors.toggleShareLink'
     )
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
-      .ok('toggle Link is unchecked')
+      .ok(`selectors.toggleShareLink.find('input') is unchecked`)
       .expect(selectors.spanLinkCreating.exist)
-      .notOk('Still creating Link')
-    await isExistingAndVisibile(selectors.btnCopyShareByLink, 'Copy Link')
+      .notOk('selectors.spanLinkCreating still exists')
+    await isExistingAndVisibile(
+      selectors.btnCopyShareByLink,
+      'selectors.btnCopyShareByLink'
+    )
 
     await overwriteCopyCommand()
 
@@ -244,11 +274,11 @@ export default class privateDrivePage extends DrivePage {
 
     await isExistingAndVisibile(
       selectors.alertWrapper,
-      '"successfull" modal alert'
+      'selectors.alertWrapper'
     )
     await isExistingAndVisibile(
       selectors.shareBadgeForRowindex(0),
-      'Share badge'
+      'selectors.shareBadgeForRowindex(0)'
     )
   }
 
@@ -256,25 +286,28 @@ export default class privateDrivePage extends DrivePage {
     await this.selectElements([0])
     await isExistingAndVisibile(
       selectors.shareBadgeForRowindex(0),
-      'Share badge'
+      'selectors.shareBadgeForRowindex(0)'
     )
     //check the bagge after selecting the 1st row, as `selectElements` already check await isExistingAndVisibile(1st row)
 
     await t.click(selectors.btnShareCozySelectionBar)
-    await isExistingAndVisibile(selectors.divShareByLink, 'div Share by Link')
+    await isExistingAndVisibile(
+      selectors.divShareByLink,
+      'selectors.divShareByLink'
+    )
     await isExistingAndVisibile(
       selectors.toggleShareLink,
-      'Toggle Share by Link'
+      'selectors.toggleShareLink'
     )
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
-      .notOk('Toggle Link is checked')
+      .notOk(`selectors.toggleShareLink.find('input') is checked`)
       .expect(selectors.btnCopyShareByLink.exists)
-      .notOk('Copy Link button still exists')
+      .notOk('selectors.btnCopyShareByLink still exists')
       .pressKey('esc')
       .expect(selectors.shareBadgeForRowindex(0).exists)
-      .notOk('Share badge still exists')
+      .notOk('selectors.shareBadgeForRowindex(0) still exists')
   }
 
   //@param { Array } filesIndexArray : Array of files index
@@ -288,7 +321,7 @@ export default class privateDrivePage extends DrivePage {
     await t
       .click(selectors.btnRemoveCozySelectionBar)
       .expect(selectors.modalFooter.visible)
-      .ok('Delete button does not show up')
+      .ok('selectors.modalFooter does not show up')
       .click(selectors.btnModalSecondButton)
     if (!t.fixtureCtx.isVR) {
       const rowCountEnd = await this.getContentRowCount('After')
@@ -321,7 +354,7 @@ export default class privateDrivePage extends DrivePage {
     }
     await this.openActionMenu()
     await t.click(selectors.btnRemoveFolder)
-    await isExistingAndVisibile(selectors.modalFooter, 'Modal delete')
+    await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
 
     if (t.fixtureCtx.isVR)
       //dates show up here, so there is a mask for screenshots
@@ -333,7 +366,7 @@ export default class privateDrivePage extends DrivePage {
     await t.click(selectors.btnModalSecondButton)
     await isExistingAndVisibile(
       selectors.alertWrapper,
-      '"successfull" modal alert'
+      'selectors.alertWrapper'
     )
 
     await this.waitForLoading()
@@ -359,7 +392,7 @@ export default class privateDrivePage extends DrivePage {
     await t.click(selectors.btnRenameCozySelectionBar)
     await isExistingAndVisibile(
       selectors.foldersNamesInputs,
-      'Folder Name input'
+      'selectors.foldersNamesInputs'
     )
     //dates shows up here, so there is a mask for screenshots
     await t.fixtureCtx.vr.takeScreenshotAndUpload({
@@ -375,9 +408,11 @@ export default class privateDrivePage extends DrivePage {
       : await t.click(selectors.contentTable)
     await t
       .expect(selectors.foldersNamesInputs.exists)
-      .notOk('Edition mode still on') //No folder in edition mode -> No input on page
+      .notOk(
+        'selectors.foldersNamesInputs still exists - Edition mode still on'
+      ) //No folder in edition mode -> No input on page
       .expect(selectors.folderOrFileName.withText(`${newName}`).exists)
-      .ok(`No folder/file named ${newName}`)
+      .ok(`selectors.folderOrFileName.withText(${newName}) doesnt exists`)
   }
 
   //@param {String} screenshotPath : path for screenshots taken in this test
@@ -405,18 +440,18 @@ export default class privateDrivePage extends DrivePage {
   async clickOnActionMenuforFile(index) {
     await isExistingAndVisibile(
       selectors.contentRows.nth(index),
-      `element with index ${index}`
+      `selectors.contentRows.nth(${index})`
     )
 
     await isExistingAndVisibile(
       selectors.elementActionMenuByRowIndex(index),
-      `Menu [...] for element with index ${index}`
+      `selectors.elementActionMenuByRowIndex(${index})`
     )
     await t.click(selectors.elementActionMenuByRowIndex(index))
 
     await isExistingAndVisibile(
       selectors.actionMenuInner,
-      'Element [...] Menu inner'
+      'selectors.actionMenuInner'
     )
   }
 
@@ -430,7 +465,10 @@ export default class privateDrivePage extends DrivePage {
   async showMoveModalForElement(elementToMove) {
     await this.clickOnActionMenuforElementName(elementToMove)
     await t.click(selectors.btnMoveToActionMenu)
-    await isExistingAndVisibile(selectors.modalContent, 'Modal Content')
+    await isExistingAndVisibile(
+      selectors.modalContent,
+      'selectors.modalContent'
+    )
     await this.waitForLoading()
   }
 
@@ -439,7 +477,10 @@ export default class privateDrivePage extends DrivePage {
     await this.goToBaseFolder(true)
     await this.goToFolder(destinationFolder, true)
 
-    await isExistingAndVisibile(selectors.btnModalSecondButton, 'Move Button')
+    await isExistingAndVisibile(
+      selectors.btnModalSecondButton,
+      'selectors.btnModalSecondButton'
+    )
 
     await t.click(selectors.btnModalSecondButton)
   }
@@ -447,8 +488,14 @@ export default class privateDrivePage extends DrivePage {
   //@param {String} screenshotPath : path for screenshots taken in this test
   //@param { mask } withmask for screenshot
   async emptyTrash({ screenshotPath: screenshotPath, withMask = false }) {
-    await isExistingAndVisibile(selectors.toolbarTrash, 'toolbar Trash')
-    await isExistingAndVisibile(selectors.btnEmptyTrash, 'Empty trash button')
+    await isExistingAndVisibile(
+      selectors.toolbarTrash,
+      'selectors.toolbarTrash'
+    )
+    await isExistingAndVisibile(
+      selectors.btnEmptyTrash,
+      'selectors.btnEmptyTrash'
+    )
     await t.click(selectors.btnEmptyTrash)
     await t.fixtureCtx.vr.takeScreenshotAndUpload({
       screenshotPath: `${screenshotPath}-emptyTrash`,
@@ -456,7 +503,7 @@ export default class privateDrivePage extends DrivePage {
     })
     await t
       .expect(selectors.modalFooter.visible)
-      .ok('Delete button does not show up')
+      .ok('selectors.modalFooter does not show up')
       .click(selectors.btnModalSecondButton)
   }
 

--- a/testcafe/tests/pages/drive/drive-model-public.js
+++ b/testcafe/tests/pages/drive/drive-model-public.js
@@ -9,23 +9,25 @@ export default class PublicDrivePage extends DrivePage {
     const isFile = type === 'file' ? true : false
     await t //Mobile elements don't exist
       .expect(selectors.btnMoreMenu.exists)
-      .notOk('[...] Menu exists')
+      .notOk('selectors.btnMoreMenu exists')
       .expect(selectors.innerPublicMoreMenu.exists)
-      .notOk('Inner More Menu exists')
-    await isExistingAndVisibile(selectors.logo, 'Logo')
+      .notOk('selectors.innerPublicMoreMenu exists')
+    await isExistingAndVisibile(selectors.logo, 'selectors.logo')
     await isExistingAndVisibile(
       isFile ? selectors.toolbarViewerPublic : selectors.toolbarDrivePublic,
-      'toolbarDrive'
+      isFile ? `selectors.toolbarViewerPublic` : `selectors.toolbarDrivePublic`
     )
     await isExistingAndVisibile(
       isFile
         ? selectors.btnViewerPublicCreateCozy
         : selectors.btnDrivePublicCreateCozy,
-      'Create my Cozy Button'
+      isFile
+        ? `selectors.btnViewerPublicCreateCozy`
+        : `selectors.btnDrivePublicCreateCozy`
     )
     await isExistingAndVisibile(
       selectors.btnPublicDownloadDrive,
-      'Download FolderButton'
+      'selectors.btnPublicDownloadDrive'
     )
   }
 
@@ -34,17 +36,17 @@ export default class PublicDrivePage extends DrivePage {
     const isFile = type === 'file' ? true : false
     await t
       .expect(selectors.btnPublicDownloadDrive.exists)
-      .notOk('Download Button (desktop) exists')
+      .notOk('selectors.btnPublicDownloadDrive exists')
       //On File Sharing, logo still exist on mobile, but is not visible (no problem on folder)
       .expect(isFile ? selectors.logo.visible : selectors.logo.exists)
-      .notOk('Logo exists/visible')
+      .notOk('selectors.logo exists/visible')
       .expect(
         (isFile ? selectors.toolbarViewerPublic : selectors.toolbarDrivePublic)
           .exists
       )
       .notOk('toolbar_file exists')
       .expect(selectors.btnViewerPublicCreateCozy.exists)
-      .notOk('Create Cozy button (desktop) exists')
+      .notOk('selectors.btnViewerPublicCreateCozy exists')
   }
 
   async checkCreateCozy() {
@@ -57,34 +59,34 @@ export default class PublicDrivePage extends DrivePage {
     await goBack()
   }
   async checkDownloadButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
     await isExistingAndVisibile(
       selectors.innerPublicMoreMenu,
-      'Innner More Menu'
+      'selectors.innerPublicMoreMenu'
     )
     await isExistingAndVisibile(
       selectors.btnPublicMobileDownload,
-      'Download Button (mobile)'
+      'selectors.btnPublicMobileDownload'
     )
   }
   async checkCozyCreationButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
     await isExistingAndVisibile(
       selectors.innerPublicMoreMenu,
-      'Innner More Menu'
+      'selectors.innerPublicMoreMenu'
     )
     await isExistingAndVisibile(
       selectors.btnPublicMobileCreateCozy,
-      'Create my Cozy Button (mobile)'
+      'selectors.btnPublicMobileCreateCozy'
     )
   }
 
   async checkNotAvailable() {
     await isExistingAndVisibile(
       selectors.errorAvailable,
-      'Not available message'
+      'selectors.errorAvailable'
     )
   }
 }

--- a/testcafe/tests/pages/drive/drive-model-public.js
+++ b/testcafe/tests/pages/drive/drive-model-public.js
@@ -1,5 +1,5 @@
 import { t } from 'testcafe'
-import { isExistingAndVisibile, getPageUrl, goBack } from '../../helpers/utils'
+import { isExistingAndVisible, getPageUrl, goBack } from '../../helpers/utils'
 import * as selectors from '../selectors'
 import DrivePage from './drive-model'
 
@@ -12,23 +12,16 @@ export default class PublicDrivePage extends DrivePage {
       .notOk('selectors.btnMoreMenu exists')
       .expect(selectors.innerPublicMoreMenu.exists)
       .notOk('selectors.innerPublicMoreMenu exists')
-    await isExistingAndVisibile(selectors.logo, 'selectors.logo')
-    await isExistingAndVisibile(
-      isFile ? selectors.toolbarViewerPublic : selectors.toolbarDrivePublic,
+    await isExistingAndVisible('selectors.logo')
+    await isExistingAndVisible(
       isFile ? `selectors.toolbarViewerPublic` : `selectors.toolbarDrivePublic`
     )
-    await isExistingAndVisibile(
-      isFile
-        ? selectors.btnViewerPublicCreateCozy
-        : selectors.btnDrivePublicCreateCozy,
+    await isExistingAndVisible(
       isFile
         ? `selectors.btnViewerPublicCreateCozy`
         : `selectors.btnDrivePublicCreateCozy`
     )
-    await isExistingAndVisibile(
-      selectors.btnPublicDownloadDrive,
-      'selectors.btnPublicDownloadDrive'
-    )
+    await isExistingAndVisible('selectors.btnPublicDownloadDrive')
   }
 
   // @param {string} type : 'file' or 'folder' : the toolbar is different depending on share type
@@ -59,34 +52,19 @@ export default class PublicDrivePage extends DrivePage {
     await goBack()
   }
   async checkDownloadButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
+    await isExistingAndVisible('selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
-    await isExistingAndVisibile(
-      selectors.innerPublicMoreMenu,
-      'selectors.innerPublicMoreMenu'
-    )
-    await isExistingAndVisibile(
-      selectors.btnPublicMobileDownload,
-      'selectors.btnPublicMobileDownload'
-    )
+    await isExistingAndVisible('selectors.innerPublicMoreMenu')
+    await isExistingAndVisible('selectors.btnPublicMobileDownload')
   }
   async checkCozyCreationButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
+    await isExistingAndVisible('selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
-    await isExistingAndVisibile(
-      selectors.innerPublicMoreMenu,
-      'selectors.innerPublicMoreMenu'
-    )
-    await isExistingAndVisibile(
-      selectors.btnPublicMobileCreateCozy,
-      'selectors.btnPublicMobileCreateCozy'
-    )
+    await isExistingAndVisible('selectors.innerPublicMoreMenu')
+    await isExistingAndVisible('selectors.btnPublicMobileCreateCozy')
   }
 
   async checkNotAvailable() {
-    await isExistingAndVisibile(
-      selectors.errorAvailable,
-      'selectors.errorAvailable'
-    )
+    await isExistingAndVisible('selectors.errorAvailable')
   }
 }

--- a/testcafe/tests/pages/drive/drive-model.js
+++ b/testcafe/tests/pages/drive/drive-model.js
@@ -10,20 +10,24 @@ export default class DrivePage {
   async waitForLoading({ isNotAvailable, isFull } = {}) {
     await t
       .expect(selectors.contentPlaceHolder.exists)
-      .notOk('selectors.contentPlaceHolder still displayed')
+      .notOk(
+        'waitForLoading - Page didnt Load : selectors.contentPlaceHolder still displayed'
+      )
     if (!isNotAvailable) {
       await isExistingAndVisibile(
         selectors.contentTable,
-        'selectors.contentTable'
+        'waitForLoading - selectors.contentTable'
       )
       if (isFull) {
         await isExistingAndVisibile(
           selectors.folderOrFileName,
-          'selectors.folderOrFileName'
+          'waitForLoading - selectors.folderOrFileName'
         )
       }
     }
-    logger.debug('Loading Ok')
+    logger.debug(
+      `drive-model : waitForLoading Ok (isNotAvailable:${isNotAvailable}, isFull:${isFull})`
+    )
   }
 
   //@param {string} when : text for logger.debug

--- a/testcafe/tests/pages/drive/drive-model.js
+++ b/testcafe/tests/pages/drive/drive-model.js
@@ -10,11 +10,17 @@ export default class DrivePage {
   async waitForLoading({ isNotAvailable, isFull } = {}) {
     await t
       .expect(selectors.contentPlaceHolder.exists)
-      .notOk('Content placeholder still displayed')
+      .notOk('selectors.contentPlaceHolder still displayed')
     if (!isNotAvailable) {
-      await isExistingAndVisibile(selectors.contentTable, 'content Table')
+      await isExistingAndVisibile(
+        selectors.contentTable,
+        'selectors.contentTable'
+      )
       if (isFull) {
-        await isExistingAndVisibile(selectors.folderOrFileName, 'folder list')
+        await isExistingAndVisibile(
+          selectors.folderOrFileName,
+          'selectors.folderOrFileName'
+        )
       }
     }
     logger.debug('Loading Ok')
@@ -33,7 +39,7 @@ export default class DrivePage {
 
   //return breadcrumb text
   async getbreadcrumb() {
-    await isExistingAndVisibile(selectors.breadcrumb, 'breadcrumb')
+    await isExistingAndVisibile(selectors.breadcrumb, 'selectors.breadcrumb')
     const childElCount = await selectors.breadcrumb.childElementCount
     let breadcrumbTitle = await selectors.breadcrumb.child(0).innerText
     if (childElCount > 1) {
@@ -55,7 +61,12 @@ export default class DrivePage {
     inModal
       ? (breadcrumb = selectors.modalBreadcrumb)
       : (breadcrumb = selectors.breadcrumb)
-    await isExistingAndVisibile(breadcrumb.child(0), 'breadcrumb (base folder)')
+    await isExistingAndVisibile(
+      breadcrumb.child(0),
+      inModal
+        ? `selectors.modalBreadcrumb.child(0)`
+        : `selectors.breadcrumb.child(0)`
+    )
     await t.click(breadcrumb.child(0))
     await this.waitForLoading()
     logger.info(`Navigation to base folder OK!`)
@@ -90,23 +101,23 @@ export default class DrivePage {
 
     await isExistingAndVisibile(
       selectors.contentRows.nth(filesIndexArray[0]),
-      `element with index ${filesIndexArray[0]}`
+      `selectors.contentRows.nth(${filesIndexArray[0]})`
     )
     await t.hover(selectors.contentRows.nth(filesIndexArray[0])) //Only one 'hover' as all checkbox should be visible once the 1st checkbox is checked
     for (let i = 0; i < filesIndexArray.length; i++) {
       await isExistingAndVisibile(
         selectors.contentRows.nth(filesIndexArray[i]),
-        `element with index ${filesIndexArray[i]}`
+        `selectors.contentRows.nth(${filesIndexArray[i]})`
       )
       await isExistingAndVisibile(
         selectors.checboxFolderByRowIndex(filesIndexArray[i]),
-        `checkbox for element with index ${filesIndexArray[i]}`
+        `selectors.checboxFolderByRowIndex(${filesIndexArray[i]})`
       )
       await t.click(selectors.checboxFolderByRowIndex(filesIndexArray[i]))
     }
     await isExistingAndVisibile(
       selectors.cozySelectionbar,
-      'Cozy Selection Bar'
+      'selectors.cozySelectionbar'
     )
   }
 

--- a/testcafe/tests/pages/drive/drive-model.js
+++ b/testcafe/tests/pages/drive/drive-model.js
@@ -108,10 +108,10 @@ export default class DrivePage {
         selectors.contentRows.nth(filesIndexArray[i])
       )
       await isExistingAndVisible(
-        `selectors.checboxFolderByRowIndex(${filesIndexArray[i]})`,
-        selectors.checboxFolderByRowIndex(filesIndexArray[i])
+        `selectors.checkboxFolderByRowIndex(${filesIndexArray[i]})`,
+        selectors.checkboxFolderByRowIndex(filesIndexArray[i])
       )
-      await t.click(selectors.checboxFolderByRowIndex(filesIndexArray[i]))
+      await t.click(selectors.checkboxFolderByRowIndex(filesIndexArray[i]))
     }
     await isExistingAndVisible('selectors.cozySelectionbar')
   }

--- a/testcafe/tests/pages/drive/drive-model.js
+++ b/testcafe/tests/pages/drive/drive-model.js
@@ -1,6 +1,6 @@
 import { t } from 'testcafe'
 import logger from '../../helpers/logger'
-import { isExistingAndVisibile } from '../../helpers/utils'
+import { isExistingAndVisible } from '../../helpers/utils'
 import * as selectors from '../selectors'
 
 export default class DrivePage {
@@ -14,15 +14,9 @@ export default class DrivePage {
         'waitForLoading - Page didnt Load : selectors.contentPlaceHolder still displayed'
       )
     if (!isNotAvailable) {
-      await isExistingAndVisibile(
-        selectors.contentTable,
-        'waitForLoading - selectors.contentTable'
-      )
+      await isExistingAndVisible('selectors.contentTable')
       if (isFull) {
-        await isExistingAndVisibile(
-          selectors.folderOrFileName,
-          'waitForLoading - selectors.folderOrFileName'
-        )
+        await isExistingAndVisible('selectors.folderOrFileName')
       }
     }
     logger.debug(
@@ -43,7 +37,7 @@ export default class DrivePage {
 
   //return breadcrumb text
   async getbreadcrumb() {
-    await isExistingAndVisibile(selectors.breadcrumb, 'selectors.breadcrumb')
+    await isExistingAndVisible('selectors.breadcrumb')
     const childElCount = await selectors.breadcrumb.childElementCount
     let breadcrumbTitle = await selectors.breadcrumb.child(0).innerText
     if (childElCount > 1) {
@@ -65,11 +59,11 @@ export default class DrivePage {
     inModal
       ? (breadcrumb = selectors.modalBreadcrumb)
       : (breadcrumb = selectors.breadcrumb)
-    await isExistingAndVisibile(
-      breadcrumb.child(0),
+    await isExistingAndVisible(
       inModal
         ? `selectors.modalBreadcrumb.child(0)`
-        : `selectors.breadcrumb.child(0)`
+        : `selectors.breadcrumb.child(0)`,
+      breadcrumb.child(0)
     )
     await t.click(breadcrumb.child(0))
     await this.waitForLoading()
@@ -103,26 +97,23 @@ export default class DrivePage {
   async selectElements(filesIndexArray) {
     logger.debug(`Selecting ${filesIndexArray.length} elements`)
 
-    await isExistingAndVisibile(
-      selectors.contentRows.nth(filesIndexArray[0]),
-      `selectors.contentRows.nth(${filesIndexArray[0]})`
+    await isExistingAndVisible(
+      `selectors.contentRows.nth(${filesIndexArray[0]})`,
+      selectors.contentRows.nth(filesIndexArray[0])
     )
     await t.hover(selectors.contentRows.nth(filesIndexArray[0])) //Only one 'hover' as all checkbox should be visible once the 1st checkbox is checked
     for (let i = 0; i < filesIndexArray.length; i++) {
-      await isExistingAndVisibile(
-        selectors.contentRows.nth(filesIndexArray[i]),
-        `selectors.contentRows.nth(${filesIndexArray[i]})`
+      await isExistingAndVisible(
+        `selectors.contentRows.nth(${filesIndexArray[i]})`,
+        selectors.contentRows.nth(filesIndexArray[i])
       )
-      await isExistingAndVisibile(
-        selectors.checboxFolderByRowIndex(filesIndexArray[i]),
-        `selectors.checboxFolderByRowIndex(${filesIndexArray[i]})`
+      await isExistingAndVisible(
+        `selectors.checboxFolderByRowIndex(${filesIndexArray[i]})`,
+        selectors.checboxFolderByRowIndex(filesIndexArray[i])
       )
       await t.click(selectors.checboxFolderByRowIndex(filesIndexArray[i]))
     }
-    await isExistingAndVisibile(
-      selectors.cozySelectionbar,
-      'selectors.cozySelectionbar'
-    )
+    await isExistingAndVisible('selectors.cozySelectionbar')
   }
 
   //@param {string} fileName : file name

--- a/testcafe/tests/pages/photos-album/album-model.js
+++ b/testcafe/tests/pages/photos-album/album-model.js
@@ -15,11 +15,12 @@ export default class Page extends PhotoPage {
   async waitForLoading() {
     await t
       .expect(selectors.loading.exists)
-      .notOk('Page still loading : selectors.loading exists')
+      .notOk('waitForLoading - Page didnt Load : selectors.loading exists')
     await isExistingAndVisibile(
       selectors.albumContentWrapper,
-      'selectors.albumContentWrapper'
+      'waitForLoading - selectors.albumContentWrapper'
     )
+    logger.debug(`album-model : waitForLoading Ok`)
   }
 
   //@param {string} when : text for logger.debug

--- a/testcafe/tests/pages/photos-album/album-model.js
+++ b/testcafe/tests/pages/photos-album/album-model.js
@@ -13,10 +13,12 @@ import PhotoPage from '../photos/photos-model'
 
 export default class Page extends PhotoPage {
   async waitForLoading() {
-    await t.expect(selectors.loading.exists).notOk('Page still loading')
+    await t
+      .expect(selectors.loading.exists)
+      .notOk('Page still loading : selectors.loading exists')
     await isExistingAndVisibile(
       selectors.albumContentWrapper,
-      'Content Wrapper'
+      'selectors.albumContentWrapper'
     )
   }
 
@@ -25,9 +27,12 @@ export default class Page extends PhotoPage {
     await checkAllImagesExists()
     await isExistingAndVisibile(
       selectors.photoSectionAddToAlbum,
-      'Photo section (add to album)'
+      'selectors.photoSectionAddToAlbum'
     )
-    await isExistingAndVisibile(selectors.allPhotosAddToAlbum, 'Photo item(s)')
+    await isExistingAndVisibile(
+      selectors.allPhotosAddToAlbum,
+      'selectors.allPhotosAddToAlbum'
+    )
     const allPhotosCount = await selectors.allPhotosAddToAlbum.count
 
     logger.debug(
@@ -43,7 +48,7 @@ export default class Page extends PhotoPage {
     for (let i = indexStart; i < indexStart + numOfFiles; i++) {
       await isExistingAndVisibile(
         selectors.photoThumb(i),
-        `${i + 1}th Photo thumb`
+        `selectors.photoThumb(${i})`
       )
       await t.click(selectors.photoToAddCheckbox.nth(i))
     }
@@ -62,7 +67,10 @@ export default class Page extends PhotoPage {
       .eql(albumName)
 
     if (photoNumber == 0) {
-      await isExistingAndVisibile(selectors.folderEmpty, 'Folder Empty')
+      await isExistingAndVisibile(
+        selectors.folderEmpty,
+        'selectors.folderEmpty'
+      )
     } else {
       const allPhotosAlbumCount = await this.getPhotosCount('On Album page')
       await t.expect(allPhotosAlbumCount).eql(photoNumber) //all expected photos are displayed
@@ -73,18 +81,24 @@ export default class Page extends PhotoPage {
   // @param {String} NewAlbumName : New Name of the album (after renamming)
   // @param {string} exit : enter or click : Choose the exit method
   async renameAlbum(OldAlbumName, NewAlbumName, exitWithEnter) {
-    await isExistingAndVisibile(selectors.albumTitle, 'Album Name')
+    await isExistingAndVisibile(selectors.albumTitle, 'selectors.albumTitle')
     await t
       .expect(selectors.albumTitle.find('input').exists)
       .notOk('Title is already in input mode')
-    await isExistingAndVisibile(selectors.toolbarAlbum, 'Toolabr Album')
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await isExistingAndVisibile(
+      selectors.toolbarAlbum,
+      'selectors.toolbarAlbum'
+    )
+    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu)
-    await isExistingAndVisibile(selectors.moreMenuRenameAlbum, 'Rename Button')
+    await isExistingAndVisibile(
+      selectors.moreMenuRenameAlbum,
+      'selectors.moreMenuRenameAlbum'
+    )
     await t.click(selectors.moreMenuRenameAlbum)
     await isExistingAndVisibile(
       selectors.albumTitle.find('input'),
-      'Input Album Name'
+      `selectors.albumTitle.find('input')`
     )
     await t
       .expect(selectors.albumTitle.find('input').value)
@@ -102,12 +116,15 @@ export default class Page extends PhotoPage {
   // @param { number } photoNumber : Number of photos to add to the new album (
   // @param {String} AlbumName : Name of the album
   async addPhotosToAlbum(albumName, count, photoNumber) {
-    await isExistingAndVisibile(selectors.toolbarAlbum, 'Toolabr Album')
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await isExistingAndVisibile(
+      selectors.toolbarAlbum,
+      'selectors.toolbarAlbum'
+    )
+    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu)
     await isExistingAndVisibile(
       selectors.moreMenuAddPhotosToAlbum,
-      'Rename Button'
+      'selectors.moreMenuAddPhotosToAlbum'
     )
     await t.click(selectors.moreMenuAddPhotosToAlbum)
 
@@ -115,7 +132,10 @@ export default class Page extends PhotoPage {
     await this.selectPhotostoAdd(count, photoNumber)
     await t.click(selectors.btnValidateAlbum)
 
-    await isExistingAndVisibile(selectors.alertWrapper, 'modal Alert')
+    await isExistingAndVisibile(
+      selectors.alertWrapper,
+      'selectors.alertWrapper'
+    )
     const modalTxt = (await selectors.alertWrapper.innerText).split(' ')
     await t.expect(modalTxt[modalTxt.length - 2]).eql(`${photoNumber}`)
 
@@ -126,7 +146,10 @@ export default class Page extends PhotoPage {
   // @param {String} count : Number of photos already in the album (needed to count photos, as photos already in the album shows up twice)
   async checkAddToAlbumPage(albumName) {
     await t.expect(getPageUrl()).contains('edit')
-    await isExistingAndVisibile(selectors.pickerAlbumName, 'Album Name')
+    await isExistingAndVisibile(
+      selectors.pickerAlbumName,
+      'selectors.pickerAlbumName'
+    )
     await t.expect(selectors.pickerAlbumName.innerText).eql(albumName)
     const photosToAddCount = await this.getPhotosToAddCount(
       'On Add to Album page'
@@ -134,14 +157,14 @@ export default class Page extends PhotoPage {
     await t.expect(photosToAddCount).eql(t.ctx.totalFilesCount) //all photos are displayed
     await isExistingAndVisibile(
       selectors.btnValidateAlbum,
-      'Add to Album Button'
+      'selectors.btnValidateAlbum'
     )
   }
 
   async backToAlbumsList() {
     await isExistingAndVisibile(
       selectors.btnBackToAlbum,
-      'Back to albums List btn'
+      'selectors.btnBackToAlbum'
     )
     await t.click(selectors.btnBackToAlbum)
     await this.waitForLoading()
@@ -154,16 +177,22 @@ export default class Page extends PhotoPage {
       photoAlbumStart = await this.getPhotosCount('In album, before')
     }
     await this.selectPhotos(photoNumber)
-    await isExistingAndVisibile(selectors.cozySelectionbar, 'Selection bar')
+    await isExistingAndVisibile(
+      selectors.cozySelectionbar,
+      'selectors.cozySelectionbar'
+    )
 
     logger.debug('Removing ' + photoNumber + ' picture(s)')
     await isExistingAndVisibile(
       selectors.btnRemoveFromAlbumCozySelectionBar,
-      'Remove from album Button'
+      'selectors.btnRemoveFromAlbumCozySelectionBars'
     )
     await t.click(selectors.btnRemoveFromAlbumCozySelectionBar)
 
-    await isExistingAndVisibile(selectors.alertWrapper, 'modal Alert')
+    await isExistingAndVisibile(
+      selectors.alertWrapper,
+      'selectors.alertWrapper'
+    )
     await checkToastAppearsAndDisappears(
       'The photo has been removed from album'
     )
@@ -174,28 +203,43 @@ export default class Page extends PhotoPage {
   }
 
   async deleteAlbum() {
-    await isExistingAndVisibile(selectors.toolbarAlbum, 'Toolabr Album')
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await isExistingAndVisibile(
+      selectors.toolbarAlbum,
+      'selectors.toolbarAlbum'
+    )
+    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu)
-    await isExistingAndVisibile(selectors.moreMenuDeleteAlbum, 'Delete Button')
+    await isExistingAndVisibile(
+      selectors.moreMenuDeleteAlbum,
+      'selectors.moreMenuDeleteAlbum'
+    )
     await t.click(selectors.moreMenuDeleteAlbum)
 
-    await isExistingAndVisibile(selectors.modalFooter, 'Modal delete')
+    await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
     await isExistingAndVisibile(
       selectors.btnModalSecondButton,
-      'Modal delete button Delete'
+      'selectors.btnModalSecondButton'
     )
     await t.click(selectors.btnModalSecondButton)
   }
 
   async shareAlbumPublicLink() {
-    await isExistingAndVisibile(selectors.toolbarAlbum, 'toolbarAlbum')
-    await isExistingAndVisibile(selectors.btnShareAlbum, `Share button`)
+    await isExistingAndVisibile(
+      selectors.toolbarAlbum,
+      'selectors.toolbarAlbum'
+    )
+    await isExistingAndVisibile(
+      selectors.btnShareAlbum,
+      `selectors.btnShareAlbum`
+    )
     await t.click(selectors.btnShareAlbum)
-    await isExistingAndVisibile(selectors.divShareByLink, 'div Share by Link')
+    await isExistingAndVisibile(
+      selectors.divShareByLink,
+      'selectors.divShareByLink'
+    )
     await isExistingAndVisibile(
       selectors.toggleShareLink,
-      'Toggle Share by Link'
+      'selectors.toggleShareLink'
     )
     await t
       .click(selectors.toggleShareLink)
@@ -203,7 +247,10 @@ export default class Page extends PhotoPage {
       .ok('toggle Link is unchecked')
       .expect(selectors.spanLinkCreating.exist)
       .notOk('Still creating Link')
-    await isExistingAndVisibile(selectors.btnCopyShareByLink, 'Copy Link')
+    await isExistingAndVisibile(
+      selectors.btnCopyShareByLink,
+      'selectors.btnCopyShareByLink'
+    )
 
     await overwriteCopyCommand()
 
@@ -214,27 +261,39 @@ export default class Page extends PhotoPage {
 
     await isExistingAndVisibile(
       selectors.alertWrapper,
-      '"successfull" modal alert'
+      'selectors.alertWrapper'
     )
   }
 
   async unshareAlbumPublicLink() {
-    await isExistingAndVisibile(selectors.toolbarAlbum, 'toolbarAlbum')
-    await isExistingAndVisibile(selectors.btnShareAlbum, `Share button`)
+    await isExistingAndVisibile(
+      selectors.toolbarAlbum,
+      'selectors.toolbarAlbum'
+    )
+    await isExistingAndVisibile(
+      selectors.btnShareAlbum,
+      `selectors.btnShareAlbum`
+    )
     await t.click(selectors.btnShareAlbum)
-    await isExistingAndVisibile(selectors.divShareByLink, 'div Share by Link')
+    await isExistingAndVisibile(
+      selectors.divShareByLink,
+      'selectors.divShareByLink'
+    )
     await isExistingAndVisibile(
       selectors.toggleShareLink,
-      'Toggle Share by Link'
+      'selectors.toggleShareLink'
     )
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
-      .notOk('Toggle Link is checked')
+      .notOk(`selectors.toggleShareLink.find('input') is checked`)
       .expect(selectors.btnCopyShareByLink.exists)
-      .notOk('Copy Link button still exists')
+      .notOk('selectors.btnCopyShareByLink still exists')
       .pressKey('esc')
 
-    await isExistingAndVisibile(selectors.btnShareAlbum, `Share button`)
+    await isExistingAndVisibile(
+      selectors.btnShareAlbum,
+      `selectors.btnShareAlbum`
+    )
   }
 }

--- a/testcafe/tests/pages/photos-album/album-model.js
+++ b/testcafe/tests/pages/photos-album/album-model.js
@@ -2,7 +2,7 @@ import { t } from 'testcafe'
 import logger from '../../helpers/logger'
 import {
   getPageUrl,
-  isExistingAndVisibile,
+  isExistingAndVisible,
   checkAllImagesExists,
   overwriteCopyCommand,
   getLastExecutedCommand
@@ -15,25 +15,16 @@ export default class Page extends PhotoPage {
   async waitForLoading() {
     await t
       .expect(selectors.loading.exists)
-      .notOk('waitForLoading - Page didnt Load : selectors.loading exists')
-    await isExistingAndVisibile(
-      selectors.albumContentWrapper,
-      'waitForLoading - selectors.albumContentWrapper'
-    )
+      .notOk('Page didnt Load : selectors.loading exists')
+    await isExistingAndVisible('selectors.albumContentWrapper')
     logger.debug(`album-model : waitForLoading Ok`)
   }
 
   //@param {string} when : text for logger.debug
   async getPhotosToAddCount(when) {
     await checkAllImagesExists()
-    await isExistingAndVisibile(
-      selectors.photoSectionAddToAlbum,
-      'selectors.photoSectionAddToAlbum'
-    )
-    await isExistingAndVisibile(
-      selectors.allPhotosAddToAlbum,
-      'selectors.allPhotosAddToAlbum'
-    )
+    await isExistingAndVisible('selectors.photoSectionAddToAlbum')
+    await isExistingAndVisible('selectors.allPhotosAddToAlbum')
     const allPhotosCount = await selectors.allPhotosAddToAlbum.count
 
     logger.debug(
@@ -47,9 +38,9 @@ export default class Page extends PhotoPage {
   async selectPhotostoAdd(indexStart, numOfFiles) {
     logger.debug(`Selecting ${numOfFiles} picture(s) from index ${indexStart}`)
     for (let i = indexStart; i < indexStart + numOfFiles; i++) {
-      await isExistingAndVisibile(
-        selectors.photoThumb(i),
-        `selectors.photoThumb(${i})`
+      await isExistingAndVisible(
+        `selectors.photoThumb(${i})`,
+        selectors.photoThumb(i)
       )
       await t.click(selectors.photoToAddCheckbox.nth(i))
     }
@@ -68,10 +59,7 @@ export default class Page extends PhotoPage {
       .eql(albumName)
 
     if (photoNumber == 0) {
-      await isExistingAndVisibile(
-        selectors.folderEmpty,
-        'selectors.folderEmpty'
-      )
+      await isExistingAndVisible('selectors.folderEmpty')
     } else {
       const allPhotosAlbumCount = await this.getPhotosCount('On Album page')
       await t.expect(allPhotosAlbumCount).eql(photoNumber) //all expected photos are displayed
@@ -82,24 +70,18 @@ export default class Page extends PhotoPage {
   // @param {String} NewAlbumName : New Name of the album (after renamming)
   // @param {string} exit : enter or click : Choose the exit method
   async renameAlbum(OldAlbumName, NewAlbumName, exitWithEnter) {
-    await isExistingAndVisibile(selectors.albumTitle, 'selectors.albumTitle')
+    await isExistingAndVisible('selectors.albumTitle')
     await t
       .expect(selectors.albumTitle.find('input').exists)
       .notOk('Title is already in input mode')
-    await isExistingAndVisibile(
-      selectors.toolbarAlbum,
-      'selectors.toolbarAlbum'
-    )
-    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
+    await isExistingAndVisible('selectors.toolbarAlbum')
+    await isExistingAndVisible('selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu)
-    await isExistingAndVisibile(
-      selectors.moreMenuRenameAlbum,
-      'selectors.moreMenuRenameAlbum'
-    )
+    await isExistingAndVisible('selectors.moreMenuRenameAlbum')
     await t.click(selectors.moreMenuRenameAlbum)
-    await isExistingAndVisibile(
-      selectors.albumTitle.find('input'),
-      `selectors.albumTitle.find('input')`
+    await isExistingAndVisible(
+      `selectors.albumTitle.find('input')`,
+      selectors.albumTitle.find('input')
     )
     await t
       .expect(selectors.albumTitle.find('input').value)
@@ -117,26 +99,17 @@ export default class Page extends PhotoPage {
   // @param { number } photoNumber : Number of photos to add to the new album (
   // @param {String} AlbumName : Name of the album
   async addPhotosToAlbum(albumName, count, photoNumber) {
-    await isExistingAndVisibile(
-      selectors.toolbarAlbum,
-      'selectors.toolbarAlbum'
-    )
-    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
+    await isExistingAndVisible('selectors.toolbarAlbum')
+    await isExistingAndVisible('selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu)
-    await isExistingAndVisibile(
-      selectors.moreMenuAddPhotosToAlbum,
-      'selectors.moreMenuAddPhotosToAlbum'
-    )
+    await isExistingAndVisible('selectors.moreMenuAddPhotosToAlbum')
     await t.click(selectors.moreMenuAddPhotosToAlbum)
 
     await this.checkAddToAlbumPage(albumName)
     await this.selectPhotostoAdd(count, photoNumber)
     await t.click(selectors.btnValidateAlbum)
 
-    await isExistingAndVisibile(
-      selectors.alertWrapper,
-      'selectors.alertWrapper'
-    )
+    await isExistingAndVisible('selectors.alertWrapper')
     const modalTxt = (await selectors.alertWrapper.innerText).split(' ')
     await t.expect(modalTxt[modalTxt.length - 2]).eql(`${photoNumber}`)
 
@@ -147,26 +120,17 @@ export default class Page extends PhotoPage {
   // @param {String} count : Number of photos already in the album (needed to count photos, as photos already in the album shows up twice)
   async checkAddToAlbumPage(albumName) {
     await t.expect(getPageUrl()).contains('edit')
-    await isExistingAndVisibile(
-      selectors.pickerAlbumName,
-      'selectors.pickerAlbumName'
-    )
+    await isExistingAndVisible('selectors.pickerAlbumName')
     await t.expect(selectors.pickerAlbumName.innerText).eql(albumName)
     const photosToAddCount = await this.getPhotosToAddCount(
       'On Add to Album page'
     )
     await t.expect(photosToAddCount).eql(t.ctx.totalFilesCount) //all photos are displayed
-    await isExistingAndVisibile(
-      selectors.btnValidateAlbum,
-      'selectors.btnValidateAlbum'
-    )
+    await isExistingAndVisible('selectors.btnValidateAlbum')
   }
 
   async backToAlbumsList() {
-    await isExistingAndVisibile(
-      selectors.btnBackToAlbum,
-      'selectors.btnBackToAlbum'
-    )
+    await isExistingAndVisible('selectors.btnBackToAlbum')
     await t.click(selectors.btnBackToAlbum)
     await this.waitForLoading()
   }
@@ -178,22 +142,13 @@ export default class Page extends PhotoPage {
       photoAlbumStart = await this.getPhotosCount('In album, before')
     }
     await this.selectPhotos(photoNumber)
-    await isExistingAndVisibile(
-      selectors.cozySelectionbar,
-      'selectors.cozySelectionbar'
-    )
+    await isExistingAndVisible('selectors.cozySelectionbar')
 
     logger.debug('Removing ' + photoNumber + ' picture(s)')
-    await isExistingAndVisibile(
-      selectors.btnRemoveFromAlbumCozySelectionBar,
-      'selectors.btnRemoveFromAlbumCozySelectionBars'
-    )
+    await isExistingAndVisible('selectors.btnRemoveFromAlbumCozySelectionBar')
     await t.click(selectors.btnRemoveFromAlbumCozySelectionBar)
 
-    await isExistingAndVisibile(
-      selectors.alertWrapper,
-      'selectors.alertWrapper'
-    )
+    await isExistingAndVisible('selectors.alertWrapper')
     await checkToastAppearsAndDisappears(
       'The photo has been removed from album'
     )
@@ -204,54 +159,30 @@ export default class Page extends PhotoPage {
   }
 
   async deleteAlbum() {
-    await isExistingAndVisibile(
-      selectors.toolbarAlbum,
-      'selectors.toolbarAlbum'
-    )
-    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
+    await isExistingAndVisible('selectors.toolbarAlbum')
+    await isExistingAndVisible('selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu)
-    await isExistingAndVisibile(
-      selectors.moreMenuDeleteAlbum,
-      'selectors.moreMenuDeleteAlbum'
-    )
+    await isExistingAndVisible('selectors.moreMenuDeleteAlbum')
     await t.click(selectors.moreMenuDeleteAlbum)
 
-    await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
-    await isExistingAndVisibile(
-      selectors.btnModalSecondButton,
-      'selectors.btnModalSecondButton'
-    )
+    await isExistingAndVisible('selectors.modalFooter')
+    await isExistingAndVisible('selectors.btnModalSecondButton')
     await t.click(selectors.btnModalSecondButton)
   }
 
   async shareAlbumPublicLink() {
-    await isExistingAndVisibile(
-      selectors.toolbarAlbum,
-      'selectors.toolbarAlbum'
-    )
-    await isExistingAndVisibile(
-      selectors.btnShareAlbum,
-      `selectors.btnShareAlbum`
-    )
+    await isExistingAndVisible('selectors.toolbarAlbum')
+    await isExistingAndVisible(`selectors.btnShareAlbum`)
     await t.click(selectors.btnShareAlbum)
-    await isExistingAndVisibile(
-      selectors.divShareByLink,
-      'selectors.divShareByLink'
-    )
-    await isExistingAndVisibile(
-      selectors.toggleShareLink,
-      'selectors.toggleShareLink'
-    )
+    await isExistingAndVisible('selectors.divShareByLink')
+    await isExistingAndVisible('selectors.toggleShareLink')
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
       .ok('toggle Link is unchecked')
       .expect(selectors.spanLinkCreating.exist)
       .notOk('Still creating Link')
-    await isExistingAndVisibile(
-      selectors.btnCopyShareByLink,
-      'selectors.btnCopyShareByLink'
-    )
+    await isExistingAndVisible('selectors.btnCopyShareByLink')
 
     await overwriteCopyCommand()
 
@@ -260,30 +191,15 @@ export default class Page extends PhotoPage {
       .expect(getLastExecutedCommand())
       .eql('copy') //check link copy actually happens
 
-    await isExistingAndVisibile(
-      selectors.alertWrapper,
-      'selectors.alertWrapper'
-    )
+    await isExistingAndVisible('selectors.alertWrapper')
   }
 
   async unshareAlbumPublicLink() {
-    await isExistingAndVisibile(
-      selectors.toolbarAlbum,
-      'selectors.toolbarAlbum'
-    )
-    await isExistingAndVisibile(
-      selectors.btnShareAlbum,
-      `selectors.btnShareAlbum`
-    )
+    await isExistingAndVisible('selectors.toolbarAlbum')
+    await isExistingAndVisible(`selectors.btnShareAlbum`)
     await t.click(selectors.btnShareAlbum)
-    await isExistingAndVisibile(
-      selectors.divShareByLink,
-      'selectors.divShareByLink'
-    )
-    await isExistingAndVisibile(
-      selectors.toggleShareLink,
-      'selectors.toggleShareLink'
-    )
+    await isExistingAndVisible('selectors.divShareByLink')
+    await isExistingAndVisible('selectors.toggleShareLink')
     await t
       .click(selectors.toggleShareLink)
       .expect(selectors.toggleShareLink.find('input').checked)
@@ -292,9 +208,6 @@ export default class Page extends PhotoPage {
       .notOk('selectors.btnCopyShareByLink still exists')
       .pressKey('esc')
 
-    await isExistingAndVisibile(
-      selectors.btnShareAlbum,
-      `selectors.btnShareAlbum`
-    )
+    await isExistingAndVisible(`selectors.btnShareAlbum`)
   }
 }

--- a/testcafe/tests/pages/photos-albums/albums-model.js
+++ b/testcafe/tests/pages/photos-albums/albums-model.js
@@ -3,6 +3,7 @@ import { getPageUrl, isExistingAndVisibile } from '../../helpers/utils'
 import * as selectors from '../selectors'
 import AlbumPage from '../photos-album/album-model'
 import PhotoPage from '../photos/photos-model'
+import logger from '../../helpers/logger'
 
 const albumPage = new AlbumPage()
 
@@ -10,11 +11,14 @@ export default class AlbumsPage extends PhotoPage {
   async waitForLoading() {
     await t
       .expect(selectors.loading.exists)
-      .notOk('selectors.loading still exists')
+      .notOk(
+        'waitForLoading - Page didnt Load : selectors.loading still exists'
+      )
     await isExistingAndVisibile(
       selectors.albumContentWrapper,
-      'selectors.albumContentWrapper'
+      'waitForLoading - selectors.albumContentWrapper'
     )
+    logger.debug(`albums-model : waitForLoading Ok`)
   }
 
   // check that the albums view is empty

--- a/testcafe/tests/pages/photos-albums/albums-model.js
+++ b/testcafe/tests/pages/photos-albums/albums-model.js
@@ -8,20 +8,22 @@ const albumPage = new AlbumPage()
 
 export default class AlbumsPage extends PhotoPage {
   async waitForLoading() {
-    await t.expect(selectors.loading.exists).notOk('Page still loading')
+    await t
+      .expect(selectors.loading.exists)
+      .notOk('selectors.loading still exists')
     await isExistingAndVisibile(
       selectors.albumContentWrapper,
-      'Content Wrapper'
+      'selectors.albumContentWrapper'
     )
   }
 
   // check that the albums view is empty
   async checkEmptyAlbum() {
     await this.waitForLoading()
-    await isExistingAndVisibile(selectors.folderEmpty, 'Empty Album')
+    await isExistingAndVisibile(selectors.folderEmpty, 'selectors.folderEmpty')
     await isExistingAndVisibile(
       selectors.albumEmptyText,
-      "Text: You don't have any album yet"
+      'selectors.albumEmptyText'
     )
   }
 
@@ -37,18 +39,21 @@ export default class AlbumsPage extends PhotoPage {
     await this.waitForLoading()
     await isExistingAndVisibile(
       selectors.toolbarAlbumsList,
-      'toolbar (album list)'
+      'selectors.toolbarAlbumsList'
     )
-    await isExistingAndVisibile(selectors.btnNewAlbum, 'New album button')
+    await isExistingAndVisibile(selectors.btnNewAlbum, 'selectors.btnNewAlbum')
     await t.click(selectors.btnNewAlbum)
     //Check new album page :
     await t.expect(getPageUrl()).contains('albums/new')
-    await isExistingAndVisibile(selectors.inputAlbumName, 'Input album Name')
+    await isExistingAndVisibile(
+      selectors.inputAlbumName,
+      'selectors.inputAlbumName'
+    )
     await t
       .expect(selectors.inputAlbumName.value)
       .eql('Untitled album')
       .expect(selectors.inputAlbumName.focused)
-      .ok('Input album Name is not focus')
+      .ok('selectors.inputAlbumName.value is not focus')
 
     const allPhotosAlbumCount = await albumPage.getPhotosToAddCount(
       'On create Album page'
@@ -56,7 +61,7 @@ export default class AlbumsPage extends PhotoPage {
     await t.expect(allPhotosAlbumCount).eql(t.ctx.totalFilesCount) //all photos are displayed
     await isExistingAndVisibile(
       selectors.btnValidateAlbum,
-      'Create Album Button'
+      'selectors.btnValidateAlbum'
     )
 
     await t.typeText(selectors.inputAlbumName, albumName)
@@ -74,14 +79,20 @@ export default class AlbumsPage extends PhotoPage {
 
   // @param {String} AlbumName : Name of the album
   async goToAlbum(albumName) {
-    await isExistingAndVisibile(selectors.album(albumName), albumName)
+    await isExistingAndVisibile(
+      selectors.album(albumName),
+      `selectors.album(${albumName})`
+    )
     await t.click(selectors.album(albumName))
   }
 
   // @param {String} AlbumName : Name of the album
   // @param { number } photoNumber : Number of photos expected in the album (
   async isAlbumExistsAndVisible(albumName, photoNumber) {
-    await isExistingAndVisibile(selectors.album(albumName), albumName)
+    await isExistingAndVisibile(
+      selectors.album(albumName),
+      `selectors.album(${albumName})`
+    )
     await t
       .expect(selectors.album(albumName).innerText)
       .contains(`${photoNumber} photo`)

--- a/testcafe/tests/pages/photos-albums/albums-model.js
+++ b/testcafe/tests/pages/photos-albums/albums-model.js
@@ -1,5 +1,5 @@
 import { t } from 'testcafe'
-import { getPageUrl, isExistingAndVisibile } from '../../helpers/utils'
+import { getPageUrl, isExistingAndVisible } from '../../helpers/utils'
 import * as selectors from '../selectors'
 import AlbumPage from '../photos-album/album-model'
 import PhotoPage from '../photos/photos-model'
@@ -11,24 +11,16 @@ export default class AlbumsPage extends PhotoPage {
   async waitForLoading() {
     await t
       .expect(selectors.loading.exists)
-      .notOk(
-        'waitForLoading - Page didnt Load : selectors.loading still exists'
-      )
-    await isExistingAndVisibile(
-      selectors.albumContentWrapper,
-      'waitForLoading - selectors.albumContentWrapper'
-    )
+      .notOk('Page didnt Load : selectors.loading still exists')
+    await isExistingAndVisible('selectors.albumContentWrapper')
     logger.debug(`albums-model : waitForLoading Ok`)
   }
 
   // check that the albums view is empty
   async checkEmptyAlbum() {
     await this.waitForLoading()
-    await isExistingAndVisibile(selectors.folderEmpty, 'selectors.folderEmpty')
-    await isExistingAndVisibile(
-      selectors.albumEmptyText,
-      'selectors.albumEmptyText'
-    )
+    await isExistingAndVisible('selectors.folderEmpty')
+    await isExistingAndVisible('selectors.albumEmptyText')
   }
 
   // @param {String} albumName : Name for the new album
@@ -41,18 +33,12 @@ export default class AlbumsPage extends PhotoPage {
     withMask = false
   }) {
     await this.waitForLoading()
-    await isExistingAndVisibile(
-      selectors.toolbarAlbumsList,
-      'selectors.toolbarAlbumsList'
-    )
-    await isExistingAndVisibile(selectors.btnNewAlbum, 'selectors.btnNewAlbum')
+    await isExistingAndVisible('selectors.toolbarAlbumsList')
+    await isExistingAndVisible('selectors.btnNewAlbum')
     await t.click(selectors.btnNewAlbum)
     //Check new album page :
     await t.expect(getPageUrl()).contains('albums/new')
-    await isExistingAndVisibile(
-      selectors.inputAlbumName,
-      'selectors.inputAlbumName'
-    )
+    await isExistingAndVisible('selectors.inputAlbumName')
     await t
       .expect(selectors.inputAlbumName.value)
       .eql('Untitled album')
@@ -63,10 +49,7 @@ export default class AlbumsPage extends PhotoPage {
       'On create Album page'
     )
     await t.expect(allPhotosAlbumCount).eql(t.ctx.totalFilesCount) //all photos are displayed
-    await isExistingAndVisibile(
-      selectors.btnValidateAlbum,
-      'selectors.btnValidateAlbum'
-    )
+    await isExistingAndVisible('selectors.btnValidateAlbum')
 
     await t.typeText(selectors.inputAlbumName, albumName)
     await albumPage.selectPhotostoAdd(0, photoNumber)
@@ -83,9 +66,9 @@ export default class AlbumsPage extends PhotoPage {
 
   // @param {String} AlbumName : Name of the album
   async goToAlbum(albumName) {
-    await isExistingAndVisibile(
-      selectors.album(albumName),
-      `selectors.album(${albumName})`
+    await isExistingAndVisible(
+      `selectors.album(${albumName})`,
+      selectors.album(albumName)
     )
     await t.click(selectors.album(albumName))
   }
@@ -93,9 +76,9 @@ export default class AlbumsPage extends PhotoPage {
   // @param {String} AlbumName : Name of the album
   // @param { number } photoNumber : Number of photos expected in the album (
   async isAlbumExistsAndVisible(albumName, photoNumber) {
-    await isExistingAndVisibile(
-      selectors.album(albumName),
-      `selectors.album(${albumName})`
+    await isExistingAndVisible(
+      `selectors.album(${albumName})`,
+      selectors.album(albumName)
     )
     await t
       .expect(selectors.album(albumName).innerText)

--- a/testcafe/tests/pages/photos-viewer/photos-viewer-model.js
+++ b/testcafe/tests/pages/photos-viewer/photos-viewer-model.js
@@ -9,10 +9,10 @@ export default class PhotoViewer extends Viewer {
   async openPhotoFullscreen(index) {
     await isExistingAndVisibile(
       selectors.photoThumb(index),
-      `${index}th Photo thumb`
+      `selectors.photoThumb(${index})`
     )
     await t.click(selectors.photoThumb(index))
-    await isExistingAndVisibile(selectors.photoFull, 'fullscreen photos')
+    await isExistingAndVisibile(selectors.photoFull, 'selectors.photoFull')
   }
 
   //@param {String} screenshotPath : path for screenshots taken in this test

--- a/testcafe/tests/pages/photos-viewer/photos-viewer-model.js
+++ b/testcafe/tests/pages/photos-viewer/photos-viewer-model.js
@@ -1,18 +1,18 @@
 import { t } from 'testcafe'
 import logger from '../../helpers/logger'
-import { isExistingAndVisibile } from '../../helpers/utils'
+import { isExistingAndVisible } from '../../helpers/utils'
 import Viewer from '../viewer/viewer-model'
 import { THUMBNAIL_DELAY } from '../../helpers/data'
 import * as selectors from '../selectors'
 
 export default class PhotoViewer extends Viewer {
   async openPhotoFullscreen(index) {
-    await isExistingAndVisibile(
-      selectors.photoThumb(index),
-      `selectors.photoThumb(${index})`
+    await isExistingAndVisible(
+      `selectors.photoThumb(${index})`,
+      selectors.photoThumb(index)
     )
     await t.click(selectors.photoThumb(index))
-    await isExistingAndVisibile(selectors.photoFull, 'selectors.photoFull')
+    await isExistingAndVisible('selectors.photoFull')
   }
 
   //@param {String} screenshotPath : path for screenshots taken in this test

--- a/testcafe/tests/pages/photos/photos-model-public.js
+++ b/testcafe/tests/pages/photos/photos-model-public.js
@@ -23,48 +23,51 @@ export default class PublicPhotos extends Photos {
   }
 
   async checkActionMenuAlbumPublicDesktop() {
-    await isExistingAndVisibile(selectors.logo, 'Logo')
+    await isExistingAndVisibile(selectors.logo, 'selectors.logo')
     await isExistingAndVisibile(
       selectors.toolbarAlbumPublic,
-      'toolbarAlbumPublic'
+      '  selectors.toolbarAlbumPublic'
     )
     await isExistingAndVisibile(
       selectors.btnAlbumPublicCreateCozyMobileDesktop,
-      'Create my Cozy Button'
+      'selectors.btnAlbumPublicCreateCozyMobileDesktop'
     )
     await isExistingAndVisibile(
       selectors.btnPublicDownloadPhotosDesktop,
-      'Download FolderButton'
+      'selectors.btnPublicDownloadPhotosDesktop'
     )
   }
 
   async checkPhotosDownloadButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
     await isExistingAndVisibile(
       selectors.innerPublicMoreMenu,
-      'Innner More Menu'
+      'selectors.innerPublicMoreMenu'
     )
     await isExistingAndVisibile(
       selectors.btnPublicDownloadPhotosMobile,
-      'Download Button (mobile)'
+      'selectors.btnPublicDownloadPhotosMobile'
     )
   }
   async checkPhotosCozyCreationButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, '[...] Button')
+    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
     await isExistingAndVisibile(
       selectors.innerPublicMoreMenu,
-      'Innner More Menu'
+      'selectors.innerPublicMoreMenu'
     )
     await isExistingAndVisibile(
       selectors.btnAlbumPublicCreateCozyMobile,
-      'Create my Cozy Button (mobile)'
+      'selectors.btnAlbumPublicCreateCozyMobile'
     )
   }
 
   async checkNotAvailable() {
-    await isExistingAndVisibile(selectors.errorAvailable, 'Not available div')
+    await isExistingAndVisibile(
+      selectors.errorAvailable,
+      'selectors.errorAvailable'
+    )
     await t
       .expect(selectors.errorAvailable.innerText)
       .contains('Sorry, this link is no longer available.') //!FIXME

--- a/testcafe/tests/pages/photos/photos-model-public.js
+++ b/testcafe/tests/pages/photos/photos-model-public.js
@@ -2,14 +2,20 @@ import { t } from 'testcafe'
 import { getPageUrl, isExistingAndVisibile, goBack } from '../../helpers/utils'
 import * as selectors from '../selectors'
 import Photos from './photos-model'
+import logger from '../../helpers/logger'
 
 export default class PublicPhotos extends Photos {
   async waitForLoading() {
-    await t.expect(selectors.loading.exists).notOk('Page still loading')
+    await t
+      .expect(selectors.loading.exists)
+      .notOk(
+        'waitForLoading - Page didnt Load : selectors.loading still exists'
+      )
     await isExistingAndVisibile(
       selectors.albumPublicLayout,
-      'Album Public Layout'
+      'waitForLoading - selectors.albumPublicLayout'
     )
+    logger.debug(`photos-model-public : waitForLoading Ok`)
   }
 
   async checkCreateCozy() {

--- a/testcafe/tests/pages/photos/photos-model-public.js
+++ b/testcafe/tests/pages/photos/photos-model-public.js
@@ -1,5 +1,5 @@
 import { t } from 'testcafe'
-import { getPageUrl, isExistingAndVisibile, goBack } from '../../helpers/utils'
+import { getPageUrl, isExistingAndVisible, goBack } from '../../helpers/utils'
 import * as selectors from '../selectors'
 import Photos from './photos-model'
 import logger from '../../helpers/logger'
@@ -8,13 +8,8 @@ export default class PublicPhotos extends Photos {
   async waitForLoading() {
     await t
       .expect(selectors.loading.exists)
-      .notOk(
-        'waitForLoading - Page didnt Load : selectors.loading still exists'
-      )
-    await isExistingAndVisibile(
-      selectors.albumPublicLayout,
-      'waitForLoading - selectors.albumPublicLayout'
-    )
+      .notOk('Page didnt Load : selectors.loading still exists')
+    await isExistingAndVisible('selectors.albumPublicLayout')
     logger.debug(`photos-model-public : waitForLoading Ok`)
   }
 
@@ -29,51 +24,29 @@ export default class PublicPhotos extends Photos {
   }
 
   async checkActionMenuAlbumPublicDesktop() {
-    await isExistingAndVisibile(selectors.logo, 'selectors.logo')
-    await isExistingAndVisibile(
-      selectors.toolbarAlbumPublic,
-      '  selectors.toolbarAlbumPublic'
-    )
-    await isExistingAndVisibile(
-      selectors.btnAlbumPublicCreateCozyMobileDesktop,
+    await isExistingAndVisible('selectors.logo')
+    await isExistingAndVisible('selectors.toolbarAlbumPublic')
+    await isExistingAndVisible(
       'selectors.btnAlbumPublicCreateCozyMobileDesktop'
     )
-    await isExistingAndVisibile(
-      selectors.btnPublicDownloadPhotosDesktop,
-      'selectors.btnPublicDownloadPhotosDesktop'
-    )
+    await isExistingAndVisible('selectors.btnPublicDownloadPhotosDesktop')
   }
 
   async checkPhotosDownloadButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
+    await isExistingAndVisible('selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
-    await isExistingAndVisibile(
-      selectors.innerPublicMoreMenu,
-      'selectors.innerPublicMoreMenu'
-    )
-    await isExistingAndVisibile(
-      selectors.btnPublicDownloadPhotosMobile,
-      'selectors.btnPublicDownloadPhotosMobile'
-    )
+    await isExistingAndVisible('selectors.innerPublicMoreMenu')
+    await isExistingAndVisible('selectors.btnPublicDownloadPhotosMobile')
   }
   async checkPhotosCozyCreationButtonOnMobile() {
-    await isExistingAndVisibile(selectors.btnMoreMenu, 'selectors.btnMoreMenu')
+    await isExistingAndVisible('selectors.btnMoreMenu')
     await t.click(selectors.btnMoreMenu, { speed: 0.5 })
-    await isExistingAndVisibile(
-      selectors.innerPublicMoreMenu,
-      'selectors.innerPublicMoreMenu'
-    )
-    await isExistingAndVisibile(
-      selectors.btnAlbumPublicCreateCozyMobile,
-      'selectors.btnAlbumPublicCreateCozyMobile'
-    )
+    await isExistingAndVisible('selectors.innerPublicMoreMenu')
+    await isExistingAndVisible('selectors.btnAlbumPublicCreateCozyMobile')
   }
 
   async checkNotAvailable() {
-    await isExistingAndVisibile(
-      selectors.errorAvailable,
-      'selectors.errorAvailable'
-    )
+    await isExistingAndVisible('selectors.errorAvailable')
     await t
       .expect(selectors.errorAvailable.innerText)
       .contains('Sorry, this link is no longer available.') //!FIXME

--- a/testcafe/tests/pages/photos/photos-model.js
+++ b/testcafe/tests/pages/photos/photos-model.js
@@ -19,8 +19,14 @@ export default class Page {
   }
 
   async goToAlbums() {
-    await isExistingAndVisibile(selectors.sidebarPhotos, 'Sidebar')
-    await isExistingAndVisibile(selectors.btnNavToAlbum, 'Album Button')
+    await isExistingAndVisibile(
+      selectors.sidebarPhotos,
+      'selectors.sidebarPhotos'
+    )
+    await isExistingAndVisibile(
+      selectors.btnNavToAlbum,
+      'selectors.btnNavToAlbum'
+    )
     await t
       .click(selectors.btnNavToAlbum)
       .expect(getPageUrl())
@@ -30,9 +36,15 @@ export default class Page {
   //@param {string} when : text for logger.debug
   async getPhotosCount(when) {
     await checkAllImagesExists()
-    await isExistingAndVisibile(selectors.photoSection, 'photo Section')
-    await isExistingAndVisibile(selectors.allPhotosWrapper, 'Picture wrapper')
-    await isExistingAndVisibile(selectors.allPhotos, 'Photo item(s)')
+    await isExistingAndVisibile(
+      selectors.photoSection,
+      'selectors.photoSection'
+    )
+    await isExistingAndVisibile(
+      selectors.allPhotosWrapper,
+      'selectors.allPhotosWrapper'
+    )
+    await isExistingAndVisibile(selectors.allPhotos, 'selectors.allPhotos')
     const allPhotosCount = await selectors.allPhotos.count
 
     logger.debug(
@@ -45,13 +57,16 @@ export default class Page {
   //@param { number } numOfFiles : number of file to select
   async selectPhotos(numOfFiles) {
     logger.debug('Selecting ' + numOfFiles + ' picture(s)')
-    await isExistingAndVisibile(selectors.photoThumb(0), '1st Photo thumb')
+    await isExistingAndVisibile(
+      selectors.photoThumb(0),
+      'selectors.photoThumb(0)'
+    )
     await t.hover(selectors.photoThumb(0)) //Only one 'hover' as all checkbox should be visible once the 1st checkbox is checked
 
     for (let i = 0; i < numOfFiles; i++) {
       await isExistingAndVisibile(
         selectors.photoThumb(i),
-        `${i + 1}th Photo thumb`
+        `selectors.photoThumb(${i})`
       )
       await t.click(selectors.photoCheckbox.nth(i))
     }
@@ -62,14 +77,14 @@ export default class Page {
     logger.debug('Selecting ' + NameArray.length + ' picture(s)')
     await isExistingAndVisibile(
       selectors.photoThumbByName(NameArray[0]),
-      `Photo thumb for ${NameArray[0]}`
+      `selectors.photoThumbByName(${NameArray[0]})`
     )
     await t.hover(selectors.photoThumbByName(NameArray[0])) //Only one 'hover' as all checkbox should be visible once the 1st checkbox is checked
 
     for (let i = 0; i < NameArray.length; i++) {
       await isExistingAndVisibile(
         selectors.photoThumbByName(NameArray[i]),
-        `Photo thumb for ${NameArray[i]}`
+        `selectors.photoThumbByName(${NameArray[i]})`
       )
       await t.click(selectors.photoThumbByNameCheckbox(NameArray[i]))
     }

--- a/testcafe/tests/pages/photos/photos-model.js
+++ b/testcafe/tests/pages/photos/photos-model.js
@@ -3,7 +3,7 @@ import { t } from 'testcafe'
 import logger from '../../helpers/logger'
 import {
   getPageUrl,
-  isExistingAndVisibile,
+  isExistingAndVisible,
   checkAllImagesExists
 } from '../../helpers/utils'
 import * as selectors from '../selectors'
@@ -19,14 +19,8 @@ export default class Page {
   }
 
   async goToAlbums() {
-    await isExistingAndVisibile(
-      selectors.sidebarPhotos,
-      'selectors.sidebarPhotos'
-    )
-    await isExistingAndVisibile(
-      selectors.btnNavToAlbum,
-      'selectors.btnNavToAlbum'
-    )
+    await isExistingAndVisible('selectors.sidebarPhotos')
+    await isExistingAndVisible('selectors.btnNavToAlbum')
     await t
       .click(selectors.btnNavToAlbum)
       .expect(getPageUrl())
@@ -36,15 +30,9 @@ export default class Page {
   //@param {string} when : text for logger.debug
   async getPhotosCount(when) {
     await checkAllImagesExists()
-    await isExistingAndVisibile(
-      selectors.photoSection,
-      'selectors.photoSection'
-    )
-    await isExistingAndVisibile(
-      selectors.allPhotosWrapper,
-      'selectors.allPhotosWrapper'
-    )
-    await isExistingAndVisibile(selectors.allPhotos, 'selectors.allPhotos')
+    await isExistingAndVisible('selectors.photoSection')
+    await isExistingAndVisible('selectors.allPhotosWrapper')
+    await isExistingAndVisible('selectors.allPhotos')
     const allPhotosCount = await selectors.allPhotos.count
 
     logger.debug(
@@ -57,16 +45,16 @@ export default class Page {
   //@param { number } numOfFiles : number of file to select
   async selectPhotos(numOfFiles) {
     logger.debug('Selecting ' + numOfFiles + ' picture(s)')
-    await isExistingAndVisibile(
-      selectors.photoThumb(0),
-      'selectors.photoThumb(0)'
+    await isExistingAndVisible(
+      'selectors.photoThumb(0)',
+      selectors.photoThumb(0)
     )
     await t.hover(selectors.photoThumb(0)) //Only one 'hover' as all checkbox should be visible once the 1st checkbox is checked
 
     for (let i = 0; i < numOfFiles; i++) {
-      await isExistingAndVisibile(
-        selectors.photoThumb(i),
-        `selectors.photoThumb(${i})`
+      await isExistingAndVisible(
+        `selectors.photoThumb(${i})`,
+        selectors.photoThumb(i)
       )
       await t.click(selectors.photoCheckbox.nth(i))
     }
@@ -75,16 +63,16 @@ export default class Page {
   //@param { [string] } NameArray: files names to select
   async selectPhotosByName(NameArray) {
     logger.debug('Selecting ' + NameArray.length + ' picture(s)')
-    await isExistingAndVisibile(
-      selectors.photoThumbByName(NameArray[0]),
-      `selectors.photoThumbByName(${NameArray[0]})`
+    await isExistingAndVisible(
+      `selectors.photoThumbByName(${NameArray[0]})`,
+      selectors.photoThumbByName(NameArray[0])
     )
     await t.hover(selectors.photoThumbByName(NameArray[0])) //Only one 'hover' as all checkbox should be visible once the 1st checkbox is checked
 
     for (let i = 0; i < NameArray.length; i++) {
-      await isExistingAndVisibile(
-        selectors.photoThumbByName(NameArray[i]),
-        `selectors.photoThumbByName(${NameArray[i]})`
+      await isExistingAndVisible(
+        `selectors.photoThumbByName(${NameArray[i]})`,
+        selectors.photoThumbByName(NameArray[i])
       )
       await t.click(selectors.photoThumbByNameCheckbox(NameArray[i]))
     }

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -7,11 +7,16 @@ import Commons from './photos-model'
 export default class Timeline extends Commons {
   //timeline specific as selectors.contentWrapper is only on timeline
   async waitForLoading() {
-    await t.expect(selectors.loading.exists).notOk('Page still loading')
+    await t
+      .expect(selectors.loading.exists)
+      .notOk(
+        'waitForLoading - Page didnt Load : selectors.loading still exists'
+      )
     await isExistingAndVisibile(
       selectors.contentWrapper,
-      'selectors.contentWrapper'
+      'waitForLoading - selectors.contentWrapper'
     )
+    logger.debug(`photos-timeline-model : waitForLoading Ok`)
   }
 
   //@param {array of fileName} files

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -8,7 +8,10 @@ export default class Timeline extends Commons {
   //timeline specific as selectors.contentWrapper is only on timeline
   async waitForLoading() {
     await t.expect(selectors.loading.exists).notOk('Page still loading')
-    await isExistingAndVisibile(selectors.contentWrapper, 'Content Wrapper')
+    await isExistingAndVisibile(
+      selectors.contentWrapper,
+      'selectors.contentWrapper'
+    )
   }
 
   //@param {array of fileName} files
@@ -18,12 +21,15 @@ export default class Timeline extends Commons {
 
     await t.expect(selectors.btnUpload.exists).ok(`Upload button doesnt exist`)
     await t.setFilesToUpload(selectors.btnUpload, files)
-    await isExistingAndVisibile(selectors.divUpload, 'Upload div')
+    await isExistingAndVisibile(selectors.divUpload, 'selectors.divUpload')
     await isExistingAndVisibile(
       selectors.divUploadSuccess,
-      'Upload pop-in successfull'
+      'selectors.divUploadSuccess'
     )
-    await isExistingAndVisibile(selectors.alertWrapper, 'Photo(s) uploaded')
+    await isExistingAndVisibile(
+      selectors.alertWrapper,
+      'selectors.alertWrapper'
+    )
     await t
       .expect(selectors.divUpload.innerText)
       .match(
@@ -36,18 +42,21 @@ export default class Timeline extends Commons {
   }
 
   async checkCozyBarOnTimeline() {
-    await isExistingAndVisibile(selectors.cozySelectionbar, 'Selection bar')
+    await isExistingAndVisibile(
+      selectors.cozySelectionbar,
+      'selectors.cozySelectionbar'
+    )
     await isExistingAndVisibile(
       selectors.btnAddToAlbumCozySelectionBar,
-      'Button "Add to Album"'
+      'selectors.btnAddToAlbumCozySelectionBar'
     )
     await isExistingAndVisibile(
       selectors.btnDownloadCozySelectionBar,
-      'Button "Download"'
+      'selectors.btnDownloadCozySelectionBar'
     )
     await isExistingAndVisibile(
       selectors.btnDeleteCozySelectionBar,
-      'Button "Delete"'
+      'selectors.btnDeleteCozySelectionBar'
     )
   }
 
@@ -57,19 +66,22 @@ export default class Timeline extends Commons {
     screenshotPath: screenshotPath,
     withMask = false
   }) {
-    await isExistingAndVisibile(selectors.cozySelectionbar, 'Selection bar')
+    await isExistingAndVisibile(
+      selectors.cozySelectionbar,
+      'selectors.cozySelectionbar'
+    )
 
     logger.debug('Deleting ' + numOfFiles + ' picture(s)')
     await isExistingAndVisibile(
       selectors.btnDeleteCozySelectionBar,
-      'Delete Button'
+      'selectors.btnDeleteCozySelectionBar'
     )
     await t.click(selectors.btnDeleteCozySelectionBar)
 
-    await isExistingAndVisibile(selectors.modalFooter, 'Modal delete')
+    await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
     await isExistingAndVisibile(
       selectors.btnModalSecondButton,
-      'Modal delete button Delete'
+      'selectors.btnModalSecondButton'
     )
     if (t.fixtureCtx.isVR)
       //dates show up here, so there is a mask for screenshots

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -1,6 +1,6 @@
 import { t } from 'testcafe'
 import logger from '../../helpers/logger'
-import { isExistingAndVisibile } from '../../helpers/utils'
+import { isExistingAndVisible } from '../../helpers/utils'
 import * as selectors from '../selectors'
 import Commons from './photos-model'
 
@@ -9,13 +9,8 @@ export default class Timeline extends Commons {
   async waitForLoading() {
     await t
       .expect(selectors.loading.exists)
-      .notOk(
-        'waitForLoading - Page didnt Load : selectors.loading still exists'
-      )
-    await isExistingAndVisibile(
-      selectors.contentWrapper,
-      'waitForLoading - selectors.contentWrapper'
-    )
+      .notOk('Page didnt Load : selectors.loading still exists')
+    await isExistingAndVisible('selectors.contentWrapper')
     logger.debug(`photos-timeline-model : waitForLoading Ok`)
   }
 
@@ -26,15 +21,9 @@ export default class Timeline extends Commons {
 
     await t.expect(selectors.btnUpload.exists).ok(`Upload button doesnt exist`)
     await t.setFilesToUpload(selectors.btnUpload, files)
-    await isExistingAndVisibile(selectors.divUpload, 'selectors.divUpload')
-    await isExistingAndVisibile(
-      selectors.divUploadSuccess,
-      'selectors.divUploadSuccess'
-    )
-    await isExistingAndVisibile(
-      selectors.alertWrapper,
-      'selectors.alertWrapper'
-    )
+    await isExistingAndVisible('selectors.divUpload')
+    await isExistingAndVisible('selectors.divUploadSuccess')
+    await isExistingAndVisible('selectors.alertWrapper')
     await t
       .expect(selectors.divUpload.innerText)
       .match(
@@ -47,22 +36,10 @@ export default class Timeline extends Commons {
   }
 
   async checkCozyBarOnTimeline() {
-    await isExistingAndVisibile(
-      selectors.cozySelectionbar,
-      'selectors.cozySelectionbar'
-    )
-    await isExistingAndVisibile(
-      selectors.btnAddToAlbumCozySelectionBar,
-      'selectors.btnAddToAlbumCozySelectionBar'
-    )
-    await isExistingAndVisibile(
-      selectors.btnDownloadCozySelectionBar,
-      'selectors.btnDownloadCozySelectionBar'
-    )
-    await isExistingAndVisibile(
-      selectors.btnDeleteCozySelectionBar,
-      'selectors.btnDeleteCozySelectionBar'
-    )
+    await isExistingAndVisible('selectors.cozySelectionbar')
+    await isExistingAndVisible('selectors.btnAddToAlbumCozySelectionBar')
+    await isExistingAndVisible('selectors.btnDownloadCozySelectionBar')
+    await isExistingAndVisible('selectors.btnDeleteCozySelectionBar')
   }
 
   //@param { number } numOfFiles : number of file to delete
@@ -71,23 +48,13 @@ export default class Timeline extends Commons {
     screenshotPath: screenshotPath,
     withMask = false
   }) {
-    await isExistingAndVisibile(
-      selectors.cozySelectionbar,
-      'selectors.cozySelectionbar'
-    )
-
+    await isExistingAndVisible('selectors.cozySelectionbar')
     logger.debug('Deleting ' + numOfFiles + ' picture(s)')
-    await isExistingAndVisibile(
-      selectors.btnDeleteCozySelectionBar,
-      'selectors.btnDeleteCozySelectionBar'
-    )
+    await isExistingAndVisible('selectors.btnDeleteCozySelectionBar')
     await t.click(selectors.btnDeleteCozySelectionBar)
 
-    await isExistingAndVisibile(selectors.modalFooter, 'selectors.modalFooter')
-    await isExistingAndVisibile(
-      selectors.btnModalSecondButton,
-      'selectors.btnModalSecondButton'
-    )
+    await isExistingAndVisible('selectors.modalFooter')
+    await isExistingAndVisible('selectors.btnModalSecondButton')
     if (t.fixtureCtx.isVR)
       //dates show up here, so there is a mask for screenshots
       await t.fixtureCtx.vr.takeScreenshotAndUpload({

--- a/testcafe/tests/pages/photos/photos-timeline-model.js
+++ b/testcafe/tests/pages/photos/photos-timeline-model.js
@@ -19,7 +19,9 @@ export default class Timeline extends Commons {
     const numOfFiles = files.length
     logger.debug('Uploading ' + numOfFiles + ' picture(s)')
 
-    await t.expect(selectors.btnUpload.exists).ok(`Upload button doesnt exist`)
+    await t
+      .expect(selectors.btnUpload.exists)
+      .ok(`selectors.btnUpload doesnt exist`)
     await t.setFilesToUpload(selectors.btnUpload, files)
     await isExistingAndVisible('selectors.divUpload')
     await isExistingAndVisible('selectors.divUploadSuccess')

--- a/testcafe/tests/pages/selectors.js
+++ b/testcafe/tests/pages/selectors.js
@@ -224,7 +224,7 @@ export const foldersNamesInputs = getElementWithTestId('name-input')
 export const folderOrFileName = getElementWithTestId(
   'fil-file-filename-and-ext'
 )
-export const checboxFolderByRowIndex = value => {
+export const checkboxFolderByRowIndex = value => {
   return contentRows
     .nth(value)
     .child('[class*="fil-content-cell"]')

--- a/testcafe/tests/pages/selectors.js
+++ b/testcafe/tests/pages/selectors.js
@@ -1,5 +1,13 @@
 import { Selector } from 'testcafe'
-import { getElementWithTestId, getElementWithTestItem } from '../helpers/utils'
+
+const getElementWithTestId = Selector(
+  id => document.querySelectorAll(`[data-test-id='${id}']`)
+  //getElementsByAttribute is not part of W3C DOM, while querySelectorAll is.
+)
+const getElementWithTestItem = Selector(
+  id => document.querySelectorAll(`[data-test-item='${id}']`)
+  //getElementsByAttribute is not part of W3C DOM, while querySelectorAll is.
+)
 //************************
 // Commons, but with different contexts
 //************************
@@ -138,9 +146,7 @@ export const viewerBtnClose = Selector('[class*="viewer-toolbar-close"]')
 //Specific viewers
 export const imageViewer = Selector('[class*="viewer-imageviewer"]')
 export const imageViewerContent = imageViewer.find('img')
-export const photoFull = Selector('[class*="viewer-imageviewer"]').find(
-  'img'
-)
+export const photoFull = Selector('[class*="viewer-imageviewer"]').find('img')
 export const audioViewer = Selector('[class*="viewer-audio"]')
 export const audioViewerControls = audioViewer.find('audio')
 export const txtViewer = Selector('[class*="viewer-text"]')

--- a/testcafe/tests/pages/viewer/viewer-model.js
+++ b/testcafe/tests/pages/viewer/viewer-model.js
@@ -5,16 +5,20 @@ import * as selectors from '../selectors'
 
 export default class Viewer {
   async waitForLoading() {
-    await t.expect(selectors.spinner.exists).notOk('Spinner still spinning')
+    await t
+      .expect(selectors.spinner.exists)
+      .notOk(
+        'waitForLoading - Page didnt Load : selectors.spinner still exists'
+      )
     await isExistingAndVisibile(
       selectors.viewerWrapper,
-      'selectors.viewerWrapper'
+      'waitForLoading - selectors.viewerWrapper'
     )
     await isExistingAndVisibile(
       selectors.viewerControls,
-      'selectors.viewerControls'
+      'waitForLoading - selectors.viewerControls'
     )
-    logger.debug('Viewer Ok')
+    logger.debug(`viewer-model : waitForLoading Ok`)
   }
 
   //@param { bool } exitWithEsc : true to exit by pressing esc, false to click on the button

--- a/testcafe/tests/pages/viewer/viewer-model.js
+++ b/testcafe/tests/pages/viewer/viewer-model.js
@@ -6,15 +6,24 @@ import * as selectors from '../selectors'
 export default class Viewer {
   async waitForLoading() {
     await t.expect(selectors.spinner.exists).notOk('Spinner still spinning')
-    await isExistingAndVisibile(selectors.viewerWrapper, 'Viewer Wrapper')
-    await isExistingAndVisibile(selectors.viewerControls, 'Viewer Controls')
+    await isExistingAndVisibile(
+      selectors.viewerWrapper,
+      'selectors.viewerWrapper'
+    )
+    await isExistingAndVisibile(
+      selectors.viewerControls,
+      'selectors.viewerControls'
+    )
     logger.debug('Viewer Ok')
   }
 
   //@param { bool } exitWithEsc : true to exit by pressing esc, false to click on the button
   async closeViewer(exitWithEsc) {
     await t.hover(selectors.viewerWrapper)
-    await isExistingAndVisibile(selectors.viewerBtnClose, 'Close button')
+    await isExistingAndVisibile(
+      selectors.viewerBtnClose,
+      'selectors.viewerWrapper'
+    )
     exitWithEsc
       ? await t.pressKey('esc')
       : await t.click(selectors.viewerBtnClose)
@@ -26,12 +35,12 @@ export default class Viewer {
       //this is the last picture, so next button does not exist
       await t
         .expect(selectors.viewerNavNext.exists)
-        .notOk('Next button on last picture')
+        .notOk('selectors.viewerNavNex on last picture')
     } else {
       await t
         .hover(selectors.viewerNavNext) //not last photo, so next button should exists
         .expect(selectors.btnViewerNavNext.visible)
-        .ok('Next arrow does not show up')
+        .ok('selectors.btnViewerNavNext does not show up')
         .click(selectors.btnViewerNavNext)
       await this.waitForLoading()
     }
@@ -43,12 +52,12 @@ export default class Viewer {
       //this is the 1st picture, so previous button does not exist
       await t
         .expect(selectors.viewerNavPrevious.exists)
-        .notOk('Previous button on first picture')
+        .notOk('selectors.viewerNavPrevious on first picture')
     } else {
       await t
         .hover(selectors.viewerNavPrevious) //not 1st photo, so previous button should exists
         .expect(selectors.btnViewerNavPrevious.visible)
-        .ok('Previous arrow does not show up')
+        .ok('selectors.btnViewerNavPrevious does not show up')
         .click(selectors.viewerNavPrevious)
       await this.waitForLoading()
     }
@@ -97,7 +106,7 @@ export default class Viewer {
     await t.hover(selectors.viewerWrapper)
     await isExistingAndVisibile(
       selectors.btnDownloadViewerToolbar,
-      'Download button in toolbar'
+      'selectors.btnDownloadViewerToolbar'
     )
     await t
       .setNativeDialogHandler(() => true)
@@ -106,10 +115,10 @@ export default class Viewer {
 
   //Specific check for imageViewer (Common to drive/photos)
   async checkImageViewer() {
-    await isExistingAndVisibile(selectors.imageViewer, 'image viewer')
+    await isExistingAndVisibile(selectors.imageViewer, 'selectors.imageViewer')
     await isExistingAndVisibile(
       selectors.imageViewerContent,
-      'image viewer controls'
+      'selectors.imageViewerContent'
     )
   }
 }

--- a/testcafe/tests/pages/viewer/viewer-model.js
+++ b/testcafe/tests/pages/viewer/viewer-model.js
@@ -1,33 +1,22 @@
 import { t } from 'testcafe'
 import logger from '../../helpers/logger'
-import { isExistingAndVisibile } from '../../helpers/utils'
+import { isExistingAndVisible } from '../../helpers/utils'
 import * as selectors from '../selectors'
 
 export default class Viewer {
   async waitForLoading() {
     await t
       .expect(selectors.spinner.exists)
-      .notOk(
-        'waitForLoading - Page didnt Load : selectors.spinner still exists'
-      )
-    await isExistingAndVisibile(
-      selectors.viewerWrapper,
-      'waitForLoading - selectors.viewerWrapper'
-    )
-    await isExistingAndVisibile(
-      selectors.viewerControls,
-      'waitForLoading - selectors.viewerControls'
-    )
+      .notOk('Page didnt Load : selectors.spinner still exists')
+    await isExistingAndVisible('selectors.viewerWrapper')
+    await isExistingAndVisible('selectors.viewerControls')
     logger.debug(`viewer-model : waitForLoading Ok`)
   }
 
   //@param { bool } exitWithEsc : true to exit by pressing esc, false to click on the button
   async closeViewer(exitWithEsc) {
     await t.hover(selectors.viewerWrapper)
-    await isExistingAndVisibile(
-      selectors.viewerBtnClose,
-      'selectors.viewerWrapper'
-    )
+    await isExistingAndVisible('selectors.viewerWrapper')
     exitWithEsc
       ? await t.pressKey('esc')
       : await t.click(selectors.viewerBtnClose)
@@ -108,10 +97,7 @@ export default class Viewer {
   //download using the common download button
   async checkCommonViewerDownload() {
     await t.hover(selectors.viewerWrapper)
-    await isExistingAndVisibile(
-      selectors.btnDownloadViewerToolbar,
-      'selectors.btnDownloadViewerToolbar'
-    )
+    await isExistingAndVisible('selectors.btnDownloadViewerToolbar')
     await t
       .setNativeDialogHandler(() => true)
       .click(selectors.btnDownloadViewerToolbar)
@@ -119,10 +105,7 @@ export default class Viewer {
 
   //Specific check for imageViewer (Common to drive/photos)
   async checkImageViewer() {
-    await isExistingAndVisibile(selectors.imageViewer, 'selectors.imageViewer')
-    await isExistingAndVisibile(
-      selectors.imageViewerContent,
-      'selectors.imageViewerContent'
-    )
+    await isExistingAndVisible('selectors.imageViewer')
+    await isExistingAndVisible('selectors.imageViewerContent')
   }
 }

--- a/testcafe/tests/photos/album_sharing_scenario.js
+++ b/testcafe/tests/photos/album_sharing_scenario.js
@@ -6,8 +6,7 @@ import {
   SLUG,
   deleteLocalFile,
   checkLocalFile,
-  setDownloadPath,
-  isExistingAndVisibile
+  setDownloadPath
 } from '../helpers/utils'
 import { initVR } from '../helpers/visualreview-utils'
 import * as selectors from '../pages/selectors'


### PR DESCRIPTION
- [x]  in `isExistingAndVisibile`, added info `please check its definition in testcafe/tests/pages/selectors`, to know where to check the selector.

- [x] when `isExistingAndVisibile` method is called, it will show the selector "name" (ie: `selectors.viewerControls`) instead of a description (ie `controls for viewer`), to make it easier to debug.

- [x] Add explicit log in `waitForLoading` to know which page didn't load

- [x] Logger display log at debug level for review purpose  as most change will only show at debug level if there are no build error -> **I'll put the logger back to `info` level before merging**  