### PR TITLE
Qualification migration service

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "cozy-device-helper": "1.10.3",
     "cozy-doctypes": "1.74.7",
     "cozy-flags": "1.11.0",
+    "cozy-logger": "1.6.0",
     "cozy-pouch-link": "15.4.2",
     "cozy-realtime": "3.9.0",
     "cozy-scanner": "0.6.0",

--- a/src/drive/lib/doctypes.js
+++ b/src/drive/lib/doctypes.js
@@ -2,6 +2,7 @@ import { Contact, Group } from 'models'
 import extraDoctypes from 'drive/lib/extraDoctypes'
 
 export const DOCTYPE_FILES = 'io.cozy.files'
+export const DOCTYPE_FILES_SETTINGS = 'io.cozy.files.settings'
 export const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 export const DOCTYPE_PHOTOS_SETTINGS = 'io.cozy.photos.settings'
 export const DOCTYPE_APPS = 'io.cozy.apps'

--- a/src/drive/lib/migration/qualification.js
+++ b/src/drive/lib/migration/qualification.js
@@ -1,4 +1,4 @@
-import { models } from 'cozy-client'
+import { models, Q } from 'cozy-client'
 import log from 'cozy-logger'
 const { Qualification } = models.document
 const { saveFileQualification } = models.file
@@ -12,8 +12,7 @@ import { get, has, isEmpty, omit, sortBy } from 'lodash'
  * @param {number} limit - The maximum number of files to return
  */
 export const queryFilesFromDate = async (client, date, limit) => {
-  const query = client
-    .find('io.cozy.files')
+  const query = Q('io.cozy.files')
     .where({
       type: 'file',
       'cozyMetadata.updatedAt': { $gt: date },

--- a/src/drive/lib/migration/qualification.js
+++ b/src/drive/lib/migration/qualification.js
@@ -1,0 +1,266 @@
+import { models } from 'cozy-client'
+import log from 'cozy-logger'
+const { Qualification } = models.document
+const { saveFileQualification } = models.file
+import { get, has, isEmpty, omit, sortBy } from 'lodash'
+
+/**
+ * Query the files indexed on their updatedAt date.
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {string} date - The starting date to query
+ * @param {number} limit - The maximum number of files to return
+ */
+export const queryFilesFromDate = async (client, date, limit) => {
+  const query = client
+    .find('io.cozy.files')
+    .where({
+      type: 'file',
+      'cozyMetadata.updatedAt': { $gt: date },
+      trashed: false
+    })
+    .indexFields(['type', 'cozyMetadata.updatedAt'])
+    .limitBy(limit)
+    .sortBy([{ type: 'asc' }, { 'cozyMetadata.updatedAt': 'asc' }])
+  return client.queryAll(query)
+}
+
+/**
+ * From a list of files, find the most recent updatedAt value
+ *
+ * @param {object} files - The unsorted files
+ * @returns {string} The most recent updatedAt value
+ */
+export const getMostRecentUpdatedDate = files => {
+  const filesWithDate = files.filter(file =>
+    get(file, 'data.attributes.cozyMetadata.updatedAt')
+  )
+  const sortedFiles = sortBy(filesWithDate, [
+    'data.attributes.cozyMetadata.updatedAt'
+  ])
+  return sortedFiles.length > 0
+    ? get(
+        sortedFiles[sortedFiles.length - 1],
+        'data.attributes.cozyMetadata.updatedAt'
+      )
+    : null
+}
+
+/**
+ * Extract the old qualification attributes from a file.
+ *
+ * @param {object} file - The file to extract old attributes from
+ * @returns {object} The old qualification attributes
+ */
+const oldQualificationAttributes = file => {
+  const oldQualification = {}
+  Object.assign(
+    oldQualification,
+    has(file, 'metadata.id') ? { id: file.metadata.id } : null,
+    has(file, 'metadata.label') ? { label: file.metadata.label } : null,
+    has(file, 'metadata.classification')
+      ? { classification: file.metadata.classification }
+      : null,
+    has(file, 'metadata.subClassification')
+      ? { subClassification: file.metadata.subClassification }
+      : null,
+    has(file, 'metadata.categorie')
+      ? { categorie: file.metadata.categorie }
+      : null,
+    has(file, 'metadata.category')
+      ? { category: file.metadata.category }
+      : null,
+    has(file, 'metadata.categories')
+      ? { categories: file.metadata.categories }
+      : null,
+    has(file, 'metadata.subject') ? { subject: file.metadata.subject } : null,
+    has(file, 'metadata.subjects') ? { subjects: file.metadata.subjects } : null
+  )
+  return isEmpty(oldQualification) ? null : oldQualification
+}
+
+/**
+ * Keep only the files with old qualification attributes
+ *
+ * @param {Array} files - The files to process
+ * @returns {Array} The list of files having old qualification attributes
+ */
+export const extractFilesToMigrate = files => {
+  return files.filter(file => {
+    const oldAttributes = oldQualificationAttributes(file)
+    // This case can happen when a file was previously migrated, as we keep
+    // the id for retro-compatibility
+    if (has(oldAttributes, 'id') && !has(oldAttributes, 'label')) {
+      return false
+    }
+    return oldAttributes
+  })
+}
+
+/**
+ * We changed some labels set by cozy-scanner: this method
+ * transform them with the new one.
+ *
+ * @param {string} label - The old qualification label
+ * @returns {string} The new qualification label
+ */
+const getNewLabelSetFromCozyScanner = oldLabel => {
+  if (oldLabel === 'registration') {
+    return 'vehicle_registration'
+  }
+  if (oldLabel === 'insurance_card') {
+    return 'national_insurance_card'
+  }
+  return oldLabel
+}
+
+/**
+ * Remove the old qualification attributes from a file.
+ *
+ * @param {object} file - The file with old attributes
+ * @returns {object} The file without the old attributes
+ */
+export const removeOldQualificationAttributes = file => {
+  const oldAttributes = oldQualificationAttributes(file)
+  // keep the id for retro-compatibility: it is used by cozy-scanner to display the label
+  if (has(oldAttributes, 'id')) {
+    delete oldAttributes.id
+  }
+  if (oldAttributes) {
+    const attributesPath = Object.keys(oldAttributes).map(oldAttribute => {
+      return `metadata.${oldAttribute}`
+    })
+    return omit(file, attributesPath)
+  }
+  return file
+}
+
+/**
+ * Takes a file with an old qualification set by cozy-scanner and
+ * returns the new qualification, by the label.
+ *
+ * @param {object} file - The file qualified by cozy-scanner
+ * @returns {Qualification} The new qualification
+ */
+const getNewQualificationSetFromCozyScanner = file => {
+  const qualificationLabel = get(file, 'metadata.label')
+  const label = getNewLabelSetFromCozyScanner(qualificationLabel)
+  return Qualification.getByLabel(label)
+}
+
+/**
+ * Takes a file with an old qualification set by a konnector and
+ * returns the new qualification.
+ * The qualification is fixed by a set of rules primarily based on the
+ * contentAuthor and old attributes in certain cases.
+ *
+ * @param {object} file - The file qualified by a konnector
+ * @returns {Qualification} The new qualification
+ */
+const getNewQualificationSetFromKonnector = file => {
+  const contentAuthor = get(file, 'metadata.contentAuthor')
+  const classification = get(file, 'metadata.classification')
+  const categories = get(file, 'metadata.categories')
+
+  // See https://github.com/konnectors/cozy-konnector-digiposte/blob/master/src/index.js
+  // See https://github.com/konnectors/orangeapi/blob/master/src/index.js
+  if (contentAuthor === 'orange') {
+    if (classification === 'invoicing') {
+      if (categories && categories.length > 0) {
+        if (categories[0] === 'phone') {
+          return Qualification.getByLabel('phone_invoice')
+        } else if (categories[0] === 'isp') {
+          return Qualification.getByLabel('telecom_invoice') // it might be both isp and phone
+        }
+      }
+    } else if (classification === 'payslip') {
+      return Qualification.getByLabel('pay_sheet')
+    }
+  }
+  // See https://github.com/konnectors/cozy-konnector-sncf/blob/master/src/index.js
+  else if (contentAuthor === 'sncf') {
+    return Qualification.getByLabel('transport_invoice')
+  }
+
+  // See https://github.com/konnectors/cozy-konnector-bouyguestelecom/blob/src/index.js
+  // See https://github.com/konnectors/cozy-konnector-bouyguesbox/blob/src/index.js
+  else if (contentAuthor === 'bouygues') {
+    return Qualification.getByLabel('telecom_invoice')
+  }
+
+  // See https://github.com/konnectors/cozy-konnector-free-mobile/blob/master/src/index.js
+  // See https://github.com/konnectors/cozy-konnector-free/blob/master/src/index.js
+  if (contentAuthor === 'free') {
+    if (categories && categories.length > 0) {
+      if (categories[0] === 'isp') {
+        return Qualification.getByLabel('isp_invoice')
+      } else if (categories[0] === 'phone') {
+        return Qualification.getByLabel('phone_invoice')
+      }
+    }
+  }
+
+  // See https://github.com/konnectors/edf/blob/master/src/index.js
+  if (contentAuthor === 'edf') {
+    return Qualification.getByLabel('energy_invoice')
+  }
+
+  // https://github.com/konnectors/cozy-konnector-ameli/blob/master/src/index.js
+  if (contentAuthor === 'ameli') {
+    return Qualification.getByLabel('health_invoice')
+  }
+
+  // https://github.com/konnectors/impots/blob/master/src/metadata.js
+  if (contentAuthor === 'impots.gouv') {
+    if (classification === 'tax_notice') {
+      return Qualification.getByLabel('tax_notice')
+    } else if (classification === 'tax_return') {
+      return Qualification.getByLabel('tax_return')
+    } else if (classification === 'tax_timetable') {
+      return Qualification.getByLabel('tax_timetable')
+    }
+  }
+  return null
+}
+
+/**
+ * Get the new qualification from a file with old qualification attributes.
+ *
+ * @param {object} file - The file to requalify
+ * @returns {object} The new qualification
+ */
+export const getFileRequalification = file => {
+  try {
+    const hasQualificationLabel = has(file, 'metadata.label')
+    // cozy-scanner stores the qualification label but konnectors don't
+    return hasQualificationLabel
+      ? getNewQualificationSetFromCozyScanner(file)
+      : getNewQualificationSetFromKonnector(file)
+  } catch (e) {
+    log('error', `The file cannot be migrated. ${e}`)
+    return null
+  }
+}
+
+/**
+ * Migrate files by removing old qualification attributes and
+ * setting the new qualification.
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {Array} files - The files to migrate
+ * @returns {Array} The saved files
+ */
+export const migrateQualifiedFiles = async (client, files) => {
+  return Promise.all(
+    files.map(async file => {
+      const newQualification = getFileRequalification(file)
+      if (newQualification) {
+        const cleanedFile = removeOldQualificationAttributes(file)
+        return saveFileQualification(client, cleanedFile, newQualification)
+      } else {
+        log('warn', 'No migration case found for this file')
+        return null
+      }
+    })
+  )
+}

--- a/src/drive/lib/migration/qualification.spec.js
+++ b/src/drive/lib/migration/qualification.spec.js
@@ -1,0 +1,182 @@
+import {
+  extractFilesToMigrate,
+  getFileRequalification,
+  removeOldQualificationAttributes,
+  getMostRecentUpdatedDate
+} from 'drive/lib/migration/qualification'
+import log from 'cozy-logger'
+
+jest.mock('cozy-logger', () => jest.fn())
+
+describe('qualification migration', () => {
+  it('should extract files to migrate based on qualification attributes', () => {
+    const fileNoQualif = {
+      metadata: {
+        datetime: '2020-01-01'
+      }
+    }
+    const fileFullQualif = {
+      metadata: {
+        id: '1',
+        label: 'dummy',
+        classification: 'dummy',
+        subClassification: 'dummy',
+        categorie: 'dummy',
+        category: 'dummy',
+        categories: ['dummies'],
+        subject: 'dummy',
+        subjects: ['dummy']
+      }
+    }
+    const files = [fileNoQualif, fileFullQualif]
+
+    const filesToMigrate = extractFilesToMigrate(files)
+    expect(filesToMigrate).toHaveLength(1)
+    expect(filesToMigrate[0]).toEqual(fileFullQualif)
+  })
+
+  it('should not extract files with id but not label attributes', () => {
+    const file = {
+      metadata: {
+        id: '1',
+        qualification: {}
+      }
+    }
+    expect(extractFilesToMigrate([file])).toHaveLength(0)
+  })
+
+  it('should get the new qualification for a file qualified by cozy-scanner', () => {
+    const file = {
+      metadata: {
+        id: '22',
+        classification: 'invoicing',
+        categorie: 'health',
+        label: 'health_invoice'
+      }
+    }
+    const qualif = getFileRequalification(file)
+    expect(qualif).toEqual({
+      label: 'health_invoice',
+      purpose: 'invoice',
+      sourceCategory: 'health'
+    })
+  })
+
+  it('should get the new qualification for a file qualified by a konnector', () => {
+    const file = {
+      metadata: {
+        contentAuthor: 'ameli',
+        classification: 'invoicing',
+        categorie: 'health',
+        label: 'health_invoice'
+      }
+    }
+    const qualif = getFileRequalification(file)
+    expect(qualif).toEqual({
+      label: 'health_invoice',
+      purpose: 'invoice',
+      sourceCategory: 'health'
+    })
+  })
+
+  it('should log an error null when no qualification is possible', () => {
+    const file = {
+      metadata: {
+        label: 'fake_label'
+      }
+    }
+    expect(getFileRequalification(file)).toBeNull()
+    expect(log).toHaveBeenCalledWith('error', expect.anything())
+  })
+
+  it('should remove old qualification attributes', () => {
+    const file = {
+      metadata: {
+        id: 1,
+        label: 'label',
+        classification: 'classification',
+        subClassification: 'subClassification',
+        categorie: 'categorie',
+        category: 'category',
+        categories: 'categories',
+        subject: 'subject',
+        subjects: 'subjects',
+        datetime: '2020-10-10'
+      }
+    }
+    expect(removeOldQualificationAttributes(file)).toEqual({
+      metadata: {
+        id: 1,
+        datetime: '2020-10-10'
+      }
+    })
+
+    file.metadata = {}
+    expect(removeOldQualificationAttributes(file)).toEqual(file)
+  })
+
+  it('should find the most recent date in a list of files', () => {
+    let files = []
+    expect(getMostRecentUpdatedDate(files)).toBeNull()
+
+    files = [{}, {}]
+    expect(getMostRecentUpdatedDate(files)).toBeNull()
+
+    files = [
+      {},
+      {
+        _id: '456',
+        data: {
+          attributes: {
+            cozyMetadata: {
+              updatedAt: '2020-01-01'
+            }
+          }
+        }
+      }
+    ]
+    expect(getMostRecentUpdatedDate(files)).toEqual('2020-01-01')
+
+    files = [
+      {},
+      {},
+      {
+        _id: '123',
+        data: {
+          attributes: {
+            cozyMetadata: {
+              updatedAt: '2020-01-01'
+            }
+          }
+        }
+      }
+    ]
+    expect(getMostRecentUpdatedDate(files)).toEqual('2020-01-01')
+
+    files = [
+      {
+        _id: '123',
+        data: {
+          attributes: {
+            cozyMetadata: {
+              updatedAt: '2020-01-02'
+            }
+          }
+        }
+      },
+      {},
+      {},
+      {
+        _id: '456',
+        data: {
+          attributes: {
+            cozyMetadata: {
+              updatedAt: '2020-01-01'
+            }
+          }
+        }
+      }
+    ]
+    expect(getMostRecentUpdatedDate(files)).toEqual('2020-01-02')
+  })
+})

--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -91,6 +91,14 @@
       "href": "/intents"
     }
   ],
+  "services": {
+    "qualificationMigration": {
+      "type": "node",
+      "file": "services/qualificationMigration/drive.js",
+      "trigger": "@event io.cozy.files:CREATED,UPDATED",
+      "debounce": "24h"
+    }
+  },
   "permissions": {
     "files": {
       "description": "Required to access the files",

--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -94,12 +94,8 @@
   "permissions": {
     "files": {
       "description": "Required to access the files",
-      "type": "io.cozy.files",
+      "type": "io.cozy.files.*",
       "verbs": ["ALL"]
-    },
-    "filesversions": {
-      "type": "io.cozy.files.versions",
-      "vebrs": ["ALL"]
     },
     "apps": {
       "description": "Required by the cozy-bar to display the icons of the apps",

--- a/src/drive/targets/services/qualificationMigration.js
+++ b/src/drive/targets/services/qualificationMigration.js
@@ -1,5 +1,5 @@
 import log from 'cozy-logger'
-import CozyClient from 'cozy-client'
+import CozyClient, { Q } from 'cozy-client'
 import { schema, DOCTYPE_FILES_SETTINGS } from 'drive/lib/doctypes'
 import {
   migrateQualifiedFiles,
@@ -23,9 +23,7 @@ export const migrateQualifications = async () => {
   const client = CozyClient.fromEnv(process.env, { schema })
 
   // Get last processed file date from the settings
-  const filesSettings = await client.query(
-    client.find(DOCTYPE_FILES_SETTINGS).limitBy(1)
-  )
+  const filesSettings = await client.query(Q(DOCTYPE_FILES_SETTINGS).limitBy(1))
   const settings =
     filesSettings && filesSettings.data.length > 0
       ? filesSettings.data[0]

--- a/src/drive/targets/services/qualificationMigration.js
+++ b/src/drive/targets/services/qualificationMigration.js
@@ -1,0 +1,77 @@
+import log from 'cozy-logger'
+import CozyClient from 'cozy-client'
+import { schema, DOCTYPE_FILES_SETTINGS } from 'drive/lib/doctypes'
+import {
+  migrateQualifiedFiles,
+  extractFilesToMigrate,
+  queryFilesFromDate,
+  getMostRecentUpdatedDate
+} from 'drive/lib/migration/qualification'
+
+const BATCH_FILES_LIMIT = 1000 // to avoid processing too many files and get timeouts
+
+/**
+ * This services migrates files qualified with the old model.
+ * The up-to-date qualification model is now saved [here](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/assets/qualifications.json)
+ * This service queries files starting from the date saved in the settings
+ * and evaluate for each f ile if some old qualification attributes exist
+ * to migrate to the new qualification model.
+ * Note we restrict the max file processing to BATCH_FILES_LIMIT to avoid
+ * service time-out.
+ */
+export const migrateQualifications = async () => {
+  const client = CozyClient.fromEnv(process.env, { schema })
+
+  // Get last processed file date from the settings
+  const filesSettings = await client.query(
+    client.find(DOCTYPE_FILES_SETTINGS).limitBy(1)
+  )
+  const settings =
+    filesSettings && filesSettings.data.length > 0
+      ? filesSettings.data[0]
+      : null
+  let lastProcessedFileDate = null
+  if (settings) {
+    lastProcessedFileDate = settings.lastProcessedFileDate
+  }
+  // Get a batch of sorted files starting from the date
+  const filesByDate = await queryFilesFromDate(
+    client,
+    lastProcessedFileDate,
+    BATCH_FILES_LIMIT
+  )
+  if (filesByDate.length < 1) {
+    log('warn', 'No new file to process')
+    return
+  }
+  lastProcessedFileDate =
+    filesByDate[filesByDate.length - 1].cozyMetadata.updatedAt
+
+  // Filter the files with old qualification attributes
+  const filesToMigrate = extractFilesToMigrate(filesByDate)
+
+  if (filesToMigrate.length < 1) {
+    log('info', 'No file found with old qualification')
+  } else {
+    const migratedFiles = await migrateQualifiedFiles(client, filesToMigrate)
+    log(
+      'info',
+      `Migrated ${migratedFiles.length} files with old qualifications`
+    )
+    lastProcessedFileDate =
+      getMostRecentUpdatedDate(migratedFiles) || lastProcessedFileDate
+  }
+
+  // Save the last processed file date in the settings
+  log('info', `Save last processed file date: ${lastProcessedFileDate}`)
+  if (settings) {
+    await client.save({ ...settings, lastProcessedFileDate })
+  } else {
+    await client.create(DOCTYPE_FILES_SETTINGS, { lastProcessedFileDate })
+  }
+}
+
+migrateQualifications().catch(e => {
+  log('critical', e)
+  process.exit(1)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -17264,10 +17264,15 @@ whatwg-fetch@3.0.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.1:
+whatwg-fetch@>=0.10.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
   integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
+
+whatwg-fetch@^3.4.1:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
+  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
We used to qualify files by manually setting specific attributes in the metadata, either in some konnectors, either through cozy-scanner.
We recently introduced a new API [here](https://github.com/cozy/cozy-client/pull/820) by using a qualification model that enforce new qualification rules.
This service migrates files qualified in the old way with the new qualification model.

Keep in my mind that:
* This PR needs this [fix](https://github.com/cozy/cozy-stack/pull/2743) for the permissions
* Eventually we want cozy-scanner and konnectors to use the new qualification API
* Some developer documentation should be added