### PR TITLE
feat: Allow service execution for all instances

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -12,7 +12,6 @@ export const COARSE_COEFFICIENT = 1
 export const EVALUATION_THRESHOLD = 500
 export const CHANGES_RUN_LIMIT = 1000
 export const TRIGGER_ELAPSED = '20m'
-export const PERCENT_INSTANCES = 66
 export const LOG_ERROR_MSG_LIMIT = 32 * 1024 - 1 // Avoid unreadable logs by the stack
 
 export const DEFAULT_SETTING = {

--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -73,30 +73,3 @@ export const convertDurationInMilliseconds = duration => {
   const seconds = offsetS > 0 ? duration.substring(offsetM + 1, offsetS) : 0
   return seconds * 1000 + minutes * 60 * 1000 + hours * 3600 * 1000
 }
-
-/**
- *  Hash a string into a 32-bit integer
- *  @param {string} toHash - The string to hash
- *  @returns {number} The 32-bit hash value
- */
-const hashCode = toHash => {
-  let hash = 0
-  let i, chr
-  if (toHash.length === 0) return toHash
-  for (i = 0; i < toHash.length; i++) {
-    chr = toHash.charCodeAt(i)
-    hash = (hash << 5) - hash + chr
-    hash = hash & hash // Convert to 32-bit integer
-  }
-  return hash
-}
-
-/**
- *  Returns true if `instance` is chosen to be part of a progressive rollout, according to `percentage`
- *  @param {string} instance - The string to hash
- *  @param {number} percent - The percent of instances that should match
- *  @returns {boolean} If the instance is picked or not
- */
-export const isPartOfProgressiveRollout = (instance, percent) => {
-  return Math.abs(hashCode(instance)) % 100 <= percent
-}

--- a/src/photos/ducks/clustering/utils.spec.js
+++ b/src/photos/ducks/clustering/utils.spec.js
@@ -1,8 +1,4 @@
-import {
-  averageTime,
-  convertDurationInMilliseconds,
-  isPartOfProgressiveRollout
-} from './utils'
+import { averageTime, convertDurationInMilliseconds } from './utils'
 
 describe('date', () => {
   it('Should compute the mean date', () => {
@@ -41,30 +37,5 @@ describe('convert duration', () => {
     expect(convertDurationInMilliseconds(d3)).toEqual(4000)
     expect(convertDurationInMilliseconds(d4)).toEqual(4215000)
     expect(convertDurationInMilliseconds(d5)).toEqual(0)
-  })
-})
-
-describe('pick instance', () => {
-  it('Should pick a % of instances', () => {
-    const instances = []
-    let match10percent = 0,
-      match0percent = 0,
-      match100percent = 0
-    for (let i = 0; i < 10000; i++) {
-      instances[i] = i + '.mycozy.cloud'
-      if (isPartOfProgressiveRollout(instances[i], 10)) {
-        match10percent++
-      }
-      if (isPartOfProgressiveRollout(instances[i], -1)) {
-        match0percent++
-      }
-      if (isPartOfProgressiveRollout(instances[i], 100)) {
-        match100percent++
-      }
-    }
-    expect(match10percent).toBeGreaterThan(900)
-    expect(match10percent).toBeLessThan(1100)
-    expect(match0percent).toEqual(0)
-    expect(match100percent).toEqual(10000)
   })
 })

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -22,7 +22,6 @@ import {
   EVALUATION_THRESHOLD,
   CHANGES_RUN_LIMIT,
   TRIGGER_ELAPSED,
-  PERCENT_INSTANCES,
   LOG_ERROR_MSG_LIMIT
 } from 'photos/ducks/clustering/consts'
 import { spatioTemporalScaled } from 'photos/ducks/clustering/metrics'
@@ -31,8 +30,7 @@ import { saveClustering, findAutoAlbums } from 'photos/ducks/clustering/albums'
 import { albumsToClusterize } from 'photos/ducks/clustering/reclusterize'
 import {
   prepareDataset,
-  convertDurationInMilliseconds,
-  isPartOfProgressiveRollout
+  convertDurationInMilliseconds
 } from 'photos/ducks/clustering/utils'
 import { getMatchingParameters } from 'photos/ducks/clustering/matching'
 
@@ -172,14 +170,6 @@ const runClustering = async (client, setting) => {
 }
 
 export const onPhotoUpload = async () => {
-  /*
-    NOTE : we do a progressive deployment: as we want to monitor
-    the clustering gradually, we only run the service for a % of instances
-   */
-  const instanceURL = process.env.COZY_URL
-  if (!isPartOfProgressiveRollout(instanceURL, PERCENT_INSTANCES)) {
-    return
-  }
   log('info', `Service called with COZY_URL: ${process.env.COZY_URL}`)
 
   const options = {


### PR DESCRIPTION
This removes the code responsible for a progressive deployment of the clustering service. Therefore, it enables the service for 100% of instances. 
Note that a more generic approach will be implemented in the future on the stack side, to allow progressive/targeted deployment of features.