### PR TITLE
Fix/make cancelable

### DIFF
--- a/src/drive/mobile/lib/withPersistentState.js
+++ b/src/drive/mobile/lib/withPersistentState.js
@@ -1,23 +1,52 @@
 import localforage from 'localforage'
 
+import { cancelable as makeCancelable } from 'cozy-client/dist/utils'
+
 // The withPersistentState HOC automatically saves the wrappped components state and restores it when the component is mounted again.
 // Since the saved state will not be available immediately when the wrapped component is mounted, a `componentStateRestored` hook will be called once the state is restored
 export const withPersistentState = (WrappedComponent, persistenceKey) => {
   class WithPersistentState extends WrappedComponent {
+    constructor(props) {
+      super(props)
+      this.persistedStatePromise = null
+      this.setItemPromise = null
+    }
     async componentWillMount() {
-      const persistedState = await localforage.getItem(persistenceKey)
-      this.setState(
-        prevState => persistedState || prevState,
-        () => {
-          if (super.componentStateRestored) super.componentStateRestored()
+      try {
+        this.persistedStatePromise = makeCancelable(
+          localforage.getItem(persistenceKey)
+        )
+        const persistedState = await this.persistedStatePromise
+        this.setState(
+          prevState => persistedState || prevState,
+          () => {
+            if (super.componentStateRestored) super.componentStateRestored()
+          }
+        )
+      } catch (e) {
+        if (e.canceled !== true) {
+          console.log('error', e)
         }
-      )
+      }
     }
 
     componentWillUpdate(nextProps, nextState) {
-      if (super.componentWillUpdate)
-        super.componentWillUpdate(nextProps, nextState)
-      localforage.setItem(persistenceKey, nextState)
+      try {
+        if (super.componentWillUpdate)
+          super.componentWillUpdate(nextProps, nextState)
+        this.setItemPromise = makeCancelable(
+          localforage.setItem(persistenceKey, nextState)
+        )
+      } catch (e) {
+        if (e.canceled !== true) {
+          console.log('error', e)
+        }
+      }
+    }
+
+    componentWillUnmount() {
+      this.setItemPromise && this.setItemPromise.cancel()
+      this.persistedStatePromise.cancel()
     }
   }
   WithPersistentState.displayName = `WithPersistentState(${WrappedComponent.displayName ||

--- a/src/drive/web/modules/drive/SharingsContainer.jsx
+++ b/src/drive/web/modules/drive/SharingsContainer.jsx
@@ -64,7 +64,7 @@ export class SharingFetcher extends React.Component {
       this.props.fetchSuccess(filesWithPath)
     } catch (e) {
       // if the error is a cancelable promise, don't use setState since the component is not mounted anymore
-      if (e.isCanceled !== true) {
+      if (e.canceled !== true) {
         this.setState({ error: e })
         this.props.fetchFailure(e)
       }

--- a/src/drive/web/modules/drive/SharingsContainer.spec.jsx
+++ b/src/drive/web/modules/drive/SharingsContainer.spec.jsx
@@ -5,6 +5,20 @@ import { shallow } from 'enzyme'
 import { SharingFetcher } from './SharingsContainer'
 import { ROOT_DIR_ID } from 'drive/constants/config.js'
 
+const all = jest
+  .fn()
+  .mockName('all')
+  .mockResolvedValue({ data: [] })
+const statByPathSpy = jest.fn().mockName('statByPath')
+const updateFileSpy = jest.fn().mockName('updateFile')
+const fakeClient = {
+  collection: () => ({
+    all: all,
+    statByPath: statByPathSpy,
+    updateFile: updateFileSpy
+  })
+}
+
 jest.mock('cozy-client', () => {
   const automaticMock = jest.genMockFromModule('cozy-client')
   return {
@@ -17,8 +31,18 @@ jest.mock('cozy-client', () => {
 describe('SharingFetcher component', () => {
   describe('componentDidMount', () => {
     it('should call fetchSharedDocuments', () => {
-      const wrapper = shallow(<SharingFetcher />, {
-        disableLifecycleMethod: true
+      const props = {
+        sharedDocuments: [],
+        params: {},
+        startFetch: jest.fn(),
+        fetchSuccess: jest.fn()
+      }
+      const wrapper = shallow(<SharingFetcher {...props} />, {
+        disableLifecycleMethod: true,
+        context: {
+          client: fakeClient,
+          t: jest.fn(() => 'whatever')
+        }
       })
       const fetchSharedDocumentsSpy = jest.fn()
       wrapper.instance().fetchSharedDocuments = fetchSharedDocumentsSpy
@@ -31,14 +55,21 @@ describe('SharingFetcher component', () => {
     it('should fetch shared documents if there are new sharings', async () => {
       const props = {
         sharedDocuments: ['foo'],
-        params: {}
+        params: {},
+        startFetch: jest.fn(),
+        fetchSuccess: jest.fn()
       }
       const nextProps = {
         sharedDocuments: ['foo', 'bar'],
-        params: {}
+        params: {},
+        startFetch: jest.fn()
       }
       const wrapper = shallow(<SharingFetcher {...props} />, {
-        disableLifecycleMethod: true
+        disableLifecycleMethod: true,
+        context: {
+          client: fakeClient,
+          t: jest.fn(() => 'whatever')
+        }
       })
       const fetchSharedDocumentsSpy = jest.fn()
       wrapper.instance().fetchSharedDocuments = fetchSharedDocumentsSpy
@@ -49,14 +80,22 @@ describe('SharingFetcher component', () => {
     it('should not fetch shared documents if there are no new sharings', async () => {
       const props = {
         sharedDocuments: ['foo'],
-        params: {}
+        params: {},
+        startFetch: jest.fn(),
+        fetchSuccess: jest.fn()
       }
       const nextProps = {
         sharedDocuments: ['foo'],
-        params: {}
+        params: {},
+        startFetch: jest.fn(),
+        fetchSuccess: jest.fn()
       }
       const wrapper = shallow(<SharingFetcher {...props} />, {
-        disableLifecycleMethod: true
+        disableLifecycleMethod: true,
+        context: {
+          client: fakeClient,
+          t: jest.fn(() => 'whatever')
+        }
       })
       const fetchSharedDocumentsSpy = jest.fn()
       wrapper.instance().fetchSharedDocuments = fetchSharedDocumentsSpy


### PR DESCRIPTION
- WithPersistent state now uses `cancelable` from cozy-client to cancel promise during unmount
- fix a regression for the SharingContainer when switching to `cancelable` from cozy-client. Our first implementation was return isCanceled and not `canceled`