### PR TITLE
fix: Only params from matching route  are extracted to redux

### DIFF
--- a/src/drive/store/connectedRouter.js
+++ b/src/drive/store/connectedRouter.js
@@ -1,7 +1,8 @@
 /**
  * Tools to store part of the react-router state inside redux
  */
-import { getParams } from 'react-router/lib/PatternUtils'
+import { matchPattern } from 'react-router/lib/PatternUtils'
+import fromPairs from 'lodash/fromPairs'
 
 const LOCATION_CHANGED = 'HISTORY.LOCATION_CHANGED'
 
@@ -13,10 +14,14 @@ const createParamsExtractor = routes => {
   return location => {
     const pathname = location.pathname
     for (let route of routes) {
-      const params = getParams(route, pathname)
-      if (params) {
-        return params
-      }
+      const match = matchPattern(route, pathname)
+      if (match && match.remainingPathname === '')
+        return fromPairs(
+          match.paramNames.map((paramName, index) => [
+            paramName,
+            match.paramValues[index]
+          ])
+        )
     }
     return {}
   }

--- a/src/drive/store/connectedRouter.spec.js
+++ b/src/drive/store/connectedRouter.spec.js
@@ -3,10 +3,12 @@ import { connectStoreToHistory, createReducer } from './connectedRouter'
 import { hashHistory as history } from 'react-router'
 
 const routes = [
-  '/folder/:folderId/file/:fileId',
-  '/files/:folderId/file/:fileId',
   '/files/:folderId',
-  '/folder/:folderId'
+  '/folder/:folderId',
+  '/files/:folderId/file/:fileId',
+  '/folder/:folderId/file/:fileId',
+  '/sharings/files/:fileId',
+  '/sharings/:folderId'
 ]
 
 describe('connectedRouter', () => {
@@ -43,5 +45,20 @@ describe('connectedRouter', () => {
     })
     const state4 = store.getState()
     expect(Object.keys(state4.params).length).toBe(0)
+
+    history.push({
+      pathname: '/sharings/12345'
+    })
+
+    const state5 = store.getState()
+    expect(state5.params.folderId).toEqual('12345')
+
+    history.push({
+      pathname: '/sharings/files/67890'
+    })
+
+    const state6 = store.getState()
+    expect(state6.params.fileId).toEqual('67890')
+    expect(state6.params.folderId).toBeFalsy()
   })
 })


### PR DESCRIPTION
So far, we extracted the first router params we found into the redux store. But several routes could be matching, with different sets of params, and only the first in the list would be extracted, not necessarily matching the correct route.

With this PR, we check for the most probable route and extract those params.