### PR TITLE
fix: Don't display the download item in the toolbar on mobile

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -60,9 +60,11 @@ const MoreMenu = ({
                 <ShareItem />
               </InsideRegularFolder>
             )}
-            <InsideRegularFolder>
-              <DownloadButtonItem />
-            </InsideRegularFolder>
+            {!isMobileApp() && (
+              <InsideRegularFolder>
+                <DownloadButtonItem />
+              </InsideRegularFolder>
+            )}
             <SelectableItem />
             {hasWriteAccess && (
               <InsideRegularFolder>


### PR DESCRIPTION
We don't allow to download a folder on the mobile app. Let's hide this action also in the toolbar