### PR TITLE
fix: Legacy toolbar display condition

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar/toolbar.jsx
@@ -10,9 +10,14 @@ const mapStateToProps = state => {
     ? getDisplayedFolder(state)
     : state.view.displayedFolder
 
+  const notRootFolder = displayedFolder && displayedFolder.id !== ROOT_DIR_ID
+  const insideRootFolder = displayedFolder && displayedFolder.id === ROOT_DIR_ID
+
   return {
     displayedFolder,
-    insideRootFolder: displayedFolder && displayedFolder.id === ROOT_DIR_ID,
+    insideRootFolder: flag('drive.client-migration.enabled')
+      ? insideRootFolder
+      : !notRootFolder,
     selectionModeActive: isSelectionBarVisible(state)
   }
 }


### PR DESCRIPTION
Follow up on #2046 — the `insideRootFolder` condition is better, but sadly it breaks the non-migrated version of drive. This PR is a quick fix for the legacy drive version while we finish the migration.

(From what I can see, the legacy `displayedFolder ` is not set on the first render, even in the root folder, which breaks the first render and never gives the redux store a chance to actually set `displayedFolder`.)