### PR TITLE
fix: splitFilename() edge cases

### DIFF
--- a/src/drive/web/modules/drive/files.js
+++ b/src/drive/web/modules/drive/files.js
@@ -1,5 +1,5 @@
-const FILE_TYPE = 'file'
-const DIR_TYPE = 'directory'
+export const FILE_TYPE = 'file'
+export const DIR_TYPE = 'directory'
 export const ALBUMS_DOCTYPE = 'io.cozy.photos.albums'
 export const isFile = file => file && file.type === FILE_TYPE
 export const isDirectory = file => file && file.type === DIR_TYPE

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -10,7 +10,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import RenameInput from 'drive/web/modules/drive/RenameInput'
 import { default as DesktopActionMenu } from 'drive/web/modules/actionmenu/ActionMenu'
 import MobileActionMenu from 'drive/web/modules/actionmenu/MobileActionMenu'
-import { isDirectory } from 'drive/web/modules/drive/files'
+import { isDirectory, isFile } from 'drive/web/modules/drive/files'
 import { Button, Icon, withBreakpoints, MidEllipsis } from 'cozy-ui/react'
 import { SharedStatus } from 'sharing'
 import FileThumbnail from 'drive/web/modules/filelist/FileThumbnail'
@@ -32,13 +32,19 @@ const ActionMenu = withBreakpoints()(
     )
 )
 
-export const splitFilename = file =>
-  isDirectory(file)
-    ? { filename: file.name, extension: '' }
-    : {
-        extension: file.name.slice(file.name.lastIndexOf('.')),
-        filename: file.name.slice(0, file.name.lastIndexOf('.'))
-      }
+const FILENAME_WITH_EXTENSION_REGEX = /(.+)(\..*)$/
+
+export const splitFilename = file => {
+  if (isFile(file)) {
+    const match = file.name.match(FILENAME_WITH_EXTENSION_REGEX)
+
+    if (match) {
+      return { filename: match[1], extension: match[2] }
+    }
+  }
+
+  return { filename: file.name, extension: '' }
+}
 
 const getParentDiv = element => {
   if (element.nodeName.toLowerCase() === 'div') {

--- a/src/drive/web/modules/filelist/File.spec.jsx
+++ b/src/drive/web/modules/filelist/File.spec.jsx
@@ -35,12 +35,12 @@ describe('splitFilename function', () => {
 
   const scenarios = [
     { filename: 'file', extension: '.ext' },
-    // FIXME: { filename: 'file', extension: '' },
+    { filename: 'file', extension: '' },
     { filename: 'file.html', extension: '.ejs' },
     { filename: 'file', extension: '.' },
     { filename: 'file.', extension: '.' },
     { filename: 'file.', extension: '.ext' },
-    // FIXME: { filename: '.file', extension: '' },
+    { filename: '.file', extension: '' },
     { filename: '.file', extension: '.ext' }
   ]
 

--- a/src/drive/web/modules/filelist/File.spec.jsx
+++ b/src/drive/web/modules/filelist/File.spec.jsx
@@ -1,6 +1,7 @@
 'use strict'
 
-import { getParentLink } from './File'
+import { getParentLink, splitFilename } from './File'
+import { FILE_TYPE, DIR_TYPE } from 'drive/web/modules/drive/files'
 
 describe('getParentLink function', () => {
   it('should return the first link in the element ancestors', () => {
@@ -22,5 +23,43 @@ describe('getParentLink function', () => {
     div.appendChild(span)
     const result = getParentLink(span)
     expect(result).toBeNull()
+  })
+})
+
+describe('splitFilename function', () => {
+  const name = ({ filename, extension }) => filename + extension
+  const doc = type => expectation => ({ type, name: name(expectation) })
+  const file = doc(FILE_TYPE)
+  const dir = doc(DIR_TYPE)
+  const { stringify } = JSON
+
+  const scenarios = [
+    { filename: 'file', extension: '.ext' },
+    // FIXME: { filename: 'file', extension: '' },
+    { filename: 'file.html', extension: '.ejs' },
+    { filename: 'file', extension: '.' },
+    { filename: 'file.', extension: '.' },
+    { filename: 'file.', extension: '.ext' },
+    // FIXME: { filename: '.file', extension: '' },
+    { filename: '.file', extension: '.ext' }
+  ]
+
+  for (const expectation of scenarios) {
+    it(`splits ${stringify(name(expectation))} into ${stringify(
+      expectation
+    )}`, () => {
+      expect(splitFilename(file(expectation))).toEqual(expectation)
+    })
+  }
+
+  it('never splits a dirname', () => {
+    const expectations = scenarios.map(scenario => ({
+      filename: name(scenario),
+      extension: ''
+    }))
+    const results = scenarios.map(expectation =>
+      splitFilename(dir(expectation))
+    )
+    expect(results).toEqual(expectations)
   })
 })


### PR DESCRIPTION
- Don't assume extension-less filename last char is extension
- Don't confuse hidden file with extension