### PR TITLE
fix: Don't allow drag and drop if no write access

### DIFF
--- a/src/drive/web/modules/layout/FolderView.jsx
+++ b/src/drive/web/modules/layout/FolderView.jsx
@@ -40,9 +40,9 @@ const FolderView = props => {
     withFilePath,
     withSharedBadge,
     isRenaming,
-    renamingFile
+    renamingFile,
+    hasWriteAccess
   } = props
-
   const nothingToDo = isTrashContext && files.length === 0
   const folderId = getFolderIdFromRoute(location, params)
   const isRootfolder = folderId === ROOT_DIR_ID
@@ -63,7 +63,7 @@ const FolderView = props => {
       </Topbar>
       <Dropzone
         role="main"
-        disabled={__TARGET__ === 'mobile' || !canDrop}
+        disabled={__TARGET__ === 'mobile' || !canDrop || !hasWriteAccess}
         displayedFolder={displayedFolder}
       >
         {__TARGET__ === 'mobile' && (


### PR DESCRIPTION
One more forgotten item. 

We're working on writing down the functional behavior for each case (combinaison between view (ie recent / shared/.. and "item" (folder, file, url) and "context" (writeAccess etc)). In the meantime, when working again on our Cozy-Client migration we need to take into account this issue. 