### PR TITLE
refactor: Remove deprecated use to Toggle and use Switch

### DIFF
--- a/src/drive/mobile/modules/settings/components/SettingCategory.jsx
+++ b/src/drive/mobile/modules/settings/components/SettingCategory.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from 'cozy-ui/transpiled/react/Button'
-import Toggle from 'cozy-ui/transpiled/react/Toggle'
+import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 import styles from '../styles.styl'
 export const ELEMENT_TEXT = 'ELEMENT_TEXT'
@@ -51,10 +51,10 @@ const SettingCategory = ({ title, elements }) => (
                   htmlFor={element.id}
                   className={styles['settings__subcategory__item']}
                 >
-                  <Toggle
-                    id={element.id}
+                  <Switch
                     checked={element.checked}
-                    onToggle={element.onChange}
+                    id={element.id}
+                    onClick={ev => element.onChange(ev.target.checked)}
                   />
                 </label>
               </div>

--- a/src/drive/web/modules/drive/MakeAvailableOfflineMenuItem.jsx
+++ b/src/drive/web/modules/drive/MakeAvailableOfflineMenuItem.jsx
@@ -1,7 +1,9 @@
 import React, { useCallback } from 'react'
 import { connect } from 'react-redux'
 import { useClient } from 'cozy-client'
-import Toggle from 'cozy-ui/transpiled/react/Toggle'
+
+import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme'
+
 import MenuItem from 'drive/web/modules/actionmenu/MenuItem'
 import {
   isAvailableOffline,
@@ -22,7 +24,11 @@ const MakeAvailableOfflineMenuItem = connect(
   return (
     <MenuItem {...rest}>
       {children}
-      <Toggle id={children} checked={checked} onToggle={onToggle} />
+      <Switch
+        id={children}
+        checked={checked}
+        onClick={ev => onToggle(ev.target.checked)}
+      />
     </MenuItem>
   )
 })


### PR DESCRIPTION
toggle is deprecated since a lot of time now. time to remove its use in Drive. 