### PR TITLE
fix: Show confirm modal before emptying the trash

### DIFF
--- a/src/drive/web/modules/trash/Toolbar.spec.jsx
+++ b/src/drive/web/modules/trash/Toolbar.spec.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render, fireEvent, act } from '@testing-library/react'
+import { waitForElementToBeRemoved } from '@testing-library/dom'
+import flag from 'cozy-flags'
+import { createMockClient } from 'cozy-client'
+import { ModalContextProvider, ModalStack } from 'drive/lib/ModalContext'
+
+import AppLike from 'test/components/AppLike'
+import { Toolbar } from './Toolbar'
+
+describe('Toolbar', () => {
+  const client = createMockClient({})
+  client.collection = jest.fn(() => client)
+  client.emptyTrash = jest.fn()
+
+  beforeEach(() => {
+    flag('drive.client-migration.enabled', true)
+  })
+
+  afterEach(() => {
+    flag('drive.client-migration.enabled', null)
+  })
+
+  it('asks for confirmation before emptying the trash', async () => {
+    const { getByText } = render(
+      <AppLike client={client}>
+        <ModalContextProvider>
+          <ModalStack />
+          <Toolbar
+            t={jest.fn(x => x)}
+            disabled={false}
+            selectionModeActive={false}
+            emptyTrash={jest.fn()}
+            breakpoints={{ isMobile: false }}
+          />
+        </ModalContextProvider>
+      </AppLike>
+    )
+
+    const emptyTrashButton = getByText('toolbar.empty_trash')
+    act(() => {
+      fireEvent.click(emptyTrashButton)
+    })
+
+    const confirmButton = getByText('Delete all')
+    act(async () => {
+      await fireEvent.click(confirmButton)
+    })
+
+    expect(client.emptyTrash).toHaveBeenCalled()
+    await waitForElementToBeRemoved(() => getByText('Delete all'))
+  })
+})

--- a/src/drive/web/modules/trash/components/EmptyTrashConfirm.jsx
+++ b/src/drive/web/modules/trash/components/EmptyTrashConfirm.jsx
@@ -24,11 +24,10 @@ const EmptyTrashConfirm = ({ t, onConfirm, onClose }) => {
       secondaryAction={onClose}
       primaryType="danger"
       primaryText={t('emptytrashconfirmation.delete')}
-      primaryAction={() =>
-        onConfirm()
-          .then(onClose)
-          .catch(onClose)
-      }
+      primaryAction={async () => {
+        await onConfirm()
+        onClose()
+      }}
     />
   )
 }


### PR DESCRIPTION
On the migrated version, we were deleting the trash straight away instead of showing a confirmation modal.

~Still needs unit tests~