### PR TITLE
feat: Display QuotaAlert when needed

### DIFF
--- a/src/photos/components/Layout.jsx
+++ b/src/photos/components/Layout.jsx
@@ -14,12 +14,14 @@ import BannerClient from '../../components/pushClient/Banner'
 import Alerter from 'cozy-ui/react/Alerter'
 import { UploadQueue } from '../ducks/upload'
 import { IconSprite } from 'cozy-ui/transpiled/react'
+import { ModalManager } from 'react-cozy-helpers'
 
 const NavLink = genNavLink(RRNavLink)
 
 export const Layout = ({ t, children }) => (
   <LayoutUI>
     <Sidebar className={styles['pho-sidebar']}>
+      <ModalManager />
       <Nav>
         <NavItem>
           <NavLink to="/photos">

--- a/src/photos/ducks/albums/components/AlbumPhotos.jsx
+++ b/src/photos/ducks/albums/components/AlbumPhotos.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 
-import { showModal, ModalManager } from 'react-cozy-helpers'
+import { showModal } from 'react-cozy-helpers'
 import { translate } from 'cozy-ui/react/I18n'
 import Alerter from 'cozy-ui/react/Alerter'
 import { ShareModal } from 'sharing'
@@ -183,7 +183,6 @@ class AlbumPhotos extends Component {
               />
             )}
             {this.renderViewer(this.props.children)}
-            <ModalManager />
           </div>
         )}
       </Selection>

--- a/src/photos/locales/en.json
+++ b/src/photos/locales/en.json
@@ -263,5 +263,11 @@
       "success_conflicts": "%{smart_count} photo uploaded with %{conflictNumber} conflict(s). |||| %{smart_count} photos uploaded with %{conflictNumber} conflict(s).",
       "errors": "Errors occurred during the photos upload."
     }
+  },
+  "quotaalert": {
+    "title": "Your disk space is full :(",
+    "desc": "Please remove files, empty your trash or increase your disk space before uploading files again.",
+    "confirm": "OK",
+    "increase": "Increase your disk space"
   }
 }


### PR DESCRIPTION
- Dispatch a quotaAlert when needed 
- Add <ModalManager at the root of the layout since it can be called from every where 
- Should use `QuotaAlert` from UI (see https://github.com/cozy/cozy-ui/pull/1218 but let's do that in an other PR when merged) 

- Disk usage should be in cozy-client (see https://github.com/cozy/cozy-client/issues/553) 