### PR TITLE
fix: Add Position fixed to the ActionMenu on the file list

### DIFF
--- a/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
+++ b/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
@@ -23,7 +23,14 @@ export const ActionMenuWithHeader = ({
 }) => {
   const { lang } = useI18n()
   return (
-    <ActionMenu onClose={onClose} anchorElRef={anchorElRef} autoclose={true}>
+    <ActionMenu
+      onClose={onClose}
+      anchorElRef={anchorElRef}
+      autoclose={true}
+      popperOptions={{
+        strategy: 'fixed'
+      }}
+    >
       <ActionMenuHeader>
         <MenuHeaderFile file={file} lang={lang} />
       </ActionMenuHeader>


### PR DESCRIPTION
Since we can have folder with only a few files, the
filelist can be pretty small in height. Resulting not
having enought space to display the ActionMenu.

In order to not depend on the FileList height, we
tell the ActionMenu to be displayed in a Fixed Position