### PR TITLE
fix: Pass onFolderOpen props to breadcrumb

### DIFF
--- a/src/drive/web/modules/public/LightFolderView.jsx
+++ b/src/drive/web/modules/public/LightFolderView.jsx
@@ -74,7 +74,7 @@ class DumbFolderView extends React.Component {
     return (
       <Main isPublic>
         <Topbar>
-          <Breadcrumb isPublic />
+          <Breadcrumb isPublic onFolderOpen={this.props.fetchFolder} />
           <PublicToolbar files={[this.props.displayedFolder]} isFile={false} />
         </Topbar>
         <Content>


### PR DESCRIPTION
We forgot to pass `onFolderOpen` on the public view. 

This resolves the bug when, being on a public page, we can not navigate through folders from the breadcrumb 