### PR TITLE
fix: Added exif creation date of asset sent back to java

### DIFF
--- a/src/drive/mobile/lib/media.js
+++ b/src/drive/mobile/lib/media.js
@@ -51,6 +51,7 @@ const generatePayloadForNative = async ({
     libraryId: file['id'],
     mimeType: file['mimeType'],
     filePath: file['filePath'],
+    createdDate: file['creationDate'],
     httpMethod: method,
     headers: {
       Authorization: 'Bearer ' + token,

--- a/src/drive/mobile/lib/media.js
+++ b/src/drive/mobile/lib/media.js
@@ -40,7 +40,7 @@ export const requestAuthorization = async () => {
 }
 /**
  * Generates an http payload for the native part.
- * The uri and file variables are from the native part, 
+ * The uri and file variables are from the native part,
  * used to return a payload with headers.
  * @param {any} file - The file to upload, used to get the id, mimeType, and filePath.
  * @param {any} uri - The uri, used to get the serverUrl.

--- a/src/drive/mobile/lib/media.js
+++ b/src/drive/mobile/lib/media.js
@@ -38,6 +38,13 @@ export const requestAuthorization = async () => {
     )
   })
 }
+/**
+ * Generates an http payload for the native part.
+ * The uri and file variables are from the native part, 
+ * used to return a payload with headers.
+ * @param {any} file - The file to upload, used to get the id, mimeType, and filePath.
+ * @param {any} uri - The uri, used to get the serverUrl.
+ */
 const generatePayloadForNative = async ({
   uri,
   file,


### PR DESCRIPTION
**Description**
This PR is related to [this PR](https://github.com/cozy/cordova-plugin-list-library-items/pull/31).
This change sends back to the java code the asset's creation date.

**How does it work ?**
This line of code `createdDate: file['creationDate'],`, adds the asset's creation date. With this, the java code use this date to format it and send it to the stack through the headers.
For more information about this, please check out [this PR](https://github.com/cozy/cordova-plugin-list-library-items/pull/31).