### PR TITLE
refactor: Use createContext API from react, not from third packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "cozy-realtime": "2.0.8",
     "cozy-scripts": "1.13.2",
     "cozy-ui": "20.8.0",
-    "create-react-context": "0.2.2",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/src/photos/ducks/selection/index.jsx
+++ b/src/photos/ducks/selection/index.jsx
@@ -1,8 +1,7 @@
 import React, { Component } from 'react'
-import createReactContext from 'create-react-context'
 import SelectionBar from 'cozy-ui/react/SelectionBar'
 
-const SelectionContext = createReactContext([])
+const SelectionContext = React.createContext([])
 
 // constants
 const SELECT_ITEM = 'SELECT_ITEM'

--- a/src/sharing/context.js
+++ b/src/sharing/context.js
@@ -1,5 +1,4 @@
-import createReactContext from 'create-react-context'
-
-const SharingContext = createReactContext()
+import React from 'react'
+const SharingContext = React.createContext()
 
 export default SharingContext

--- a/yarn.lock
+++ b/yarn.lock
@@ -4775,14 +4775,6 @@ create-react-class@^15.5.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-create-react-context@0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
-  integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
-
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.4, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -6605,7 +6597,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -7330,11 +7322,6 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 gzip-size@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
I think create-react-context was there for historical reason. Since we use React now, we can use it from React directly 