### PR TITLE
fix: Await the unlink to be sure to have destroyed the Pouch.

### DIFF
--- a/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
+++ b/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
@@ -61,8 +61,8 @@ class DriveMobileRouter extends Component {
     }
   }
 
-  afterLogout = () => {
-    this.props.unlink(this.props.client)
+  afterLogout = async () => {
+    await this.props.unlink(this.props.client)
     this.props.history.replace('/')
   }
 

--- a/src/drive/mobile/modules/authorization/duck/actions.js
+++ b/src/drive/mobile/modules/authorization/duck/actions.js
@@ -11,8 +11,8 @@ export const setToken = token => ({ type: SET_TOKEN, token })
 
 export const revokeClient = () => ({ type: REVOKE })
 
-export const unlink = (client, clientInfo) => async dispatch => {
-  client.logout()
+export const unlink = async (client, clientInfo) => async dispatch => {
+  await client.logout()
 
   resetClient(client, clientInfo)
 


### PR DESCRIPTION
Thanks to this PR (https://github.com/cozy/cozy-bar/pull/689), I checked
the code in Drive to handle the logout since we have this kind of issue
(not having the pouch really deleted). I think it can help.

Needs https://github.com/cozy/cozy-bar/pull/689 