### PR TITLE
fix: Create StyledApp component to inject CSS and style

### DIFF
--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -13,6 +13,7 @@ import {
   getTracker
 } from 'cozy-ui/transpiled/react/helpers/tracker'
 import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
+import StyledApp from 'drive/web/modules/drive/StyledApp'
 
 import appMetadata from 'drive/appMetadata'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
@@ -80,7 +81,9 @@ document.addEventListener('DOMContentLoaded', () => {
 const AppComponent = props => (
   <I18n lang={props.lang} polyglot={props.polyglot}>
     <CozyProvider client={props.client}>
-      <Router history={props.history} routes={AppRoute} />
+      <StyledApp>
+        <Router history={props.history} routes={AppRoute} />
+      </StyledApp>
     </CozyProvider>
   </I18n>
 )

--- a/src/drive/targets/intents/index.jsx
+++ b/src/drive/targets/intents/index.jsx
@@ -10,6 +10,7 @@ import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import { getQueryParameter } from 'react-cozy-helpers'
 import appMetadata from 'drive/appMetadata'
 import { schema } from 'drive/lib/doctypes'
+import StyledApp from 'drive/web/modules/drive/StyledApp'
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.getElementById('main')
@@ -38,7 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
       dictRequire={lang => require(`drive/locales/${lang}`)}
     >
       <CozyProvider client={client}>
-        <IntentHandler intentId={intent} />
+        <StyledApp>
+          <IntentHandler intentId={intent} />
+        </StyledApp>
       </CozyProvider>
     </I18n>,
     root

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -16,6 +16,7 @@ import configureStore from 'drive/store/configureStore'
 import { loadState } from 'drive/store/persistedState'
 import { startBackgroundService } from 'drive/mobile/lib/background'
 import { configureReporter } from 'drive/lib/reporter'
+import StyledApp from 'drive/web/modules/drive/StyledApp'
 
 import {
   startTracker,
@@ -245,7 +246,9 @@ class InitAppMobile {
     render(
       <I18n lang={getLang()} polyglot={polyglot}>
         <CozyProvider client={client}>
-          <DriveMobileRouter history={hashHistory} />
+          <StyledApp>
+            <DriveMobileRouter history={hashHistory} />
+          </StyledApp>
         </CozyProvider>
       </I18n>,
       root,

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -4,6 +4,8 @@ import 'whatwg-fetch'
 import React from 'react'
 import { render } from 'react-dom'
 
+import StyledApp from 'drive/web/modules/drive/StyledApp'
+
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 import CozyClient, { CozyProvider } from 'cozy-client'
 import { I18n, initTranslation } from 'cozy-ui/transpiled/react/I18n'
@@ -85,18 +87,20 @@ const init = async () => {
     render(
       <I18n lang={lang} polyglot={polyglot}>
         <CozyProvider client={client}>
-          {isFile ? (
-            <PublicLayout>
-              <LightFileViewer files={[data]} isFile={true} />
-            </PublicLayout>
-          ) : (
-            <Router history={hashHistory}>
-              <Route component={PublicLayout}>
-                <Route path="files(/:folderId)" component={LightFolderView} />
-              </Route>
-              <Redirect from="/*" to={`files/${sharedDocumentId}`} />
-            </Router>
-          )}
+          <StyledApp>
+            {isFile ? (
+              <PublicLayout>
+                <LightFileViewer files={[data]} isFile={true} />
+              </PublicLayout>
+            ) : (
+              <Router history={hashHistory}>
+                <Route component={PublicLayout}>
+                  <Route path="files(/:folderId)" component={LightFolderView} />
+                </Route>
+                <Redirect from="/*" to={`files/${sharedDocumentId}`} />
+              </Router>
+            )}
+          </StyledApp>
         </CozyProvider>
       </I18n>,
       root

--- a/src/drive/web/modules/drive/StyledApp.jsx
+++ b/src/drive/web/modules/drive/StyledApp.jsx
@@ -1,0 +1,7 @@
+import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'cozy-sharing/dist/stylesheet.css'
+//eslint-disable-next-line
+import mainStyles from 'drive/styles/main.styl'
+
+const StyleApp = ({ children }) => children
+export default StyleApp

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -19,11 +19,6 @@ import { Container as Trash } from 'drive/web/modules/trash'
 import FileHistory from '../../../../components/FileHistory'
 import UploadFromMobile from 'drive/mobile/modules/upload'
 
-import 'cozy-ui/transpiled/react/stylesheet.css'
-import 'cozy-sharing/dist/stylesheet.css'
-//eslint-disable-next-line
-import mainStyles from 'drive/styles/main.styl'
-
 const AppRoute = (
   <Route>
     <Route component={Layout}>

--- a/src/photos/components/AppRoute.jsx
+++ b/src/photos/components/AppRoute.jsx
@@ -5,9 +5,6 @@ import Layout from './Layout'
 import Timeline from '../ducks/timeline'
 import { AlbumsView, AlbumPhotos, PhotosPicker } from '../ducks/albums'
 import PhotosViewer from '../components/PhotosViewer'
-import 'cozy-ui/transpiled/react/stylesheet.css'
-import 'photos/styles/main.styl'
-import 'cozy-sharing/dist/stylesheet.css'
 
 const AppRoute = (
   <Route component={Layout}>

--- a/src/photos/components/StyledApp.jsx
+++ b/src/photos/components/StyledApp.jsx
@@ -1,0 +1,7 @@
+import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'photos/styles/main.styl'
+import 'cozy-sharing/dist/stylesheet.css'
+
+const StyledApp = ({ children }) => children
+
+export default StyledApp

--- a/src/photos/targets/browser/index.jsx
+++ b/src/photos/targets/browser/index.jsx
@@ -14,6 +14,7 @@ import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
 
 import appReducers from 'photos/reducers'
 import AppRoute from 'photos/components/AppRoute'
+import StyledApp from 'photos/components/StyledApp'
 import {
   shouldEnableTracking,
   getTracker,
@@ -77,9 +78,11 @@ document.addEventListener('DOMContentLoaded', () => {
   render(
     <I18n lang={lang} dictRequire={lang => require(`photos/locales/${lang}`)}>
       <CozyProvider client={client}>
-        <SharingProvider doctype={DOCTYPE_ALBUMS} documentType="Albums">
-          <Router history={history} routes={AppRoute} />
-        </SharingProvider>
+        <StyledApp>
+          <SharingProvider doctype={DOCTYPE_ALBUMS} documentType="Albums">
+            <Router history={history} routes={AppRoute} />
+          </SharingProvider>
+        </StyledApp>
       </CozyProvider>
     </I18n>,
     root

--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -17,6 +17,8 @@ import doctypes from '../browser/doctypes'
 
 import App from './App'
 import PhotosViewer from 'photos/components/PhotosViewer'
+import StyledApp from 'photos/components/StyledApp'
+
 import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
 
 document.addEventListener('DOMContentLoaded', init)
@@ -66,12 +68,14 @@ async function init() {
     const id = await getSharedDocument(client)
     app = (
       <CozyProvider client={client}>
-        <Router history={hashHistory}>
-          <Route path="shared/:albumId" component={App}>
-            <Route path=":photoId" component={PhotosViewer} />
-          </Route>
-          <Redirect from="/*" to={`shared/${id}`} />
-        </Router>
+        <StyledApp>
+          <Router history={hashHistory}>
+            <Route path="shared/:albumId" component={App}>
+              <Route path=":photoId" component={PhotosViewer} />
+            </Route>
+            <Redirect from="/*" to={`shared/${id}`} />
+          </Router>
+        </StyledApp>
       </CozyProvider>
     )
   } catch (e) {
@@ -80,8 +84,10 @@ async function init() {
     render(
       <I18n lang={lang} dictRequire={lang => require(`photos/locales/${lang}`)}>
         <>
-          {app}
-          <IconSprite />
+          <StyledApp>
+            {app}
+            <IconSprite />
+          </StyledApp>
         </>
       </I18n>,
       root


### PR DESCRIPTION
In a previous commit, I was importing CSS in `AppRoute` component. But this component is not loaded when we are in a public context. I created a `StyledApp` which only import styles / css 