### PR TITLE
Fix/photos

### DIFF
--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -29,6 +29,7 @@ const TIMELINE_QUERY = client =>
     .sortBy({
       'metadata.datetime': 'desc'
     })
+    .include(['albums'])
 
 const TIMELINE_MUTATIONS = client => ({
   uploadPhoto: async (file, dirId) => {

--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -13,7 +13,7 @@ import {
   isEqualOrOlder,
   isEqualOrNewer
 } from './dates'
-
+import { format } from 'date-fns'
 // constants
 const TIMELINE = 'timeline'
 const FILES_DOCTYPE = 'io.cozy.files'
@@ -182,7 +182,7 @@ export class TimelineBoard extends React.Component {
       >
         {({ data, ...result }, mutations) => (
           <Timeline
-            lists={data ? getPhotosByClusters(data, this.props.f) : []}
+            lists={data ? getPhotosByClusters(data, format) : []}
             data={data}
             {...mutations}
             {...result}

--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -13,7 +13,7 @@ import {
   isEqualOrOlder,
   isEqualOrNewer
 } from './dates'
-import { format } from 'date-fns'
+import { translate } from 'cozy-ui/react/I18n'
 // constants
 const TIMELINE = 'timeline'
 const FILES_DOCTYPE = 'io.cozy.files'
@@ -173,11 +173,11 @@ const getPhotosByClusters = (photos, f) => {
 }
 
 // eslint-disable-next-line
-export default props => (
+export default translate()(props => (
   <Query query={TIMELINE_QUERY} as={TIMELINE} mutations={TIMELINE_MUTATIONS}>
     {({ data, ...result }, mutations) => (
       <Timeline
-        lists={data ? getPhotosByClusters(data, format) : []}
+        lists={data ? getPhotosByClusters(data, props.f) : []}
         data={data}
         {...mutations}
         {...result}
@@ -185,18 +185,18 @@ export default props => (
       />
     )}
   </Query>
-)
+))
 
 /**
  *
  * This component is used by the Picker, when we create an album
  * We have to deal with selection for instance
  */
-export const TimelineBoard = ({ selection, ...props }) => (
+export const TimelineBoard = translate()(({ selection, ...props }) => (
   <Query query={TIMELINE_QUERY}>
     {({ data, ...result }) => (
       <PhotoBoard
-        lists={data ? getPhotosByClusters(data, format) : []}
+        lists={data ? getPhotosByClusters(data, props.f) : []}
         photosContext="timeline"
         onPhotoToggle={selection.toggle}
         onPhotosSelect={selection.select}
@@ -206,4 +206,4 @@ export const TimelineBoard = ({ selection, ...props }) => (
       />
     )}
   </Query>
-)
+))

--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Query } from 'cozy-client'
 import Timeline from './components/Timeline'
-import { translate } from 'cozy-ui/react/I18n'
+import PhotoBoard from '../../components/PhotoBoard'
 import {
   formatDMY,
   formatD,
@@ -172,26 +172,38 @@ const getPhotosByClusters = (photos, f) => {
   })
 }
 
-export class TimelineBoard extends React.Component {
-  render() {
-    return (
-      <Query
-        query={TIMELINE_QUERY}
-        as={TIMELINE}
-        mutations={TIMELINE_MUTATIONS}
-      >
-        {({ data, ...result }, mutations) => (
-          <Timeline
-            lists={data ? getPhotosByClusters(data, format) : []}
-            data={data}
-            {...mutations}
-            {...result}
-            {...this.props}
-          />
-        )}
-      </Query>
-    )
-  }
-}
+// eslint-disable-next-line
+export default props => (
+  <Query query={TIMELINE_QUERY} as={TIMELINE} mutations={TIMELINE_MUTATIONS}>
+    {({ data, ...result }, mutations) => (
+      <Timeline
+        lists={data ? getPhotosByClusters(data, format) : []}
+        data={data}
+        {...mutations}
+        {...result}
+        {...props}
+      />
+    )}
+  </Query>
+)
 
-export default translate()(TimelineBoard)
+/**
+ *
+ * This component is used by the Picker, when we create an album
+ * We have to deal with selection for instance
+ */
+export const TimelineBoard = ({ selection, ...props }) => (
+  <Query query={TIMELINE_QUERY}>
+    {({ data, ...result }) => (
+      <PhotoBoard
+        lists={data ? getPhotosByClusters(data, format) : []}
+        photosContext="timeline"
+        onPhotoToggle={selection.toggle}
+        onPhotosSelect={selection.select}
+        onPhotosUnselect={selection.unselect}
+        {...result}
+        {...props}
+      />
+    )}
+  </Query>
+)


### PR DESCRIPTION
Since the merge of the "clustered timeline", we have few bugs : 
- can't create an album anymore. `f` was not defined. So I use `f` from `translate()`
- can't add photos during the creation of an album (also, selection bar was visible when selecting). To fix that, we needed to re-export the right component 