### PR TITLE
FilesViewer2

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -17,6 +17,7 @@
     "^viewer(.*)": "<rootDir>/src/viewer$1",
     "^react-cozy-helpers(.*)": "<rootDir>/src/lib/react-cozy-helpers$1",
     "^components(.*)": "<rootDir>/src/components$1",
+    "^test(.*)": "<rootDir>/test/$1",
     "^folder-references(.*)": "<rootDir>/src/folder-references$1",
     "^lib(.*)": "<rootDir>/src/lib$1",
     "react-pdf/dist/pdf.worker.entry.js": "<rootDir>/jestHelpers/mocks/pdfjsWorkerMock.js",
@@ -31,6 +32,7 @@
   "testEnvironment": "jest-environment-jsdom-sixteen",
   "testMatch": ["**/(*.)(spec|test).js?(x)"],
   "globals": {
-    "__APP_SLUG__": "drive"
+    "__APP_SLUG__": "drive",
+    "__TARGET__": "browser"
   }
 }

--- a/src/drive/mobile/lib/background.js
+++ b/src/drive/mobile/lib/background.js
@@ -98,11 +98,11 @@ const backgroundService = () =>
         const cozyURL = persistedState.mobile.settings.serverUrl
         configureReporter()
         const client = initClient(cozyURL)
-        const store = configureStore(
+        const store = configureStore({
           client,
-          getTranslateFunction(),
-          persistedState
-        )
+          t: getTranslateFunction(),
+          initialState: persistedState
+        })
         return store.dispatch(startMediaBackup())
       })
       .then(resolve)

--- a/src/drive/mobile/modules/mediaBackup/duck/fixBackupFolderNamesBug.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/fixBackupFolderNamesBug.js
@@ -45,8 +45,6 @@ export const fixMagicFolderName = async (client, savedFromMyDeviceFolder) => {
     const folderSyncPhoto = await client
       .collection('io.cozy.files')
       .statByPath(pathSavedFromMobileFolder)
-    //eslint-disable-next-line
-    console.log('folderSyncPhoto', folderSyncPhoto)
 
     const hasEmptyRightFolder =
       folderSyncPhoto.included && folderSyncPhoto.included.length === 0
@@ -87,7 +85,7 @@ export const fixMagicFolderName = async (client, savedFromMyDeviceFolder) => {
       ])
   } catch (e) {
     //eslint-disable-next-line
-    console.log('error stat remove ref', e)
+    console.warn('error stat remove ref', e)
   }
 
   await getOrCreateFolderWithReference(client, photosRootPath, REF_PHOTOS)

--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -11,8 +11,23 @@ import thunkMiddleware from 'redux-thunk'
 import createRootReducer from './rootReducer'
 import { saveState } from './persistedState'
 import { ANALYTICS_URL, getReporterConfiguration } from 'drive/lib/reporter'
+import { connectStoreToHistory } from './connectedRouter'
 
-const configureStore = (client, t, initialState = {}) => {
+/**
+ * Creates the redux store
+ *
+ * Contains cozy-client's state and router state
+ *
+ * @param  {Object} options Options
+ * @param  {Object} options.client CozyClient
+ * @param  {Object} options.t Polygot t function
+ * @param  {Object} options.history History
+ *
+ * @return {ReduxStore}
+ */
+const configureStore = options => {
+  const { client, t, initialState = {}, history } = options
+
   const middlewares = [thunkMiddleware.withExtraArgument({ client, t })]
   if (__TARGET__ === 'mobile') {
     middlewares.push(RavenMiddleWare(ANALYTICS_URL, getReporterConfiguration()))
@@ -26,7 +41,7 @@ const configureStore = (client, t, initialState = {}) => {
   const composeEnhancers =
     (__DEVELOPMENT__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
 
-  const rootReducer = createRootReducer(client)
+  const rootReducer = createRootReducer(client, history)
 
   const store = createStore(
     rootReducer,
@@ -48,6 +63,10 @@ const configureStore = (client, t, initialState = {}) => {
         availableOffline: store.getState().availableOffline
       })
     )
+  }
+
+  if (history) {
+    connectStoreToHistory(store, history)
   }
 
   client.setStore(store)

--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -41,7 +41,7 @@ const configureStore = options => {
   const composeEnhancers =
     (__DEVELOPMENT__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
 
-  const rootReducer = createRootReducer(client, history)
+  const rootReducer = createRootReducer(client)
 
   const store = createStore(
     rootReducer,

--- a/src/drive/store/connectedRouter.js
+++ b/src/drive/store/connectedRouter.js
@@ -1,0 +1,53 @@
+/**
+ * Tools to store part of the react-router state inside redux
+ */
+import { getParams } from 'react-router/lib/PatternUtils'
+
+const LOCATION_CHANGED = 'HISTORY.LOCATION_CHANGED'
+
+/**
+ * Given all the parameterized route, returns a function that will return
+ * all params from a location object.
+ */
+const createParamsExtractor = routes => {
+  return location => {
+    const pathname = location.pathname
+    for (let route of routes) {
+      const params = getParams(route, pathname)
+      if (params) {
+        return params
+      }
+    }
+    return {}
+  }
+}
+
+export const createReducer = options => {
+  const extractParams = createParamsExtractor(options.routes)
+  return (state = {}, action = null) => {
+    if (action === null) {
+      return state
+    } else if (action.type === LOCATION_CHANGED) {
+      const params = extractParams(action.location)
+      return {
+        location: action.location,
+        params
+      }
+    }
+    return state
+  }
+}
+
+export const locationChanged = (location, action) => ({
+  type: LOCATION_CHANGED,
+  location: location,
+  action: action
+})
+
+export const connectStoreToHistory = (store, history) => {
+  store.dispatch(locationChanged(history.getCurrentLocation()))
+
+  history.listen((location, action) => {
+    store.dispatch(locationChanged(location, action))
+  })
+}

--- a/src/drive/store/connectedRouter.js
+++ b/src/drive/store/connectedRouter.js
@@ -38,7 +38,7 @@ export const createReducer = options => {
   }
 }
 
-export const locationChanged = (location, action) => ({
+const locationChanged = (location, action) => ({
   type: LOCATION_CHANGED,
   location: location,
   action: action

--- a/src/drive/store/connectedRouter.spec.js
+++ b/src/drive/store/connectedRouter.spec.js
@@ -1,0 +1,33 @@
+import { locationChanged, createReducer } from './connectedRouter'
+
+const routes = [
+  '/folder/:folderId/file/:fileId',
+  '/files/:folderId/file/:fileId',
+  '/files/:folderId',
+  '/folder/:folderId'
+]
+
+describe('connectedRouter', () => {
+  it('should extract params from actions', () => {
+    const reducer = createReducer({
+      routes
+    })
+    const state = reducer()
+    expect(state).toEqual({})
+    const state2 = reducer(
+      state,
+      locationChanged({
+        pathname: '/folder/12345'
+      })
+    )
+    expect(state2.params.folderId).toEqual('12345')
+    const state3 = reducer(
+      state2,
+      locationChanged({
+        pathname: '/folder/12345/file/67890'
+      })
+    )
+    expect(state3.params.folderId).toEqual('12345')
+    expect(state3.params.fileId).toEqual('67890')
+  })
+})

--- a/src/drive/store/connectedRouter.spec.js
+++ b/src/drive/store/connectedRouter.spec.js
@@ -1,4 +1,6 @@
-import { locationChanged, createReducer } from './connectedRouter'
+import { createStore } from 'redux'
+import { connectStoreToHistory, createReducer } from './connectedRouter'
+import { hashHistory as history } from 'react-router'
 
 const routes = [
   '/folder/:folderId/file/:fileId',
@@ -12,21 +14,27 @@ describe('connectedRouter', () => {
     const reducer = createReducer({
       routes
     })
-    const state = reducer()
-    expect(state).toEqual({})
-    const state2 = reducer(
-      state,
-      locationChanged({
-        pathname: '/folder/12345'
+    const store = createStore(reducer)
+    connectStoreToHistory(store, history)
+
+    expect(store.getState()).toEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({
+          pathname: '/'
+        })
       })
     )
+
+    history.push('/folder/12345')
+
+    const state2 = store.getState()
     expect(state2.params.folderId).toEqual('12345')
-    const state3 = reducer(
-      state2,
-      locationChanged({
-        pathname: '/folder/12345/file/67890'
-      })
-    )
+
+    history.push({
+      pathname: '/folder/12345/file/67890'
+    })
+
+    const state3 = store.getState()
     expect(state3.params.folderId).toEqual('12345')
     expect(state3.params.fileId).toEqual('67890')
   })

--- a/src/drive/store/rootReducer.js
+++ b/src/drive/store/rootReducer.js
@@ -18,6 +18,8 @@ import {
   UNLINK
 } from 'drive/mobile/modules/authorization/duck'
 import { default as replication } from 'drive/mobile/modules/replication/duck'
+import { createReducer as createRouterReducer } from './connectedRouter'
+import { routes } from 'drive/web/modules/navigation/AppRoute'
 
 // Per Dan Abramov: https://stackoverflow.com/questions/35622588/how-to-reset-the-state-of-a-redux-store/35641992#35641992
 const createRootReducer = client => {
@@ -38,17 +40,21 @@ const createRootReducer = client => {
     mediaBackup
   })
 
-  const appReducer =
-    __TARGET__ === 'mobile'
-      ? combineReducers({
-          ...baseReducers,
-          mobile: mobileReducer,
-          cozy: client.reducer()
-        })
-      : combineReducers({
-          ...baseReducers,
-          cozy: client.reducer()
-        })
+  const routerReducer = createRouterReducer({
+    routes
+  })
+
+  const reducers = {
+    ...baseReducers,
+    cozy: client.reducer(),
+    router: routerReducer
+  }
+
+  if (__TARGET__ === 'mobile') {
+    reducers.mobile = mobileReducer
+  }
+
+  const appReducer = combineReducers(reducers)
 
   const rootReducer = (state, action) => {
     if (action.type === UNLINK) {

--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -47,7 +47,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const polyglot = initTranslation(data.cozyLocale, lang =>
     require(`drive/locales/${lang}`)
   )
-  const store = configureStore(client, polyglot.t.bind(polyglot))
+  let history = hashHistory
+
+  const store = configureStore({
+    client,
+    t: polyglot.t.bind(polyglot),
+    history
+  })
 
   cozy.client.init({
     cozyURL: cozyUrl,
@@ -63,7 +69,6 @@ document.addEventListener('DOMContentLoaded', () => {
     replaceTitleOnMobile: false
   })
 
-  let history = hashHistory
   if (shouldEnableTracking() && getTracker()) {
     let trackerInstance = getTracker()
     history = trackerInstance.connectToHistory(hashHistory)

--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -1,4 +1,4 @@
-/* global cozy */
+/* global cozy, __DEVELOPMENT__ */
 // eslint-disable-next-line no-unused-vars
 import mainStyles from 'drive/styles/main.styl'
 
@@ -24,6 +24,13 @@ import { hot } from 'react-hot-loader'
 import { Document } from 'cozy-doctypes'
 
 import App from 'components/App/App'
+
+import flag from 'cozy-flags'
+
+if (__DEVELOPMENT__) {
+  window.flag = flag
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -130,11 +130,11 @@ class InitAppMobile {
     const client = await this.getClient()
     const polyglot = this.getPolyglot()
     const persistedState = await this.getPersistedState()
-    this.store = configureStore(
-      client,
-      polyglot.t.bind(polyglot),
-      persistedState
-    )
+    this.store = configureStore({
+      client: client,
+      t: polyglot.t.bind(polyglot),
+      initialState: persistedState
+    })
     return this.store
   }
 

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -85,7 +85,11 @@ const init = async () => {
     require(`drive/locales/${lang}`)
   )
 
-  const store = configureStore(client, polyglot.t.bind(polyglot))
+  const store = configureStore({
+    client,
+    t: polyglot.t.bind(polyglot),
+    history: hashHistory
+  })
 
   try {
     const sharedDocumentId = await getSharedDocument(client)

--- a/src/drive/web/modules/actionmenu/MobileActionMenu.jsx
+++ b/src/drive/web/modules/actionmenu/MobileActionMenu.jsx
@@ -27,13 +27,13 @@ const Menu = props => {
       {actionNames.map(actionName => {
         const Component = actions[actionName].Component || MenuItem
         const action = actions[actionName].action
-        const onClick = !action
-          ? undefined
-          : () => {
+        const onClick = action
+          ? () => {
               const promise = action([file])
               onClose()
               return promise
             }
+          : null
         return (
           <Component
             key={actionName}

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -8,7 +8,8 @@ import OnBoarding from 'drive/mobile/modules/onboarding/OnBoarding'
 
 import Layout from 'drive/web/modules/layout/Layout'
 import FileExplorer from './FileExplorer'
-import FilesViewer from 'drive/web/modules/viewer/FilesViewer'
+import FilesViewerV1 from 'drive/web/modules/viewer/FilesViewer'
+import FilesViewerV2 from 'drive/web/modules/viewer/FilesViewerV2'
 import FileOpenerExternal from 'drive/web/modules/viewer/FileOpenerExternal'
 import {
   FolderContainer as Folder,
@@ -31,6 +32,10 @@ export const routes = [
   '/files/:folderId',
   '/folder/:folderId'
 ]
+
+const FilesViewer = flag('drive.client-migration.enabled')
+  ? FilesViewerV2
+  : FilesViewerV1
 
 const AppRoute = (
   <Route>

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -22,6 +22,16 @@ import UploadFromMobile from 'drive/mobile/modules/upload'
 import ExternalRedirect from './ExternalRedirect'
 import DriveView from '../views/Drive'
 
+// To keep in sync with AppRoute below, used to extract params
+// in the "router" redux slice. Innermost routes should be
+// first
+export const routes = [
+  '/folder/:folderId/file/:fileId',
+  '/files/:folderId/file/:fileId',
+  '/files/:folderId',
+  '/folder/:folderId'
+]
+
 const AppRoute = (
   <Route>
     <Route path="external/:fileId" component={ExternalRedirect} />

--- a/src/drive/web/modules/navigation/duck/actions.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.jsx
@@ -26,6 +26,11 @@ export const OPEN_FOLDER_FAILURE = 'OPEN_FOLDER_FAILURE'
 export const SORT_FOLDER = 'SORT_FOLDER'
 export const SORT_FOLDER_SUCCESS = 'SORT_FOLDER_SUCCESS'
 export const SORT_FOLDER_FAILURE = 'SORT_FOLDER_FAILURE'
+
+// Difference with previous SORT_FOLDER is that the following action
+// will not have effect on a fetch status of the folder
+export const SORT_FOLDER_V2 = 'SORT_FOLDER_V2'
+
 export const FETCH_RECENT = 'FETCH_RECENT'
 export const FETCH_RECENT_SUCCESS = 'FETCH_RECENT_SUCCESS'
 export const FETCH_RECENT_FAILURE = 'FETCH_RECENT_FAILURE'
@@ -128,6 +133,15 @@ export const sortFolder = (folderId, sortAttribute, sortOrder = 'asc') => {
       })
       return dispatch({ type: SORT_FOLDER_FAILURE, error: err })
     }
+  }
+}
+
+export const sortFolderV2 = (folderId, sortAttribute, sortOrder = 'asc') => {
+  return {
+    type: SORT_FOLDER,
+    folderId,
+    sortAttribute,
+    sortOrder
   }
 }
 

--- a/src/drive/web/modules/navigation/duck/hooks.js
+++ b/src/drive/web/modules/navigation/duck/hooks.js
@@ -1,0 +1,19 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { sortFolderV2, getSort } from 'drive/web/modules/navigation/duck'
+
+const useFolderSort = folderId => {
+  const defaultSort = { attribute: 'name', order: 'asc' }
+  const dispatch = useDispatch()
+  const currentSort = useSelector(getSort) || defaultSort
+  const setOrder = useCallback(
+    ({ sortAttribute, sortOrder }) => {
+      dispatch(sortFolderV2(folderId, sortAttribute, sortOrder))
+    },
+    [dispatch, folderId]
+  )
+  return [currentSort, setOrder]
+}
+
+export { useFolderSort }

--- a/src/drive/web/modules/navigation/duck/index.js
+++ b/src/drive/web/modules/navigation/duck/index.js
@@ -12,6 +12,7 @@ export {
 export {
   openFolder,
   sortFolder,
+  sortFolderV2,
   fetchMoreFiles,
   fetchRecentFiles,
   addFile,
@@ -25,3 +26,5 @@ export {
   exportFilesNative,
   openFileWith
 } from './actions'
+
+export { useFolderSort } from './hooks'

--- a/src/drive/web/modules/navigation/duck/reducer.js
+++ b/src/drive/web/modules/navigation/duck/reducer.js
@@ -8,6 +8,7 @@ import {
   SORT_FOLDER,
   SORT_FOLDER_SUCCESS,
   SORT_FOLDER_FAILURE,
+  SORT_FOLDER_V2,
   FETCH_RECENT,
   FETCH_RECENT_SUCCESS,
   FETCH_RECENT_FAILURE,
@@ -181,6 +182,11 @@ const fileCount = (state = null, action) => {
 const sort = (state = null, action) => {
   switch (action.type) {
     case SORT_FOLDER:
+      return {
+        attribute: action.sortAttribute,
+        order: action.sortOrder
+      }
+    case SORT_FOLDER_V2:
       return {
         attribute: action.sortAttribute,
         order: action.sortOrder

--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -1,0 +1,28 @@
+import CozyClient, { Q } from 'cozy-client'
+import { TRASH_DIR_ID } from 'drive/constants/config'
+
+const DEFAULT_CACHE_TIMEOUT_QUERIES = 30 * 60 * 1000
+
+const buildQuery = ({ currentFolderId, type, sortAttribute, sortOrder }) => ({
+  definition: () =>
+    Q('io.cozy.files')
+      .where({
+        dir_id: currentFolderId,
+        _id: { $ne: TRASH_DIR_ID },
+        type
+      })
+      .indexFields(['dir_id', 'type', sortAttribute])
+      .sortBy([
+        { dir_id: sortOrder },
+        { type: sortOrder },
+        { [sortAttribute]: sortOrder }
+      ]),
+  options: {
+    as: `${type}-${currentFolderId}-${sortAttribute}-${sortOrder}`,
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(
+      DEFAULT_CACHE_TIMEOUT_QUERIES
+    )
+  }
+})
+
+export { buildQuery }

--- a/src/drive/web/modules/routeUtils.js
+++ b/src/drive/web/modules/routeUtils.js
@@ -1,0 +1,7 @@
+export const getFolderPath = folderId => {
+  return `/folder/${folderId}`
+}
+
+export const getViewerPath = (folderId, fileId) => {
+  return `/folder/${folderId}/file/${fileId}`
+}

--- a/src/drive/web/modules/selectors.js
+++ b/src/drive/web/modules/selectors.js
@@ -1,0 +1,8 @@
+export const getCurrentFolderId = rootState => {
+  return rootState.router.params.folderId
+}
+
+export const getCurrentFileId = rootState => {
+  return rootState.router.params.fileId
+}
+

--- a/src/drive/web/modules/selectors.js
+++ b/src/drive/web/modules/selectors.js
@@ -5,4 +5,3 @@ export const getCurrentFolderId = rootState => {
 export const getCurrentFileId = rootState => {
   return rootState.router.params.fileId
 }
-

--- a/src/drive/web/modules/services/components/Picker/withReduxStore.jsx
+++ b/src/drive/web/modules/services/components/Picker/withReduxStore.jsx
@@ -11,7 +11,10 @@ const withReduxStore = WrappedComponent => {
     }
     render() {
       const { client, t } = this.context
-      const store = configureStore(client, t)
+      const store = configureStore({
+        client,
+        t
+      })
 
       return (
         <Provider store={store}>

--- a/src/drive/web/modules/viewer/FilesViewer2.spec.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer2.spec.jsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { Overlay, Viewer } from 'cozy-ui/transpiled/react'
+import FilesViewer from './FilesViewerV2'
+import CozyClient, { useQuery } from 'cozy-client'
+import AppLike from 'test/components/AppLike'
+
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+
+const filesFixture = [
+  {
+    dir_id: 'io.cozy.files.root-dir',
+    displayedPath: '/',
+    id: 'foobar',
+    name: 'foobar.pdf',
+    path: '/foobar.pdf',
+    type: 'file'
+  },
+  {
+    dir_id: 'io.cozy.files.root-dir',
+    displayedPath: '/',
+    id: 'foobar2',
+    name: 'foobar2.pdf',
+    path: '/foobar2.pdf',
+    type: 'file'
+  },
+  {
+    dir_id: 'io.cozy.files.root-dir',
+    displayedPath: '/',
+    id: 'foobar3',
+    name: 'foobar3.pdf',
+    path: '/foobar3.pdf',
+    type: 'file'
+  }
+]
+
+describe('FilesViewer', () => {
+  const setup = () => {
+    const client = new CozyClient({})
+    const store = {
+      subscribe: () => {},
+      getState: () => ({
+        router: {
+          params: {
+            fileId: 'foobar',
+            folderId: 'folder-id'
+          }
+        }
+      })
+    }
+    const root = mount(
+      <AppLike client={client} store={store}>
+        <FilesViewer client={client} fileId="foobar" files={filesFixture} />
+      </AppLike>
+    )
+    return {
+      root
+    }
+  }
+
+  it('should render a Viewer', () => {
+    useQuery.mockReturnValue({
+      data: filesFixture,
+      count: filesFixture.length,
+      fetchMore: jest.fn().mockImplementation(() => {
+        throw new Error('Fetch more should not be called')
+      })
+    })
+    const { root } = setup()
+    expect(root.find(Overlay).length).toBe(1)
+    expect(root.find(Viewer).length).toBe(1)
+  })
+})

--- a/src/drive/web/modules/viewer/FilesViewer2.spec.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer2.spec.jsx
@@ -7,36 +7,35 @@ import AppLike from 'test/components/AppLike'
 
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 
-const filesFixture = [
-  {
-    dir_id: 'io.cozy.files.root-dir',
-    displayedPath: '/',
-    id: 'foobar',
-    name: 'foobar.pdf',
-    path: '/foobar.pdf',
-    type: 'file'
-  },
-  {
-    dir_id: 'io.cozy.files.root-dir',
-    displayedPath: '/',
-    id: 'foobar2',
-    name: 'foobar2.pdf',
-    path: '/foobar2.pdf',
-    type: 'file'
-  },
-  {
-    dir_id: 'io.cozy.files.root-dir',
-    displayedPath: '/',
-    id: 'foobar3',
-    name: 'foobar3.pdf',
-    path: '/foobar3.pdf',
-    type: 'file'
+const generateFile = i => ({
+  dir_id: 'io.cozy.files.root-dir',
+  displayedPath: '/',
+  id: `foobar${i}`,
+  name: `foobar${i}.pdf`,
+  path: `/foobar${i}.pdf`,
+  type: 'file'
+})
+
+const generateFiles = nbFiles => {
+  const res = []
+  for (let i = 0; i < nbFiles; i++) {
+    const file = generateFile(i)
+    res.push(file)
   }
-]
+  return res
+}
+
+const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
 
 describe('FilesViewer', () => {
-  const setup = () => {
-    const client = new CozyClient({})
+  const setup = ({
+    fileId = 'foobar0',
+    nbFiles = 3,
+    totalCount,
+    client,
+    useQueryResultAttributes
+  } = {}) => {
+    client = client || new CozyClient({})
     const store = {
       subscribe: () => {},
       getState: () => ({
@@ -48,19 +47,21 @@ describe('FilesViewer', () => {
         },
         router: {
           params: {
-            fileId: 'foobar',
+            fileId: fileId,
             folderId: 'folder-id'
           }
         }
       })
     }
 
+    const filesFixture = generateFiles(nbFiles)
     useQuery.mockReturnValue({
       data: filesFixture,
-      count: filesFixture.length,
+      count: totalCount || filesFixture.length,
       fetchMore: jest.fn().mockImplementation(() => {
         throw new Error('Fetch more should not be called')
-      })
+      }),
+      ...useQueryResultAttributes
     })
 
     const root = mount(
@@ -88,5 +89,62 @@ describe('FilesViewer', () => {
       as: 'file-folder-id-name-desc',
       fetchPolicy: expect.any(Function)
     })
+  })
+
+  it('should fetch the file if necessary', async () => {
+    const client = new CozyClient({})
+    client.query = jest.fn().mockResolvedValue({
+      data: generateFile('51')
+    })
+    const { root } = setup({
+      client,
+      nbFiles: 50,
+      totalCount: 100,
+      fileId: 'foobar51'
+    })
+
+    expect(root.find(Viewer).length).toBe(0)
+
+    // Let promise resolve
+    await sleep(0)
+
+    root.update()
+
+    expect(root.find(Overlay).length).toBe(1)
+    expect(root.find(Viewer).length).toBe(1)
+    expect(client.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'foobar51',
+        doctype: 'io.cozy.files'
+      })
+    )
+  })
+
+  it('should fetch more files if necessary', async () => {
+    const client = new CozyClient({})
+    client.query = jest.fn().mockResolvedValue({
+      data: generateFile('51')
+    })
+    const fetchMore = jest.fn().mockImplementation(async () => {
+      await sleep(10)
+    })
+    const { root } = setup({
+      client,
+      nbFiles: 50,
+      totalCount: 100,
+      fileId: 'foobar48',
+      useQueryResultAttributes: {
+        fetchMore
+      }
+    })
+
+    // Let promise resolve
+    await sleep(0)
+
+    root.update()
+
+    expect(root.find(Overlay).length).toBe(1)
+    expect(root.find(Viewer).length).toBe(1)
+    expect(fetchMore).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/drive/web/modules/viewer/FilesViewer2.spec.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer2.spec.jsx
@@ -40,6 +40,12 @@ describe('FilesViewer', () => {
     const store = {
       subscribe: () => {},
       getState: () => ({
+        view: {
+          sort: {
+            sortAttribute: 'name',
+            sortOrder: 'desc'
+          }
+        },
         router: {
           params: {
             fileId: 'foobar',
@@ -48,17 +54,7 @@ describe('FilesViewer', () => {
         }
       })
     }
-    const root = mount(
-      <AppLike client={client} store={store}>
-        <FilesViewer client={client} fileId="foobar" files={filesFixture} />
-      </AppLike>
-    )
-    return {
-      root
-    }
-  }
 
-  it('should render a Viewer', () => {
     useQuery.mockReturnValue({
       data: filesFixture,
       count: filesFixture.length,
@@ -66,8 +62,31 @@ describe('FilesViewer', () => {
         throw new Error('Fetch more should not be called')
       })
     })
+
+    const root = mount(
+      <AppLike client={client} store={store}>
+        <FilesViewer client={client} fileId="foobar" files={filesFixture} />
+      </AppLike>
+    )
+
+    return {
+      root
+    }
+  }
+
+  it('should render a Viewer', () => {
     const { root } = setup()
     expect(root.find(Overlay).length).toBe(1)
     expect(root.find(Viewer).length).toBe(1)
+  })
+
+  it('should use sort attribute/order from state', () => {
+    const { root } = setup()
+    expect(root.find(Overlay).length).toBe(1)
+    expect(root.find(Viewer).length).toBe(1)
+    expect(useQuery).toHaveBeenCalledWith(expect.any(Function), {
+      as: 'file-folder-id-name-desc',
+      fetchPolicy: expect.any(Function)
+    })
   })
 })

--- a/src/drive/web/modules/viewer/FilesViewerV2.jsx
+++ b/src/drive/web/modules/viewer/FilesViewerV2.jsx
@@ -42,9 +42,10 @@ class FilesViewer extends Component {
     this._mounted = false
   }
 
-  // If we can't find the file in the loaded files, that's probably because the user is trying to open
-  // a direct link to a file that wasn't in the first 50 files of the containing folder
-  // (it comes from a fetchMore...) ; we load the file attributes directly as a contingency measure
+  // If we can't find the file in the loaded files, that's probably because the user
+  // is trying to open a direct link to a file that wasn't in the first 50 files of
+  // the containing folder (it comes from a fetchMore...) ; we load the file attributes
+  // directly as a contingency measure
   async fetchFileIfNecessary() {
     if (this.getCurrentIndex() !== -1) return
     if (this.state.currentFile && this._mounted) {

--- a/src/drive/web/modules/viewer/FilesViewerV2.jsx
+++ b/src/drive/web/modules/viewer/FilesViewerV2.jsx
@@ -122,10 +122,6 @@ class FilesViewer extends Component {
   }
 }
 
-const getViewableFiles = files => {
-  return files.filter(f => f.type !== 'directory')
-}
-
 const mapStateToProps = state => ({
   folderId: getCurrentFolderId(state),
   fileId: getCurrentFileId(state)
@@ -141,7 +137,7 @@ const FilesViewerWithQuery = ({ ...props }) => {
   })
   const results = useQuery(filesQuery.definition, filesQuery.options)
   if (results.data) {
-    const viewableFiles = getViewableFiles(results.data)
+    const viewableFiles = results.data
     return <FilesViewer {...props} files={viewableFiles} filesQuery={results} />
   } else {
     return <FilesViewerLoading />

--- a/src/drive/web/modules/viewer/FilesViewerV2.jsx
+++ b/src/drive/web/modules/viewer/FilesViewerV2.jsx
@@ -8,6 +8,7 @@ import logger from 'lib/logger'
 import Fallback from 'drive/web/modules/viewer/Fallback'
 import palette from 'cozy-ui/transpiled/react/palette'
 import { buildQuery } from 'drive/web/modules/queries'
+import { useFolderSort } from 'drive/web/modules/navigation/duck'
 import {
   getCurrentFolderId,
   getCurrentFileId
@@ -131,11 +132,12 @@ const mapStateToProps = state => ({
 })
 
 const FilesViewerWithQuery = ({ ...props }) => {
+  const [{ sortAttribute, sortOrder }] = useFolderSort()
   const filesQuery = buildQuery({
     currentFolderId: props.folderId,
     type: 'file',
-    sortAttribute: 'name',
-    sortOrder: 'asc'
+    sortAttribute: sortAttribute,
+    sortOrder: sortOrder
   })
   const results = useQuery(filesQuery.definition, filesQuery.options)
   if (results.data) {

--- a/src/drive/web/modules/viewer/FilesViewerV2.jsx
+++ b/src/drive/web/modules/viewer/FilesViewerV2.jsx
@@ -1,0 +1,153 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import compose from 'lodash/flowRight'
+import { useQuery, withClient } from 'cozy-client'
+import { Overlay, Spinner, Viewer } from 'cozy-ui/transpiled/react'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
+import logger from 'lib/logger'
+import Fallback from 'drive/web/modules/viewer/Fallback'
+import palette from 'cozy-ui/transpiled/react/palette'
+import { buildQuery } from 'drive/web/modules/queries'
+import {
+  getCurrentFolderId,
+  getCurrentFileId
+} from 'drive/web/modules/selectors'
+import { getFolderPath, getViewerPath } from 'drive/web/modules/routeUtils'
+
+const FilesViewerLoading = () => (
+  <Overlay>
+    <Spinner size="xxlarge" middle noMargin color={palette.white} />
+  </Overlay>
+)
+
+class FilesViewer extends Component {
+  state = {
+    currentFile: null
+  }
+
+  _mounted = false
+
+  componentDidMount() {
+    this._mounted = true
+    this.fetchFileIfNecessary()
+    this.fetchMoreIfNecessary()
+  }
+
+  componentWillReceiveProps() {
+    this.fetchMoreIfNecessary()
+  }
+
+  componentWillUnmount() {
+    this._mounted = false
+  }
+
+  // If we can't find the file in the loaded files, that's probably because the user is trying to open
+  // a direct link to a file that wasn't in the first 50 files of the containing folder
+  // (it comes from a fetchMore...) ; we load the file attributes directly as a contingency measure
+  async fetchFileIfNecessary() {
+    if (this.getCurrentIndex() !== -1) return
+    if (this.state.currentFile && this._mounted) {
+      this.setState({ currentFile: null })
+    }
+
+    const { fileId, client } = this.props
+    try {
+      const { data } = await client.query(client.get('io.cozy.files', fileId))
+      this.setState({
+        currentFile: data
+      })
+    } catch (e) {
+      logger.warn("can't find the file")
+      this.onClose()
+    }
+  }
+
+  fetchMoreIfNecessary() {
+    const { files, fileId, filesQuery } = this.props
+    const fileCount = filesQuery.count
+    // If we get close of the last file fetched, but we know there are more in the folder
+    // (it shouldn't happen in /recent), we fetch more files
+    const currentIndex = files.findIndex(f => f.id === fileId)
+
+    if (files.length !== fileCount && files.length - currentIndex <= 5) {
+      filesQuery.fetchMore()
+    }
+  }
+
+  onClose = () => {
+    const { router, folderId } = this.props
+    router.push({
+      pathname: getFolderPath(folderId)
+    })
+  }
+
+  onChange = nextFile => {
+    const { router, folderId } = this.props
+    router.push({
+      pathname: getViewerPath(folderId, nextFile.id)
+    })
+  }
+
+  getCurrentIndex() {
+    const { files, fileId } = this.props
+    return files.findIndex(f => f.id === fileId)
+  }
+
+  render() {
+    const { t, files } = this.props
+    const currentIndex = this.getCurrentIndex(files)
+
+    // If we can't find the file, we fallback to the (potentially loading)
+    // direct stat made by the viewer
+    if (currentIndex === -1 && !this.state.currentFile) {
+      return <FilesViewerLoading />
+    } else {
+      const hasCurrentIndex = currentIndex != -1
+      const viewerFiles = hasCurrentIndex ? files : [this.state.currentFile]
+      const viewerIndex = hasCurrentIndex ? currentIndex : 0
+
+      return (
+        <Overlay>
+          <Viewer
+            files={viewerFiles}
+            currentIndex={viewerIndex}
+            onChangeRequest={this.onChange}
+            onCloseRequest={this.onClose}
+            renderFallbackExtraContent={file => <Fallback file={file} t={t} />}
+          />
+        </Overlay>
+      )
+    }
+  }
+}
+
+const getViewableFiles = files => {
+  return files.filter(f => f.type !== 'directory')
+}
+
+const mapStateToProps = state => ({
+  folderId: getCurrentFolderId(state),
+  fileId: getCurrentFileId(state)
+})
+
+const FilesViewerWithQuery = ({ ...props }) => {
+  const filesQuery = buildQuery({
+    currentFolderId: props.folderId,
+    type: 'file',
+    sortAttribute: 'name',
+    sortOrder: 'asc'
+  })
+  const results = useQuery(filesQuery.definition, filesQuery.options)
+  if (results.data) {
+    const viewableFiles = getViewableFiles(results.data)
+    return <FilesViewer {...props} files={viewableFiles} filesQuery={results} />
+  } else {
+    return <FilesViewerLoading />
+  }
+}
+
+export default compose(
+  withClient,
+  connect(mapStateToProps),
+  translate()
+)(FilesViewerWithQuery)

--- a/src/drive/web/modules/viewer/FilesViewerV2.jsx
+++ b/src/drive/web/modules/viewer/FilesViewerV2.jsx
@@ -63,15 +63,23 @@ class FilesViewer extends Component {
     }
   }
 
-  fetchMoreIfNecessary() {
-    const { files, fileId, filesQuery } = this.props
-    const fileCount = filesQuery.count
-    // If we get close of the last file fetched, but we know there are more in the folder
-    // (it shouldn't happen in /recent), we fetch more files
-    const currentIndex = files.findIndex(f => f.id === fileId)
+  async fetchMoreIfNecessary() {
+    if (this.fetchingMore) {
+      return
+    }
+    this.fetchingMore = true
+    try {
+      const { files, fileId, filesQuery } = this.props
+      const fileCount = filesQuery.count
+      // If we get close of the last file fetched, but we know there are more in the folder
+      // (it shouldn't happen in /recent), we fetch more files
+      const currentIndex = files.findIndex(f => f.id === fileId)
 
-    if (files.length !== fileCount && files.length - currentIndex <= 5) {
-      filesQuery.fetchMore()
+      if (files.length !== fileCount && files.length - currentIndex <= 5) {
+        await filesQuery.fetchMore()
+      }
+    } finally {
+      this.fetchingMore = false
     }
   }
 

--- a/src/drive/web/modules/viewer/FilesViewerV2.jsx
+++ b/src/drive/web/modules/viewer/FilesViewerV2.jsx
@@ -136,7 +136,7 @@ const mapStateToProps = state => ({
   fileId: getCurrentFileId(state)
 })
 
-const FilesViewerWithQuery = ({ ...props }) => {
+const FilesViewerWithQuery = props => {
   const [{ sortAttribute, sortOrder }] = useFolderSort()
   const filesQuery = buildQuery({
     currentFolderId: props.folderId,

--- a/src/drive/web/modules/viewer/FilesViewerV2.jsx
+++ b/src/drive/web/modules/viewer/FilesViewerV2.jsx
@@ -21,6 +21,14 @@ const FilesViewerLoading = () => (
   </Overlay>
 )
 
+/**
+ * Shows a set of files through cozy-ui's Viewer
+ *
+ * - Re-uses the cozy-client's Query for the current directory files
+ *   with the same sort order.
+ * - If the file to show is not present in the query results, will call
+ *   fetchMore() on the query
+ */
 class FilesViewer extends Component {
   state = {
     currentFile: null

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -1,5 +1,5 @@
 /* global __TARGET__ */
-import React, { useCallback, useState, useContext } from 'react'
+import React, { useCallback, useContext } from 'react'
 import { connect } from 'react-redux'
 import { useQuery } from 'cozy-client'
 
@@ -31,13 +31,14 @@ import Breadcrumb from './Breadcrumb'
 import File from './FileWithActions'
 import { buildQuery } from 'drive/web/modules/queries'
 import { getCurrentFolderId } from 'drive/web/modules/selectors'
+import { useFolderSort } from 'drive/web/modules/navigation/duck'
 
 const DriveView = ({ folderId, router, children }) => {
   const { isBigThumbnail, toggleThumbnailSize } = useContext(
     ThumbnailSizeContext
   )
-  const [sortOrder, setSortOder] = useState({ attribute: 'name', order: 'asc' })
   const currentFolderId = folderId || ROOT_DIR_ID
+  const [sortOrder, setSortOrder] = useFolderSort(folderId)
 
   const folderQuery = buildQuery({
     currentFolderId,
@@ -64,7 +65,7 @@ const DriveView = ({ folderId, router, children }) => {
   })
 
   const changeSortOrder = useCallback((folderId_legacy, attribute, order) =>
-    setSortOder({ attribute, order })
+    setSortOrder({ sortAttribute: attribute, sortOrder: order })
   )
 
   const isInError =

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -1,6 +1,7 @@
 /* global __TARGET__ */
 import React, { useCallback, useState, useContext } from 'react'
-import { useQuery, Q } from 'cozy-client'
+import { connect } from 'react-redux'
+import { useQuery } from 'cozy-client'
 
 import SharingProvider from 'cozy-sharing'
 import {
@@ -14,7 +15,7 @@ import Dropzone from 'drive/web/modules/upload/Dropzone'
 import Main from 'drive/web/modules/layout/Main'
 import Topbar from 'drive/web/modules/layout/Topbar'
 import Toolbar from 'drive/web/modules/drive/Toolbar'
-import { ROOT_DIR_ID, TRASH_DIR_ID } from 'drive/constants/config'
+import { ROOT_DIR_ID } from 'drive/constants/config'
 
 import { FileListv2 } from 'drive/web/modules/filelist/FileList'
 import { ConnectedFileListBodyV2 as FileListBodyV2 } from 'drive/web/modules/filelist/FileListBody'
@@ -28,25 +29,7 @@ import { isMobileApp } from 'cozy-device-helper'
 import LoadMore from 'drive/web/modules/filelist/LoadMoreV2'
 import Breadcrumb from './Breadcrumb'
 import File from './FileWithActions'
-
-const buildQuery = ({ currentFolderId, type, sortAttribute, sortOrder }) => ({
-  definition: () =>
-    Q('io.cozy.files')
-      .where({
-        dir_id: currentFolderId,
-        _id: { $ne: TRASH_DIR_ID },
-        type
-      })
-      .indexFields(['dir_id', 'type', sortAttribute])
-      .sortBy([
-        { dir_id: sortOrder },
-        { type: sortOrder },
-        { [sortAttribute]: sortOrder }
-      ]),
-  options: {
-    as: `${type}-${currentFolderId}-${sortAttribute}-${sortOrder}`
-  }
-})
+import { buildQuery } from 'drive/web/modules/queries'
 
 const DriveView = ({ params, router, children }) => {
   const { isBigThumbnail, toggleThumbnailSize } = useContext(

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -30,12 +30,12 @@ import LoadMore from 'drive/web/modules/filelist/LoadMoreV2'
 import Breadcrumb from './Breadcrumb'
 import File from './FileWithActions'
 import { buildQuery } from 'drive/web/modules/queries'
+import { getCurrentFolderId } from 'drive/web/modules/selectors'
 
-const DriveView = ({ params, router, children }) => {
+const DriveView = ({ folderId, router, children }) => {
   const { isBigThumbnail, toggleThumbnailSize } = useContext(
     ThumbnailSizeContext
   )
-  const { folderId } = params
   const [sortOrder, setSortOder] = useState({ attribute: 'name', order: 'asc' })
   const currentFolderId = folderId || ROOT_DIR_ID
 
@@ -180,4 +180,6 @@ const DriveViewWithProvider = props => (
   </SharingProvider>
 )
 
-export default DriveViewWithProvider
+export default connect(state => ({
+  folderId: getCurrentFolderId(state)
+}))(DriveViewWithProvider)


### PR DESCRIPTION
- Uses cozy-client query for data
- Uses redux for folderId and fileId

~~Still~~ Not anymore in draft ~~since I want to fix~~, since I've addest tests for: 

- [x] the sorting, that should be based on the sorting of the DriveView (meaning
I will put the sort config inside Redux I think).
- [x] add more tests, mainly on the fetch more files part

I think it's already readable and I'd like some feedback on the initial changes, mainly the router state inside redux. Are we ok to continue this way ?

