### PR TITLE
feat: Since we now have revisions, let's remove this check

### DIFF
--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -1,8 +1,7 @@
 import { combineReducers } from 'redux'
 import logger from 'lib/logger'
-
-import { hasSharedParent, isShared } from 'cozy-sharing/dist/state'
 import { CozyFile } from 'models'
+
 //!TODO Remove this method from Scanner and use from cozy-client files models
 //see https://github.com/cozy/cozy-client/pull/571
 import { doUpload } from 'cozy-scanner/dist/ScannerUpload'
@@ -170,15 +169,10 @@ export const processNextFile = (
     if (uploadError.status === CONFLICT_ERROR) {
       try {
         const path = await CozyFile.getFullpath(dirID, file.name)
-        if (
-          !isShared(sharingState, { path }) &&
-          !hasSharedParent(sharingState, { path })
-        ) {
-          const uploadedFile = await overwriteFile(client, file, path)
-          fileUploadedCallback(uploadedFile)
-          dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file, isUpdate: true })
-          error = null
-        }
+        const uploadedFile = await overwriteFile(client, file, path)
+        fileUploadedCallback(uploadedFile)
+        dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file, isUpdate: true })
+        error = null
       } catch (updateError) {
         error = updateError
       }

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -210,65 +210,6 @@ describe('processNextFile function', () => {
     })
   })
 
-  it('should not update a file in conflict if it is shared', async () => {
-    const getState = () => ({
-      upload: {
-        queue: [
-          {
-            status: 'pending',
-            file,
-            entry: '',
-            isDirectory: false
-          }
-        ]
-      }
-    })
-    createFileSpy.mockRejectedValue({
-      status: 409,
-      title: 'Conflict',
-      detail: 'file already exists',
-      source: {}
-    })
-
-    statByPathSpy.mockResolvedValue({
-      data: {
-        dir_id: 'my-dir',
-        id: 'b552a167-1aa4'
-      }
-    })
-
-    updateFileSpy.mockResolvedValue({ data: file })
-
-    const sharingState = {
-      sharedPaths: ['/my-dir']
-    }
-
-    const asyncProcess = processNextFile(
-      fileUploadedCallbackSpy,
-      queueCompletedCallbackSpy,
-      dirId,
-      sharingState
-    )
-    await asyncProcess(dispatchSpy, getState, { client: fakeClient })
-
-    expect(dispatchSpy).toHaveBeenNthCalledWith(1, {
-      type: 'UPLOAD_FILE',
-      file
-    })
-    expect(createFileSpy).toHaveBeenCalledWith(file, {
-      dirId: 'my-dir',
-      onUploadProgress: expect.any(Function)
-    })
-
-    expect(fileUploadedCallbackSpy).not.toHaveBeenCalled()
-
-    expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
-      file,
-      status: 'conflict',
-      type: 'RECEIVE_UPLOAD_ERROR'
-    })
-  })
-
   it('should handle an error during overwrite', async () => {
     const getState = () => ({
       upload: {


### PR DESCRIPTION
We added this check before having the file's revisions. Now that the file's history is now live for a few months now, we can remove this check and let the stack handling the update. 