### PR TITLE
fix: Close selection bar after all actions

### DIFF
--- a/src/drive/web/modules/actions/useActions.jsx
+++ b/src/drive/web/modules/actions/useActions.jsx
@@ -1,8 +1,29 @@
 import keyBy from 'lodash/keyBy'
+import { useDispatch } from 'react-redux'
+import { hideSelectionBar } from 'drive/web/modules/selection/duck'
+
+const withHideSelectionBarDispatch = (action, dispatch) => {
+  if (!action.action) return action
+
+  const actionFn = action.action
+  const actionFnWithSelectionDispatch = (...args) => {
+    actionFn(...args)
+    dispatch(hideSelectionBar())
+  }
+
+  return {
+    ...action,
+    action: actionFnWithSelectionDispatch
+  }
+}
 
 const useActions = (actionCreators, actionOptions = {}) => {
+  const dispatch = useDispatch()
+
   return keyBy(
-    actionCreators.map(createAction => createAction(actionOptions)),
+    actionCreators.map(createAction =>
+      withHideSelectionBarDispatch(createAction(actionOptions), dispatch)
+    ),
     'icon'
   )
 }

--- a/src/drive/web/modules/actions/useActions.spec.jsx
+++ b/src/drive/web/modules/actions/useActions.spec.jsx
@@ -17,6 +17,7 @@ import {
 } from './utils'
 import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
 import * as renameModule from 'drive/web/modules/drive/renameV2'
+import * as selectionModule from 'drive/web/modules/selection/duck'
 
 import useActions from './useActions'
 import {
@@ -125,9 +126,7 @@ describe('useActions', () => {
   }
 
   it('returns actions keyed by icon', () => {
-    const { result } = renderActionsHook({
-      canMove: true
-    })
+    const { result } = renderActionsHook(defaultHookArgs)
     expect(Object.keys(result.current)).toEqual([
       'share',
       'download',
@@ -141,6 +140,19 @@ describe('useActions', () => {
       'restore',
       'destroy'
     ])
+  })
+
+  it('always hides the selection bar after an action is activated', () => {
+    const { result } = renderActionsHook(defaultHookArgs)
+
+    Object.values(result.current).forEach(action => {
+      if (action.action) {
+        const hideSelectionBar = jest.spyOn(selectionModule, 'hideSelectionBar')
+        action.action([{ id: 'abc', name: 'my-file.md' }])
+        expect(hideSelectionBar).toHaveBeenCalled()
+        hideSelectionBar.mockRestore()
+      }
+    })
   })
 
   describe('share action', () => {


### PR DESCRIPTION
Automatically closes the selection bar after actions are activated. In the previous version [we used to dispatch a meta field in the redux action with most actions](https://github.com/cozy/cozy-drive/blob/master/src/drive/web/modules/navigation/duck/actions.jsx#L433). I think it was a bit of a hack and wasn't very explicit. And for some actions we forgot and the bar wasn't closing.
Instead all actions are "enhanced" with the desired behavior. Alternatively, we could add the dispatch call in each action, for example if we wanted some actions *not* to close the bar.