### PR TITLE
[cozy-client-migration] History action

### DIFF
--- a/src/drive/lib/RouterContext.jsx
+++ b/src/drive/lib/RouterContext.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { withRouter } from 'react-router'
+
+export const RouterContext = React.createContext()
+
+export const RouterContextProvider = withRouter(
+  ({ children, router, params, location, routes }) => {
+    return (
+      <RouterContext.Provider value={{ router, params, location, routes }}>
+        {children}
+      </RouterContext.Provider>
+    )
+  }
+)

--- a/src/drive/lib/RouterContext.jsx
+++ b/src/drive/lib/RouterContext.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { withRouter } from 'react-router'
 
 export const RouterContext = React.createContext()
@@ -12,3 +12,7 @@ export const RouterContextProvider = withRouter(
     )
   }
 )
+
+export const useRouter = () => {
+  return useContext(RouterContext)
+}

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -22,6 +22,12 @@ import UploadFromMobile from 'drive/mobile/modules/upload'
 import ExternalRedirect from './ExternalRedirect'
 import DriveView from '../views/Drive'
 
+const LegacyDriveView = routerProps => (
+  <FileExplorer {...routerProps}>
+    <Folder {...routerProps} />
+  </FileExplorer>
+)
+
 const AppRoute = (
   <Route>
     <Route path="external/:fileId" component={ExternalRedirect} />
@@ -30,31 +36,23 @@ const AppRoute = (
         <Route path="uploadfrommobile" component={UploadFromMobile} />
       )}
       <Redirect from="/files/:folderId" to="/folder/:folderId" />
-      {flag('drive.client-migration.enabled') ? (
-        <Route path="folder" component={DriveView}>
-          <Route path=":folderId">
-            <Route path="file/:fileId" component={FilesViewer} />
-            <Route path="file/:fileId/revision" component={FileHistory} />
-          </Route>
-          {/* Those 2 following routes are needed for the root directory since the url is only /folder, so 
-        next url will be /folder/file/:fileId/ */}
+
+      <Route
+        path="folder"
+        component={
+          flag('drive.client-migration.enabled') ? DriveView : LegacyDriveView
+        }
+      >
+        <Route path=":folderId">
           <Route path="file/:fileId" component={FilesViewer} />
           <Route path="file/:fileId/revision" component={FileHistory} />
         </Route>
-      ) : (
-        <Route component={FileExplorer}>
-          <Route path="folder" component={Folder}>
-            <Route path=":folderId">
-              <Route path="file/:fileId" component={FilesViewer} />
-              <Route path="file/:fileId/revision" component={FileHistory} />
-            </Route>
-            {/* Those 2 following routes are needed for the root directory since the url is only /folder, so 
+        {/* Those 2 following routes are needed for the root directory since the url is only /folder, so 
           next url will be /folder/file/:fileId/ */}
-            <Route path="file/:fileId" component={FilesViewer} />
-            <Route path="file/:fileId/revision" component={FileHistory} />
-          </Route>
-        </Route>
-      )}
+        <Route path="file/:fileId" component={FilesViewer} />
+        <Route path="file/:fileId/revision" component={FileHistory} />
+      </Route>
+
       <Route component={FileExplorer}>
         <Redirect from="/" to="folder" />
         <Route path="recent" component={Recent}>

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -43,12 +43,11 @@ const AppRoute = (
           flag('drive.client-migration.enabled') ? DriveView : LegacyDriveView
         }
       >
+        {/* For FilesViewer and FileHistory, we want 2 routes to match: `/folder/:folderId/file/:fileId` and `/folder/file/:fileId`. The `:folderId` is not present when opening a file from the root folder. */}
         <Route path=":folderId">
           <Route path="file/:fileId" component={FilesViewer} />
           <Route path="file/:fileId/revision" component={FileHistory} />
         </Route>
-        {/* Those 2 following routes are needed for the root directory since the url is only /folder, so 
-          next url will be /folder/file/:fileId/ */}
         <Route path="file/:fileId" component={FilesViewer} />
         <Route path="file/:fileId/revision" component={FileHistory} />
       </Route>

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -31,8 +31,15 @@ const AppRoute = (
       )}
       <Redirect from="/files/:folderId" to="/folder/:folderId" />
       {flag('drive.client-migration.enabled') ? (
-        <Route path="folder(/:folderId)" component={DriveView}>
+        <Route path="folder" component={DriveView}>
+          <Route path=":folderId">
+            <Route path="file/:fileId" component={FilesViewer} />
+            <Route path="file/:fileId/revision" component={FileHistory} />
+          </Route>
+          {/* Those 2 following routes are needed for the root directory since the url is only /folder, so 
+        next url will be /folder/file/:fileId/ */}
           <Route path="file/:fileId" component={FilesViewer} />
+          <Route path="file/:fileId/revision" component={FileHistory} />
         </Route>
       ) : (
         <Route component={FileExplorer}>

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -8,6 +8,7 @@ import {
   ThumbnailSizeContextProvider
 } from 'drive/lib/ThumbnailSizeContext'
 import { ModalStack, ModalContextProvider } from 'drive/lib/ModalContext'
+import { RouterContextProvider } from 'drive/lib/RouterContext'
 
 import SelectionBar from './SelectionBarWithActions'
 import Dropzone from 'drive/web/modules/upload/Dropzone'
@@ -190,9 +191,11 @@ const DriveView = ({ params, router, children }) => {
 const DriveViewWithProvider = props => (
   <SharingProvider doctype="io.cozy.files" documentType="Files">
     <ThumbnailSizeContextProvider>
-      <ModalContextProvider>
-        <DriveView {...props} />
-      </ModalContextProvider>
+      <RouterContextProvider>
+        <ModalContextProvider>
+          <DriveView {...props} />
+        </ModalContextProvider>
+      </RouterContextProvider>
     </ThumbnailSizeContextProvider>
   </SharingProvider>
 )

--- a/src/drive/web/modules/views/Drive/useActions.jsx
+++ b/src/drive/web/modules/views/Drive/useActions.jsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux'
 import { models, useClient } from 'cozy-client'
 import { SharingContext, ShareModal } from 'cozy-sharing'
 import { ModalContext } from 'drive/lib/ModalContext'
-import { RouterContext } from 'drive/lib/RouterContext'
+import { useRouter } from 'drive/lib/RouterContext'
 import keyBy from 'lodash/keyBy'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 
@@ -176,7 +176,7 @@ export const openFileWith = async (file, client, filename) => {
 const useActions = (documentId, { canMove } = {}) => {
   const { pushModal, popModal } = useContext(ModalContext)
   const { hasWriteAccess, refresh } = useContext(SharingContext)
-  const { router, location } = useContext(RouterContext)
+  const { router, location } = useRouter()
   const client = useClient()
   const dispatch = useDispatch()
 

--- a/src/drive/web/modules/views/Drive/useActions.jsx
+++ b/src/drive/web/modules/views/Drive/useActions.jsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import { models, useClient } from 'cozy-client'
 import { SharingContext, ShareModal } from 'cozy-sharing'
 import { ModalContext } from 'drive/lib/ModalContext'
+import { RouterContext } from 'drive/lib/RouterContext'
 import keyBy from 'lodash/keyBy'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 
@@ -175,6 +176,7 @@ export const openFileWith = async (file, client, filename) => {
 const useActions = (documentId, { canMove } = {}) => {
   const { pushModal, popModal } = useContext(ModalContext)
   const { hasWriteAccess, refresh } = useContext(SharingContext)
+  const { router, location } = useContext(RouterContext)
   const client = useClient()
   const dispatch = useDispatch()
 
@@ -271,12 +273,9 @@ const useActions = (documentId, { canMove } = {}) => {
       icon: 'history',
       displayCondition: selection =>
         selection.length === 1 && isFile(selection[0]),
-      action: () => {
-        alert('not implemented')
+      action: files => {
         // trackEvent()
-        // return ownProps.router.push(
-        //   `${ownProps.location.pathname}/file/${files[0].id}/revision`
-        // )
+        return router.push(`${location.pathname}/file/${files[0].id}/revision`)
       }
     },
     offline: {


### PR DESCRIPTION
The last action that needed to be fixed with the migration to cozy-client was the "File History" one. It doesn't use cozy-client, but the format of the action definition has changed.

It used to be a `mapDispatchToProps`, and the history action was using `ownProps.router` to push a change of route. This wasn't necessarily a good thing because:

a) Accessing `ownProps` in `mapDispatchToProps` is discouraged
b) The component that needs the actions needs to have access to the router props, but it's not obvious by looking at the component. This is even truer now where [this component](https://github.com/cozy/cozy-drive/blob/master/src/drive/web/modules/views/Drive/FileWithActions.jsx) would need a `withRouter` call just to use `useActions`

To avoid injecting and passing around the router props, I wanted to use `useContext(RouterContext)` in the hook. Unfortunately react-router-v3 uses the legacy context which doesn't support hooks. I worked around it by exposing the router props in a modern Context provider. Let me know what you think about that! The alternative would be to use `withRouter` in components that need actions, and to pass `router` and `location` as params to `useActions`.