### PR TITLE
refactor: Remove url-polyfill dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "redux-raven-middleware": "1.2.0",
     "redux-thunk": "2.3.0",
     "scheduler": "0.17.0",
-    "url-polyfill": "1.1.7",
     "webpack-node-externals": "1.7.2",
     "whatwg-fetch": "3.0.0"
   }


### PR DESCRIPTION
Was used by the SharingModal (https://github.com/cozy/cozy-drive/pull/816) but since sharing was moved in its own lib let's remove this ref. 

(also since we don't target edge 16 anymore, we don't need this polyfill at all) 