### PR TITLE
feat: Redirect to trash if the folder is trashed

### DIFF
--- a/src/components/sharing/PublicBanner.jsx
+++ b/src/components/sharing/PublicBanner.jsx
@@ -124,7 +124,13 @@ const SharingBannerByLink = ({ onClose }) => {
     <Banner
       bgcolor={palette['paleGrey']}
       text={<SharingBannerByLinkText />}
-      buttonOne={<Button theme="text" label={t('Share.banner.close')} onClick={onClose} />}
+      buttonOne={
+        <Button
+          theme="text"
+          label={t('Share.banner.close')}
+          onClick={onClose}
+        />
+      }
       inline
     />
   )

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -41,6 +41,8 @@ import FolderViewHeader from '../Folder/FolderViewHeader'
 import FolderViewBody from '../Folder/FolderViewBody'
 import FolderViewBreadcrumb from '../Folder/FolderViewBreadcrumb'
 
+import { useTrashRedirect } from './useTrashRedirect'
+
 const getBreadcrumbPath = (t, displayedFolder) =>
   uniqBy(
     [
@@ -72,6 +74,8 @@ const DriveView = ({
   children,
   displayedFolder
 }) => {
+  useTrashRedirect(displayedFolder)
+
   const [sortOrder] = useFolderSort(currentFolderId)
 
   const folderQuery = buildDriveQuery({

--- a/src/drive/web/modules/views/Drive/useTrashRedirect.jsx
+++ b/src/drive/web/modules/views/Drive/useTrashRedirect.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+import { useRouter } from 'drive/lib/RouterContext'
+import { TRASH_DIR_PATH } from 'drive/constants/config'
+export const useTrashRedirect = displayedFolder => {
+  const { router } = useRouter()
+  useEffect(
+    () => {
+      if (displayedFolder && displayedFolder.path.startsWith(TRASH_DIR_PATH)) {
+        router.push({
+          pathname: '/trash/' + displayedFolder.id
+        })
+      }
+    },
+    [router, displayedFolder]
+  )
+}


### PR DESCRIPTION
Previously, if you manually go to /folder/trashedFolder, it would
display the Drive view with all actions on the folder / files. But we
don't want that. So we redirect to the TrashView.

Also, some apps (like Notes) are redirecting to the note's folder in
Drive without checking if the note is trashed or not.

This is a Drive's responsibility to redirect at the right place.