### PR TITLE
feat: Disable public note creation

### DIFF
--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -24,7 +24,6 @@ import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/SelectableItem'
 import AddFolderItem from 'drive/web/modules/drive/Toolbar/components/AddFolderItem'
 import UploadItem from 'drive/web/modules/drive/Toolbar/components/UploadItem'
-import CreateNoteItem from 'drive/web/modules/drive/Toolbar/components/CreateNoteItem'
 import CreateShortcut from 'drive/web/modules/drive/Toolbar/components/CreateShortcut'
 
 const { BarRight } = cozy.bar
@@ -107,7 +106,6 @@ const MoreMenu = withBreakpoints()(
                 : t('toolbar.menu_download_folder')}
             </ActionMenuItem>
             {hasWriteAccess && <AddFolderItem />}
-            {hasWriteAccess && <CreateNoteItem hasAppsPermissions={false} />}
             {hasWriteAccess && (
               <CreateShortcut onCreated={refreshFolderContent} />
             )}


### PR DESCRIPTION
This PR temporarily disables the notes creation from the public page. After the note is created, we need to redirect to the public page of the note (with a sharecode in the URL), but this requires some more work and we would like to publish a new version of drive before handling this.