### PR TITLE
fix: Don't display trashed file or folder in Sharing View

### DIFF
--- a/src/drive/web/modules/views/Recent/useFilesQueryWithPath.jsx
+++ b/src/drive/web/modules/views/Recent/useFilesQueryWithPath.jsx
@@ -3,10 +3,14 @@ import get from 'lodash/get'
 import uniq from 'lodash/uniq'
 import keyBy from 'lodash/keyBy'
 import { buildParentsByIdsQuery } from 'drive/web/modules/queries'
+import { TRASH_DIR_ID } from 'drive/constants/config'
 
+export const excludeTrashedFiles = files => {
+  return files.filter(f => f.dir_id !== TRASH_DIR_ID && f.trashed !== true)
+}
 export const useFilesQueryWithPath = query => {
   const result = useQuery(query.definition, query.options)
-  const resultData = result.data || []
+  const resultData = excludeTrashedFiles(result.data || []) 
 
   const dirIds = uniq(resultData.map(({ dir_id }) => dir_id))
   const parentsQuery = buildParentsByIdsQuery(dirIds)

--- a/src/drive/web/modules/views/Recent/useFilesQueryWithPath.jsx
+++ b/src/drive/web/modules/views/Recent/useFilesQueryWithPath.jsx
@@ -5,12 +5,12 @@ import keyBy from 'lodash/keyBy'
 import { buildParentsByIdsQuery } from 'drive/web/modules/queries'
 import { TRASH_DIR_ID } from 'drive/constants/config'
 
-export const excludeTrashedFiles = files => {
-  return files.filter(f => f.dir_id !== TRASH_DIR_ID && f.trashed !== true)
-}
+export const isFileTrashed = file =>
+  file.dir_id !== TRASH_DIR_ID && file.trashed !== true
+
 export const useFilesQueryWithPath = query => {
   const result = useQuery(query.definition, query.options)
-  const resultData = excludeTrashedFiles(result.data || []) 
+  const resultData = (result.data || []).filter(isFileTrashed)
 
   const dirIds = uniq(resultData.map(({ dir_id }) => dir_id))
   const parentsQuery = buildParentsByIdsQuery(dirIds)

--- a/src/drive/web/modules/views/Recent/useFilesQueryWithPath.spec.jsx
+++ b/src/drive/web/modules/views/Recent/useFilesQueryWithPath.spec.jsx
@@ -1,8 +1,7 @@
 import { useQuery } from 'cozy-client'
 
 import { TRASH_DIR_ID } from 'drive/constants/config'
-import { useFilesQueryWithPath, excludeTrashedFiles } from './useFilesQueryWithPath'
-
+import { useFilesQueryWithPath, isFileTrashed } from './useFilesQueryWithPath'
 
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 
@@ -64,5 +63,9 @@ test('excludeTrashedFiles', () => {
     dir_id: '1',
     trashed: false
   }
-  expect(excludeTrashedFiles([trashedFile1, trashedFile2, trashedFolder, folder1, file1, file2])).toEqual([folder1, file1, file2])
+  expect(
+    [trashedFile1, trashedFile2, trashedFolder, folder1, file1, file2].filter(
+      isFileTrashed
+    )
+  ).toEqual([folder1, file1, file2])
 })

--- a/src/drive/web/modules/views/Recent/useFilesQueryWithPath.spec.jsx
+++ b/src/drive/web/modules/views/Recent/useFilesQueryWithPath.spec.jsx
@@ -1,5 +1,9 @@
-import { useFilesQueryWithPath } from './useFilesQueryWithPath'
 import { useQuery } from 'cozy-client'
+
+import { TRASH_DIR_ID } from 'drive/constants/config'
+import { useFilesQueryWithPath, excludeTrashedFiles } from './useFilesQueryWithPath'
+
+
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 
 describe('useFilesWithPath', () => {
@@ -28,4 +32,37 @@ describe('useFilesWithPath', () => {
       ]
     })
   })
+})
+
+test('excludeTrashedFiles', () => {
+  const trashedFile1 = {
+    _id: 1,
+    dir_id: TRASH_DIR_ID
+  }
+  const trashedFile2 = {
+    _id: 3,
+    dir_id: 'bug',
+    trashed: true
+  }
+  const trashedFolder = {
+    _id: 3,
+    dir_id: TRASH_DIR_ID
+  }
+  const folder1 = {
+    _id: 4,
+    type: 'folder',
+    dir_id: '1'
+  }
+  const file1 = {
+    _id: 1,
+    type: 'file',
+    dir_id: '1'
+  }
+  const file2 = {
+    _id: 1,
+    type: 'file',
+    dir_id: '1',
+    trashed: false
+  }
+  expect(excludeTrashedFiles([trashedFile1, trashedFile2, trashedFolder, folder1, file1, file2])).toEqual([folder1, file1, file2])
 })


### PR DESCRIPTION
We don't want to display shared file that are in the trash in the "Sharing View"

