### PR TITLE
fix: Use display contents when supported. Use flex when not

### DIFF
--- a/src/drive/web/modules/filelist/fileopener.styl
+++ b/src/drive/web/modules/filelist/fileopener.styl
@@ -1,8 +1,14 @@
-.file-opener
-     display flex
-     flex 1 1 auto
-     align-items center
-     width 100%
+@supports (display: contents) 
+     .file-opener
+          display contents
+
+@supports not (display: contents)
+     .file-opener
+          display flex
+          flex 1 1 auto
+          align-items center
+          width 100%
+
 .file-opener__a
     text-decoration none
     color var(--coolGrey)


### PR DESCRIPTION
Using flex comes with a few drawback and we only want them on Edge 18, not on all the browsers. 

I know this fix is not optimal since we have a small alignment issue on Edge 18, but I don't see how I can fix it without editing the all table. @y-lohse any idea is welcomed! 