### PR TITLE
Few fixs

### DIFF
--- a/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
+++ b/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
@@ -15,10 +15,15 @@ import styles from 'drive/styles/actionmenu.styl'
 
 import { getBoundT } from 'cozy-scanner'
 
-export const ActionMenuWithHeader = ({ file, actions, onClose }) => {
+export const ActionMenuWithHeader = ({
+  file,
+  actions,
+  onClose,
+  anchorElRef
+}) => {
   const { lang } = useI18n()
   return (
-    <ActionMenu onClose={onClose} autoclose={true}>
+    <ActionMenu onClose={onClose} anchorElRef={anchorElRef}>
       <ActionMenuHeader>
         <MenuHeaderFile file={file} lang={lang} />
       </ActionMenuHeader>

--- a/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
+++ b/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
@@ -23,7 +23,7 @@ export const ActionMenuWithHeader = ({
 }) => {
   const { lang } = useI18n()
   return (
-    <ActionMenu onClose={onClose} anchorElRef={anchorElRef}>
+    <ActionMenu onClose={onClose} anchorElRef={anchorElRef} autoclose={true}>
       <ActionMenuHeader>
         <MenuHeaderFile file={file} lang={lang} />
       </ActionMenuHeader>

--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -47,11 +47,18 @@ const MoreMenu = ({
     },
     [setMenuVisible]
   )
+  const toggleMenu = useCallback(
+    () => {
+      if (menuIsVisible) return closeMenu()
+      openMenu()
+    },
+    [closeMenu, openMenu, menuIsVisible]
+  )
 
   return (
     <div>
       <div ref={anchorRef}>
-        <MoreButton onClick={openMenu} disabled={isDisabled} />
+        <MoreButton onClick={toggleMenu} disabled={isDisabled} />
       </div>
       <ScanWrapper>
         {menuIsVisible && (

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -270,6 +270,10 @@ const File = props => {
   const [actionMenuVisible, setActionMenuVisible] = useState(false)
   const filerowMenuToggleRef = useRef()
 
+  const toggleActionMenu = () => {
+    if (actionMenuVisible) return hideActionMenu()
+    else showActionMenu()
+  }
   const showActionMenu = () => {
     if (window.StatusBar && isIOSApp()) {
       window.StatusBar.backgroundColorByHexString('#989AA0')
@@ -375,9 +379,8 @@ const File = props => {
         <FileAction
           t={t}
           ref={filerowMenuToggleRef}
-          onClick={e => {
-            showActionMenu()
-            e.stopPropagation()
+          onClick={() => {
+            toggleActionMenu()
           }}
         />
       )}
@@ -385,7 +388,7 @@ const File = props => {
         actionMenuVisible && (
           <ActionMenuWithHeader
             file={attributes}
-            reference={filerowMenuToggleRef.current}
+            anchorElRef={filerowMenuToggleRef}
             actions={actions}
             onClose={hideActionMenu}
           />

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -162,11 +162,13 @@ const DriveView = ({
   return (
     <FolderView>
       <FolderViewHeader>
-        <FolderViewBreadcrumb
-          getBreadcrumbPath={geTranslatedBreadcrumbPath}
-          currentFolderId={currentFolderId}
-          navigateToFolder={navigateToFolder}
-        />
+        {currentFolderId && (
+          <FolderViewBreadcrumb
+            getBreadcrumbPath={geTranslatedBreadcrumbPath}
+            currentFolderId={currentFolderId}
+            navigateToFolder={navigateToFolder}
+          />
+        )}
         <Toolbar
           canUpload={true}
           canCreateFolder={true}

--- a/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
+++ b/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
@@ -122,11 +122,13 @@ const SharingsFolderView = ({
   return (
     <FolderView>
       <FolderViewHeader>
-        <FolderViewBreadcrumb
-          getBreadcrumbPath={geTranslatedBreadcrumbPath}
-          currentFolderId={currentFolderId}
-          navigateToFolder={navigateToFolder}
-        />
+        {currentFolderId && (
+          <FolderViewBreadcrumb
+            getBreadcrumbPath={geTranslatedBreadcrumbPath}
+            currentFolderId={currentFolderId}
+            navigateToFolder={navigateToFolder}
+          />
+        )}
         <Toolbar canUpload={hasWriteAccess} canCreateFolder={hasWriteAccess} />
       </FolderViewHeader>
       <FolderViewBody

--- a/src/drive/web/modules/views/Trash/TrashFolderView.jsx
+++ b/src/drive/web/modules/views/Trash/TrashFolderView.jsx
@@ -107,11 +107,13 @@ const TrashFolderView = ({ currentFolderId, router, children }) => {
   return (
     <FolderView>
       <FolderViewHeader>
-        <FolderViewBreadcrumb
-          getBreadcrumbPath={geTranslatedBreadcrumbPath}
-          currentFolderId={currentFolderId}
-          navigateToFolder={navigateToFolder}
-        />
+        {currentFolderId && (
+          <FolderViewBreadcrumb
+            getBreadcrumbPath={geTranslatedBreadcrumbPath}
+            currentFolderId={currentFolderId}
+            navigateToFolder={navigateToFolder}
+          />
+        )}
         <TrashToolbar />
       </FolderViewHeader>
       {needsToWait && <FileListRowsPlaceholder />}


### PR DESCRIPTION
- Can close the ActionMenu by clicking on the Dots again (needs an upgrade of UI but UI have issues ATM to be published, it's ok to merge it without since anchorEl gives a better placement of the menu) 
- check if currentFolderID is setted before displaying the FolderBreadcrumb 
- autoclose on Menu 