### PR TITLE
tests: Fix upload redux slice tests after "progress" introduction

### DIFF
--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -50,21 +50,24 @@ const CONFLICT_ERROR = 409
 
 const itemInitialState = item => ({
   ...item,
-  status: PENDING
+  status: PENDING,
+  progress: null
 })
 
-const getStatus = (action, state) => {
+const getStatus = (state, action) => {
   switch (action.type) {
     case UPLOAD_FILE:
       return LOADING
     case RECEIVE_UPLOAD_SUCCESS:
       return action.isUpdate ? UPDATED : CREATED
+    case RECEIVE_UPLOAD_ERROR:
+      return action.status
     default:
       return state.status
   }
 }
 
-const getProgress = (action, state) => {
+const getProgress = (state, action) => {
   switch (action.type) {
     case UPLOAD_PROGRESS:
       return {
@@ -80,8 +83,8 @@ const getProgress = (action, state) => {
 
 const item = (state, action = { isUpdate: false }) => ({
   ...state,
-  status: getStatus(action, state),
-  progress: getProgress(action, state)
+  status: getStatus(state, action),
+  progress: getProgress(state, action)
 })
 
 export const queue = (state = [], action) => {

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -144,7 +144,8 @@ describe('processNextFile function', () => {
       file
     })
     expect(createFileSpy).toHaveBeenCalledWith(file, {
-      dirId: 'my-dir'
+      dirId: 'my-dir',
+      onUploadProgress: expect.any(Function)
     })
   })
 
@@ -190,7 +191,8 @@ describe('processNextFile function', () => {
       file
     })
     expect(createFileSpy).toHaveBeenCalledWith(file, {
-      dirId: 'my-dir'
+      dirId: 'my-dir',
+      onUploadProgress: expect.any(Function)
     })
 
     expect(updateFileSpy).toHaveBeenCalledWith(file, {
@@ -253,7 +255,8 @@ describe('processNextFile function', () => {
       file
     })
     expect(createFileSpy).toHaveBeenCalledWith(file, {
-      dirId: 'my-dir'
+      dirId: 'my-dir',
+      onUploadProgress: expect.any(Function)
     })
 
     expect(fileUploadedCallbackSpy).not.toHaveBeenCalled()
@@ -412,19 +415,22 @@ describe('queue reducer', () => {
       status: 'pending',
       file: {
         name: 'doc1.odt'
-      }
+      },
+      progress: null
     },
     {
       status: 'pending',
       file: {
         name: 'doc2.odt'
-      }
+      },
+      progress: null
     },
     {
       status: 'pending',
       file: {
         name: 'doc3.odt'
-      }
+      },
+      progress: null
     }
   ]
   it('should be empty (initial state)', () => {
@@ -453,19 +459,22 @@ describe('queue reducer', () => {
         status: 'loading',
         file: {
           name: 'doc1.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'pending',
         file: {
           name: 'doc2.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'pending',
         file: {
           name: 'doc3.odt'
-        }
+        },
+        progress: null
       }
     ]
     const result = queue(state, action)
@@ -477,26 +486,30 @@ describe('queue reducer', () => {
       type: 'RECEIVE_UPLOAD_SUCCESS',
       file: {
         name: 'doc3.odt'
-      }
+      },
+      progress: null
     }
     const expected = [
       {
         status: 'pending',
         file: {
           name: 'doc1.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'pending',
         file: {
           name: 'doc2.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'created',
         file: {
           name: 'doc3.odt'
-        }
+        },
+        progress: null
       }
     ]
     const result = queue(state, action)
@@ -516,19 +529,22 @@ describe('queue reducer', () => {
         status: 'pending',
         file: {
           name: 'doc1.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'pending',
         file: {
           name: 'doc2.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'updated',
         file: {
           name: 'doc3.odt'
-        }
+        },
+        progress: null
       }
     ]
     const result = queue(state, action)
@@ -541,26 +557,71 @@ describe('queue reducer', () => {
       file: {
         name: 'doc2.odt'
       },
-      status: 'conflict'
+      status: 'conflict',
+      progress: null
     }
     const expected = [
       {
         status: 'pending',
         file: {
           name: 'doc1.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'conflict',
         file: {
           name: 'doc2.odt'
-        }
+        },
+        progress: null
       },
       {
         status: 'pending',
         file: {
           name: 'doc3.odt'
+        },
+        progress: null
+      }
+    ]
+    const result = queue(state, action)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle UPLOAD_PROGRESS action type', () => {
+    const action = {
+      type: 'UPLOAD_PROGRESS',
+      file: {
+        name: 'doc1.odt'
+      },
+      event: {
+        loaded: 100,
+        total: 400
+      }
+    }
+    const expected = [
+      {
+        status: 'pending',
+        file: {
+          name: 'doc1.odt'
+        },
+        progress: {
+          loaded: 100,
+          total: 400
         }
+      },
+      {
+        status: 'pending',
+        file: {
+          name: 'doc2.odt'
+        },
+        progress: null
+      },
+      {
+        status: 'pending',
+        file: {
+          name: 'doc3.odt'
+        },
+        progress: null
       }
     ]
     const result = queue(state, action)


### PR DESCRIPTION
I made a mistake and merged while the PR was still in the red. After
introduction of the "progress" property in the upload redux slice,
some tests needed an update.