### PR TITLE
fix: Rename files after upload

### DIFF
--- a/src/drive/web/modules/drive/RenameInput.jsx
+++ b/src/drive/web/modules/drive/RenameInput.jsx
@@ -10,7 +10,11 @@ import { abortRenaming } from './rename'
 // If we set the _rev then CozyClient tries to update. Else
 // it tries to create
 const updateFileNameQuery = async (client, file, newName) => {
-  return client.save({ ...file, name: newName, _rev: file.meta.rev })
+  return client.save({
+    ...file,
+    name: newName,
+    _rev: file._rev || file.meta.rev
+  })
 }
 
 export const RenameInput = ({ onAbort, file, refreshFolderContent }) => {

--- a/src/drive/web/modules/filelist/FilenameInput.jsx
+++ b/src/drive/web/modules/filelist/FilenameInput.jsx
@@ -98,7 +98,8 @@ class FilenameInput extends Component {
     //Since we're mounting the component and focusing it at the same time
     // let's add a small timeout to be sure the ref is populated
     setTimeout(() => {
-      this.textInput.current.setSelectionRange(0, filename.length)
+      if (this.textInput.current)
+        this.textInput.current.setSelectionRange(0, filename.length)
     }, 5)
   }
   render() {


### PR DESCRIPTION
Files that have just been uploaded don't have a `meta.rev` field, but they do have a plain `_rev` field. Trying to read `meta.rev` was causing an error when renaming a file just after it had been uploaded.