### PR TITLE
fix: Display Empty Trash button even on "tablet"

### DIFF
--- a/src/drive/web/modules/trash/Toolbar.jsx
+++ b/src/drive/web/modules/trash/Toolbar.jsx
@@ -83,14 +83,15 @@ export const Toolbar = ({
       className={styles['fil-toolbar-trash']}
       role="toolbar"
     >
-      <Button
-        theme="danger-outline"
-        className="u-hide--mob"
-        onClick={onEmptyTrash}
-        disabled={disabled || selectionModeActive}
-        icon="trash"
-        label={t('toolbar.empty_trash')}
-      />
+      {!isMobile && (
+        <Button
+          theme="danger-outline"
+          onClick={onEmptyTrash}
+          disabled={disabled || selectionModeActive}
+          icon="trash"
+          label={t('toolbar.empty_trash')}
+        />
+      )}
 
       {isMobile ? (
         <BarRight>


### PR DESCRIPTION
u-hide--mob hides all the elements less than "desktop" size (< 1024px). isMobile refers to max-width: 768px... 

see https://github.com/cozy/cozy-ui/issues/1528 