### PR TITLE
Fix/sharing view empty

### DIFF
--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -115,7 +115,8 @@ const PublicToolbarByLink = ({
   const client = useClient()
   const { isMobile } = useBreakpoints()
 
-  const shouldDisplayMoreMenu = isMobile || !isFile
+  const shouldDisplayMoreMenu =
+    isMobile || (!isFile && files.length > 0) || hasWriteAccess
   const [isOpened, setIsOpened] = useState(true)
   const onClose = useCallback(() => setIsOpened(false), [setIsOpened])
 

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -172,6 +172,7 @@ const PublicFolderView = ({
               canSort={false}
               currentFolderId={currentFolderId}
               refreshFolderContent={refreshFolderContent}
+              canUpload={hasWritePermissions}
             />
 
             {viewerOpened &&


### PR DESCRIPTION
We were displaying : 
"Empty folder => Upload files" even if the user didn't have the right to write 
Displaying the MoreMenu even if there was no action in it 