### PR TITLE
fix: Build issue

### DIFF
--- a/src/photos/styles/addToAlbum.styl
+++ b/src/photos/styles/addToAlbum.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'components/modals.styl'
 
 :local
     @extend $modals


### PR DESCRIPTION
Ça devrait résoudre le souci de build de Photo depuis une upgrade de cozy-ui (https://travis-ci.org/cozy/cozy-drive/jobs/595608157#L395) 

Par contre, ça veut dire que : 
- avant quand on faisait @require cozy-ui ça importait tout, dont $modal. 
- certainement u'on devrait retirer l'import de ui 