### PR TITLE
fix: Overflow hidden only on mobile

### DIFF
--- a/src/drive/web/modules/filelist/FileListRows.jsx
+++ b/src/drive/web/modules/filelist/FileListRows.jsx
@@ -69,7 +69,10 @@ class FileListRows extends PureComponent {
 
   render() {
     return (
-      <div className="u-ov-hidden" ref={this.myFilesListRowsContainer}>
+      <div
+        className={isMobileApp() ? 'u-ov-hidden' : ''}
+        ref={this.myFilesListRowsContainer}
+      >
         {this.props.files.map((file, index) => {
           return this.rowRenderer({ index, key: file.id })
         })}


### PR DESCRIPTION
We recently applied an overflow hidden to fix the scroll issue on Android. But since, we broke the scroll on a web browser. Let's add this fix only on a mobileApp ;) 