### PR TITLE
[DRAFT] feat: Persist Cozy store in localStorage

### DIFF
--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -9,7 +9,6 @@ import {
 } from 'cozy-ui/transpiled/react/helpers/tracker'
 import thunkMiddleware from 'redux-thunk'
 import createRootReducer from './rootReducer'
-import { saveState } from './persistedState'
 import { ANALYTICS_URL, getReporterConfiguration } from 'drive/lib/reporter'
 import { connectStoreToHistory } from './connectedRouter'
 
@@ -51,23 +50,6 @@ const configureStore = options => {
     initialState,
     composeEnhancers(applyMiddleware(...middlewares))
   )
-
-  if (__TARGET__ === 'mobile') {
-    store.subscribe(() => {
-      const currentState = store.getState()
-      saveState({
-        mobile: {
-          authorization: currentState.mobile.authorization,
-          settings: currentState.mobile.settings,
-          replication: currentState.mobile.replication,
-          mediaBackup: {
-            uploaded: currentState.mobile.mediaBackup.uploaded
-          }
-        },
-        availableOffline: currentState.availableOffline
-      })
-    })
-  }
 
   if (history) {
     connectStoreToHistory(store, history)

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -184,7 +184,8 @@ class InitAppMobile {
           uploaded: currentState.mobile.mediaBackup.uploaded
         }
       },
-      availableOffline: currentState.availableOffline
+      availableOffline: currentState.availableOffline,
+      cozy: currentState.cozy
     })
   }
 

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import { hashHistory } from 'react-router'
 import localforage from 'localforage'
+import { saveState } from 'drive/store/persistedState'
 
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import { isIOSApp } from 'cozy-device-helper'
@@ -173,6 +174,18 @@ class InitAppMobile {
         text: t('mobile.notifications.backup_paused')
       })
     } */
+    const currentState = store.getState()
+    saveState({
+      mobile: {
+        authorization: currentState.mobile.authorization,
+        settings: currentState.mobile.settings,
+        replication: currentState.mobile.replication,
+        mediaBackup: {
+          uploaded: currentState.mobile.mediaBackup.uploaded
+        }
+      },
+      availableOffline: currentState.availableOffline
+    })
   }
 
   /**


### PR DESCRIPTION
J'aimerais avoir vos avis là-dessus @ptbrowne @y-lohse 

Aujourd'hui, quand on se balade dans Drive, Cozy Client peuple son store avec les queries et les documents. Donc le premier accès à un répertoire est "lent", mais quand on refait la même manipulation, ça devient instantané. 

Ici, l'idée est de faire persister le store de Cozy Client en localStorage pour que lorsque l'on quitte l'application et qu'on revient dedans, ça re-devient instantané. 

Par contre, ça veut dire pas mal de choses : 
- On ne vide jamais le store de Cozy Client pour le moment (sauf si CC le fait de lui même), et donc il va avoir tendance à grossier considérablement dans le temps. A voir quelle limite de taille on a sur le localStorage en mobile ? A voir si on peut faire une policy pour supprimer les trop anciennes (genre après X jours) ? 
- Et tout ça devrait bien sur être une option de CozyClient ou un plugin. 

Mais vu que je touchais à ça, j'ai mis ça là pour avoir vos avis 