### PR TITLE
Sharing urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "cozy-realtime": "3.9.0",
     "cozy-scanner": "0.5.1",
     "cozy-scripts": "1.13.2",
-    "cozy-sharing": "1.15.1",
+    "cozy-sharing": "1.16.0",
     "cozy-stack-client": "13.15.1",
     "cozy-ui": "36.1.2",
     "date-fns": "1.30.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "cozy-scripts": "1.13.2",
     "cozy-sharing": "1.15.1",
     "cozy-stack-client": "13.15.1",
-    "cozy-ui": "35.40.2",
+    "cozy-ui": "36.1.2",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "cozy-authentication": "^2.0.5",
     "cozy-bar": "7.12.2",
     "cozy-ci": "0.4.1",
-    "cozy-client": "14.0.0",
+    "cozy-client": "14.3.0",
     "cozy-client-js": "0.17.3",
     "cozy-device-helper": "1.10.1",
     "cozy-doctypes": "1.72.2",

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import PropTypes from 'prop-types'
 import { CozyProvider } from 'cozy-client'
 import { I18n } from 'cozy-ui/transpiled/react/I18n'
+import { BreakpointsProvider } from 'cozy-ui/react/hooks/useBreakpoints'
 import SharingProvider from 'cozy-sharing'
 import { ThumbnailSizeContextProvider } from 'drive/lib/ThumbnailSizeContext'
 import { ModalContextProvider } from 'drive/lib/ModalContext'
@@ -17,7 +18,9 @@ const App = props => {
           <SharingProvider doctype="io.cozy.files" documentType="Files">
             <ThumbnailSizeContextProvider>
               <ModalContextProvider>
-                <StyledApp>{props.children}</StyledApp>
+                <BreakpointsProvider>
+                  <StyledApp>{props.children}</StyledApp>
+                </BreakpointsProvider>
               </ModalContextProvider>
             </ThumbnailSizeContextProvider>
           </SharingProvider>

--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -106,6 +106,11 @@
       "type": "io.cozy.apps",
       "verbs": ["GET"]
     },
+    "sharings": {
+      "description": "Required to have access to the sharings in realtime",
+      "type": "io.cozy.sharings",
+      "verbs": ["GET"]
+    },
     "albums": {
       "description": "Required to manage photos albums",
       "type": "io.cozy.photos.albums",

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -286,11 +286,14 @@ const File = props => {
     breakpoints: { isExtraLarge, isMobile }
   } = props
 
+  const isImage = attributes.class === 'image'
+  const isLargeRow = isImage && thumbnailSizeBig
+
   const filContentRowSelected = classNames(styles['fil-content-row'], {
     [styles['fil-content-row-selected']]: selected,
     [styles['fil-content-row-actioned']]: actionMenuVisible,
     [styles['fil-content-row-disabled']]: disabled,
-    [styles['fil-content-row-bigger']]: thumbnailSizeBig
+    [styles['fil-content-row-bigger']]: isLargeRow
   })
   const formattedSize = isDirectory(attributes)
     ? undefined
@@ -319,10 +322,7 @@ const File = props => {
         toggle={toggle}
         isRenaming={isRenaming}
       >
-        <FileThumbnail
-          file={attributes}
-          size={thumbnailSizeBig ? 96 : undefined}
-        />
+        <FileThumbnail file={attributes} size={isLargeRow ? 96 : undefined} />
         <FileName
           attributes={attributes}
           isRenaming={isRenaming}

--- a/src/drive/web/modules/filelist/FileIcon.jsx
+++ b/src/drive/web/modules/filelist/FileIcon.jsx
@@ -1,29 +1,31 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-import { Icon } from 'cozy-ui/transpiled/react'
-import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
-import { isDirectory } from 'drive/web/modules/drive/files'
+import FileIconMime from 'drive/web/modules/filelist/FileIconMime'
 import FileIconShortcut from 'drive/web/modules/filelist/FileIconShortcut'
+import { ImageLoader } from 'components/Image'
+import styles from 'drive/styles/filelist.styl'
 
-const FileIcon = ({ file, size = 32 }) => {
-  if (file.class === 'shortcut') {
-    return <FileIconShortcut file={file} size={size} />
-  }
-  return (
-    <Icon
-      icon={getMimeTypeIcon(isDirectory(file), file.name, file.mime)}
-      size={size}
-    />
-  )
-}
+const FileIcon = ({ file, size }) => {
+  const isImage = file.class === 'image'
+  const isShortcut = file.class === 'shortcut'
 
-FileIcon.propTypes = {
-  file: PropTypes.shape({
-    class: PropTypes.string,
-    mime: PropTypes.string,
-    name: PropTypes.string
-  }).isRequired,
-  size: PropTypes.number
+  if (isImage)
+    return (
+      <ImageLoader
+        file={file}
+        size="small"
+        render={src => (
+          <img
+            src={src}
+            width={size || 32}
+            height={size || 32}
+            className={styles['fil-file-thumbnail-image']}
+          />
+        )}
+        renderFallback={() => <FileIconMime file={file} size={size} />}
+      />
+    )
+  else if (isShortcut) return <FileIconShortcut file={file} size={size} />
+  else return <FileIconMime file={file} size={size} />
 }
 
 export default FileIcon

--- a/src/drive/web/modules/filelist/FileIconMime.jsx
+++ b/src/drive/web/modules/filelist/FileIconMime.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Icon } from 'cozy-ui/transpiled/react'
+import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
+import { isDirectory } from 'drive/web/modules/drive/files'
+
+const FileIcon = ({ file, size = 32 }) => (
+  <Icon
+    icon={getMimeTypeIcon(isDirectory(file), file.name, file.mime)}
+    size={size}
+  />
+)
+
+FileIcon.propTypes = {
+  file: PropTypes.shape({
+    class: PropTypes.string,
+    mime: PropTypes.string,
+    name: PropTypes.string
+  }).isRequired,
+  size: PropTypes.number
+}
+
+export default FileIcon

--- a/src/drive/web/modules/filelist/FileIconShortcut.jsx
+++ b/src/drive/web/modules/filelist/FileIconShortcut.jsx
@@ -3,7 +3,7 @@ import { withClient, useFetchShortcut } from 'cozy-client'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import palette from 'cozy-ui/transpiled/react/palette'
 
-const FileIconShortcut = ({ file, size, client }) => {
+const FileIconShortcut = ({ file, size = 32, client }) => {
   const { shortcutImg } = useFetchShortcut(client, file.id)
   return (
     <>

--- a/src/drive/web/modules/filelist/FileIconShortcut.jsx
+++ b/src/drive/web/modules/filelist/FileIconShortcut.jsx
@@ -1,31 +1,23 @@
 import React from 'react'
 import { withClient, useFetchShortcut } from 'cozy-client'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import Badge from 'cozy-ui/transpiled/react/Badge'
 import palette from 'cozy-ui/transpiled/react/palette'
 
 const FileIconShortcut = ({ file, size, client }) => {
   const { shortcutImg } = useFetchShortcut(client, file.id)
   return (
-    <Badge
-      content={<Icon icon="link" size={10} />}
-      type="normal"
-      alignment="bottom-right"
-      size="medium"
-    >
-      <>
-        <div style={{ display: shortcutImg ? 'block' : 'none' }}>
-          <img src={shortcutImg} width={size} height={size} />
-        </div>
-        <div
-          style={{
-            display: !shortcutImg ? 'block' : 'none'
-          }}
-        >
-          <Icon icon="globe" size={size} color={palette.coolGrey} />
-        </div>
-      </>
-    </Badge>
+    <>
+      <div style={{ display: shortcutImg ? 'block' : 'none' }}>
+        <img src={shortcutImg} width={size} height={size} />
+      </div>
+      <div
+        style={{
+          display: !shortcutImg ? 'block' : 'none'
+        }}
+      >
+        <Icon icon="globe" size={size} color={palette.coolGrey} />
+      </div>
+    </>
   )
 }
 

--- a/src/drive/web/modules/filelist/FileIconShortcut.jsx
+++ b/src/drive/web/modules/filelist/FileIconShortcut.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { withClient, useFetchShortcut } from 'cozy-client'
+import { useClient, useFetchShortcut } from 'cozy-client'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import palette from 'cozy-ui/transpiled/react/palette'
 
-const FileIconShortcut = ({ file, size = 32, client }) => {
+const FileIconShortcut = ({ file, size = 32 }) => {
+  const client = useClient()
   const { shortcutImg } = useFetchShortcut(client, file.id)
   return (
     <>
@@ -21,4 +22,4 @@ const FileIconShortcut = ({ file, size = 32, client }) => {
   )
 }
 
-export default withClient(FileIconShortcut)
+export default FileIconShortcut

--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -6,12 +6,13 @@ import { SharedBadge, SharingOwnerAvatar } from 'cozy-sharing'
 import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
 import GhostFileBadge from 'cozy-ui/transpiled/react/GhostFileBadge'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
+import useBreakpoints from 'cozy-ui/react/hooks/useBreakpoints'
 import FileIcon from 'drive/web/modules/filelist/FileIcon'
 import SharingShortcutBadge from 'drive/web/modules/filelist/SharingShortcutBadge'
 import styles from 'drive/styles/filelist.styl'
 
-const FileThumbnail = ({ file, breakpoints: { isMobile }, size }) => {
+const FileThumbnail = ({ file, size }) => {
+  const { isMobile } = useBreakpoints()
   const isSharingShorcut = Boolean(get(file, 'metadata.sharing'))
   const isRegularShortcut = !isSharingShorcut && file.class === 'shortcut'
   const isSimpleFile = !isSharingShorcut && !isRegularShortcut
@@ -62,4 +63,4 @@ FileThumbnail.propTypes = {
   size: PropTypes.number
 }
 
-export default withBreakpoints()(FileThumbnail)
+export default FileThumbnail

--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -1,17 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
-import { SharedBadge } from 'cozy-sharing'
-import FileIcon from 'drive/web/modules/filelist/FileIcon'
-import styles from 'drive/styles/filelist.styl'
-import Badge from 'cozy-ui/transpiled/react/Badge'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import get from 'lodash/get'
+import { SharedBadge, SharingOwnerAvatar } from 'cozy-sharing'
+import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
+import GhostFileBadge from 'cozy-ui/transpiled/react/GhostFileBadge'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
+import FileIcon from 'drive/web/modules/filelist/FileIcon'
+import SharingShortcutBadge from 'drive/web/modules/filelist/SharingShortcutBadge'
+import styles from 'drive/styles/filelist.styl'
 
 const FileThumbnail = ({ file, breakpoints: { isMobile }, size }) => {
-  const isRegularShortcut = file.class === 'shortcut'
-  const isSimpleFile = !isRegularShortcut
+  const isSharingShorcut = Boolean(get(file, 'metadata.sharing'))
+  const isRegularShortcut = !isSharingShorcut && file.class === 'shortcut'
+  const isSimpleFile = !isSharingShorcut && !isRegularShortcut
+
   return (
     <div
       className={cx(styles['fil-content-cell'], styles['fil-file-thumbnail'], {
@@ -20,13 +24,16 @@ const FileThumbnail = ({ file, breakpoints: { isMobile }, size }) => {
     >
       {isSimpleFile && <FileIcon file={file} size={size} />}
       {isRegularShortcut && (
-        <Badge
-          badgeContent={<Icon icon="link" size={10} />}
-          anchorOrigin={{ vertical: 'bottom' }}
-          variant={'qualifier'}
-        >
+        <InfosBadge badgeContent={<Icon icon="link" size={10} />}>
           <FileIcon file={file} size={size} />
-        </Badge>
+        </InfosBadge>
+      )}
+      {isSharingShorcut && (
+        <GhostFileBadge
+          badgeContent={<SharingShortcutBadge file={file} size={16} />}
+        >
+          <SharingOwnerAvatar docId={file.id} size={'small'} />
+        </GhostFileBadge>
       )}
       {/**
        * @todo
@@ -51,9 +58,6 @@ FileThumbnail.propTypes = {
     class: PropTypes.string,
     mime: PropTypes.string,
     name: PropTypes.string
-  }).isRequired,
-  breakpoints: PropTypes.shape({
-    isMobile: PropTypes.bool
   }).isRequired,
   size: PropTypes.number
 }

--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -2,35 +2,31 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
-import { ImageLoader } from 'components/Image'
 import { SharedBadge } from 'cozy-sharing'
 import FileIcon from 'drive/web/modules/filelist/FileIcon'
 import styles from 'drive/styles/filelist.styl'
+import Badge from 'cozy-ui/transpiled/react/Badge'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import get from 'lodash/get'
 
 const FileThumbnail = ({ file, breakpoints: { isMobile }, size }) => {
-  const isImage = file.class === 'image'
+  const isRegularShortcut = file.class === 'shortcut'
+  const isSimpleFile = !isRegularShortcut
   return (
     <div
       className={cx(styles['fil-content-cell'], styles['fil-file-thumbnail'], {
         'u-pl-0': !isMobile
       })}
     >
-      {isImage ? (
-        <ImageLoader
-          file={file}
-          size="small"
-          render={src => (
-            <img
-              src={src}
-              width={size || 32}
-              height={size || 32}
-              className={styles['fil-file-thumbnail-image']}
-            />
-          )}
-          renderFallback={() => <FileIcon file={file} size={size} />}
-        />
-      ) : (
-        <FileIcon file={file} size={size} />
+      {isSimpleFile && <FileIcon file={file} size={size} />}
+      {isRegularShortcut && (
+        <Badge
+          badgeContent={<Icon icon="link" size={10} />}
+          anchorOrigin={{ vertical: 'bottom' }}
+          variant={'qualifier'}
+        >
+          <FileIcon file={file} size={size} />
+        </Badge>
       )}
       {/**
        * @todo

--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import get from 'lodash/get'
 import { SharedBadge, SharingOwnerAvatar } from 'cozy-sharing'
+import Badge from 'cozy-ui/transpiled/react/Badge'
 import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
 import GhostFileBadge from 'cozy-ui/transpiled/react/GhostFileBadge'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -13,7 +14,9 @@ import styles from 'drive/styles/filelist.styl'
 
 const FileThumbnail = ({ file, size }) => {
   const { isMobile } = useBreakpoints()
-  const isSharingShorcut = Boolean(get(file, 'metadata.sharing'))
+  const sharingStatus = get(file, 'metadata.sharing.status')
+  const isSharingShorcut = Boolean(sharingStatus)
+  const isNewSharingShortcut = sharingStatus === 'new'
   const isRegularShortcut = !isSharingShorcut && file.class === 'shortcut'
   const isSimpleFile = !isSharingShorcut && !isRegularShortcut
 
@@ -31,7 +34,15 @@ const FileThumbnail = ({ file, size }) => {
       )}
       {isSharingShorcut && (
         <GhostFileBadge
-          badgeContent={<SharingShortcutBadge file={file} size={16} />}
+          badgeContent={
+            isNewSharingShortcut ? (
+              <Badge variant="dot" color="error">
+                <SharingShortcutBadge file={file} size={16} />
+              </Badge>
+            ) : (
+              <SharingShortcutBadge file={file} size={16} />
+            )
+          }
         >
           <SharingOwnerAvatar docId={file.id} size={'small'} />
         </GhostFileBadge>

--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import get from 'lodash/get'
 import { SharedBadge, SharingOwnerAvatar } from 'cozy-sharing'
-import Badge from 'cozy-ui/transpiled/react/Badge'
 import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
 import GhostFileBadge from 'cozy-ui/transpiled/react/GhostFileBadge'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -14,9 +13,7 @@ import styles from 'drive/styles/filelist.styl'
 
 const FileThumbnail = ({ file, size }) => {
   const { isMobile } = useBreakpoints()
-  const sharingStatus = get(file, 'metadata.sharing.status')
-  const isSharingShorcut = Boolean(sharingStatus)
-  const isNewSharingShortcut = sharingStatus === 'new'
+  const isSharingShorcut = Boolean(get(file, 'metadata.sharing.status'))
   const isRegularShortcut = !isSharingShorcut && file.class === 'shortcut'
   const isSimpleFile = !isSharingShorcut && !isRegularShortcut
 
@@ -34,15 +31,7 @@ const FileThumbnail = ({ file, size }) => {
       )}
       {isSharingShorcut && (
         <GhostFileBadge
-          badgeContent={
-            isNewSharingShortcut ? (
-              <Badge variant="dot" color="error">
-                <SharingShortcutBadge file={file} size={16} />
-              </Badge>
-            ) : (
-              <SharingShortcutBadge file={file} size={16} />
-            )
-          }
+          badgeContent={<SharingShortcutBadge file={file} size={16} />}
         >
           <SharingOwnerAvatar docId={file.id} size={'small'} />
         </GhostFileBadge>

--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import get from 'lodash/get'
+import { models } from 'cozy-client'
 import { SharedBadge, SharingOwnerAvatar } from 'cozy-sharing'
 import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
 import GhostFileBadge from 'cozy-ui/transpiled/react/GhostFileBadge'
@@ -13,7 +13,7 @@ import styles from 'drive/styles/filelist.styl'
 
 const FileThumbnail = ({ file, size }) => {
   const { isMobile } = useBreakpoints()
-  const isSharingShorcut = Boolean(get(file, 'metadata.sharing.status'))
+  const isSharingShorcut = models.file.isSharingShorcut(file)
   const isRegularShortcut = !isSharingShorcut && file.class === 'shortcut'
   const isSimpleFile = !isSharingShorcut && !isRegularShortcut
 

--- a/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
+++ b/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import get from 'lodash/get'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
+import { isDirectory } from 'drive/web/modules/drive/files'
+import FileIconShortcut from 'drive/web/modules/filelist/FileIconShortcut'
+
+const SharingShortcutBadge = ({ file, size }) => {
+  const actualFileMime = get(file, 'metadata.target.mime')
+  const isShortcut = actualFileMime === 'application/internet-shortcut'
+
+  return isShortcut ? (
+    <FileIconShortcut file={file} size={size} />
+  ) : (
+    <Icon
+      icon={getMimeTypeIcon(isDirectory(file), file.name, actualFileMime)}
+      size={size}
+    />
+  )
+}
+
+export default SharingShortcutBadge

--- a/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
+++ b/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import get from 'lodash/get'
+import { models } from 'cozy-client'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Badge from 'cozy-ui/transpiled/react/Badge'
 import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
@@ -7,8 +7,8 @@ import { DOCTYPE_FILES } from 'drive/lib/doctypes'
 import FileIconShortcut from 'drive/web/modules/filelist/FileIconShortcut'
 
 const SharingShortcutBadge = ({ file, size }) => {
-  const targetMimeType = get(file, 'metadata.target.mime')
-  const targetDoctype = get(file, 'metadata.target._type')
+  const targetMimeType = models.file.getSharingShortcutTargetMime(file)
+  const targetDoctype = models.file.getSharingShortcutTargetDoctype(file)
   const isShortcut = targetMimeType === 'application/internet-shortcut'
   const targetIsDirectory =
     targetMimeType === '' && targetDoctype === DOCTYPE_FILES
@@ -26,7 +26,7 @@ const SharingShortcutBadge = ({ file, size }) => {
 const withNewStatusBadge = WrappedComponent => {
   const ComponentWithNewStatusBadge = props => {
     const { file } = props
-    const isNewSharingShortcut = get(file, 'metadata.sharing.status') === 'new'
+    const isNewSharingShortcut = models.file.isSharingShorcutNew(file)
 
     return isNewSharingShortcut ? (
       <Badge variant="dot" color="error">

--- a/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
+++ b/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
@@ -6,16 +6,17 @@ import { DOCTYPE_FILES } from 'drive/lib/doctypes'
 import FileIconShortcut from 'drive/web/modules/filelist/FileIconShortcut'
 
 const SharingShortcutBadge = ({ file, size }) => {
-  const actualFileMime = get(file, 'metadata.target.mime')
-  const doctype = get(file, 'metadata.target._type')
-  const isShortcut = actualFileMime === 'application/internet-shortcut'
-  const isDirectory = actualFileMime === '' && doctype === DOCTYPE_FILES
+  const targetMimeType = get(file, 'metadata.target.mime')
+  const targetDoctype = get(file, 'metadata.target._type')
+  const isShortcut = targetMimeType === 'application/internet-shortcut'
+  const targetIsDirectory =
+    targetMimeType === '' && targetDoctype === DOCTYPE_FILES
 
   return isShortcut ? (
     <FileIconShortcut file={file} size={size} />
   ) : (
     <Icon
-      icon={getMimeTypeIcon(isDirectory, file.name, actualFileMime)}
+      icon={getMimeTypeIcon(targetIsDirectory, file.name, targetMimeType)}
       size={size}
     />
   )

--- a/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
+++ b/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import get from 'lodash/get'
 import Icon from 'cozy-ui/transpiled/react/Icon'
+import Badge from 'cozy-ui/transpiled/react/Badge'
 import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
 import { DOCTYPE_FILES } from 'drive/lib/doctypes'
 import FileIconShortcut from 'drive/web/modules/filelist/FileIconShortcut'
@@ -22,4 +23,21 @@ const SharingShortcutBadge = ({ file, size }) => {
   )
 }
 
-export default SharingShortcutBadge
+const withNewStatusBadge = WrappedComponent => {
+  const ComponentWithNewStatusBadge = props => {
+    const { file } = props
+    const isNewSharingShortcut = get(file, 'metadata.sharing.status') === 'new'
+
+    return isNewSharingShortcut ? (
+      <Badge variant="dot" color="error">
+        <WrappedComponent {...props} />
+      </Badge>
+    ) : (
+      <WrappedComponent {...props} />
+    )
+  }
+
+  return ComponentWithNewStatusBadge
+}
+
+export default withNewStatusBadge(SharingShortcutBadge)

--- a/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
+++ b/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
@@ -2,18 +2,20 @@ import React from 'react'
 import get from 'lodash/get'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
-import { isDirectory } from 'drive/web/modules/drive/files'
+import { DOCTYPE_FILES } from 'drive/lib/doctypes'
 import FileIconShortcut from 'drive/web/modules/filelist/FileIconShortcut'
 
 const SharingShortcutBadge = ({ file, size }) => {
   const actualFileMime = get(file, 'metadata.target.mime')
+  const doctype = get(file, 'metadata.target._type')
   const isShortcut = actualFileMime === 'application/internet-shortcut'
+  const isDirectory = actualFileMime === '' && doctype === DOCTYPE_FILES
 
   return isShortcut ? (
     <FileIconShortcut file={file} size={size} />
   ) : (
     <Icon
-      icon={getMimeTypeIcon(isDirectory(file), file.name, actualFileMime)}
+      icon={getMimeTypeIcon(isDirectory, file.name, actualFileMime)}
       size={size}
     />
   )

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux'
 import langEn from 'drive/locales/en.json'
 import { createStore } from 'redux'
 import { ThumbnailSizeContextProvider } from 'drive/lib/ThumbnailSizeContext'
+import { BreakpointsProvider } from 'cozy-ui/react/hooks/useBreakpoints'
 import { ModalContext } from 'drive/lib/ModalContext'
 import { SharingContext } from 'cozy-sharing'
 import { RouterContext } from 'drive/lib/RouterContext'
@@ -58,11 +59,13 @@ const AppLike = ({
             value={routerContextValue || mockRouterContextValue}
           >
             <ThumbnailSizeContextProvider>
-              <ModalContext.Provider
-                value={modalContextValue || mockModalContextValue}
-              >
-                {children}
-              </ModalContext.Provider>
+              <BreakpointsProvider>
+                <ModalContext.Provider
+                  value={modalContextValue || mockModalContextValue}
+                >
+                  {children}
+                </ModalContext.Provider>
+              </BreakpointsProvider>
             </ThumbnailSizeContextProvider>
           </RouterContext.Provider>
         </SharingContext.Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5298,10 +5298,10 @@ cozy-doctypes@1.72.2, cozy-doctypes@^1.72.0:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.74.4:
-  version "1.74.4"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.74.4.tgz#658f8ce8086b0b59130ed6dc431d097c52d79cdf"
-  integrity sha512-+XC2SyJYIhHAduEvQ9vbkf2UNZJbzRXkDMlj7473zcfBm4G0vKFUqjkbz/uoQchdvksjuiJxSCcC9yNLFg6CnA==
+cozy-doctypes@^1.74.5:
+  version "1.74.5"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.74.5.tgz#e1baa9482452a992fcaff9f44cb5cff413f9bb5b"
+  integrity sha512-YRMXAxtCcoXbqoF0A4W8vPO1wGYqFOAwbe/ue2F4gSkLE0K40gmWchRICPG3A1VjFWCmfKLLCOUBZV4N4cPwKw==
   dependencies:
     "@babel/runtime" "7.5.5"
     cozy-logger "^1.6.0"
@@ -5408,10 +5408,10 @@ cozy-realtime@3.9.0:
     cozy-device-helper "^1.9.2"
     minilog "https://github.com/cozy/minilog.git#master"
 
-cozy-realtime@^3.10.3:
-  version "3.10.3"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.10.3.tgz#2587e352b8376849802b92ff226ece8ff7448c1f"
-  integrity sha512-xYGPskHY1eFEaw3samE/HIjZfGyC2e9wXX4ICZKjbgiWwE/yF24Ai90nJbpWHNw5h5OB8OhX9Xho1gxzhFXgww==
+cozy-realtime@^3.10.4:
+  version "3.10.4"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.10.4.tgz#2ecec98141ed9d00b71829f3064c9cc40dce90ad"
+  integrity sha512-87MR+ECZU0QDHhhpSmVbQU1TypAtKacarjpmbOVwM0MEBcpAou3MyuJCTN+ZFBKMSmUNbb4UkPTLG4POqk9nZg==
   dependencies:
     cozy-device-helper "^1.10.1"
     minilog "https://github.com/cozy/minilog.git#master"
@@ -5475,17 +5475,17 @@ cozy-scripts@1.13.2:
     webpack-dev-server "3.1.10"
     webpack-merge "4.2.1"
 
-cozy-sharing@1.15.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-1.15.1.tgz#2cd9cef2b67cb8a171b885872f3e9d1675f3b1e3"
-  integrity sha512-bS1k3T+caYH8v/jwInTnrCJms9vftUJ/ARQ3GBf6tr3janK31jA99v5nP2N967OU4UbWYjmBUrheUmJVHp+t5g==
+cozy-sharing@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-1.16.0.tgz#c836ddede697bcd87262cd266ca24b6009276be4"
+  integrity sha512-qPjKtXWpIlElLXz4pURI3oOXS+aBN3j91BnzhSp7P5b3iajKKjMmJ30F4e8o7q0GsRE+2Iivh/TnUmL2B4fj7w==
   dependencies:
     babel-plugin-inline-react-svg "^1.1.0"
     classnames "^2.2.6"
     copy-text-to-clipboard "^2.1.1"
     cozy-device-helper "^1.10.1"
-    cozy-doctypes "^1.74.4"
-    cozy-realtime "^3.10.3"
+    cozy-doctypes "^1.74.5"
+    cozy-realtime "^3.10.4"
     lodash "^4.17.19"
     minilog "https://github.com/cozy/minilog.git#master"
     react-autosuggest "^9.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,15 +5199,15 @@ cozy-client@13.1.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-14.0.0.tgz#8352155a449c3e785ee340557b23d7c340d85d42"
-  integrity sha512-1cRJP7cvnb1ogL45A7/+ARQblBt4GwlFc5IAgqYGR9aY3IUEV+V/PA+gYVLEpDIs9gcg2cIl5+tmxVGApN5CSQ==
+cozy-client@14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-14.3.0.tgz#0319901b538cb13ec51391e8a855b450fa01a450"
+  integrity sha512-jOa2rn+IK26eGYEOKs2ozKkg4wbBqSXNC0V0Op5j7BrjZSlnQl0IpRDnvKjOV10ULrJP6FxLSbqQeVQPMGed4g==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^14.0.0"
+    cozy-stack-client "^14.1.2"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5518,10 +5518,10 @@ cozy-stack-client@^13.16.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-14.0.0.tgz#212aa56d8499865d97c7be7b5bf2ac00c1b77f05"
-  integrity sha512-0v7sBx6F7A00ZwN2wbSc59GrgLGNhX0W8P2xMBybSe1F7CLhx6SXlVe4lqKwunpYfbMSW+BM7fCjBmFu1hGNGw==
+cozy-stack-client@^14.1.2:
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-14.1.2.tgz#606ce89cabf4def2875cb8749b28b3ee8b96d18f"
+  integrity sha512-0IyYvBQu+vuwN9qe6PHA7khXBQT8TGSjVia7SVTGQ88tEFSLLGXjfZe3pkZQ1ihBdJvmeon12dm0BWeEb+9KZw==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5544,10 +5544,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@35.40.2:
-  version "35.40.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.40.2.tgz#58866f9a8307e373f74ad09fc2700fbe227860b5"
-  integrity sha512-kNlz1FsgYsp67Kvxo5od62wgE/Wy9MQ5tuiH2e3WSpDa4kHl/+mNXM3/lDys+LQi4hKYZePRfQiZcW/M6Vc/yg==
+cozy-ui@36.1.2:
+  version "36.1.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-36.1.2.tgz#db2c47e77be94a90bf2bedb131399148e56b83bf"
+  integrity sha512-OH2Ql1afVRMFw6hV5wYHBmr2umVj85V6g5IaGloBAbp4cMJya7pUV8Zj/ZswjZPzcyTZGzSV1vu1JMmrFsJWVA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
~~Draft PR, waiting on https://github.com/cozy/cozy-libs/pull/1090 and https://github.com/cozy/cozy-ui/pull/1542.~~

Updates the file thumbnails so that sharing previews are distinguishable from other types of files. The file logic has changed a bit:

- FileThumbnail is responsible for rendering FileIcon and decorating it with the appropriate badge
- FileIcon renders the correct icon depending on the file (image thumbnails, shortcut favicons or mime-type icon)