### PR TITLE
fix: Dropzone used a no longer existent icon

### DIFF
--- a/src/drive/web/modules/upload/IconDropZone.jsx
+++ b/src/drive/web/modules/upload/IconDropZone.jsx
@@ -1,3 +1,3 @@
-export const IconDropZone = 'cozy-negative'
+export const IconDropZone = 'cloud'
 
 export default IconDropZone


### PR DESCRIPTION
Icon was renamed to cloud a long time ago