### PR TITLE
Fix versions view

### DIFF
--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -139,7 +139,7 @@ const init = async () => {
                       path="external/:fileId"
                       component={ExternalRedirect}
                     />
-                    <Redirect from="/*" to={`files/${sharedDocumentId}`} />
+                    <Redirect from="/*" to={`folder/${sharedDocumentId}`} />
                   </Router>
                 )}
               </ModalContextProvider>

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -26,16 +26,19 @@ import FilesViewerRecent from '../views/Recent/FilesViewerRecent'
 // in the "router" redux slice. Innermost routes should be
 // first
 export const routes = [
-  '/folder/:folderId/file/:fileId',
-  '/files/:folderId/file/:fileId',
-  '/files/:folderId',
   '/folder/:folderId',
+  '/folder/:folderId/file/:fileId',
+  '/folder/:folderId/file/:fileId/revision',
   '/recent/file/:fileId',
-  '/sharings/:folderId/file/:fileId',
-  '/sharings/file/:fileId',
+  '/recent/file/:fileId/revision',
   '/sharings/:folderId',
+  '/sharings/:folderId/file/:fileId',
+  '/sharings/:folderId/file/:fileId/revision',
+  '/sharings/file/:fileId',
+  '/sharings/file/:fileId/revision',
   '/trash/:folderId/file/:fileId',
-  '/trash/:folderId'
+  '/trash/:folderId',
+  '/file/:fileId'
 ]
 
 const RootComponent = routerProps => (

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -8,7 +8,7 @@ import OnBoarding from 'drive/mobile/modules/onboarding/OnBoarding'
 import { RouterContextProvider } from 'drive/lib/RouterContext'
 import Layout from 'drive/web/modules/layout/Layout'
 import FileOpenerExternal from 'drive/web/modules/viewer/FileOpenerExternal'
-import FileHistory from '../../../../components/FileHistory'
+import FileHistory from 'components/FileHistory'
 import UploadFromMobile from 'drive/mobile/modules/upload'
 
 import ExternalRedirect from './ExternalRedirect'

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -82,12 +82,17 @@ const AppRoute = (
 
       <Route path="sharings">
         <IndexRoute component={SharingsView} />
-        <Route path=":folderId" component={SharingsFolderView}>
-          <Route path="file/:fileId" component={SharingsFilesViewer} />
+        <Route component={SharingsView}>
+          <Route path="file/:fileId" component={() => SharingsFilesViewer} />
+          {/* This route must be a child of SharingsView so the modal opens on top of the sharing view */}
           <Route path="file/:fileId/revision" component={FileHistory} />
         </Route>
-        <Route path="file/:fileId" component={SharingsFilesViewer} />
-        <Route path="file/:fileId/revision" component={FileHistory} />
+        {/* This route must be inside the /sharing path for the nav to have an activate state */}
+        <Route path=":folderId" component={SharingsFolderView}>
+          <Route path="file/:fileId" component={SharingsFilesViewer} />
+          {/* This route must be a child of SharingsFolderView so the modal opens on top of the folder view */}
+          <Route path="file/:fileId/revision" component={FileHistory} />
+        </Route>
       </Route>
 
       {__TARGET__ === 'mobile' && (

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -56,6 +56,7 @@ const PublicFolderView = ({
   currentFolderId,
   parentFolder,
   router,
+  location,
   children
 }) => {
   const client = useClient()

--- a/src/drive/web/modules/views/Public/index.spec.jsx
+++ b/src/drive/web/modules/views/Public/index.spec.jsx
@@ -14,7 +14,13 @@ import PublicFolderView from './index'
 jest.mock('./usePublicFilesQuery', () => {
   return jest.fn()
 })
-jest.mock('components/FileHistory', () => () => <div>FileHistory stub</div>)
+jest.mock(
+  'components/FileHistory',
+  () =>
+    function FileHistoryStub() {
+      return <div>FileHistory stub</div>
+    }
+)
 jest.mock('components/pushClient')
 
 describe('Public View', () => {

--- a/src/drive/web/modules/views/Recent/index.jsx
+++ b/src/drive/web/modules/views/Recent/index.jsx
@@ -29,7 +29,7 @@ import {
 import { buildRecentQuery } from 'drive/web/modules/queries'
 import { useFilesQueryWithPath } from './useFilesQueryWithPath'
 
-export const RecentView = ({ router, children }) => {
+export const RecentView = ({ router, location, children }) => {
   const { t } = useI18n()
   const query = buildRecentQuery()
   const result = useFilesQueryWithPath(query)

--- a/src/drive/web/modules/views/Recent/index.spec.jsx
+++ b/src/drive/web/modules/views/Recent/index.spec.jsx
@@ -12,7 +12,13 @@ import { generateFileFixtures, getByTextWithMarkup } from '../testUtils'
 
 jest.mock('components/pushClient')
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
-jest.mock('components/FileHistory', () => () => <div>FileHistory stub</div>)
+jest.mock(
+  'components/FileHistory',
+  () =>
+    function FileHistoryStub() {
+      return <div>FileHistory stub</div>
+    }
+)
 jest.mock('./useFilesQueryWithPath', () => ({
   ...jest.requireActual('./useFilesQueryWithPath'),
   useFilesQueryWithPath: jest.fn()

--- a/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
+++ b/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
@@ -56,6 +56,7 @@ const SharingsFolderView = ({
   currentFolderId,
   sharedDocumentIds,
   router,
+  location,
   children
 }) => {
   const [sortOrder] = useFolderSort(currentFolderId)

--- a/src/drive/web/modules/views/Sharings/index.jsx
+++ b/src/drive/web/modules/views/Sharings/index.jsx
@@ -31,7 +31,12 @@ import {
 import { buildSharingsQuery } from 'drive/web/modules/queries'
 import { useFilesQueryWithPath } from '../Recent/useFilesQueryWithPath'
 
-export const SharingsView = ({ router, sharedDocumentIds, children }) => {
+export const SharingsView = ({
+  router,
+  location,
+  sharedDocumentIds = [],
+  children
+}) => {
   const { t } = useI18n()
   const query = buildSharingsQuery(sharedDocumentIds)
   const result = useFilesQueryWithPath(query)

--- a/src/drive/web/modules/views/Sharings/index.spec.jsx
+++ b/src/drive/web/modules/views/Sharings/index.spec.jsx
@@ -1,20 +1,20 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
-import { Router, hashHistory, Route, Redirect } from 'react-router'
+import { Router, hashHistory, Route, Redirect, IndexRoute } from 'react-router'
 import FileHistory from 'components/FileHistory'
 
 import { setupStoreAndClient } from 'test/setup'
 import AppLike from 'test/components/AppLike'
 
-import RecentViewWithProvider from './index'
-import { useFilesQueryWithPath } from './useFilesQueryWithPath'
+import { SharingsView } from './index'
 import { generateFileFixtures, getByTextWithMarkup } from '../testUtils'
+import { useFilesQueryWithPath } from '../Recent/useFilesQueryWithPath'
 
 jest.mock('components/pushClient')
-jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 jest.mock('components/FileHistory', () => () => <div>FileHistory stub</div>)
-jest.mock('./useFilesQueryWithPath', () => ({
-  ...jest.requireActual('./useFilesQueryWithPath'),
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+jest.mock('../Recent/useFilesQueryWithPath', () => ({
+  ...jest.requireActual('../Recent/useFilesQueryWithPath'),
   useFilesQueryWithPath: jest.fn()
 }))
 
@@ -33,9 +33,12 @@ const setup = () => {
   const rendered = render(
     <AppLike client={client} store={store}>
       <Router history={hashHistory}>
-        <Redirect from="/" to="/recent" />
-        <Route path="/recent" component={RecentViewWithProvider}>
-          <Route path="file/:fileId/revision" component={FileHistory} />
+        <Redirect from="/" to="/sharings" />
+        <Route path="sharings">
+          <IndexRoute component={SharingsView} />
+          <Route component={SharingsView}>
+            <Route path="file/:fileId/revision" component={FileHistory} />
+          </Route>
         </Route>
       </Router>
     </AppLike>
@@ -43,8 +46,8 @@ const setup = () => {
   return { ...rendered, client }
 }
 
-describe('Recent View', () => {
-  it('tests the recent view', async () => {
+describe('Sharings View', () => {
+  it('tests the sharings view', async () => {
     const nbFiles = 2
     const path = '/test'
     const dir_id = 'dirIdParent'

--- a/src/drive/web/modules/views/Sharings/index.spec.jsx
+++ b/src/drive/web/modules/views/Sharings/index.spec.jsx
@@ -11,7 +11,13 @@ import { generateFileFixtures, getByTextWithMarkup } from '../testUtils'
 import { useFilesQueryWithPath } from '../Recent/useFilesQueryWithPath'
 
 jest.mock('components/pushClient')
-jest.mock('components/FileHistory', () => () => <div>FileHistory stub</div>)
+jest.mock(
+  'components/FileHistory',
+  () =>
+    function FileHistoryStub() {
+      return <div>FileHistory stub</div>
+    }
+)
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 jest.mock('../Recent/useFilesQueryWithPath', () => ({
   ...jest.requireActual('../Recent/useFilesQueryWithPath'),


### PR DESCRIPTION
The file versions views on Recent and Sharings were still broken, because we were accidentally passing the global `location` object to our actions instead of the `location` object provided by react-router, which includes the pathname of the current view etc.

I also had to tweak the sharing route configuration a little so that all components are in the right hierarchy — they all need to be children of `/sharing` in order for the nav  to stay active, but once inside a shared folder we want a different main route.