### PR TITLE
Add spinner for folder/file still in sync

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -13,6 +13,7 @@
 
 .fil-content-cell
     @extend $table-cell
+    display flex
 
 .fil-content-row-head
     @extend $table-row-head
@@ -146,10 +147,13 @@ column-width-thumbnail-bigger = 7rem
     flex 0 0 "calc(%s - %s)" % (column-width-large column-width-thumbnail-bigger)
 
 .fil-file-thumbnail
-  position relative
-  flex 0 0 column-width-thumbnail - 1rem //width without padding
-  svg
-    display block
+    position relative
+    flex 0 0 column-width-thumbnail - 1rem //width without padding
+    svg
+        display block
+
+    &--spinner
+        margin 0 .25rem !important // to override default cozy-ui margin
 
 .fil-file-thumbnail-image
   object-fit cover

--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -23,7 +23,7 @@
         .fil-content-file-select
             opacity 1
         .fil-content-sharestatus
-            span > div:first-child
+            span > div:first-child // targets sharing avatars
                 border-color var(--paleGrey)
     &--center
         justify-content center
@@ -123,32 +123,34 @@ column-width-thumbnail-bigger = 7rem
     background-repeat no-repeat
     background-size rem(32) rem(32)
 
+    &-openable
+        cursor pointer
+
 .fil-content-header.fil-content-file
     padding-left 0
 
-.fil-content-cell.fil-content-file
-    flex 0 0 "calc(%s - %s)" % (column-width-large column-width-thumbnail)
-    display flex
-    align-items center
-    padding   0 2rem 0 0
-    font-size      1rem
-    line-height    1.3
-    white-space    nowrap
-    overflow       hidden
-    color var(--charcoalGrey)
-    height 100%
+.fil-content-cell
+    &.fil-content-file
+        flex 0 0 "calc(%s - %s)" % (column-width-large column-width-thumbnail)
+        display flex
+        align-items center
+        padding   0 2rem 0 0
+        font-size      1rem
+        line-height    1.3
+        white-space    nowrap
+        overflow       hidden
+        color var(--charcoalGrey)
+        height 100%
 
 .fil-content-row-bigger .fil-content-cell.fil-content-file
     flex 0 0 "calc(%s - %s)" % (column-width-large column-width-thumbnail-bigger)
-
-.fil-content-file-openable
-    cursor pointer
 
 .fil-file-thumbnail
   position relative
   flex 0 0 column-width-thumbnail - 1rem //width without padding
   svg
     display block
+
 .fil-file-thumbnail-image
   object-fit cover
 
@@ -313,6 +315,9 @@ column-width-thumbnail-bigger = 7rem
 
 .fil-content-sharestatus
     cursor pointer
+    &--disabled
+        cursor default
+
 +medium-screen()
     .fil-content-table-selection
         .fil-content-body
@@ -387,6 +392,11 @@ column-width-thumbnail-bigger = 7rem
 
 .fil-content-file-action
     opacity 1
+    &--disabled
+        opacity .4
+        button
+            cursor default
+
 .fil-content-row-actioned
     .fil-content-file-action
         button

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -170,7 +170,7 @@ const FileName = ({
   )
 }
 
-const _LastUpdate = ({ date, formatted = '-' }) => (
+const _LastUpdate = ({ date, formatted = '—' }) => (
   <div
     className={classNames(
       styles['fil-content-cell'],
@@ -182,7 +182,7 @@ const _LastUpdate = ({ date, formatted = '-' }) => (
 )
 
 const LastUpdate = React.memo(_LastUpdate)
-const _Size = ({ filesize = '-' }) => (
+const _Size = ({ filesize = '—' }) => (
   <div
     className={classNames(
       styles['fil-content-cell'],

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -315,6 +315,7 @@ const File = props => {
     withFilePath,
     isAvailableOffline,
     disabled,
+    styleDisabled,
     thumbnailSizeBig,
     selectionModeActive,
     refreshFolderContent,
@@ -327,7 +328,7 @@ const File = props => {
   const filContentRowSelected = classNames(styles['fil-content-row'], {
     [styles['fil-content-row-selected']]: selected,
     [styles['fil-content-row-actioned']]: actionMenuVisible,
-    [styles['fil-content-row-disabled']]: disabled,
+    [styles['fil-content-row-disabled']]: styleDisabled,
     [styles['fil-content-row-bigger']]: isLargeRow
   })
   const formattedSize = isDirectory(attributes)
@@ -407,7 +408,10 @@ File.propTypes = {
   withSelectionCheckbox: PropTypes.bool.isRequired,
   withFilePath: PropTypes.bool,
   isAvailableOffline: PropTypes.bool.isRequired,
+  /** Disables row actions */
   disabled: PropTypes.bool,
+  /** Apply disabled style on row */
+  styleDisabled: PropTypes.bool,
   breakpoints: PropTypes.object.isRequired,
   selectionModeActive: PropTypes.bool.isRequired,
   /** When a user click on a Folder */

--- a/src/drive/web/modules/filelist/File.spec.jsx
+++ b/src/drive/web/modules/filelist/File.spec.jsx
@@ -4,7 +4,47 @@ jest.mock('cozy-ui/transpiled/react/utils/color', () => ({
   getCssVariableValue: () => '#fff'
 }))
 
-import { getParentLink } from './File'
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import { createMockClient } from 'cozy-client'
+
+import AppLike from 'test/components/AppLike'
+import { DumbFile, getParentLink } from './File'
+import { folder, actionsMenu } from 'test/data'
+
+const client = createMockClient({})
+
+const setup = ({
+  attributes = folder,
+  actions = actionsMenu,
+  selected = false,
+  withSelectionCheckbox = true,
+  isAvailableOffline = false,
+  selectionModeActive = false,
+  onFolderOpen = jest.fn(),
+  onFileOpen = jest.fn(),
+  onCheckboxToggle = jest.fn(),
+  isInSyncFromSharing = false
+} = {}) => {
+  const root = render(
+    <AppLike client={client}>
+      <DumbFile
+        attributes={attributes}
+        actions={actions}
+        selected={selected}
+        withSelectionCheckbox={withSelectionCheckbox}
+        isAvailableOffline={isAvailableOffline}
+        selectionModeActive={selectionModeActive}
+        onFolderOpen={onFolderOpen}
+        onFileOpen={onFileOpen}
+        onCheckboxToggle={onCheckboxToggle}
+        isInSyncFromSharing={isInSyncFromSharing}
+      />
+    </AppLike>
+  )
+  return { root }
+}
 
 describe('getParentLink function', () => {
   it('should return the first link in the element ancestors', () => {
@@ -26,5 +66,62 @@ describe('getParentLink function', () => {
     div.appendChild(span)
     const result = getParentLink(span)
     expect(result).toBeNull()
+  })
+})
+
+describe('File', () => {
+  describe('default behavior', () => {
+    it('should show a select box', () => {
+      const { root } = setup()
+      const { getByRole } = root
+
+      expect(getByRole('checkbox'))
+    })
+
+    it('should not show spinner', () => {
+      const { root } = setup()
+      const { queryByTestId } = root
+
+      expect(queryByTestId('fil-file-thumbnail--spinner')).toBeNull()
+    })
+
+    it('should show actions menu when clicking the actionsMenu button', async () => {
+      const { root } = setup()
+      const { getByRole, findByText } = root
+
+      fireEvent.click(getByRole('button', { name: 'More' }))
+      expect(await findByText('ActionsMenuItem'))
+    })
+  })
+
+  describe('In sync from sharing behavior', () => {
+    it('should show spinner', () => {
+      const { root } = setup({ isInSyncFromSharing: true })
+      const { getByTestId } = root
+
+      expect(getByTestId('fil-file-thumbnail--spinner'))
+    })
+
+    it('should not show actions menu when clicking the actionsMenu button', () => {
+      const { root } = setup({ isInSyncFromSharing: true })
+      const { getByRole, queryByText } = root
+
+      fireEvent.click(getByRole('button', { name: 'More' }))
+      expect(queryByText('ActionsMenuItem')).toBeNull()
+    })
+
+    it('should not show a select box', () => {
+      const { root } = setup({ isInSyncFromSharing: true })
+      const { queryByRole } = root
+
+      expect(queryByRole('checkbox')).toBeNull()
+    })
+
+    it('should not have clickable sharing avatars', () => {
+      const { root } = setup({ isInSyncFromSharing: true })
+      const { getByTestId } = root
+
+      expect(getByTestId('fil-content-sharestatus--noAvatar'))
+    })
   })
 })

--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -1,21 +1,27 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+
 import { models } from 'cozy-client'
 import { SharedBadge, SharingOwnerAvatar } from 'cozy-sharing'
 import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
 import GhostFileBadge from 'cozy-ui/transpiled/react/GhostFileBadge'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
 import FileIcon from 'drive/web/modules/filelist/FileIcon'
 import SharingShortcutBadge from 'drive/web/modules/filelist/SharingShortcutBadge'
 import styles from 'drive/styles/filelist.styl'
 
-const FileThumbnail = ({ file, size }) => {
+const FileThumbnail = ({ file, size, isInSyncFromSharing }) => {
   const { isMobile } = useBreakpoints()
-  const isSharingShorcut = models.file.isSharingShorcut(file)
-  const isRegularShortcut = !isSharingShorcut && file.class === 'shortcut'
-  const isSimpleFile = !isSharingShorcut && !isRegularShortcut
+  const isSharingShorcut =
+    models.file.isSharingShorcut(file) && !isInSyncFromSharing
+  const isRegularShortcut =
+    !isSharingShorcut && file.class === 'shortcut' && !isInSyncFromSharing
+  const isSimpleFile =
+    !isSharingShorcut && !isRegularShortcut && !isInSyncFromSharing
 
   return (
     <div
@@ -36,6 +42,14 @@ const FileThumbnail = ({ file, size }) => {
           <SharingOwnerAvatar docId={file.id} size={'small'} />
         </GhostFileBadge>
       )}
+      {isInSyncFromSharing && (
+        <span data-testid="fil-file-thumbnail--spinner">
+          <Spinner
+            size="large"
+            className={styles['fil-file-thumbnail--spinner']}
+          />
+        </span>
+      )}
       {/**
        * @todo
        * Since for shortcut we already display a kind of badge we're currently just
@@ -44,7 +58,8 @@ const FileThumbnail = ({ file, size }) => {
        * this badge from here. In the meantime, we take this workaround
        */}
       {file.class !== 'shortcut' &&
-        isMobile && (
+        isMobile &&
+        !isInSyncFromSharing && (
           <SharedBadge
             docId={file.id}
             className={styles['fil-content-shared']}

--- a/src/drive/web/modules/move/FileList.jsx
+++ b/src/drive/web/modules/move/FileList.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { DumbFile as File } from 'drive/web/modules/filelist/File'
 
-const isValidMoveTarget = (subjects, target) => {
+const isInvalidMoveTarget = (subjects, target) => {
   const isASubject = subjects.find(subject => subject._id === target._id)
   const isAFile = target.type === 'file'
 
@@ -14,7 +14,8 @@ const FileList = ({ targets, files, navigateTo }) => (
     {files.map(file => (
       <File
         key={file.id}
-        disabled={isValidMoveTarget(targets, file)}
+        disabled={isInvalidMoveTarget(targets, file)}
+        styleDisabled={isInvalidMoveTarget(targets, file)}
         attributes={file}
         displayedFolder={null}
         actions={null}

--- a/test/data.js
+++ b/test/data.js
@@ -1,0 +1,128 @@
+export const folder = {
+  id: 'cc0a6981d593205dcefe29dcb2021b80',
+  _id: 'cc0a6981d593205dcefe29dcb2021b80',
+  _type: 'io.cozy.files',
+  type: 'directory',
+  attributes: {
+    type: 'directory',
+    name: 'Folder Name',
+    dir_id: 'io.cozy.files.root-dir',
+    created_at: '2020-11-03T12:31:43.027718+01:00',
+    updated_at: '2020-11-03T12:31:43.027718+01:00',
+    tags: [],
+    path: '/Folder Name',
+    cozyMetadata: {
+      doctypeVersion: '1',
+      metadataVersion: 1,
+      createdAt: '2020-11-03T12:31:43.028779+01:00',
+      createdByApp: 'drive',
+      updatedAt: '2020-11-03T12:31:43.028779+01:00',
+      updatedByApps: [
+        {
+          slug: 'drive',
+          date: '2020-11-03T12:31:43.028779+01:00',
+          instance: 'http://cozy.tools:8080/'
+        }
+      ],
+      createdOn: 'http://cozy.tools:8080/'
+    }
+  },
+  meta: {
+    rev: '1-99e787c29e88dc5a8a2a7aafc4f682ed'
+  },
+  links: {
+    self: '/files/cc0a6981d593205dcefe29dcb2021b80'
+  },
+  name: 'Folder Name',
+  dir_id: 'io.cozy.files.root-dir',
+  created_at: '2020-11-03T12:31:43.027718+01:00',
+  updated_at: '2020-11-03T12:31:43.027718+01:00',
+  tags: [],
+  path: '/Folder Name',
+  cozyMetadata: {
+    doctypeVersion: '1',
+    metadataVersion: 1,
+    createdAt: '2020-11-03T12:31:43.028779+01:00',
+    createdByApp: 'drive',
+    updatedAt: '2020-11-03T12:31:43.028779+01:00',
+    updatedByApps: [
+      {
+        slug: 'drive',
+        date: '2020-11-03T12:31:43.028779+01:00',
+        instance: 'http://cozy.tools:8080/'
+      }
+    ],
+    createdOn: 'http://cozy.tools:8080/'
+  },
+  old_versions: {
+    target: {
+      id: 'cc0a6981d593205dcefe29dcb2021b80',
+      _id: 'cc0a6981d593205dcefe29dcb2021b80',
+      _type: 'io.cozy.files',
+      type: 'directory',
+      attributes: {
+        type: 'directory',
+        name: 'Folder Name',
+        dir_id: 'io.cozy.files.root-dir',
+        created_at: '2020-11-03T12:31:43.027718+01:00',
+        updated_at: '2020-11-03T12:31:43.027718+01:00',
+        tags: [],
+        path: '/Folder Name',
+        cozyMetadata: {
+          doctypeVersion: '1',
+          metadataVersion: 1,
+          createdAt: '2020-11-03T12:31:43.028779+01:00',
+          createdByApp: 'drive',
+          updatedAt: '2020-11-03T12:31:43.028779+01:00',
+          updatedByApps: [
+            {
+              slug: 'drive',
+              date: '2020-11-03T12:31:43.028779+01:00',
+              instance: 'http://cozy.tools:8080/'
+            }
+          ],
+          createdOn: 'http://cozy.tools:8080/'
+        }
+      },
+      meta: {
+        rev: '1-99e787c29e88dc5a8a2a7aafc4f682ed'
+      },
+      links: {
+        self: '/files/cc0a6981d593205dcefe29dcb2021b80'
+      },
+      name: 'Folder Name',
+      dir_id: 'io.cozy.files.root-dir',
+      created_at: '2020-11-03T12:31:43.027718+01:00',
+      updated_at: '2020-11-03T12:31:43.027718+01:00',
+      tags: [],
+      path: '/Folder Name',
+      cozyMetadata: {
+        doctypeVersion: '1',
+        metadataVersion: 1,
+        createdAt: '2020-11-03T12:31:43.028779+01:00',
+        createdByApp: 'drive',
+        updatedAt: '2020-11-03T12:31:43.028779+01:00',
+        updatedByApps: [
+          {
+            slug: 'drive',
+            date: '2020-11-03T12:31:43.028779+01:00',
+            instance: 'http://cozy.tools:8080/'
+          }
+        ],
+        createdOn: 'http://cozy.tools:8080/'
+      }
+    },
+    name: 'old_versions',
+    doctype: 'io.cozy.files.versions'
+  }
+}
+
+export const actionsMenu = [
+  {
+    item: {
+      icon: 'item',
+      Component: jest.fn().mockReturnValue('ActionsMenuItem'),
+      action: jest.fn()
+    }
+  }
+]


### PR DESCRIPTION
Dans le cadre de la synchronisation, on souhaite afficher un spinner dans certains cas (non définit ici). Pour l'instant on passe par un flag afin d'afficher ou non les lignes dans un état "en cours de synchronisation".

![Capture d’écran 2020-11-19 à 15 37 22](https://user-images.githubusercontent.com/67680939/99680321-3990c680-2a7d-11eb-8bdb-6c72980f55e1.png)
![Capture d’écran 2020-11-19 à 15 46 20](https://user-images.githubusercontent.com/67680939/99681415-64c7e580-2a7e-11eb-9abf-258b501ed59b.png)
---

![Capture d’écran 2020-11-19 à 15 37 39](https://user-images.githubusercontent.com/67680939/99680325-3a295d00-2a7d-11eb-9cb2-5ff7f926e307.png)
![Capture d’écran 2020-11-19 à 15 45 22](https://user-images.githubusercontent.com/67680939/99681295-44982680-2a7e-11eb-8efe-3f684c83f4f0.png)
