### PR TITLE
feat: Activate service for % of instances

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -12,6 +12,7 @@ export const COARSE_COEFFICIENT = 1
 export const EVALUATION_THRESHOLD = 500
 export const CHANGES_RUN_LIMIT = 1000
 export const TRIGGER_ELAPSED = '20m'
+export const PERCENT_INSTANCES = 5
 
 export const DEFAULT_SETTING = {
   type: SETTING_TYPE,

--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -92,11 +92,11 @@ const hashCode = toHash => {
 }
 
 /**
- *  Pick the instance if it matches the condition, met a percentage of cases
+ *  Returns true if `instance` is chosen to be part of a progressive rollout, according to `percentage`
  *  @param {string} instance - The string to hash
  *  @param {number} percent - The percent of instances that should match
  *  @returns {boolean} If the instance is picked or not
  */
-export const pickInstance = (instance, percent) => {
+export const isPartOfProgressiveRollout = (instance, percent) => {
   return Math.abs(hashCode(instance)) % 100 <= percent
 }

--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -58,12 +58,11 @@ export const averageTime = photos => {
 }
 
 /**
-  Convert a duration into milliseconds.
-  See https://golang.org/pkg/time/#ParseDuration for the duration format
-  @param {string} duration - The duration in hms format
-  @returns {number} The duration in milliseconds
-
-*/
+ *  Convert a duration into milliseconds.
+ *  See https://golang.org/pkg/time/#ParseDuration for the duration format
+ *  @param {string} duration - The duration in hms format
+ *  @returns {number} The duration in milliseconds
+ */
 export const convertDurationInMilliseconds = duration => {
   const offsetH = duration.indexOf('h')
   const offsetM = duration.indexOf('m')
@@ -73,4 +72,31 @@ export const convertDurationInMilliseconds = duration => {
   const minutes = offsetM > 0 ? duration.substring(offsetH + 1, offsetM) : 0
   const seconds = offsetS > 0 ? duration.substring(offsetM + 1, offsetS) : 0
   return seconds * 1000 + minutes * 60 * 1000 + hours * 3600 * 1000
+}
+
+/**
+ *  Hash a string into a 32-bit integer
+ *  @param {string} toHash - The string to hash
+ *  @returns {number} The 32-bit hash value
+ */
+const hashCode = toHash => {
+  let hash = 0
+  let i, chr
+  if (toHash.length === 0) return toHash
+  for (i = 0; i < toHash.length; i++) {
+    chr = toHash.charCodeAt(i)
+    hash = (hash << 5) - hash + chr
+    hash = hash & hash // Convert to 32-bit integer
+  }
+  return hash
+}
+
+/**
+ *  Pick the instance if it matches the condition, met a percentage of cases
+ *  @param {string} instance - The string to hash
+ *  @param {number} percent - The percent of instances that should match
+ *  @returns {boolean} If the instance is picked or not
+ */
+export const pickInstance = (instance, percent) => {
+  return Math.abs(hashCode(instance)) % 100 <= percent
 }

--- a/src/photos/ducks/clustering/utils.spec.js
+++ b/src/photos/ducks/clustering/utils.spec.js
@@ -1,7 +1,7 @@
 import {
   averageTime,
   convertDurationInMilliseconds,
-  pickInstance
+  isPartOfProgressiveRollout
 } from './utils'
 
 describe('date', () => {
@@ -52,13 +52,13 @@ describe('pick instance', () => {
       match100percent = 0
     for (let i = 0; i < 10000; i++) {
       instances[i] = i + '.mycozy.cloud'
-      if (pickInstance(instances[i], 10)) {
+      if (isPartOfProgressiveRollout(instances[i], 10)) {
         match10percent++
       }
-      if (pickInstance(instances[i], -1)) {
+      if (isPartOfProgressiveRollout(instances[i], -1)) {
         match0percent++
       }
-      if (pickInstance(instances[i], 100)) {
+      if (isPartOfProgressiveRollout(instances[i], 100)) {
         match100percent++
       }
     }

--- a/src/photos/ducks/clustering/utils.spec.js
+++ b/src/photos/ducks/clustering/utils.spec.js
@@ -1,4 +1,8 @@
-import { averageTime, convertDurationInMilliseconds } from './utils'
+import {
+  averageTime,
+  convertDurationInMilliseconds,
+  pickInstance
+} from './utils'
 
 describe('date', () => {
   it('Should compute the mean date', () => {
@@ -37,5 +41,30 @@ describe('convert duration', () => {
     expect(convertDurationInMilliseconds(d3)).toEqual(4000)
     expect(convertDurationInMilliseconds(d4)).toEqual(4215000)
     expect(convertDurationInMilliseconds(d5)).toEqual(0)
+  })
+})
+
+describe('pick instance', () => {
+  it('Should pick a % of instances', () => {
+    const instances = []
+    let match10percent = 0,
+      match0percent = 0,
+      match100percent = 0
+    for (let i = 0; i < 10000; i++) {
+      instances[i] = i + '.mycozy.cloud'
+      if (pickInstance(instances[i], 10)) {
+        match10percent++
+      }
+      if (pickInstance(instances[i], -1)) {
+        match0percent++
+      }
+      if (pickInstance(instances[i], 100)) {
+        match100percent++
+      }
+    }
+    expect(match10percent).toBeGreaterThan(900)
+    expect(match10percent).toBeLessThan(1100)
+    expect(match0percent).toEqual(0)
+    expect(match100percent).toEqual(10000)
   })
 })

--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -43,7 +43,7 @@
     "onPhotoUpload": {
       "type": "node",
       "file": "services/onPhotoUpload/photos.js",
-      "trigger": "@event io.cozy.clusters.dummy",
+      "trigger": "@event io.cozy.files:CREATED:image:class",
       "debounce": "1s"
     }
   },

--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -44,7 +44,7 @@
       "type": "node",
       "file": "services/onPhotoUpload/photos.js",
       "trigger": "@event io.cozy.files:CREATED:image:class",
-      "debounce": "1s"
+      "debounce": "5m"
     }
   },
   "permissions": {

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -31,7 +31,7 @@ import { albumsToClusterize } from 'photos/ducks/clustering/reclusterize'
 import {
   prepareDataset,
   convertDurationInMilliseconds,
-  pickInstance
+  isPartOfProgressiveRollout
 } from 'photos/ducks/clustering/utils'
 import { getMatchingParameters } from 'photos/ducks/clustering/matching'
 
@@ -176,7 +176,7 @@ export const onPhotoUpload = async () => {
     the clustering gradually, we only run the service for a % of instances
    */
   const instanceURL = process.env.COZY_URL
-  if (!pickInstance(instanceURL, PERCENT_INSTANCES)) {
+  if (!isPartOfProgressiveRollout(instanceURL, PERCENT_INSTANCES)) {
     return
   }
   log('info', `Service called with COZY_URL: ${process.env.COZY_URL}`)

--- a/src/photos/targets/services/onPhotoUpload.spec.js
+++ b/src/photos/targets/services/onPhotoUpload.spec.js
@@ -1,6 +1,9 @@
 import { onPhotoUpload } from './onPhotoUpload'
 import { readSetting } from 'photos/ducks/clustering/settings'
-import { convertDurationInMilliseconds } from 'photos/ducks/clustering/utils'
+import {
+  convertDurationInMilliseconds,
+  pickInstance
+} from 'photos/ducks/clustering/utils'
 import CozyClient from 'cozy-client'
 
 CozyClient.fromEnv = jest.fn()
@@ -8,7 +11,8 @@ jest.mock('photos/ducks/clustering/settings', () => ({
   readSetting: jest.fn()
 }))
 jest.mock('photos/ducks/clustering/utils', () => ({
-  convertDurationInMilliseconds: jest.fn()
+  convertDurationInMilliseconds: jest.fn(),
+  pickInstance: jest.fn()
 }))
 jest.mock('cozy-client')
 const client = new CozyClient({})
@@ -17,6 +21,7 @@ client.save = jest.fn(() => Promise.resolve({ data: {} }))
 describe('onPhotoUpload', () => {
   beforeEach(() => {
     jest.spyOn(Date, 'now').mockImplementation(() => 1000)
+    pickInstance.mockReturnValue(true)
   })
   afterEach(() => {
     jest.restoreAllMocks()

--- a/src/photos/targets/services/onPhotoUpload.spec.js
+++ b/src/photos/targets/services/onPhotoUpload.spec.js
@@ -2,7 +2,7 @@ import { onPhotoUpload } from './onPhotoUpload'
 import { readSetting } from 'photos/ducks/clustering/settings'
 import {
   convertDurationInMilliseconds,
-  pickInstance
+  isPartOfProgressiveRollout
 } from 'photos/ducks/clustering/utils'
 import CozyClient from 'cozy-client'
 
@@ -12,7 +12,7 @@ jest.mock('photos/ducks/clustering/settings', () => ({
 }))
 jest.mock('photos/ducks/clustering/utils', () => ({
   convertDurationInMilliseconds: jest.fn(),
-  pickInstance: jest.fn()
+  isPartOfProgressiveRollout: jest.fn()
 }))
 jest.mock('cozy-client')
 const client = new CozyClient({})
@@ -21,7 +21,7 @@ client.save = jest.fn(() => Promise.resolve({ data: {} }))
 describe('onPhotoUpload', () => {
   beforeEach(() => {
     jest.spyOn(Date, 'now').mockImplementation(() => 1000)
-    pickInstance.mockReturnValue(true)
+    isPartOfProgressiveRollout.mockReturnValue(true)
   })
   afterEach(() => {
     jest.restoreAllMocks()


### PR DESCRIPTION
This activates the clustering service, by using the real trigger condition, i.e. when a new photo is uploaded. However, we only run it for a fixed 5% of instances, in order to make a progressive deployment ; we plan to increase this % progressively.