### PR TITLE
fix: Translate all public alerts

### DIFF
--- a/src/drive/web/modules/public/PublicLayout.jsx
+++ b/src/drive/web/modules/public/PublicLayout.jsx
@@ -2,13 +2,17 @@ import React from 'react'
 import { Layout } from 'cozy-ui/transpiled/react/Layout'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { IconSprite } from 'cozy-ui/transpiled/react'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-const PublicLayout = ({ t, children }) => (
-  <Layout>
-    <Alerter t={t} />
-    {children}
-    <IconSprite />
-  </Layout>
-)
+const PublicLayout = ({ children }) => {
+  const { t } = useI18n()
+  return (
+    <Layout>
+      <Alerter t={t} />
+      {children}
+      <IconSprite />
+    </Layout>
+  )
+}
 
 export default PublicLayout

--- a/src/drive/web/modules/public/PublicLayout.spec.jsx
+++ b/src/drive/web/modules/public/PublicLayout.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { createMockClient } from 'cozy-client'
+import Alerter from 'cozy-ui/transpiled/react/Alerter'
+import AppLike from '../../../../../test/components/AppLike'
+import PublicLayout from './PublicLayout'
+
+const client = new createMockClient({})
+
+describe('PublicLayout', () => {
+  it('should show translated alert messages', async () => {
+    const { findByText } = render(
+      <AppLike client={client}>
+        <PublicLayout>
+          <div>content</div>
+        </PublicLayout>
+      </AppLike>
+    )
+
+    Alerter.info('alert.try_again')
+    const translatedAlert = await findByText(
+      'An error has occurred, please try again in a moment.'
+    )
+    expect(translatedAlert).toBeTruthy()
+  })
+})


### PR DESCRIPTION
The `Alerter` component on the public page did not receive a `t` function, which means that all calls to `Alert.xxx` had to be done with a translated string, eg. `Alert.info(t('error'))` and not `Alert.info('error')`.
We still have several calls to `Alert.xxx` that are in redux dispatch calls where getting an instance of `t` is not so easy. This PR makes sure we pass a valid `t` function to `Alerter`.