### PR TITLE
feat: Improve parameters recomputing

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -1,4 +1,3 @@
-export const THRESHOLD = 314
 export const DEFAULT_PERIOD = 'all'
 export const DEFAULT_MODE = 'default'
 export const SETTING_TYPE = 'clustering'
@@ -10,12 +9,11 @@ export const MIN_EPS_SPATIAL = 2.5
 export const PERCENTILE = 99.5
 export const MAX_DISTANCE = 24 * 7
 export const COARSE_COEFFICIENT = 1
-export const EVALUATION_THRESHOLD = 314
+export const EVALUATION_THRESHOLD = 500
 export const CHANGES_RUN_LIMIT = 1000
 
 export const DEFAULT_SETTING = {
   type: SETTING_TYPE,
-  lastSeq: 0,
   evaluationCount: 0,
   parameters: []
 }

--- a/src/photos/ducks/clustering/setting.spec.js
+++ b/src/photos/ducks/clustering/setting.spec.js
@@ -1,0 +1,82 @@
+import { updateParamsPeriod, createParameter } from './settings'
+import { DEFAULT_EPS_TEMPORAL, DEFAULT_EPS_SPATIAL } from './consts'
+import CozyClient from 'cozy-client'
+jest.mock('cozy-client')
+const client = new CozyClient({})
+
+client.save = jest.fn(() => Promise.resolve({ data: {} }))
+
+const photos = [
+  {
+    datetime: '2018-03-01'
+  },
+  {
+    datetime: '2018-04-01'
+  },
+  {
+    datetime: '2019-01-01'
+  }
+]
+
+describe('setting', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('Should update the params period ', async () => {
+    const params = [
+      {
+        period: {
+          start: '2017-01-01',
+          end: '2017-12-31'
+        }
+      },
+      {
+        period: {
+          start: '2018-01-01',
+          end: '2018-03-01'
+        }
+      },
+      {
+        period: {
+          start: '2018-03-02',
+          end: '2018-12-31'
+        }
+      }
+    ]
+
+    const setting = {
+      parameters: params
+    }
+    const newParams = {
+      ...params[2],
+      period: { start: params[2].period.start, end: photos[2].datetime }
+    }
+    const parameters = [...setting.parameters]
+    parameters[2] = newParams
+
+    await updateParamsPeriod(client, setting, params[2], photos)
+    expect(client.save).toHaveBeenCalledWith({ ...setting, parameters })
+  })
+
+  it('Should return the correct default parameters', () => {
+    const defaultParams = createParameter(photos)
+    expect(defaultParams.period).toEqual({
+      start: photos[0].datetime,
+      end: photos[0].datetime
+    })
+    expect(defaultParams.evaluation).toEqual({
+      start: photos[0].datetime,
+      end: photos[photos.length - 1].datetime
+    })
+    expect(defaultParams.defaultEvaluation).toEqual(true)
+    expect(defaultParams.modes[0].epsTemporal).toEqual(DEFAULT_EPS_TEMPORAL)
+    expect(defaultParams.modes[0].epsSpatial).toEqual(DEFAULT_EPS_SPATIAL)
+  })
+
+  it('Should return the correct parameters', () => {
+    const params = createParameter(photos, 8, 4)
+    expect(params.modes[0].epsTemporal).toEqual(8)
+    expect(params.modes[0].epsSpatial).toEqual(4)
+    expect(params.defaultEvaluation).toEqual(false)
+  })
+})

--- a/src/photos/ducks/clustering/settings.js
+++ b/src/photos/ducks/clustering/settings.js
@@ -59,6 +59,10 @@ export const getDefaultParameters = photos => {
   return {
     period: {
       start: photos[0].datetime,
+      end: photos[0].datetime
+    },
+    evaluation: {
+      start: photos[0].datetime,
       end: photos[photos.length - 1].datetime
     },
     defaultEvaluation: true,

--- a/src/photos/ducks/clustering/settings.js
+++ b/src/photos/ducks/clustering/settings.js
@@ -55,24 +55,24 @@ export const getDefaultParametersMode = params => {
   }
 }
 
-export const getDefaultParameters = photos => {
+export const createParameter = (dataset, epsTemporal, epsSpatial) => {
   return {
-    period: {
-      start: photos[0].datetime,
-      end: photos[0].datetime
-    },
     evaluation: {
-      start: photos[0].datetime,
-      end: photos[photos.length - 1].datetime
+      start: dataset[0].datetime,
+      end: dataset[dataset.length - 1].datetime
     },
-    defaultEvaluation: true,
+    period: {
+      start: dataset[0].datetime,
+      end: dataset[0].datetime
+    },
     modes: [
       {
         name: DEFAULT_MODE,
-        epsTemporal: DEFAULT_EPS_TEMPORAL,
-        epsSpatial: DEFAULT_EPS_SPATIAL
+        epsTemporal: epsTemporal ? epsTemporal : DEFAULT_EPS_TEMPORAL,
+        epsSpatial: epsSpatial ? epsSpatial : DEFAULT_EPS_SPATIAL
       }
-    ]
+    ],
+    defaultEvaluation: epsTemporal ? false : true
   }
 }
 

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -7,7 +7,7 @@ import {
   readSetting,
   createSetting,
   updateParameters,
-  getDefaultParameters,
+  createParameter,
   updateSettingStatus,
   getDefaultParametersMode,
   updateParamsPeriod
@@ -19,7 +19,6 @@ import {
 } from 'photos/ducks/clustering/service'
 import {
   PERCENTILE,
-  DEFAULT_MODE,
   EVALUATION_THRESHOLD,
   CHANGES_RUN_LIMIT
 } from 'photos/ducks/clustering/consts'
@@ -99,25 +98,6 @@ const clusterizePhotos = async (client, setting, dataset, albums) => {
   return { setting, clusteredCount }
 }
 
-const createParameter = (dataset, epsTemporal, epsSpatial) => {
-  return {
-    evaluation: {
-      start: dataset[0].datetime,
-      end: dataset[dataset.length - 1].datetime
-    },
-    period: {
-      start: dataset[0].datetime,
-      end: dataset[0].datetime
-    },
-    modes: [
-      {
-        name: DEFAULT_MODE,
-        epsTemporal: epsTemporal,
-        epsSpatial: epsSpatial
-      }
-    ]
-  }
-}
 const initParameters = dataset => {
   log('info', `Compute clustering parameters on ${dataset.length} photos`)
   const epsTemporal = computeEpsTemporal(dataset, PERCENTILE)
@@ -202,7 +182,7 @@ const onPhotoUpload = async () => {
     const params =
       dataset.length > EVALUATION_THRESHOLD
         ? initParameters(dataset)
-        : getDefaultParameters(dataset)
+        : createParameter(dataset)
     setting = await createSetting(client, params)
     log(
       'info',

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -213,6 +213,17 @@ const onPhotoUpload = async () => {
   }
 
   try {
+    const lastParams = setting.parameters[setting.parameters.length - 1]
+    if (!lastParams.evaluation) {
+      // Temporary code for migration: existing instances with clusters do not
+      // have the evaluation parameter
+      lastParams.evaluation = {
+        start: lastParams.period.start,
+        end: lastParams.period.end
+      }
+      setting = await client.save({ ...setting })
+    }
+
     if (setting.evaluationCount > EVALUATION_THRESHOLD) {
       // Recompute parameters when enough photos had been processed
       const newParams = await recomputeParameters(client, setting)


### PR DESCRIPTION
We used to store the period of the photos concerned by a set of parameters, to be able to know which photos' period were clustered with which set of parameters, to retrieve the correct parameters for new photos (e.g. the photo with the datetime 2019-02-01 will be clustered with the params having a `period` between 2019-01-01 and 2019-03-01).

Additionally, we kept track of how many new photos were clustered since the last re-evaluation of params, to start a new params recomputing when  `evaluationCount > EVALUATION_THRESHOLD`.

However, this was not efficient, because `evaluationCount` was incremented for each new photo, even though the datetime was not necessary newer than the last params period, while a new params recomputing will only be on photos newer than the last params period, causing [unecessary attemps](https://github.com/cozy/cozy-drive/blob/a8f705ef3b45084e88c08b91e78fcebc43425cf0/src/photos/targets/services/onPhotoUpload.js#L137-L139). 

So, we introduce an `evaluation` period,  which is checked to know if it is worth to increment the `evaluationCount`.
