### PR TITLE
fix: Don't subscribe to Store change, but save it before closing the app

### DIFF
--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -9,7 +9,6 @@ import {
 } from 'cozy-ui/transpiled/react/helpers/tracker'
 import thunkMiddleware from 'redux-thunk'
 import createRootReducer from './rootReducer'
-import { saveState } from './persistedState'
 import { ANALYTICS_URL, getReporterConfiguration } from 'drive/lib/reporter'
 import { connectStoreToHistory } from './connectedRouter'
 
@@ -51,23 +50,6 @@ const configureStore = options => {
     initialState,
     composeEnhancers(applyMiddleware(...middlewares))
   )
-
-  if (__TARGET__ === 'mobile') {
-    store.subscribe(() => {
-      const currentState = store.getState()
-      saveState({
-        mobile: {
-          authorization: currentState.mobile.authorization,
-          settings: currentState.mobile.settings,
-          replication: currentState.mobile.replication,
-          mediaBackup: {
-            uploaded: currentState.mobile.mediaBackup.uploaded
-          }
-        },
-        availableOffline: currentState.availableOffline
-      })
-    })
-  }
 
   if (history) {
     connectStoreToHistory(store, history)

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import { hashHistory } from 'react-router'
 import localforage from 'localforage'
+import { saveState } from 'drive/store/persistedState'
 
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import { isIOSApp } from 'cozy-device-helper'
@@ -161,7 +162,12 @@ class InitAppMobile {
     store.dispatch(backupImages())
     if (isAnalyticsOn(store.getState())) startHeartBeat()
   }
-
+  /**
+   * onPause is called when the app goes to background.
+   * So it's also called when we kill an application since
+   * we've to put the app in background (multi-task for instance)
+   * to kill it
+   */
   onPause = async () => {
     const store = await this.getStore()
     if (isAnalyticsOn(store.getState())) stopHeartBeat()
@@ -173,6 +179,18 @@ class InitAppMobile {
         text: t('mobile.notifications.backup_paused')
       })
     } */
+    const currentState = store.getState()
+    saveState({
+      mobile: {
+        authorization: currentState.mobile.authorization,
+        settings: currentState.mobile.settings,
+        replication: currentState.mobile.replication,
+        mediaBackup: {
+          uploaded: currentState.mobile.mediaBackup.uploaded
+        }
+      },
+      availableOffline: currentState.availableOffline
+    })
   }
 
   /**


### PR DESCRIPTION
Before, we were subscribing to all the store changes. resulting in a lot of localStorage write...

Now we only saveState when the app goes in background. 