### PR TITLE
fix: Use query to limit fetched documents

### DIFF
--- a/src/drive/lib/migration/qualification.js
+++ b/src/drive/lib/migration/qualification.js
@@ -21,7 +21,7 @@ export const queryFilesFromDate = async (client, date, limit) => {
     .indexFields(['type', 'cozyMetadata.updatedAt'])
     .limitBy(limit)
     .sortBy([{ type: 'asc' }, { 'cozyMetadata.updatedAt': 'asc' }])
-  return client.queryAll(query)
+  return client.query(query)
 }
 
 /**


### PR DESCRIPTION
The `queryAll` function will try to fetch all the documents available for
this query. Here, we want
to query a fixed number of documents, through the `limit`
parameter, hence we use the `query` function.