### PR TITLE
fix: Use snarkdown instead of react-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "react-autosuggest": "9.3.4",
     "react-dom": "16.13.1",
     "react-dropzone": "5.1.1",
-    "react-markdown": "3.6.0",
     "react-measure": "2.5.0",
     "react-redux": "7.2.0",
     "react-router": "3.2.4",
@@ -157,6 +156,7 @@
     "redux-raven-middleware": "1.2.0",
     "redux-thunk": "2.3.0",
     "scheduler": "0.17.0",
+    "snarkdown": "2.0.0",
     "webpack-node-externals": "1.7.2",
     "whatwg-fetch": "3.0.0"
   }

--- a/src/components/sharing/PublicBanner.jsx
+++ b/src/components/sharing/PublicBanner.jsx
@@ -124,7 +124,13 @@ const SharingBannerByLink = ({ onClose }) => {
     <Banner
       bgcolor={palette['paleGrey']}
       text={<SharingBannerByLinkText />}
-      buttonOne={<Button theme="text" label={t('Share.banner.close')} onClick={onClose} />}
+      buttonOne={
+        <Button
+          theme="text"
+          label={t('Share.banner.close')}
+          onClick={onClose}
+        />
+      }
       inline
     />
   )

--- a/src/components/sharing/PublicBanner.jsx
+++ b/src/components/sharing/PublicBanner.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import snarkdown from 'snarkdown'
 
 import { useClient } from 'cozy-client'
 import Banner from 'cozy-ui/transpiled/react/Banner'
 import Button from 'cozy-ui/transpiled/react/Button'
 import palette from 'cozy-ui/transpiled/react/palette'
 import { useI18n } from 'cozy-ui/transpiled/react'
-import ReactMarkdown from 'react-markdown'
 
 import styles from './publicBanner.styl'
 
@@ -34,15 +34,18 @@ const PublicBannerCozyToCozyContent = ({
       {t('Share.banner.know_more')}
     </a>
   )
-
+  const withAvatar = snarkdown(
+    t('Share.banner.shared_from', {
+      name: name,
+      image: avatarURL
+    })
+  )
   return (
     <>
-      <ReactMarkdown className={styles['bannermarkdown']}>
-        {t('Share.banner.shared_from', {
-          name: name,
-          image: avatarURL
-        })}
-      </ReactMarkdown>
+      <span
+        className={styles['bannermarkdown']}
+        dangerouslySetInnerHTML={{ __html: withAvatar }}
+      />
       <span>
         {' '}
         {text} {knowMore}

--- a/src/drive/mobile/modules/authorization/UserActionRequired.jsx
+++ b/src/drive/mobile/modules/authorization/UserActionRequired.jsx
@@ -1,8 +1,10 @@
 /* global __TARGET__ */
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import ReactMarkdown from 'react-markdown'
+
+import snarkdown from 'snarkdown'
 import PropTypes from 'prop-types'
+
 import {
   Modal,
   Icon,
@@ -14,32 +16,37 @@ import tosIcon from 'drive/mobile/assets/icons/icon-tos.svg'
 import { unlink, getClientSettings } from './duck'
 import styles from './styles.styl'
 
-const TosUpdatedModal = translate()(({ t, newTosLink, onAccept, onRefuse }) => (
-  <Modal closable={false}>
-    <Modal.ModalHeader />
-    <Modal.ModalDescription className={styles['tosupdated']}>
-      <Icon icon={tosIcon} width={96} height={96} />
-      <h2 className={styles['tosupdated-title']}>{t('TOS.updated.title')}</h2>
-      <ReactMarkdown
-        className={styles['tosupdated-desc']}
-        source={t('TOS.updated.detail', { link: newTosLink })}
-      />
-      <Button
-        extension="full"
-        label={t('TOS.updated.cta')}
-        onClick={onAccept}
-      />
-      <Button
-        subtle
-        size="small"
-        extension="full"
-        style={{ marginTop: '1.5rem' }}
-        label={t('TOS.updated.disconnect')}
-        onClick={onRefuse}
-      />
-    </Modal.ModalDescription>
-  </Modal>
-))
+const TosUpdatedModal = translate()(({ t, newTosLink, onAccept, onRefuse }) => {
+  const updatedDetails = snarkdown(
+    t('TOS.updated.detail', { link: newTosLink })
+  )
+  return (
+    <Modal closable={false}>
+      <Modal.ModalHeader />
+      <Modal.ModalDescription className={styles['tosupdated']}>
+        <Icon icon={tosIcon} width={96} height={96} />
+        <h2 className={styles['tosupdated-title']}>{t('TOS.updated.title')}</h2>
+        <div
+          className={styles['tosupdated-desc']}
+          dangerouslySetInnerHTML={{ __html: updatedDetails }}
+        />
+        <Button
+          extension="full"
+          label={t('TOS.updated.cta')}
+          onClick={onAccept}
+        />
+        <Button
+          subtle
+          size="small"
+          extension="full"
+          style={{ marginTop: '1.5rem' }}
+          label={t('TOS.updated.disconnect')}
+          onClick={onRefuse}
+        />
+      </Modal.ModalDescription>
+    </Modal>
+  )
+})
 
 class UserActionRequired extends Component {
   static contextTypes = {

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -41,6 +41,8 @@ import FolderViewHeader from '../Folder/FolderViewHeader'
 import FolderViewBody from '../Folder/FolderViewBody'
 import FolderViewBreadcrumb from '../Folder/FolderViewBreadcrumb'
 
+import { useTrashRedirect } from './useTrashRedirect'
+
 const getBreadcrumbPath = (t, displayedFolder) =>
   uniqBy(
     [
@@ -72,6 +74,8 @@ const DriveView = ({
   children,
   displayedFolder
 }) => {
+  useTrashRedirect(displayedFolder)
+
   const [sortOrder] = useFolderSort(currentFolderId)
 
   const folderQuery = buildDriveQuery({

--- a/src/drive/web/modules/views/Drive/useTrashRedirect.jsx
+++ b/src/drive/web/modules/views/Drive/useTrashRedirect.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+import { useRouter } from 'drive/lib/RouterContext'
+import { TRASH_DIR_PATH } from 'drive/constants/config'
+export const useTrashRedirect = displayedFolder => {
+  const { router } = useRouter()
+  useEffect(
+    () => {
+      if (displayedFolder && displayedFolder.path.startsWith(TRASH_DIR_PATH)) {
+        router.push({
+          pathname: '/trash/' + displayedFolder.id
+        })
+      }
+    },
+    [router, displayedFolder]
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13544,18 +13544,6 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-markdown@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.6.0.tgz#29f6aaab5270c8ef0a5e234093a873ec3e01722b"
-  integrity sha512-TV0wQDHHPCEeKJHWXFfEAKJ8uSEsJ9LgrMERkXx05WV/3q6Ig+59KDNaTmjcoqlCpE/sH5PqqLMh4t0QWKrJ8Q==
-  dependencies:
-    mdast-add-list-metadata "1.0.1"
-    prop-types "^15.6.1"
-    remark-parse "^5.0.0"
-    unified "^6.1.5"
-    unist-util-visit "^1.3.0"
-    xtend "^4.0.1"
-
 react-markdown@^4.0.8:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
@@ -15077,6 +15065,11 @@ snarkdown@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
   integrity sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ=
+
+snarkdown@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-2.0.0.tgz#b1feb4db91b9f94a8ebbd7a50f3e99aee18b1e03"
+  integrity sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A==
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
Remove the use of react-markdown. Let's use snarkdown instead. It's much lighter. Also React-markdown adds a wrapper (p) we don't want in some case. 

https://bundlephobia.com/result?p=snarkdown@2.0.0 vs https://bundlephobia.com/result?p=react-markdown@5.0.2 