### PR TITLE
fix: iOS shared action

### DIFF
--- a/src/drive/web/modules/drive/Container.jsx
+++ b/src/drive/web/modules/drive/Container.jsx
@@ -28,6 +28,7 @@ import {
 } from 'drive/mobile/modules/offline/duck'
 import { extractFileAttributes } from 'drive/web/modules/navigation/duck/async'
 import styles from 'drive/styles/actionmenu.styl'
+import { isIOSApp } from 'cozy-device-helper'
 
 const ShareMenuItem = ({ docId, ...rest }, { t }) => (
   <SharedDocument docId={docId}>
@@ -102,11 +103,13 @@ const mapDispatchToProps = (dispatch, ownProps) => {
           __TARGET__ === 'mobile'
             ? {
                 action: files => dispatch(exportFilesNative(files)),
-                displayCondition: files =>
-                  files.reduce(
+                displayCondition: files => {
+                  if (isIOSApp()) return files.length === 1 && isFile(files[0])
+                  return files.reduce(
                     (onlyFiles, file) => onlyFiles && isFile(file),
                     true
                   )
+                }
               }
             : {
                 action: files => dispatch(downloadFiles(files))


### PR DESCRIPTION
To fix the native shared menu, I used the `url` attribute of
cordova social plugin. It works great but only with one file, so
instead of having an error, let's hide this functionnality if we
select more than one file