### PR TITLE
fix: Typo in route name

### DIFF
--- a/src/drive/mobile/modules/mediaBackup/duck/index.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/index.js
@@ -41,6 +41,7 @@ export const startMediaBackup = (isManualBackup = false) => async (
   { client }
 ) => {
   dispatch({ type: MEDIA_UPLOAD_START })
+  client.getStackClient().fetchJSON('POST', '/settings/synchronized')
   if (!(await isAuthorized())) {
     const promptForPermissions = isManualBackup
     const receivedAuthorisation = await updateValueAfterRequestAuthorization(

--- a/src/drive/mobile/modules/mediaBackup/duck/index.spec.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/index.spec.js
@@ -90,7 +90,7 @@ describe('StartMediaBackup', () => {
     )
     expect(client.getStackClient().fetchJSON).toHaveBeenCalledWith(
       'POST',
-      '/settings/synchonized'
+      '/settings/synchronized'
     )
   })
 


### PR DESCRIPTION
We missed the "r" in "synchronized"…