### PR TITLE
fix: Median dot display

### DIFF
--- a/src/photos/ducks/timeline-clusters/index.jsx
+++ b/src/photos/ducks/timeline-clusters/index.jsx
@@ -87,7 +87,7 @@ const getSectionTitleHours = (dates, index, section, f) => {
       const startPeriod = section.album.period.start
       const endPeriod = section.album.period.end
 
-      let titleWithHours = section.title + ' ⠂' + formatH(f, startPeriod) + 'h'
+      let titleWithHours = section.title + ' · ' + formatH(f, startPeriod) + 'h'
       if (!isSameHour(f, endPeriod, startPeriod)) {
         titleWithHours += '-' + formatH(f, endPeriod) + 'h'
       }


### PR DESCRIPTION
The `⠂` character (U+2802) wasn't correctly displayed on Chrome in MacOs. It is therefore replaced by `·` (U+00B7 )