### PR TITLE
Public navigation fixes

### DIFF
--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -112,7 +112,8 @@ const init = async () => {
             ) : (
               <Router history={hashHistory}>
                 <Route component={PublicLayout}>
-                  <Route path="files(/:folderId)" component={LightFolderView}>
+                  <Redirect from="/files/:folderId" to="/folder/:folderId" />
+                  <Route path="folder(/:folderId)" component={LightFolderView}>
                     <Route
                       path="file/:fileId/revision"
                       component={FileHistory}

--- a/src/drive/web/modules/public/LightFolderView.jsx
+++ b/src/drive/web/modules/public/LightFolderView.jsx
@@ -27,7 +27,7 @@ import { FILES_FETCH_LIMIT } from 'drive/constants/config'
 import Viewer from 'drive/web/modules/viewer/PublicViewer'
 import { isMobileApp } from 'cozy-device-helper'
 
-class DumbFolderView extends React.Component {
+export class DumbFolderView extends React.Component {
   state = {
     revoked: false,
     viewerOpened: false,
@@ -112,7 +112,7 @@ class DumbFolderView extends React.Component {
     return (
       <Main isPublic>
         <Topbar>
-          <Breadcrumb isPublic onFolderOpen={this.props.fetchFolder} />
+          <Breadcrumb isPublic onFolderOpen={this.navigateToFolder} />
           <PublicToolbar
             files={[this.props.displayedFolder]}
             isFile={false}

--- a/src/drive/web/modules/public/LightFolderView.spec.jsx
+++ b/src/drive/web/modules/public/LightFolderView.spec.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { DumbFolderView } from './LightFolderView'
+
+describe('LightFolderView', () => {
+  it('changes the URL when navigating to a new folder', async () => {
+    const fetchFolderMock = jest.fn().mockResolvedValue([])
+    const router = {
+      push: jest.fn()
+    }
+    const currentFolderId = '123'
+
+    const comp = shallow(
+      <DumbFolderView
+        location={{ pathname: '/folder' }}
+        params={{
+          folderId: currentFolderId
+        }}
+        router={router}
+        displayedFolder={currentFolderId}
+        openedFolderId={currentFolderId}
+        fileCount={0}
+        files={[]}
+        fetchFolder={fetchFolderMock}
+      />
+    )
+
+    await comp.instance().navigateToFolder('456')
+    expect(router.push).toHaveBeenCalledWith('/folder/456')
+  })
+})


### PR DESCRIPTION
The navigation on the public view uses `/files/:folderId` format, whereas the private app uses `/folder/:folderId`. This trips up some internal functions like [getFolderUrl](https://github.com/cozy/cozy-drive/blob/master/src/drive/web/modules/public/LightFolderView.jsx#L102).

This PR makes both public and private app use the same format. This solves 2 problems:

1. Navigating on the public view changes the URL, meaning you can use the browsers back button etc
2. Reloading the content of the view actually reloads the currently displayed folder, and not the first opened folder