### PR TITLE
Fix selection

### DIFF
--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -256,7 +256,7 @@ const File = props => {
   const toggle = e => {
     e.stopPropagation()
     const { attributes, onCheckboxToggle, selected } = props
-    onCheckboxToggle(attributes.id, selected)
+    onCheckboxToggle(attributes, selected)
   }
 
   const open = (e, attributes) => {
@@ -391,7 +391,7 @@ File.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  selected: isSelected(state, ownProps.attributes.id),
+  selected: isSelected(state, ownProps.attributes),
   isAvailableOffline: isAvailableOffline(state, ownProps.attributes.id),
   selectionModeActive: isSelectionBarVisible(state),
   isRenaming:

--- a/src/drive/web/modules/selection/duck.js
+++ b/src/drive/web/modules/selection/duck.js
@@ -1,8 +1,5 @@
 import { combineReducers } from 'redux'
-import get from 'lodash/get'
-
-const getFileByIdFromCozyClient = (state, id) =>
-  get(state, ['cozy', 'documents', 'io.cozy.files', id])
+import uniqBy from 'lodash/uniqBy'
 
 // constants
 const SELECT_ITEM = 'SELECT_ITEM'
@@ -12,21 +9,21 @@ const SHOW_SELECTION_BAR = 'SHOW_SELECTION_BAR'
 const HIDE_SELECTION_BAR = 'HIDE_SELECTION_BAR'
 
 // selectors
-export const isSelected = (state, id) =>
-  state.selection.selected.find(_id => _id === id) !== undefined
-export const getSelectedIds = state => state.selection.selected
+export const isSelected = (state, file) =>
+  state.selection.selected.find(({ id }) => id === file.id) !== undefined
 export const isSelectionBarVisible = state =>
   state.selection.selected.length !== 0 || state.selection.isSelectionBarOpened
-export const getSelectedFiles = state =>
-  getSelectedIds(state).map(id => getFileByIdFromCozyClient(state, id))
+export const getSelectedFiles = state => {
+  return state.selection.selected
+}
 
 // actions
 export const showSelectionBar = () => ({ type: SHOW_SELECTION_BAR })
 export const hideSelectionBar = () => ({ type: HIDE_SELECTION_BAR })
 export const toggleSelectionBar = () => ({ type: TOGGLE_SELECTION_BAR })
-export const toggleItemSelection = (id, selected) => ({
+export const toggleItemSelection = (file, selected) => ({
   type: selected ? UNSELECT_ITEM : SELECT_ITEM,
-  id
+  file
 })
 
 // reducers
@@ -36,10 +33,9 @@ const selected = (state = [], action) => {
   }
   switch (action.type) {
     case SELECT_ITEM:
-      return [...state, action.id]
+      return uniqBy([...state, action.file], 'id')
     case UNSELECT_ITEM: {
-      const idx = state.indexOf(action.id)
-      return [...state.slice(0, idx), ...state.slice(idx + 1)]
+      return state.filter(({ id }) => action.file.id !== id)
     }
     case HIDE_SELECTION_BAR:
       return []

--- a/src/drive/web/modules/selection/duck.js
+++ b/src/drive/web/modules/selection/duck.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux'
-import uniqBy from 'lodash/uniqBy'
+import omit from 'lodash/omit'
 
 // constants
 const SELECT_ITEM = 'SELECT_ITEM'
@@ -10,11 +10,12 @@ const HIDE_SELECTION_BAR = 'HIDE_SELECTION_BAR'
 
 // selectors
 export const isSelected = (state, file) =>
-  state.selection.selected.find(({ id }) => id === file.id) !== undefined
+  state.selection.selected[file.id] !== undefined
 export const isSelectionBarVisible = state =>
-  state.selection.selected.length !== 0 || state.selection.isSelectionBarOpened
+  Object.keys(state.selection.selected).length !== 0 ||
+  state.selection.isSelectionBarOpened
 export const getSelectedFiles = state => {
-  return state.selection.selected
+  return Object.values(state.selection.selected)
 }
 
 // actions
@@ -27,18 +28,18 @@ export const toggleItemSelection = (file, selected) => ({
 })
 
 // reducers
-const selected = (state = [], action) => {
+const selected = (state = {}, action) => {
   if (action.meta && action.meta.cancelSelection) {
-    return []
+    return {}
   }
   switch (action.type) {
     case SELECT_ITEM:
-      return uniqBy([...state, action.file], 'id')
+      return { ...state, [action.file.id]: action.file }
     case UNSELECT_ITEM: {
-      return state.filter(({ id }) => action.file.id !== id)
+      return omit(state, [action.file.id])
     }
     case HIDE_SELECTION_BAR:
-      return []
+      return {}
     default:
       return state
   }

--- a/src/drive/web/modules/selection/duck.spec.jsx
+++ b/src/drive/web/modules/selection/duck.spec.jsx
@@ -1,3 +1,4 @@
+import { generateFile } from 'test/generate'
 import { combineReducers, createStore } from 'redux'
 import reducer, {
   showSelectionBar,
@@ -12,8 +13,11 @@ import reducer, {
 describe('selection store', () => {
   const setup = () => createStore(combineReducers({ selection: reducer }))
 
-  const item1 = { id: 1, name: 'item 1' }
-  const item2 = { id: 2, name: 'item 2' }
+  const item1 = generateFile({ i: 1 })
+  const item2 = generateFile({ i: 2 })
+
+  const itemIsSelected = true
+  const itemIsNotSelected = false
 
   it('shows and hides the selection bar', () => {
     const store = setup()
@@ -38,33 +42,33 @@ describe('selection store', () => {
     const store = setup()
 
     // selecting one item
-    store.dispatch(toggleItemSelection(item1, false))
+    store.dispatch(toggleItemSelection(item1, itemIsNotSelected))
     expect(isSelected(store.getState(), item1)).toBe(true)
     expect(isSelected(store.getState(), item2)).toBe(false)
     expect(isSelectionBarVisible(store.getState())).toBe(true)
 
-    // reselecting the same item does nothing
-    store.dispatch(toggleItemSelection(item1, false))
+    // reselecting the same item keeps it selected
+    store.dispatch(toggleItemSelection(item1, itemIsNotSelected))
     expect(isSelected(store.getState(), item1)).toBe(true)
 
     // selecting a second item
-    store.dispatch(toggleItemSelection(item2, false))
+    store.dispatch(toggleItemSelection(item2, itemIsNotSelected))
     expect(isSelected(store.getState(), item1)).toBe(true)
     expect(isSelected(store.getState(), item2)).toBe(true)
     expect(isSelectionBarVisible(store.getState())).toBe(true)
 
     // deselecting the first item
-    store.dispatch(toggleItemSelection(item1, true))
+    store.dispatch(toggleItemSelection(item1, itemIsSelected))
     expect(isSelected(store.getState(), item1)).toBe(false)
     expect(isSelected(store.getState(), item2)).toBe(true)
     expect(isSelectionBarVisible(store.getState())).toBe(true)
 
-    // deselecting the same item again does nothing
-    store.dispatch(toggleItemSelection(item1, true))
+    // deselecting the same item keepts it deselected
+    store.dispatch(toggleItemSelection(item1, itemIsSelected))
     expect(isSelected(store.getState(), item1)).toBe(false)
 
     // deselecting the second item
-    store.dispatch(toggleItemSelection(item2, true))
+    store.dispatch(toggleItemSelection(item2, itemIsSelected))
     expect(isSelected(store.getState(), item1)).toBe(false)
     expect(isSelected(store.getState(), item2)).toBe(false)
     expect(isSelectionBarVisible(store.getState())).toBe(false)
@@ -73,8 +77,8 @@ describe('selection store', () => {
   it('returns the list of items', () => {
     const store = setup()
 
-    store.dispatch(toggleItemSelection(item1, false))
-    store.dispatch(toggleItemSelection(item2, false))
+    store.dispatch(toggleItemSelection(item1, itemIsNotSelected))
+    store.dispatch(toggleItemSelection(item2, itemIsNotSelected))
 
     const selection = getSelectedFiles(store.getState())
     expect(selection).toEqual(expect.arrayContaining([item2, item2]))

--- a/src/drive/web/modules/selection/duck.spec.jsx
+++ b/src/drive/web/modules/selection/duck.spec.jsx
@@ -1,0 +1,82 @@
+import { combineReducers, createStore } from 'redux'
+import reducer, {
+  showSelectionBar,
+  hideSelectionBar,
+  toggleSelectionBar,
+  isSelectionBarVisible,
+  toggleItemSelection,
+  isSelected,
+  getSelectedFiles
+} from './duck.js'
+
+describe('selection store', () => {
+  const setup = () => createStore(combineReducers({ selection: reducer }))
+
+  const item1 = { id: 1, name: 'item 1' }
+  const item2 = { id: 2, name: 'item 2' }
+
+  it('shows and hides the selection bar', () => {
+    const store = setup()
+
+    store.dispatch(showSelectionBar())
+    expect(isSelectionBarVisible(store.getState())).toBe(true)
+    store.dispatch(showSelectionBar())
+    expect(isSelectionBarVisible(store.getState())).toBe(true)
+
+    store.dispatch(hideSelectionBar())
+    expect(isSelectionBarVisible(store.getState())).toBe(false)
+    store.dispatch(hideSelectionBar())
+    expect(isSelectionBarVisible(store.getState())).toBe(false)
+
+    store.dispatch(toggleSelectionBar())
+    expect(isSelectionBarVisible(store.getState())).toBe(true)
+    store.dispatch(toggleSelectionBar())
+    expect(isSelectionBarVisible(store.getState())).toBe(false)
+  })
+
+  it('selects and deselects item', () => {
+    const store = setup()
+
+    // selecting one item
+    store.dispatch(toggleItemSelection(item1, false))
+    expect(isSelected(store.getState(), item1)).toBe(true)
+    expect(isSelected(store.getState(), item2)).toBe(false)
+    expect(isSelectionBarVisible(store.getState())).toBe(true)
+
+    // reselecting the same item does nothing
+    store.dispatch(toggleItemSelection(item1, false))
+    expect(isSelected(store.getState(), item1)).toBe(true)
+
+    // selecting a second item
+    store.dispatch(toggleItemSelection(item2, false))
+    expect(isSelected(store.getState(), item1)).toBe(true)
+    expect(isSelected(store.getState(), item2)).toBe(true)
+    expect(isSelectionBarVisible(store.getState())).toBe(true)
+
+    // deselecting the first item
+    store.dispatch(toggleItemSelection(item1, true))
+    expect(isSelected(store.getState(), item1)).toBe(false)
+    expect(isSelected(store.getState(), item2)).toBe(true)
+    expect(isSelectionBarVisible(store.getState())).toBe(true)
+
+    // deselecting the same item again does nothing
+    store.dispatch(toggleItemSelection(item1, true))
+    expect(isSelected(store.getState(), item1)).toBe(false)
+
+    // deselecting the second item
+    store.dispatch(toggleItemSelection(item2, true))
+    expect(isSelected(store.getState(), item1)).toBe(false)
+    expect(isSelected(store.getState(), item2)).toBe(false)
+    expect(isSelectionBarVisible(store.getState())).toBe(false)
+  })
+
+  it('returns the list of items', () => {
+    const store = setup()
+
+    store.dispatch(toggleItemSelection(item1, false))
+    store.dispatch(toggleItemSelection(item2, false))
+
+    const selection = getSelectedFiles(store.getState())
+    expect(selection).toEqual(expect.arrayContaining([item2, item2]))
+  })
+})

--- a/src/drive/web/modules/views/Recent/index.jsx
+++ b/src/drive/web/modules/views/Recent/index.jsx
@@ -15,7 +15,6 @@ import { MobileAwareBreadcrumb as Breadcrumb } from 'drive/web/modules/navigatio
 
 import useActions from 'drive/web/modules/actions/useActions'
 import {
-  share,
   download,
   trash,
   open,
@@ -55,11 +54,11 @@ export const RecentView = ({ router, children }) => {
     dispatch,
     router,
     location,
-    hasWriteAccess: false,
+    hasWriteAccess: true,
     canMove: true
   }
   const actions = useActions(
-    [share, download, trash, open, rename, move, qualify, versions, offline],
+    [download, trash, open, rename, move, qualify, versions, offline],
     actionsOptions
   )
 

--- a/src/drive/web/modules/views/Sharings/index.jsx
+++ b/src/drive/web/modules/views/Sharings/index.jsx
@@ -17,7 +17,6 @@ import { MobileAwareBreadcrumb as Breadcrumb } from 'drive/web/modules/navigatio
 
 import useActions from 'drive/web/modules/actions/useActions'
 import {
-  share,
   download,
   trash,
   open,
@@ -56,11 +55,11 @@ export const SharingsView = ({ router, sharedDocumentIds, children }) => {
     dispatch,
     router,
     location,
-    hasWriteAccess: false,
+    hasWriteAccess: true,
     canMove: true
   }
   const actions = useActions(
-    [share, download, trash, open, rename, move, qualify, versions, offline],
+    [download, trash, open, rename, move, qualify, versions, offline],
     actionsOptions
   )
 


### PR DESCRIPTION
The selection on the public page was slightly broken, because we used to store only file ids and get the full file object by searching in the cozy-client redux store. However due to limitations on the public page, we don't use a query and so the documents are not in the store.

Instead the selection now stores the full object instead  of just the id.

I also enabled the trash and rename actions on the Recent and Sharings view… because we can.