### PR TITLE
fix: Don't display those new actions if no write access

### DIFF
--- a/src/drive/web/modules/drive/Container.jsx
+++ b/src/drive/web/modules/drive/Container.jsx
@@ -154,7 +154,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         moveto: {
           action: selected =>
             dispatch(showModal(<MoveModal entries={selected} />)),
-          displayCondition: () => canMove
+          displayCondition: () => hasWriteAccess && canMove
         },
         qualify: {
           action: selected =>
@@ -169,7 +169,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
               )
             ),
           displayCondition: selections =>
-            selections.length === 1 && isFile(selections[0])
+            hasWriteAccess && selections.length === 1 && isFile(selections[0])
         },
         history: {
           action: selected => {


### PR DESCRIPTION
We don't want to display "Move" or "Qualify" if we don't have write access on the folder / file. 