### PR TITLE
fix: Sort wants an array now

### DIFF
--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -26,9 +26,11 @@ const TIMELINE_QUERY = client =>
       trashed: false
     })
     .select(['dir_id', 'name', 'size', 'updated_at', 'metadata'])
-    .sortBy({
-      'metadata.datetime': 'desc'
-    })
+    .sortBy([
+      {
+        'metadata.datetime': 'desc'
+      }
+    ])
     .include(['albums'])
 
 const TIMELINE_MUTATIONS = client => ({


### PR DESCRIPTION
Since we upgraded Cozyclient, we forgot to update our sortBy instruction. We now need to pass an array instead 