### PR TITLE
fix: Calls order between cozyClient setStore and cozy-bar init

### DIFF
--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -41,6 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!Document.cozyClient) {
     Document.registerClient(client)
   }
+  const polyglot = initTranslation(data.cozyLocale, lang =>
+    require(`drive/locales/${lang}`)
+  )
+  configureStore(client, polyglot.t.bind(polyglot))
 
   cozy.client.init({
     cozyURL: cozyUrl,
@@ -62,12 +66,6 @@ document.addEventListener('DOMContentLoaded', () => {
     history = trackerInstance.connectToHistory(hashHistory)
     trackerInstance.track(hashHistory.getCurrentLocation()) // when using a hash history, the initial visit is not tracked by piwik react router
   }
-
-  const polyglot = initTranslation(data.cozyLocale, lang =>
-    require(`drive/locales/${lang}`)
-  )
-
-  configureStore(client, polyglot.t.bind(polyglot))
 
   render(
     <HotedApp


### PR DESCRIPTION
I was trying to use cozy-client in the bar by making a query. But since I was instancing cozy-bar before making client.setStore in Drive, I had this error and I didn't know what to do.

thanks to @ptbrowne, I now know that, when you call a query before setting a store, cozy-client creates by itself its store. So calling setStore later throws an exception.

https://github.com/cozy/cozy-client/pull/568