### PR TITLE
fix: Assume we're in the root folder if there's no displayedFolder

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/components/NotRootFolder.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/NotRootFolder.jsx
@@ -1,9 +1,13 @@
 import toolbarContainer from 'drive/web/modules/drive/Toolbar/toolbar'
-const NotRootFolder = ({ notRootfolder, children }) => {
-  if (notRootfolder) {
-    return children
+
+/**
+ * Displays its children only if we are not displaying the root folder
+ */
+const NotRootFolder = ({ insideRootFolder, children }) => {
+  if (insideRootFolder) {
+    return null
   }
-  return null
+  return children
 }
 
 export default toolbarContainer(NotRootFolder)

--- a/src/drive/web/modules/drive/Toolbar/toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar/toolbar.jsx
@@ -12,7 +12,7 @@ const mapStateToProps = state => {
 
   return {
     displayedFolder,
-    notRootfolder: !displayedFolder || displayedFolder.id !== ROOT_DIR_ID,
+    insideRootFolder: displayedFolder && displayedFolder.id === ROOT_DIR_ID,
     selectionModeActive: isSelectionBarVisible(state)
   }
 }


### PR DESCRIPTION
Here, we change the notRootfolder boolean to be positive and only assume that we are in the root folder if we have the displayedFolder.

 