### PR TITLE
fix: Empty input[type=file] so that the user can upload the same file

### DIFF
--- a/src/drive/web/modules/upload/UploadButton.jsx
+++ b/src/drive/web/modules/upload/UploadButton.jsx
@@ -15,6 +15,7 @@ const UploadButton = ({ label, disabled, onUpload, className }) => (
     multiple
     onChange={onUpload}
     data-test-id="upload-btn"
+    value={[]} // always erase the value to be able to re-upload the same file
   >
     <span>
       <Icon icon="upload" />

--- a/src/photos/components/UploadButton.jsx
+++ b/src/photos/components/UploadButton.jsx
@@ -13,6 +13,7 @@ const UploadButton = ({ label, inMenu, disabled, onUpload, className }) => (
     disabled={disabled}
     multiple
     onChange={onUpload}
+    value={[]} // always erase the value to be able to re-upload the same file
   >
     <span>
       {!inMenu && <Icon icon="upload" />}


### PR DESCRIPTION
We have to empty the value of the input[type=file] so that the user can upload the same file twice. If the input is uncontrolled, it leads to a strange behavior because nothing happens