### PR TITLE
fix: Add margin-bottom to SupportUS button

### DIFF
--- a/src/components/pushClient/supportUs.styl
+++ b/src/components/pushClient/supportUs.styl
@@ -3,6 +3,7 @@
 .SupportUs__wrapper
     margin-left 1.5rem
     margin-right 1.5rem
+    margin-bottom 1.5rem
 .Supportus__button    
     display flex
     height 2rem


### PR DESCRIPTION
add bottom margin, specially needed if we don't hav e the "Desktop pushClient button" since this one give us margin... 