### PR TITLE
feat: Drop iOS 10 support

### DIFF
--- a/src/drive/targets/mobile/config.xml
+++ b/src/drive/targets/mobile/config.xml
@@ -47,7 +47,7 @@
         <splash density="port-xxxhdpi" src="res/screens/android/screen-xxxhdpi-portrait.png" />
     </platform>
     <platform name="ios">
-        <preference name="deployment-target" value="10.0" />
+        <preference name="deployment-target" value="11.0" />
         <preference name="StatusBarOverlaysWebView" value="false" />
         <preference name="StatusBarStyle" value="default" />
         <preference name="Suppresses3DTouchGesture" value="true" />


### PR DESCRIPTION
Since we need to have access to Crypto API on the browser, we have to drop iOS 10 support. See https://github.com/cozy/cozy-stack/pull/2310 