### PR TITLE
fix: More defensive code.

### DIFF
--- a/src/drive/web/modules/navigation/duck/actions.spec.js
+++ b/src/drive/web/modules/navigation/duck/actions.spec.js
@@ -1,0 +1,59 @@
+import { mergeFilesWithParents } from './actions'
+
+describe('Navigation Duck Actions MergeFilesWithParents', () => {
+  it('should work', () => {
+    const files = [
+      {
+        id: 1,
+        _id: 1,
+        name: 'file 1',
+        dir_id: 'exist'
+      }
+    ]
+
+    const folders = {
+      total_rows: 1,
+      rows: [
+        {
+          id: 'exist',
+          key: 'exist',
+          doc: {
+            _id: 'exist',
+            name: 'folder exists',
+            path: 'exist/'
+          }
+        }
+      ]
+    }
+    const filesWithParents = mergeFilesWithParents(files, folders)
+    expect(filesWithParents).toEqual([
+      { _id: 1, dir_id: 'exist', id: 1, name: 'file 1', path: 'exist/' }
+    ])
+  })
+
+  it('should also work if the parent doesnt exist anymore due to "CouchDB / Stack" issue', () => {
+    const files = [
+      {
+        id: 1,
+        _id: 1,
+        name: 'file 1',
+        dir_id: 'exist'
+      }
+    ]
+
+    const folders = {
+      total_rows: 1,
+      rows: [
+        {
+          id: 'exist',
+          key: 'exist',
+          doc: null
+        }
+      ]
+    }
+    const filesWithParents = mergeFilesWithParents(files, folders)
+    expect(filesWithParents).toEqual([
+      { _id: 1, dir_id: 'exist', id: 1, name: 'file 1', path: '' }
+    ])
+  })
+})


### PR DESCRIPTION
We can have FSCK's issue mostly `index_orphan_tree` or `filesystem_missing`.
In that case, we can receive an empty doc without path. So let's be
more defensive to not crash the `recent's view`.

We display the file in this view but without its folder below. The user will have an error when trying to download it. But it's better than crashing the view