### PR TITLE
fix: Trash query for pouch

### DIFF
--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -101,7 +101,8 @@ const buildTrashQueryFolder = ({
     Q('io.cozy.files')
       .where({
         dir_id: currentFolderId,
-        type
+        type,
+        [sortAttribute]: { $gt: null }
       })
       .indexFields(['dir_id', 'type', sortAttribute])
       .sortBy([


### PR DESCRIPTION
Pouch needs all fields in the selector, like the other queries.