### PR TITLE
Update photos permissions

### DIFF
--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -54,7 +54,8 @@
       "verbs": [
         "GET",
         "POST",
-        "PUT"
+        "PUT",
+        "PATCH"
       ]
     },
     "apps": {


### PR DESCRIPTION
The photos app needs the permission on io.cozy.files for the PATCH verb to allow moving photos to the trash.