### PR TITLE
fix: Don't unsubscribe the realtime event

### DIFF
--- a/src/components/Image/ImageLoader.jsx
+++ b/src/components/Image/ImageLoader.jsx
@@ -38,7 +38,6 @@ class ImageLoader extends React.Component {
     const { file, size } = this.props
     if (file._id === doc._id && doc.format === size) {
       this.loadLink()
-      this.unsubscribeRealtime()
     }
   }
 


### PR DESCRIPTION
Since we can have new versions of a file now, we should not unsubscribe 
since we can receive several messages even after the first one

