### PR TITLE
fix: Handle section dates

### DIFF
--- a/src/photos/ducks/timeline-clusters/dates.js
+++ b/src/photos/ducks/timeline-clusters/dates.js
@@ -48,7 +48,7 @@ const addYear = (f, date) => {
 export const isSameMonth = (f, newerDate, olderDate) => {
   const newer = formatDate(f, newerDate)
   const older = formatDate(f, olderDate)
-  return differenceInCalendarMonths(newer, older) < 1
+  return differenceInCalendarMonths(newer, older) === 0
 }
 
 export const isSameDay = (f, newerDate, olderDate) => {
@@ -60,7 +60,7 @@ export const isSameDay = (f, newerDate, olderDate) => {
 export const isSameHour = (f, newerDate, olderDate) => {
   const newer = formatDate(f, newerDate)
   const older = formatDate(f, olderDate)
-  return differenceInHours(newer, older) < 1
+  return differenceInHours(newer, older) === 0
 }
 
 export const isEqualOrNewer = (newerDate, olderDate) => {

--- a/src/photos/ducks/timeline-clusters/dates.js
+++ b/src/photos/ducks/timeline-clusters/dates.js
@@ -20,7 +20,8 @@ import {
  */
 const formatDate = (f, date, formatter) => {
   const [year, month, day] = date.substr(0, 10).split('-')
-  const [hours, minutes, seconds] = date.substr(11, 8).split(':')
+  const [hours, minutes, seconds] =
+    date.length > 10 ? date.substr(11, 8).split(':') : [0, 0, 0]
   return f(new Date(year, month - 1, day, hours, minutes, seconds), formatter)
 }
 
@@ -53,7 +54,7 @@ export const isSameMonth = (f, newerDate, olderDate) => {
 export const isSameDay = (f, newerDate, olderDate) => {
   const newer = formatDate(f, newerDate)
   const older = formatDate(f, olderDate)
-  return differenceInCalendarDays(newer, older) < 1
+  return differenceInCalendarDays(newer, older) === 0
 }
 
 export const isSameHour = (f, newerDate, olderDate) => {

--- a/src/photos/ducks/timeline-clusters/index.jsx
+++ b/src/photos/ducks/timeline-clusters/index.jsx
@@ -126,7 +126,6 @@ const getMatchingSection = (sections, datetime, f) => {
 const getPhotosByClusters = (photos, f) => {
   const sections = {}
   const photosNotClustered = []
-
   photos.forEach(p => {
     const refAlbums = p.albums ? p.albums.data : []
     // A photo can be referenced by only one auto album


### PR DESCRIPTION
This fixes situations where non-clustered photos wouldn't be displayed in the timeline because the date section (which are days for non-clustered-yet photos) was not properly managed.