### PR TITLE
fix: Always display upload item

### DIFF
--- a/src/drive/styles/toolbar.styl
+++ b/src/drive/styles/toolbar.styl
@@ -67,7 +67,6 @@
                 right    1rem
                 top      .1rem
 
-    .fil-action-upload
     .fil-action-share
         display none
 


### PR DESCRIPTION
We had a condition to display or not the upload item if we are in a shared menu (ie we already have a primary action button) or not. But with this condition, if we are in a shared menu, we didn't have the upload item anymore. 

The current fix is to display the upload button anytime in the more menu. 

