### PR TITLE
fix: Add DropZone to DriveView

### DIFF
--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -111,7 +111,7 @@ const DriveView = ({
   const { pushModal, popModal } = useContext(ModalContext)
   const { refresh } = useContext(SharingContext)
   const dispatch = useDispatch()
-  const hasTheWriteAccess = hasWriteAccess(currentFolderId)
+  const canWriteToCurrentFolder = hasWriteAccess(currentFolderId)
   const actionsOptions = {
     client,
     pushModal,
@@ -120,7 +120,7 @@ const DriveView = ({
     dispatch,
     router,
     location,
-    hasWriteAccess: hasTheWriteAccess,
+    hasWriteAccess: canWriteToCurrentFolder,
     canMove: true
   }
   const actions = useActions(
@@ -157,7 +157,7 @@ const DriveView = ({
       )}
       <Dropzone
         role="main"
-        disabled={__TARGET__ === 'mobile' || !hasTheWriteAccess}
+        disabled={__TARGET__ === 'mobile' || !canWriteToCurrentFolder}
         displayedFolder={displayedFolder}
       >
         <FolderViewBody


### PR DESCRIPTION
We forgot to add our DropZone component in the Drive view. Our users were not able to drag and drop a file... It fixes the issue 