### PR TITLE
fix: Added device name to JS payload

### DIFF
--- a/src/drive/mobile/lib/media.js
+++ b/src/drive/mobile/lib/media.js
@@ -116,8 +116,6 @@ export const uploadLibraryItem = async (
       file: libraryItem,
       uri
     })
-    console.log("JS PART: The id of asset is: " + libraryItem['id']);
-    console.log("JS PART: The device name is: " + libraryItem['deviceName']);
     return uploadNativeItem(payload, progressCallback, thumbnailCallback)
   }
 

--- a/src/drive/mobile/lib/media.js
+++ b/src/drive/mobile/lib/media.js
@@ -51,6 +51,7 @@ const generatePayloadForNative = async ({
     libraryId: file['id'],
     mimeType: file['mimeType'],
     filePath: file['filePath'],
+    deviceName: file['deviceName'],
     httpMethod: method,
     headers: {
       Authorization: 'Bearer ' + token,
@@ -115,6 +116,8 @@ export const uploadLibraryItem = async (
       file: libraryItem,
       uri
     })
+    console.log("JS PART: The id of asset is: " + libraryItem['id']);
+    console.log("JS PART: The device name is: " + libraryItem['deviceName']);
     return uploadNativeItem(payload, progressCallback, thumbnailCallback)
   }
 


### PR DESCRIPTION
**Description**
This PR is iOS and Android related. It sends the asset's creation date and the device name to the JS side.
The related changes on the native side are available in this [PR](https://github.com/cozy/cordova-plugin-list-library-items/pull/34).
**How does it work ?**
To sync an asset, both iOS and Android native side sends additional information to the JS side, through a data structure (Dictionary for iOS, JSON object for Android).
Asset's creation date and device name are set in a data structure, and sent here, to the JS side.