### PR TITLE
refactor: Use isSharingShortcut instead of deprecated isSharingShorcut

### DIFF
--- a/src/drive/web/modules/filelist/FileThumbnail.jsx
+++ b/src/drive/web/modules/filelist/FileThumbnail.jsx
@@ -18,12 +18,12 @@ import styles from 'drive/styles/filelist.styl'
 
 const FileThumbnail = ({ file, size, isInSyncFromSharing }) => {
   const { isMobile } = useBreakpoints()
-  const isSharingShorcut =
-    models.file.isSharingShorcut(file) && !isInSyncFromSharing
+  const isSharingShortcut =
+    models.file.isSharingShortcut(file) && !isInSyncFromSharing
   const isRegularShortcut =
-    !isSharingShorcut && file.class === 'shortcut' && !isInSyncFromSharing
+    !isSharingShortcut && file.class === 'shortcut' && !isInSyncFromSharing
   const isSimpleFile =
-    !isSharingShorcut && !isRegularShortcut && !isInSyncFromSharing
+    !isSharingShortcut && !isRegularShortcut && !isInSyncFromSharing
 
   return (
     <TableCell
@@ -37,7 +37,7 @@ const FileThumbnail = ({ file, size, isInSyncFromSharing }) => {
           <FileIcon file={file} size={size} />
         </InfosBadge>
       )}
-      {isSharingShorcut && (
+      {isSharingShortcut && (
         <GhostFileBadge
           badgeContent={<SharingShortcutBadge file={file} size={16} />}
         >

--- a/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
+++ b/src/drive/web/modules/filelist/SharingShortcutBadge.jsx
@@ -26,7 +26,7 @@ const SharingShortcutBadge = ({ file, size }) => {
 const withNewStatusBadge = WrappedComponent => {
   const ComponentWithNewStatusBadge = props => {
     const { file } = props
-    const isNewSharingShortcut = models.file.isSharingShorcutNew(file)
+    const isNewSharingShortcut = models.file.isSharingShortcutNew(file)
 
     return isNewSharingShortcut ? (
       <Badge variant="dot" color="error">

--- a/src/drive/web/modules/navigation/Index.jsx
+++ b/src/drive/web/modules/navigation/Index.jsx
@@ -60,7 +60,7 @@ export const fetchSharing = async ({
     const referencedFile = hasReferencedFile ? referencedFiles[0] : null
 
     const isSharingShortcut = hasReferencedFile
-      ? models.file.isSharingShorcut(referencedFile)
+      ? models.file.isSharingShortcut(referencedFile)
       : false
 
     if (isSharingShortcut) {

--- a/src/drive/web/modules/navigation/Index.spec.js
+++ b/src/drive/web/modules/navigation/Index.spec.js
@@ -16,7 +16,7 @@ const setup = async ({ sharingId, withReferencedFiles, withShortcut } = {}) => {
   client.query = jest
     .fn()
     .mockReturnValue(sharingId ? sharingRes : { data: [] })
-  mockFileModels.isSharingShorcut = () => (withShortcut ? true : false)
+  mockFileModels.isSharingShortcut = () => (withShortcut ? true : false)
   client.collection = jest.fn(() => ({
     findReferencedBy: jest
       .fn()

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux'
 import get from 'lodash/get'
 
 import { useClient, useCapabilities } from 'cozy-client'
-import { isSharingShorcut } from 'cozy-client/dist/models/file'
+import { isSharingShortcut } from 'cozy-client/dist/models/file'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import { ThumbnailSizeContext } from 'drive/lib/ThumbnailSizeContext'
@@ -179,7 +179,7 @@ const FolderViewBody = ({
                           actions={actions}
                           refreshFolderContent={refreshFolderContent}
                           isInSyncFromSharing={
-                            !isSharingContextEmpty && isSharingShorcut(file)
+                            !isSharingContextEmpty && isSharingShortcut(file)
                           }
                         />
                       ))}


### PR DESCRIPTION
refactor after cozy-client update