### PR TITLE
feat: Optimize timeline query

### DIFF
--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -23,10 +23,19 @@ const TIMELINE_QUERY = client =>
     .find(FILES_DOCTYPE)
     .where({
       class: 'image',
+      'metadata.datetime': {
+        $gt: null
+      }
+    })
+    .partialIndex({
       trashed: false
     })
+    .indexFields(['class', 'metadata.datetime'])
     .select(['dir_id', 'name', 'size', 'updated_at', 'metadata'])
     .sortBy([
+      {
+        class: 'desc'
+      },
       {
         'metadata.datetime': 'desc'
       }


### PR DESCRIPTION
This is meant to improve the Photos' timeline query by : 
* Explicitly index `class` and `metadata.datetime` in this order, as `metadata.datetime` is an interval query and should therefore be at the end, as explained [here](https://docs.cozy.io/en/tutorials/data/advanced/#indexes-performances-and-design)
* Sort `metadata.datetime` after `class: 'image'` for the same reason
* Use a partial index to filter trashed photos, so the index will be smaller and more efficient if many photos are trashed.