### PR TITLE
feat: Don't open Note on Notes if not mine

### DIFF
--- a/src/drive/web/modules/drive/files.js
+++ b/src/drive/web/modules/drive/files.js
@@ -1,4 +1,6 @@
 //!TODO Put this to cozy-client/models/files
+import get from 'lodash/get'
+
 const FILE_TYPE = 'file'
 const DIR_TYPE = 'directory'
 export const ALBUMS_DOCTYPE = 'io.cozy.photos.albums'
@@ -20,4 +22,15 @@ export const isReferencedByAlbum = file => {
     }
   }
   return false
+}
+/**
+ *
+ * @param {object} file io.cozy.files
+ * @param {object} client CozyClient instance
+ * @return boolean If the file was created on my cozy
+ */
+export const isNoteMine = (file, client) => {
+  const myCozyUrl = client.getStackClient().uri
+  const noteCreatedOnCozy = get(file, 'cozyMetadata.createdOn')
+  return noteCreatedOnCozy.startsWith(myCozyUrl)
 }

--- a/src/drive/web/modules/drive/files.spec.jsx
+++ b/src/drive/web/modules/drive/files.spec.jsx
@@ -1,0 +1,22 @@
+import { isNoteMine } from './files'
+describe('files helper', () => {
+  it('should tell if the note is mine or not', () => {
+    const client = {
+      getStackClient: () => ({
+        uri: 'http://cozy.tools'
+      })
+    }
+    const myNote = {
+      cozyMetadata: {
+        createdOn: 'http://cozy.tools/'
+      }
+    }
+    const sharedNote = {
+      cozyMetadata: {
+        createdOn: 'http://q.cozy.tools/'
+      }
+    }
+    expect(isNoteMine(myNote, client)).toBe(true)
+    expect(isNoteMine(sharedNote, client)).toBe(false)
+  })
+})


### PR DESCRIPTION
Since Notes app doesn't handle sharing at the moment, we don't want top open the note in Notes if the file is note created on my cozy (aka the file is shared with me). If the file is shared, then we display the markdown in the viewer. 