### PR TITLE
fix: Scroll issue on chrome / android

### DIFF
--- a/src/drive/web/modules/filelist/FileListRows.jsx
+++ b/src/drive/web/modules/filelist/FileListRows.jsx
@@ -69,7 +69,7 @@ class FileListRows extends PureComponent {
 
   render() {
     return (
-      <div style={{ overflow: 'hidden' }} ref={this.myFilesListRowsContainer}>
+      <div className="u-ov-hidden" ref={this.myFilesListRowsContainer}>
         {this.props.files.map((file, index) => {
           return this.rowRenderer({ index, key: file.id })
         })}

--- a/src/drive/web/modules/filelist/FileListRows.jsx
+++ b/src/drive/web/modules/filelist/FileListRows.jsx
@@ -69,7 +69,7 @@ class FileListRows extends PureComponent {
 
   render() {
     return (
-      <div ref={this.myFilesListRowsContainer}>
+      <div style={{ overflow: 'hidden' }} ref={this.myFilesListRowsContainer}>
         {this.props.files.map((file, index) => {
           return this.rowRenderer({ index, key: file.id })
         })}


### PR DESCRIPTION
We added recently this div to be able to scrollToTop when we change between forlder and we play with the size of the thumbnails. 

But it appaers that we have a small overflow on this div causing a bug when the user try to scroll on the FileList since this div was catching first the scroll then scrolled for a few pixels... Having an overflow hidden seems to fix the issue.

As I can't reproduce on my smartphone, let's wait to see if it fix the bug on eric/ben's phone

edit: confirmed by ben, it works ;)