### PR TITLE
fix: Back button in breadcrumb

### DIFF
--- a/src/drive/web/modules/navigation/Breadcrumb/MobileAwareBreadcrumb.jsx
+++ b/src/drive/web/modules/navigation/Breadcrumb/MobileAwareBreadcrumb.jsx
@@ -1,12 +1,12 @@
 /* global cozy */
-import React from 'react'
+import React, { useCallback } from 'react'
 import { withBreakpoints } from 'cozy-ui/transpiled/react'
 import RouterBreadCrumb from 'drive/web/modules/navigation/Breadcrumb/RouterBreadcrumb'
 import RouterPreviousButton from 'drive/web/modules/navigation/Breadcrumb/RouterPreviousButton'
 import BreadCrumb from 'drive/web/modules/navigation/Breadcrumb/Breadcrumb'
 import PreviousButton from 'drive/web/modules/navigation/Breadcrumb/PreviousButton'
 
-const MobileAwareBreadcrumb = props => {
+const LegacyMobileAwareBreadcrumb = props => {
   const { BarCenter, BarLeft } = cozy.bar
 
   return props.breakpoints.isMobile ? (
@@ -25,16 +25,24 @@ const MobileAwareBreadcrumb = props => {
   )
 }
 
-export default withBreakpoints()(MobileAwareBreadcrumb)
+export default withBreakpoints()(LegacyMobileAwareBreadcrumb)
 
-export const MobileAwareBreadcrumbV2 = withBreakpoints()(props => {
+export const MobileAwareBreadcrumb = props => {
   const { BarCenter, BarLeft } = cozy.bar
+  const { onBreadcrumbClick, path } = props
+  const navigateBack = useCallback(
+    () => {
+      const parentFolder = path[path.length - 2]
+      onBreadcrumbClick(parentFolder)
+    },
+    [onBreadcrumbClick, path]
+  )
 
   return props.breakpoints.isMobile ? (
     <div>
       {props.path.length >= 2 && (
         <BarLeft>
-          <PreviousButton {...props} />
+          <PreviousButton onClick={navigateBack} />
         </BarLeft>
       )}
       <BarCenter>
@@ -44,4 +52,6 @@ export const MobileAwareBreadcrumbV2 = withBreakpoints()(props => {
   ) : (
     <BreadCrumb {...props} />
   )
-})
+}
+
+export const MobileAwareBreadcrumbV2 = withBreakpoints()(MobileAwareBreadcrumb)

--- a/src/drive/web/modules/navigation/Breadcrumb/MobileAwareBreadcrumb.spec.jsx
+++ b/src/drive/web/modules/navigation/Breadcrumb/MobileAwareBreadcrumb.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { createMockClient } from 'cozy-client'
+import AppLike from 'test/components/AppLike'
+
+import { MobileAwareBreadcrumb } from './MobileAwareBreadcrumb'
+
+describe('MobileAwareBreadcrumb', () => {
+  it('works', async () => {
+    const BarComponentMock = ({ children }) => <div>{children}</div>
+    global.cozy.bar.BarCenter = BarComponentMock
+    global.cozy.bar.BarLeft = BarComponentMock
+
+    const path = [
+      { id: '1', name: 'root folder' },
+      { id: '2', name: 'parent folder' },
+      { id: '3', name: 'current folder' }
+    ]
+
+    const onBreadcrumbClick = jest.fn()
+
+    const { findByText } = render(
+      <AppLike client={createMockClient({})}>
+        <MobileAwareBreadcrumb
+          breakpoints={{ isMobile: true }}
+          path={path}
+          onBreadcrumbClick={onBreadcrumbClick}
+        />
+      </AppLike>
+    )
+
+    //rznders the path
+    const rootLink = await findByText('root folder')
+    await findByText('parent folder')
+    await findByText('current folder')
+
+    fireEvent.click(rootLink)
+    expect(onBreadcrumbClick).toHaveBeenCalledWith({
+      id: '1',
+      name: 'root folder'
+    })
+
+    const backButton = document.querySelector('button')
+    fireEvent.click(backButton)
+    expect(onBreadcrumbClick).toHaveBeenCalledWith({
+      id: '2',
+      name: 'parent folder'
+    })
+  })
+})


### PR DESCRIPTION
The back button on mobile had no `onClick` prop bound to it, so it wasn't working.