### PR TITLE
fix: Close the menu after the scanner is called

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -15,6 +15,7 @@ import CreateNoteItem from './CreateNoteItem'
 import CreateShortcut from './CreateShortcut'
 import DownloadButtonItem from './DownloadButtonItem'
 import ShareItem from '../share/ShareItem'
+import StartScanner from './StartScanner'
 import ScanWrapper from './ScanWrapper'
 
 const MoreMenu = ({
@@ -35,40 +36,43 @@ const MoreMenu = ({
       <div ref={anchorRef}>
         <MoreButton onClick={openMenu} />
       </div>
-      {menuIsVisible && (
-        <ActionMenu
-          placement="bottom-end"
-          anchorElRef={anchorRef}
-          onClose={closeMenu}
-          autoclose
-        >
-          {canCreateFolder && hasWriteAccess && <AddFolderItem />}
-          {hasWriteAccess && <CreateNoteItem />}
-          {hasWriteAccess && <CreateShortcut />}
-          {canUpload && hasWriteAccess && <UploadItem disabled={isDisabled} />}
-          {isMobileApp() &&
-            canUpload &&
-            hasWriteAccess && (
-              <ScanWrapper insideMoreMenu disabled={isDisabled} />
+      <ScanWrapper>
+        {menuIsVisible && (
+          <ActionMenu
+            placement="bottom-end"
+            anchorElRef={anchorRef}
+            onClose={closeMenu}
+            autoclose
+          >
+            {canCreateFolder && hasWriteAccess && <AddFolderItem />}
+            {hasWriteAccess && <CreateNoteItem />}
+            {hasWriteAccess && <CreateShortcut />}
+            {canUpload &&
+              hasWriteAccess && <UploadItem disabled={isDisabled} />}
+            {isMobileApp() &&
+              canUpload &&
+              hasWriteAccess && (
+                <StartScanner insideMoreMenu disabled={isDisabled} />
+              )}
+            {hasWriteAccess && <hr />}
+            {isMobile && (
+              <NotRootFolder>
+                <ShareItem />
+              </NotRootFolder>
             )}
-          {hasWriteAccess && <hr />}
-          {isMobile && (
             <NotRootFolder>
-              <ShareItem />
+              <DownloadButtonItem />
             </NotRootFolder>
-          )}
-          <NotRootFolder>
-            <DownloadButtonItem />
-          </NotRootFolder>
-          <SelectableItem />
-          {hasWriteAccess && (
-            <NotRootFolder>
-              <hr />
-              <DeleteItem />
-            </NotRootFolder>
-          )}
-        </ActionMenu>
-      )}
+            <SelectableItem />
+            {hasWriteAccess && (
+              <NotRootFolder>
+                <hr />
+                <DeleteItem />
+              </NotRootFolder>
+            )}
+          </ActionMenu>
+        )}
+      </ScanWrapper>
     </div>
   )
 }

--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
@@ -1,20 +1,17 @@
 import React from 'react'
-import { mount } from 'enzyme'
-import { act } from 'react-dom/test-utils'
-import { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
+import { render, fireEvent, configure } from '@testing-library/react'
 import { setupFolderContent, mockCozyClientRequestQuery } from 'test/setup'
 import { downloadFiles } from 'drive/web/modules/actions/utils'
-import MoreMenu from 'drive/web/modules/drive/Toolbar/components/MoreMenu'
+import MoreMenu from './MoreMenu'
 import AppLike from 'test/components/AppLike'
-import { MoreButton } from 'components/Button'
 
 jest.mock('drive/web/modules/actions/utils', () => ({
   downloadFiles: jest.fn().mockResolvedValue()
 }))
 
-const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
-
 mockCozyClientRequestQuery()
+
+configure({ testIdAttribute: 'data-test-id' })
 
 describe('MoreMenu', () => {
   const setup = async () => {
@@ -23,7 +20,7 @@ describe('MoreMenu', () => {
       folderId
     })
 
-    const root = mount(
+    const result = render(
       <AppLike client={client} store={store}>
         <MoreMenu
           isDisabled={false}
@@ -33,31 +30,17 @@ describe('MoreMenu', () => {
       </AppLike>
     )
 
-    await sleep(1)
+    const { getByTestId } = result
+    fireEvent.click(getByTestId('more-button'))
 
-    // Open the menu
-    act(() => {
-      root
-        .find(MoreButton)
-        .props()
-        .onClick()
-    })
-    root.update()
-
-    return { root, store, client }
+    return { ...result, store, client }
   }
 
   describe('DownloadButton', () => {
     it('should work', async () => {
-      const { root } = await setup()
+      const { getByText } = await setup()
 
-      const actionMenuItem = root.findWhere(node => {
-        return (
-          node.type() === ActionMenuItem && node.text() == 'Download folder'
-        )
-      })
-      actionMenuItem.props().onClick()
-      await sleep(0)
+      fireEvent.click(getByText('Download folder'))
       expect(downloadFiles).toHaveBeenCalled()
     })
   })

--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent, configure } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { setupFolderContent, mockCozyClientRequestQuery } from 'test/setup'
 import { downloadFiles } from 'drive/web/modules/actions/utils'
 import MoreMenu from './MoreMenu'
@@ -19,8 +19,6 @@ jest.mock('cozy-device-helper', () => ({
 }))
 
 mockCozyClientRequestQuery()
-
-configure({ testIdAttribute: 'data-test-id' })
 
 describe('MoreMenu', () => {
   const setup = async () => {

--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
@@ -4,9 +4,18 @@ import { setupFolderContent, mockCozyClientRequestQuery } from 'test/setup'
 import { downloadFiles } from 'drive/web/modules/actions/utils'
 import MoreMenu from './MoreMenu'
 import AppLike from 'test/components/AppLike'
+import { isMobileApp } from 'cozy-device-helper'
+
+// CreateNoteItem uses async hooks which produces act() warning in tests
+jest.mock('./CreateNoteItem', () => () => null)
 
 jest.mock('drive/web/modules/actions/utils', () => ({
   downloadFiles: jest.fn().mockResolvedValue()
+}))
+
+jest.mock('cozy-device-helper', () => ({
+  ...jest.requireActual('cozy-device-helper'),
+  isMobileApp: jest.fn().mockReturnValue(false)
 }))
 
 mockCozyClientRequestQuery()
@@ -20,12 +29,15 @@ describe('MoreMenu', () => {
       folderId
     })
 
+    client.stackClient.uri = 'http://cozy.tools'
+
     const result = render(
       <AppLike client={client} store={store}>
         <MoreMenu
           isDisabled={false}
           canCreateFolder={false}
-          canUpload={false}
+          canUpload
+          hasWriteAccess
         />
       </AppLike>
     )
@@ -37,11 +49,47 @@ describe('MoreMenu', () => {
   }
 
   describe('DownloadButton', () => {
-    it('should work', async () => {
+    it('download files', async () => {
       const { getByText } = await setup()
 
       fireEvent.click(getByText('Download folder'))
       expect(downloadFiles).toHaveBeenCalled()
+    })
+  })
+
+  describe('Scanner', () => {
+    let cameraObject
+
+    beforeAll(() => {
+      isMobileApp.mockReturnValue(true)
+      cameraObject = window.navigator.camera
+      window.navigator.camera = {
+        DestinationType: {},
+        PictureSourceType: {},
+        getPicture: jest.fn(onSuccess => {
+          onSuccess('/fake/file')
+        }),
+        cleanup: jest.fn()
+      }
+    })
+
+    afterAll(() => {
+      window.navigator.camera = cameraObject
+    })
+
+    it('opens and closes the scanner', async () => {
+      const { getByText, queryByText } = await setup()
+
+      isMobileApp
+
+      // opens the scanner
+      fireEvent.click(getByText('Scan a doc'))
+      expect(queryByText('Save the doc')).not.toBeNull()
+
+      // closes the scanner and the menu
+      fireEvent.click(getByText('Cancel'))
+      expect(queryByText('Save the doc')).toBeNull()
+      expect(queryByText('Scan a doc')).toBeNull()
     })
   })
 })

--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
@@ -80,8 +80,6 @@ describe('MoreMenu', () => {
     it('opens and closes the scanner', async () => {
       const { getByText, queryByText } = await setup()
 
-      isMobileApp
-
       // opens the scanner
       fireEvent.click(getByText('Scan a doc'))
       expect(queryByText('Save the doc')).not.toBeNull()

--- a/src/drive/web/modules/drive/Toolbar/components/StartScanner.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/StartScanner.jsx
@@ -1,0 +1,45 @@
+import React, { useContext } from 'react'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
+import { SCANNER_UPLOADING } from 'cozy-scanner'
+import { ScannerContext } from './ScanWrapper'
+
+const StartScanner = ({ t }) => {
+  const { status, online, startScanner } = useContext(ScannerContext)
+
+  const offlineMessage = () => {
+    return alert(t('Scan.error.offlinee'))
+  }
+  const uploadingMessage = () => {
+    return alert(t('Scan.error.uploading'))
+  }
+
+  const actionOnClick = (() => {
+    if (status === SCANNER_UPLOADING) return uploadingMessage
+    if (!online) return offlineMessage
+    return startScanner
+  })()
+
+  const trackEvent = () => {
+    const tracker = getTracker()
+    if (tracker) {
+      tracker.push(['trackEvent', 'Drive', 'Scanner', 'Scan Click'])
+    }
+  }
+
+  return (
+    <ActionMenuItem
+      onClick={() => {
+        trackEvent()
+        actionOnClick()
+      }}
+      left={<Icon icon="camera" />}
+    >
+      {t('Scan.scan_a_doc')}
+    </ActionMenuItem>
+  )
+}
+
+export default translate()(StartScanner)

--- a/test/setup.jsx
+++ b/test/setup.jsx
@@ -4,12 +4,15 @@
 
 import React from 'react'
 import { mount } from 'enzyme'
+import { configure } from '@testing-library/react'
 import CozyClient from 'cozy-client'
 
 import configureStore from '../src/drive/store/configureStore'
 import AppLike from 'test/components/AppLike'
 import FolderContent from 'test/components/FolderContent'
 import { generateFile } from './generate'
+
+configure({ testIdAttribute: 'data-test-id' })
 
 export const mockCozyClientRequestQuery = () => {
   beforeEach(() => {


### PR DESCRIPTION
We currently have a problem where the more menu in the top corner stays open after we start the cozy-scanner. This was introduced as a workaround [here](https://github.com/cozy/cozy-drive/pull/2017/files#r423532174) — the `Scanner` component needs to be rendered in order to run the scanner, but the ActionMenu closes itself after an action is selected, which unmounts `Scanner`.

So i moved `Scanner` outside of the `ActionMenu` so that it can stay in the render tree independently from the menu. However the scanner also exposes a `startScan` function that needs to be called from inside the menu. To make this function accessible, the `ScanWrapper` now renders a context provider, and the corresponding menu item is a consumer of that context. This way the scanner and the menu still work together, but without needing to be rendered together.