### PR TITLE
feat: Increase percent of instances having clustering

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -12,7 +12,7 @@ export const COARSE_COEFFICIENT = 1
 export const EVALUATION_THRESHOLD = 500
 export const CHANGES_RUN_LIMIT = 1000
 export const TRIGGER_ELAPSED = '20m'
-export const PERCENT_INSTANCES = 5
+export const PERCENT_INSTANCES = 25
 
 export const DEFAULT_SETTING = {
   type: SETTING_TYPE,


### PR DESCRIPTION
No problem has been noticed with the current 5% of instances having the clustering service ; therefore we increase to 25%.