### PR TITLE
feat: Disable more menu in toolbar

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -34,7 +34,7 @@ const MoreMenu = ({
   return (
     <div>
       <div ref={anchorRef}>
-        <MoreButton onClick={openMenu} />
+        <MoreButton onClick={openMenu} disabled={isDisabled} />
       </div>
       <ScanWrapper>
         {menuIsVisible && (


### PR DESCRIPTION
We have a `disable` state in the toolbar that isn't honored by the more menu. The toolbar is notably disabled when the selection mode is active.