### PR TITLE
fix: Perm issue

### DIFF
--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -102,6 +102,11 @@
   "permissions": {
     "files": {
       "description": "Required to access the files",
+      "type": "io.cozy.files",
+      "verbs": ["ALL"]
+    },
+    "allFiles": {
+      "description": "Required to access the files",
       "type": "io.cozy.files.*",
       "verbs": ["ALL"]
     },


### PR DESCRIPTION
Wildcard on io.cozy.files has been fixed recently, but
we still have issue when requesting /sharing/doctype routes

So let's add the both option, and remove the first one
when the stack is fixed


see https://trello.com/c/B7zOlZJx/876-stack-wildcard-iocozyfiles-et-sharings-doctype-iocozyfiles