### PR TITLE
Fix/move modal

### DIFF
--- a/src/drive/styles/topbar.styl
+++ b/src/drive/styles/topbar.styl
@@ -9,6 +9,7 @@
     margin-right 2rem
     margin-left 2rem
     flex 0 0 auto
+    min-height 2rem
 
 +small-screen()
   .fil-topbar
@@ -17,6 +18,7 @@
     margin-left 0
     padding-right .5rem
     padding-left .5rem
-
+    min-height 2rem
+    
     &.hidden-mobile
           display none

--- a/src/drive/web/modules/filelist/FileListHeader.jsx
+++ b/src/drive/web/modules/filelist/FileListHeader.jsx
@@ -223,22 +223,25 @@ const FileListHeader = ({
           styles['fil-content-header-action']
         )}
       >
-        <Button
-          theme={'action'}
-          onClick={() => {
-            toggleThumbnailSize()
-          }}
-          label={t('table.head_thumbnail_size')}
-          extension="narrow"
-          icon={
-            <Icon
-              icon={thumbnailSizeBig ? iconListMin : iconList}
-              size={17}
-              label={t('table.head_thumbnail_size')}
-            />
-          }
-          iconOnly
-        />
+        {/** in order to not display this button in a MoveModal for instance */}
+        {canSort && (
+          <Button
+            theme={'action'}
+            onClick={() => {
+              toggleThumbnailSize()
+            }}
+            label={t('table.head_thumbnail_size')}
+            extension="narrow"
+            icon={
+              <Icon
+                icon={thumbnailSizeBig ? iconListMin : iconList}
+                size={17}
+                label={t('table.head_thumbnail_size')}
+              />
+            }
+            iconOnly
+          />
+        )}
       </div>
     </div>
   )

--- a/src/drive/web/modules/filelist/FileListRows.jsx
+++ b/src/drive/web/modules/filelist/FileListRows.jsx
@@ -22,6 +22,14 @@ class FileListRows extends PureComponent {
   intersectionObserver = null
   loadMoreElement = null
 
+  constructor(props) {
+    super(props)
+    this.myFilesListRowsContainer = React.createRef()
+  }
+
+  componentDidMount() {
+    this.myFilesListRowsContainer.current.scrollTo(0, 0)
+  }
   componentWillMount() {
     this.intersectionObserver = new IntersectionObserver(
       this.checkIntersectionsEntries
@@ -61,7 +69,7 @@ class FileListRows extends PureComponent {
 
   render() {
     return (
-      <div>
+      <div ref={this.myFilesListRowsContainer}>
         {this.props.files.map((file, index) => {
           return this.rowRenderer({ index, key: file.id })
         })}

--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -171,6 +171,7 @@ export class MoveModal extends React.Component {
         mobileFullscreen
         into="body"
         aria-label={t('Move.modalTitle')}
+        className={'u-mih-100'}
       >
         <Header entries={entries} onClose={onClose} />
         <Query query={this.breadcrumbQuery} key={`breadcrumb-${folderId}`}>


### PR DESCRIPTION
- MoveModal now have a fixed height to avoid flash between small folder and big one
- Topbar has a min-height to 2rem to avoid flashing when we create a breacrumb 
- We now scroll to top on every didMount FileList to be sure to be... on top 