### PR TITLE
fix: Regression with isomorphic fetch in cozy-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "lodash": "4.17.19",
     "log-prefix": "0.1.1",
     "mime-types": "2.1.24",
+    "node-fetch": "2.6.1",
     "node-polyglot": "2.4.0",
     "node-uuid": "1.4.8",
     "piwik-react-router": "0.8.2",

--- a/src/drive/targets/services/qualificationMigration.js
+++ b/src/drive/targets/services/qualificationMigration.js
@@ -10,6 +10,9 @@ import {
 
 const BATCH_FILES_LIMIT = 1000 // to avoid processing too many files and get timeouts
 
+// fixes an import problem of isomorphic fetch in cozy-client
+global.fetch = require('node-fetch').default
+
 /**
  * This services migrates files qualified with the old model.
  * The up-to-date qualification model is now saved [here](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/assets/qualifications.json)
@@ -20,6 +23,8 @@ const BATCH_FILES_LIMIT = 1000 // to avoid processing too many files and get tim
  * service time-out.
  */
 export const migrateQualifications = async () => {
+  log('info', `Start qualification migration`)
+
   const client = CozyClient.fromEnv(process.env, { schema })
 
   // Get last processed file date from the settings


### PR DESCRIPTION
This is related to https://github.com/konnectors/libs/pull/724