### PR TITLE
fix: Download a single file

### DIFF
--- a/src/drive/web/modules/actions/utils.js
+++ b/src/drive/web/modules/actions/utils.js
@@ -49,15 +49,12 @@ export const downloadFiles = async (client, files) => {
     const file = files[0]
 
     try {
+      const filename = file.name
       const downloadURL = await client
         .collection('io.cozy.files')
-        .getDownloadLinkById(file.id)
-      const filename = file.name
+        .getDownloadLinkById(file.id, filename)
 
-      forceFileDownload(
-        `${client.getStackClient().uri}${downloadURL}?Dl=1`,
-        filename
-      )
+      forceFileDownload(`${downloadURL}?Dl=1`, filename)
     } catch (error) {
       Alerter.error(downloadFileError(error))
     }


### PR DESCRIPTION
Downloading a single file was broken because `client.getDownloadLinkById` returns a full URL, whereas the cozy-client-js version returned the path only, without the domain name.