### PR TITLE
feat: Update client queries in real time

### DIFF
--- a/src/drive/web/modules/views/Drive/RealTimeQueries.jsx
+++ b/src/drive/web/modules/views/Drive/RealTimeQueries.jsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react'
+import { useClient, Mutations } from 'cozy-client'
+import { receiveMutationResult } from 'cozy-client/dist/store'
+
+const RealTimeQueries = ({ doctype }) => {
+  const client = useClient()
+
+  const dispatchChange = (document, mutationDefinitionCreator) => {
+    const response = { data: { ...document, _type: doctype } }
+    const options = {}
+    client.dispatch(
+      receiveMutationResult(
+        client.generateId(),
+        response,
+        options,
+        mutationDefinitionCreator(document)
+      )
+    )
+  }
+
+  useEffect(
+    () => {
+      const realtime = client.plugins.realtime
+
+      const dispatchCreate = document => {
+        dispatchChange(document, Mutations.createDocument)
+      }
+      const dispatchUpdate = document => {
+        dispatchChange(document, Mutations.updateDocument)
+      }
+      const dispatchDelete = document => {
+        dispatchChange(document, Mutations.deleteDocument)
+      }
+
+      const subscribe = async () => {
+        await realtime.subscribe('created', doctype, dispatchCreate)
+        await realtime.subscribe('updated', doctype, dispatchUpdate)
+        await realtime.subscribe('deleted', doctype, dispatchDelete)
+      }
+      subscribe()
+
+      return () => {
+        realtime.unsubscribe('created', doctype, dispatchCreate)
+        realtime.unsubscribe('updated', doctype, dispatchUpdate)
+        realtime.unsubscribe('deleted', doctype, dispatchDelete)
+      }
+    },
+    [client, dispatchChange]
+  )
+
+  return null
+}
+
+export default RealTimeQueries

--- a/src/drive/web/modules/views/Drive/RealTimeQueries.spec.jsx
+++ b/src/drive/web/modules/views/Drive/RealTimeQueries.spec.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import RealTimeQueries from './RealTimeQueries'
+import AppLike from '../../../../../../test/components/AppLike'
+import { createMockClient } from 'cozy-client'
+
+describe('RealTimeQueries', () => {
+  it('notifies the cozy-client store', async () => {
+    const realtimeCallbacks = {}
+    const client = new createMockClient({})
+    client.plugins.realtime = {
+      subscribe: jest.fn((event, doctype, callback) => {
+        realtimeCallbacks[event] = callback
+      }),
+      unsubscribe: jest.fn()
+    }
+    client.dispatch = jest.fn()
+
+    const { unmount } = render(
+      <AppLike client={client}>
+        <RealTimeQueries doctype="io.cozy.files" />
+      </AppLike>
+    )
+
+    await waitFor(() =>
+      expect(client.plugins.realtime.subscribe).toHaveBeenCalledTimes(3)
+    )
+
+    realtimeCallbacks['created']({ id: 'mock-created' })
+    expect(client.dispatch).toHaveBeenCalledWith({
+      definition: {
+        document: { id: 'mock-created' },
+        mutationType: 'CREATE_DOCUMENT'
+      },
+      mutationId: 1,
+      response: { data: { _type: 'io.cozy.files', id: 'mock-created' } },
+      type: 'RECEIVE_MUTATION_RESULT'
+    })
+
+    realtimeCallbacks['updated']({ id: 'mock-updated' })
+    expect(client.dispatch).toHaveBeenCalledWith({
+      definition: {
+        document: { id: 'mock-updated' },
+        mutationType: 'UPDATE_DOCUMENT'
+      },
+      mutationId: 2,
+      response: { data: { _type: 'io.cozy.files', id: 'mock-updated' } },
+      type: 'RECEIVE_MUTATION_RESULT'
+    })
+
+    realtimeCallbacks['deleted']({ id: 'mock-deleted' })
+    expect(client.dispatch).toHaveBeenCalledWith({
+      definition: {
+        document: { id: 'mock-deleted' },
+        mutationType: 'DELETE_DOCUMENT'
+      },
+      mutationId: 3,
+      response: { data: { _type: 'io.cozy.files', id: 'mock-deleted' } },
+      type: 'RECEIVE_MUTATION_RESULT'
+    })
+
+    unmount()
+    expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -34,6 +34,8 @@ import { buildQuery } from 'drive/web/modules/queries'
 import { getCurrentFolderId } from 'drive/web/modules/selectors'
 import { useFolderSort } from 'drive/web/modules/navigation/duck'
 
+import RealTimeQueries from './RealTimeQueries'
+
 const DriveView = ({ folderId, router, children }) => {
   const { isBigThumbnail, toggleThumbnailSize } = useContext(
     ThumbnailSizeContext
@@ -83,6 +85,7 @@ const DriveView = ({ folderId, router, children }) => {
 
   return (
     <Main>
+      <RealTimeQueries doctype="io.cozy.files" />
       <ModalStack />
       <Topbar>
         <Breadcrumb


### PR DESCRIPTION
This PR allows to keep query results up to date by relying on the realtime connection. Ultimately I want to integrate this in cozy-client and will post there shortly with a few questions and an API proposal, but in the meantime this is a quick way to make it work in cozy-drive.

TODO:

- [x] Add tests