### PR TITLE
feat: Use a better index

### DIFF
--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -152,7 +152,8 @@ export class MoveModal extends React.Component {
           $ne: TRASH_DIR_ID
         }
       })
-      .sortBy([{ type: 'asc' }, { name: 'asc' }])
+      .indexFields(['dir_id', 'type', 'name'])
+      .sortBy([{ dir_id: 'asc' }, { type: 'asc' }, { name: 'asc' }])
   }
 
   breadcrumbQuery = client => {


### PR DESCRIPTION
indexing by dir_is first since we're looking for files in a specific dir_id. The order of the indexes are very important 

See: https://docs.cozy.io/en/cozy-stack/pouchdb-quirks/#indexing-more-than-one-field
> Furthermore, the order in which fields are indexed on a multi-index is significant, most notably when it comes to sorting.
