### PR TITLE
Fix/scanner2

### DIFF
--- a/src/drive/web/modules/drive/Toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar.jsx
@@ -41,6 +41,7 @@ class Toolbar extends Component {
   render() {
     const {
       t,
+      lang,
       disabled,
       selectionModeActive,
       canUpload,
@@ -141,6 +142,7 @@ class Toolbar extends Component {
               client={client}
               store={this.context.store}
               t={t}
+              lang={lang}
             >
               <SharingProvider doctype="io.cozy.files" documentType="Files">
                 {MoreMenu}

--- a/src/drive/web/modules/drive/Toolbar/components/PortaledQueue.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/PortaledQueue.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
-import { UploadQueue } from 'drive/web/modules/upload/UploadQueue'
+import { DumbUploadQueue as UploadQueue } from 'drive/web/modules/upload/UploadQueue'
 import { translate } from 'cozy-ui/transpiled/react'
 class PortaledQueue extends Component {
   render() {

--- a/src/drive/web/modules/drive/Toolbar/components/ScanWrapper.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/ScanWrapper.jsx
@@ -4,6 +4,7 @@ import { Icon, translate } from 'cozy-ui/transpiled/react'
 import { Scanner, SCANNER_DONE, SCANNER_UPLOADING } from 'cozy-scanner'
 import toolbarContainer from '../toolbar'
 import PortaledQueue from './PortaledQueue'
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 import {
   startMediaBackup,
@@ -59,7 +60,7 @@ class ScanWrapper extends Component {
   render() {
     const { displayedFolder, stopMediaBackup, startMediaBackup } = this.props
     return (
-      <>
+      <MuiCozyTheme>
         <Scanner
           dirId={displayedFolder.id} //Pour savoir où uploader
           pluginConfig={{
@@ -118,7 +119,7 @@ class ScanWrapper extends Component {
             )
           }}
         </Scanner>
-      </>
+      </MuiCozyTheme>
     )
   }
 }

--- a/src/drive/web/modules/upload/UploadQueue.jsx
+++ b/src/drive/web/modules/upload/UploadQueue.jsx
@@ -11,7 +11,7 @@ import {
   purgeUploadQueue
 } from '.'
 
-const DumbUploadQueue = translate()(props => {
+export const DumbUploadQueue = translate()(props => {
   return (
     <UIUploadQueue
       popover={true}


### PR DESCRIPTION
- Before Scanner was using the old `ExperimentalModal` that was calling MuiCozyTheme by itself. Now that this behavior is removed on the UI's side, let's call `MuiCozyTheme` from Drive since this content is displayed in the Cozy Bar. (see https://github.com/cozy/cozy-bar/issues/683#issuecomment-620020307)

- Since cozy-scanner use `lang` to use the right translation file, we need to pass it to the barcontext provider

- UploadQueue was reworked recently let's adapt the code to it 