### PR TITLE
Fix sharing avatars in mobile action menu

### DIFF
--- a/src/drive/styles/actionmenu.styl
+++ b/src/drive/styles/actionmenu.styl
@@ -16,11 +16,11 @@
     .fil-actionmenu-recipients
         display none
 
-.fil-actionmenu-inner
-    .fil-action:hover
-        background-color var(--paleGrey)
-    .fil-action:active
-        background-color var(--silver)
+    .fil-action
+        &:hover
+            background-color var(--paleGrey)
+        &:active
+            background-color var(--silver)
 
 .fil-actionmenu-overlay
   opacity 0
@@ -34,7 +34,7 @@
 .fil-mobileactionmenu-header
     font-weight bold
     max-width 100%
-    display flex 
+    display flex
 
 .fil-mobileactionmenu-file-name
     overflow hidden
@@ -44,12 +44,12 @@
 
 .fil-mobileactionmenu-file-ext
     color var(--coolGrey)
+
 .fil-mobileactionmenu-category
     padding-left rem(4)
     line-height rem(18)
 
-
 .fil-actionmenu-recipients
     position absolute
     right    1rem
-    top      .1rem
+    top      .2rem

--- a/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
+++ b/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
@@ -45,7 +45,7 @@ const MenuHeaderFile = ({ file, lang }) => {
   const scannerT = getBoundT(lang)
   return (
     <div>
-      <div className={'u-p-1 u-flex u-flex-items-center'}>
+      <div className={'u-flex u-flex-items-center'}>
         <Icon
           icon={getMimeTypeIcon(isDirectory(file), file.name, file.mime)}
           size={32}

--- a/src/drive/web/modules/actionmenu/ActionsItems.jsx
+++ b/src/drive/web/modules/actionmenu/ActionsItems.jsx
@@ -6,6 +6,7 @@ import styles from 'drive/styles/actionmenu.styl'
 export const getActionName = actionObject => {
   return Object.keys(actionObject)[0]
 }
+
 // We need to clean Actions since action has a displayable
 // conditions and we can't know from the begining what the
 // behavior will be. For instance, we can't know that
@@ -39,6 +40,7 @@ export const getOnlyNeededActions = (actions, file) => {
   }
   return cleanedActions
 }
+
 /**
  *
  * ActionsItems only shows `actions` that are  suitable for the given
@@ -64,12 +66,16 @@ export const ActionsItems = ({ actions, file, onClose }) => {
         }
       : null
     return (
-      <Component
+      <div
+        className={cx(
+          'u-pos-relative',
+          styles['fil-action'],
+          styles[`fil-action-${actionName}`]
+        )}
         key={actionName + i}
-        className={cx(styles['fil-action'], styles[`fil-action-${actionName}`])}
-        onClick={onClick}
-        files={[file]}
-      />
+      >
+        <Component onClick={onClick} files={[file]} />
+      </div>
     )
   })
 }


### PR DESCRIPTION
Fix padding in header + sharing avatar position (avatar size is little bit different because of https://github.com/cozy/cozy-libs/pull/1159 not merged on "before" branch)

**Before**
![Capture d’écran 2020-11-19 à 11 48 12](https://user-images.githubusercontent.com/67680939/99656501-40a7dc80-2a5d-11eb-9e4e-438fb23844cc.png)

**After**
![Capture d’écran 2020-11-19 à 11 48 02](https://user-images.githubusercontent.com/67680939/99656521-46052700-2a5d-11eb-9ca6-f477b178ec6f.png)
