### PR TITLE
feat: Use @in triggers to postpone next service

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -11,6 +11,7 @@ export const MAX_DISTANCE = 24 * 7
 export const COARSE_COEFFICIENT = 1
 export const EVALUATION_THRESHOLD = 500
 export const CHANGES_RUN_LIMIT = 1000
+export const TRIGGER_ELAPSED = '20m'
 
 export const DEFAULT_SETTING = {
   type: SETTING_TYPE,

--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -56,3 +56,21 @@ export const averageTime = photos => {
   const averageHours = sumHours / photos.length
   return new Date(averageHours * 3600 * 1000).getTime()
 }
+
+/**
+  Convert a duration into milliseconds.
+  See https://golang.org/pkg/time/#ParseDuration for the duration format
+  @param {string} duration - The duration in hms format
+  @returns {number} The duration in milliseconds
+
+*/
+export const convertDurationInMilliseconds = duration => {
+  const offsetH = duration.indexOf('h')
+  const offsetM = duration.indexOf('m')
+  const offsetS = duration.indexOf('s')
+
+  const hours = offsetH > 0 ? duration.substring(0, offsetH) : 0
+  const minutes = offsetM > 0 ? duration.substring(offsetH + 1, offsetM) : 0
+  const seconds = offsetS > 0 ? duration.substring(offsetM + 1, offsetS) : 0
+  return seconds * 1000 + minutes * 60 * 1000 + hours * 3600 * 1000
+}

--- a/src/photos/ducks/clustering/utils.spec.js
+++ b/src/photos/ducks/clustering/utils.spec.js
@@ -1,4 +1,4 @@
-import { averageTime } from './utils'
+import { averageTime, convertDurationInMilliseconds } from './utils'
 
 describe('date', () => {
   it('Should compute the mean date', () => {
@@ -22,5 +22,20 @@ describe('date', () => {
     ]
     const expectedTime = new Date('2018-06-13T01:35:26.249Z').getTime()
     expect(averageTime(data)).toEqual(expectedTime)
+  })
+})
+
+describe('convert duration', () => {
+  it('Should correctly convert duration', () => {
+    const d1 = '2h'
+    const d2 = '3m'
+    const d3 = '4s'
+    const d4 = '1h10m15s'
+    const d5 = 'wrongduration'
+    expect(convertDurationInMilliseconds(d1)).toEqual(7200000)
+    expect(convertDurationInMilliseconds(d2)).toEqual(180000)
+    expect(convertDurationInMilliseconds(d3)).toEqual(4000)
+    expect(convertDurationInMilliseconds(d4)).toEqual(4215000)
+    expect(convertDurationInMilliseconds(d5)).toEqual(0)
   })
 })

--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -110,9 +110,9 @@
       "type": "cc.cozycloud.sentry",
       "verbs": ["POST"]
     },
-    "clustering": {
+    "triggers": {
       "description": "Required to re-execute the clustering",
-      "type": "io.cozy.jobs",
+      "type": "io.cozy.triggers",
       "verbs": ["POST"],
       "selector": "worker",
       "values": ["service"]

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -168,7 +168,7 @@ const runClustering = async (client, setting) => {
   return { photos, newSetting: setting }
 }
 
-const onPhotoUpload = async () => {
+export const onPhotoUpload = async () => {
   log('info', `Service called with COZY_URL: ${process.env.COZY_URL}`)
 
   const options = {

--- a/src/photos/targets/services/onPhotoUpload.spec.js
+++ b/src/photos/targets/services/onPhotoUpload.spec.js
@@ -1,0 +1,37 @@
+import { onPhotoUpload } from './onPhotoUpload'
+import { readSetting } from 'photos/ducks/clustering/settings'
+import { convertDurationInMilliseconds } from 'photos/ducks/clustering/utils'
+import CozyClient from 'cozy-client'
+
+CozyClient.fromEnv = jest.fn()
+jest.mock('photos/ducks/clustering/settings', () => ({
+  readSetting: jest.fn()
+}))
+jest.mock('photos/ducks/clustering/utils', () => ({
+  convertDurationInMilliseconds: jest.fn()
+}))
+jest.mock('cozy-client')
+const client = new CozyClient({})
+client.save = jest.fn(() => Promise.resolve({ data: {} }))
+
+describe('onPhotoUpload', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 1000)
+  })
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('Should stop if running', async () => {
+    readSetting.mockReturnValueOnce({ jobStatus: 'running' })
+    await onPhotoUpload()
+    expect(client.save).toHaveBeenCalledTimes(0)
+  })
+
+  it('Should stop if postponed', async () => {
+    readSetting.mockReturnValueOnce({ jobStatus: 'postponed', lastExec: 500 })
+    convertDurationInMilliseconds.mockReturnValueOnce(600)
+    await onPhotoUpload()
+    expect(client.save).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
There is currently a rate limit for the thumbnails jobs creation, set to [5000 per hour](https://github.com/cozy/cozy-stack/blob/master/pkg/limits/rate_limiting.go#L102-L107). This limit will be reached if one runs the clustering service with more than 5000 photos, as the writes on io.cozy.files triggers the thumbnails jobs.

Therefore, we use `@in` triggers to postpone the next service execution and save the last execution date to avoid running anything by this time (in case there are new uploaded photos ).
