### PR TITLE
fix: Only the right shortcut should turn into a spinner

### DIFF
--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -5,9 +5,9 @@ import cx from 'classnames'
 import filesize from 'filesize'
 import get from 'lodash/get'
 
+import { isIOSApp } from 'cozy-device-helper'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
-import { isIOSApp } from 'cozy-device-helper'
 import { TableRow } from 'cozy-ui/transpiled/react/Table'
 
 import { ActionMenuWithHeader } from 'drive/web/modules/actionmenu/ActionMenuWithHeader'
@@ -15,11 +15,11 @@ import { isDirectory } from 'drive/web/modules/drive/files'
 import FileThumbnail from 'drive/web/modules/filelist/FileThumbnail'
 import {
   toggleItemSelection,
-  isSelected
+  isSelected,
+  isSelectionBarVisible
 } from 'drive/web/modules/selection/duck'
 import { isRenaming, getRenamingFile } from 'drive/web/modules/drive/rename'
 import { isAvailableOffline } from 'drive/mobile/modules/offline/duck'
-import { isSelectionBarVisible } from 'drive/web/modules/selection/duck'
 import FileOpener from 'drive/web/modules/filelist/FileOpener'
 import {
   SelectBox,

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -23,6 +23,7 @@ import { TRASH_DIR_ID } from 'drive/constants/config'
 import createFileOpeningHandler from 'drive/web/modules/views/Folder/createFileOpeningHandler'
 import AcceptingSharingContext from 'drive/lib/AcceptingSharingContext'
 import { useSyncingFakeFile } from './useSyncingFakeFile'
+import { isReferencedByShareInSharingContext } from 'drive/web/modules/views/Folder/syncHelpers'
 
 const FolderViewBody = ({
   currentFolderId,
@@ -179,7 +180,12 @@ const FolderViewBody = ({
                           actions={actions}
                           refreshFolderContent={refreshFolderContent}
                           isInSyncFromSharing={
-                            !isSharingContextEmpty && isSharingShortcut(file)
+                            !isSharingContextEmpty &&
+                            isSharingShortcut(file) &&
+                            isReferencedByShareInSharingContext(
+                              file,
+                              sharingsValue
+                            )
                           }
                         />
                       ))}

--- a/src/drive/web/modules/views/Folder/syncHelpers.js
+++ b/src/drive/web/modules/views/Folder/syncHelpers.js
@@ -1,3 +1,5 @@
+import get from 'lodash/get'
+
 /**
  * Whether there is a file referenced by a share id
  * @param {array} queryResults - List of folders and files
@@ -133,4 +135,21 @@ export const computeSyncingFakeFile = ({
   })
 
   return updatedSyncingFakeFile
+}
+
+/**
+ * Whether the file is referenced by a share in the sharing context
+ * @param {object} file - An io.cozy.files doc
+ * @param {object} sharingsValue - Sharing Context value
+ * @returns {bool}
+ */
+export const isReferencedByShareInSharingContext = (file, sharingsValue) => {
+  const fileReferences = get(file, 'relationships.referenced_by.data')
+  if (!fileReferences) return false
+
+  const fileSharingId = fileReferences.find(
+    reference => reference.type === 'io.cozy.sharings'
+  ).id
+
+  return get(sharingsValue, fileSharingId, false) !== false
 }

--- a/src/drive/web/modules/views/Folder/syncHelpers.spec.js
+++ b/src/drive/web/modules/views/Folder/syncHelpers.spec.js
@@ -2,7 +2,8 @@ import {
   isThereFileReferencedBySharingId,
   createSyncingFakeFile,
   computeSyncingFakeFile,
-  checkSyncingFakeFileObsolescence
+  checkSyncingFakeFileObsolescence,
+  isReferencedByShareInSharingContext
 } from './syncHelpers'
 
 const queryResults = [
@@ -197,6 +198,43 @@ describe('syncHelpers', () => {
         id: 'id1',
         type: 'directory'
       })
+    })
+  })
+
+  describe('isReferencedByShareInSharingContext', () => {
+    it('should return true or false if the file is referenced or not by a share in sharing context', () => {
+      const referencedFile = {
+        id: 'fileId',
+        relationships: {
+          referenced_by: {
+            data: [{ id: 'file-with-sharing-id', type: 'io.cozy.sharings' }]
+          }
+        }
+      }
+      const notReferencedFile = {
+        id: 'fileId',
+        relationships: {
+          referenced_by: {
+            data: [{ id: 'file-without-sharing-id', type: 'io.cozy.sharings' }]
+          }
+        }
+      }
+      const FileWithNoReference = {
+        id: 'fileId',
+        relationships: {
+          referenced_by: undefined
+        }
+      }
+
+      expect(
+        isReferencedByShareInSharingContext(referencedFile, sharingsValue)
+      ).toBeTruthy()
+      expect(
+        isReferencedByShareInSharingContext(notReferencedFile, sharingsValue)
+      ).toBeFalsy()
+      expect(
+        isReferencedByShareInSharingContext(FileWithNoReference, sharingsValue)
+      ).toBeFalsy()
     })
   })
 })

--- a/src/drive/web/modules/views/Folder/syncHelpers.spec.js
+++ b/src/drive/web/modules/views/Folder/syncHelpers.spec.js
@@ -41,20 +41,7 @@ const queryResults = [
   }
 ]
 
-const sharingsValue = {
-  id1: {
-    id: 'id1',
-    attributes: {
-      description: 'fileName.ext'
-    }
-  },
-  'file-with-sharing-id': {
-    id: 'file-with-sharing-id',
-    attributes: {
-      description: 'folderName'
-    }
-  }
-}
+let sharingsValue
 
 const setupComputeSyncingFakeFile = ({
   isEmpty = false,
@@ -78,119 +65,138 @@ const setupComputeSyncingFakeFile = ({
   return { syncingFakeFile }
 }
 
-describe('isThereFileReferencedBySharingId', () => {
-  it('should return true if a directory is referenced by the sharing id', () => {
-    expect(
-      isThereFileReferencedBySharingId(queryResults, 'directory-sharing-id')
-    ).toBeTruthy()
+describe('syncHelpers', () => {
+  beforeEach(() => {
+    sharingsValue = {
+      id1: {
+        id: 'id1',
+        attributes: {
+          description: 'fileName.ext'
+        }
+      },
+      'file-with-sharing-id': {
+        id: 'file-with-sharing-id',
+        attributes: {
+          description: 'folderName'
+        }
+      }
+    }
   })
 
-  it('should return true if a file is referenced by the sharing id', () => {
-    expect(
-      isThereFileReferencedBySharingId(queryResults, 'file-with-sharing-id')
-    ).toBeTruthy()
-  })
+  describe('isThereFileReferencedBySharingId', () => {
+    it('should return true if a directory is referenced by the sharing id', () => {
+      expect(
+        isThereFileReferencedBySharingId(queryResults, 'directory-sharing-id')
+      ).toBeTruthy()
+    })
 
-  it('should return false if no directory/file is referenced by the sharing id', () => {
-    expect(
-      isThereFileReferencedBySharingId(queryResults, 'no-sharing-id')
-    ).toBeFalsy()
-  })
+    it('should return true if a file is referenced by the sharing id', () => {
+      expect(
+        isThereFileReferencedBySharingId(queryResults, 'file-with-sharing-id')
+      ).toBeTruthy()
+    })
 
-  it('should return false if the reference id is not for io.cozy.sharings', () => {
-    expect(
-      isThereFileReferencedBySharingId(queryResults, 'other-type-id')
-    ).toBeFalsy()
-  })
-})
+    it('should return false if no directory/file is referenced by the sharing id', () => {
+      expect(
+        isThereFileReferencedBySharingId(queryResults, 'no-sharing-id')
+      ).toBeFalsy()
+    })
 
-describe('createSyncingFakeFile', () => {
-  it('should return null if no sharing value', () => {
-    expect(createSyncingFakeFile({})).toBeNull()
-  })
-
-  it('should return fake file well formated according to the sharing value', () => {
-    expect(
-      createSyncingFakeFile({
-        sharingValue: sharingsValue.id1
-      })
-    ).toMatchObject({
-      name: 'fileName.ext',
-      id: 'id1',
-      type: 'directory'
+    it('should return false if the reference id is not for io.cozy.sharings', () => {
+      expect(
+        isThereFileReferencedBySharingId(queryResults, 'other-type-id')
+      ).toBeFalsy()
     })
   })
-})
 
-describe('checkSyncingFakeFileObsolescence', () => {
-  it('should return syncingFakeFile if there is no file with the same id', () => {
-    const syncingFakeFile = {
-      id: 'fakeFileId'
-    }
+  describe('createSyncingFakeFile', () => {
+    it('should return null if no sharing value', () => {
+      expect(createSyncingFakeFile({})).toBeNull()
+    })
 
-    expect(
-      checkSyncingFakeFileObsolescence({
-        queryResults,
-        sharingId: 'id1',
-        sharingsValue,
-        setSharingsValue: jest.fn(),
-        syncingFakeFile
+    it('should return fake file well formated according to the sharing value', () => {
+      expect(
+        createSyncingFakeFile({
+          sharingValue: sharingsValue.id1
+        })
+      ).toMatchObject({
+        name: 'fileName.ext',
+        id: 'id1',
+        type: 'directory'
       })
-    ).toMatchObject(syncingFakeFile)
+    })
   })
 
-  it('should return null if there is a file with the same id', () => {
-    expect(
-      checkSyncingFakeFileObsolescence({
-        queryResults,
+  describe('checkSyncingFakeFileObsolescence', () => {
+    it('should return syncingFakeFile if there is no file with the same id', () => {
+      const syncingFakeFile = {
+        id: 'fakeFileId'
+      }
+
+      expect(
+        checkSyncingFakeFileObsolescence({
+          queryResults,
+          sharingId: 'id1',
+          sharingsValue,
+          setSharingsValue: jest.fn(),
+          syncingFakeFile
+        })
+      ).toMatchObject(syncingFakeFile)
+    })
+
+    it('should return null if there is a file with the same id', () => {
+      expect(
+        checkSyncingFakeFileObsolescence({
+          queryResults,
+          sharingId: 'file-with-sharing-id',
+          sharingsValue,
+          setSharingsValue: jest.fn()
+        })
+      ).toBeNull()
+    })
+  })
+
+  describe('computeSyncingFakeFile', () => {
+    it('should return null if no content', () => {
+      const { syncingFakeFile } = setupComputeSyncingFakeFile({ isEmpty: true })
+      expect(syncingFakeFile).toBeNull()
+    })
+
+    it('should return null if no sharing context', () => {
+      const { syncingFakeFile } = setupComputeSyncingFakeFile({
+        isSharingContextEmpty: true
+      })
+      expect(syncingFakeFile).toBeNull()
+    })
+
+    it('should return null if no syncingFakeFile created (for example because no sharing context found)', () => {
+      const { syncingFakeFile } = setupComputeSyncingFakeFile({
+        sharingId: 'no-id',
+        sharingsValue
+      })
+      expect(syncingFakeFile).toBeNull()
+    })
+
+    it('should return null if syncingFakeFile is no longer needed', () => {
+      const { syncingFakeFile } = setupComputeSyncingFakeFile({
         sharingId: 'file-with-sharing-id',
         sharingsValue,
-        setSharingsValue: jest.fn()
+        queryResults
       })
-    ).toBeNull()
-  })
-})
-
-describe('computeSyncingFakeFile', () => {
-  it('should return null if no content', () => {
-    const { syncingFakeFile } = setupComputeSyncingFakeFile({ isEmpty: true })
-    expect(syncingFakeFile).toBeNull()
-  })
-
-  it('should return null if no sharing context', () => {
-    const { syncingFakeFile } = setupComputeSyncingFakeFile({
-      isSharingContextEmpty: true
+      expect(syncingFakeFile).toBeNull()
     })
-    expect(syncingFakeFile).toBeNull()
-  })
 
-  it('should return null if no syncingFakeFile created (for example because no sharing context found)', () => {
-    const { syncingFakeFile } = setupComputeSyncingFakeFile({
-      sharingId: 'no-id',
-      sharingsValue
-    })
-    expect(syncingFakeFile).toBeNull()
-  })
-
-  it('should return null if syncingFakeFile is no longer needed', () => {
-    const { syncingFakeFile } = setupComputeSyncingFakeFile({
-      sharingId: 'file-with-sharing-id',
-      sharingsValue,
-      queryResults
-    })
-    expect(syncingFakeFile).toBeNull()
-  })
-
-  it('should return syncingFakeFile if still needed', () => {
-    const { syncingFakeFile } = setupComputeSyncingFakeFile({
-      sharingId: 'id1',
-      sharingsValue,
-      queryResults
-    })
-    expect(syncingFakeFile).toMatchObject({
-      name: 'fileName.ext',
-      id: 'id1',
-      type: 'directory'
+    it('should return syncingFakeFile if still needed', () => {
+      const { syncingFakeFile } = setupComputeSyncingFakeFile({
+        sharingId: 'id1',
+        sharingsValue,
+        queryResults
+      })
+      expect(syncingFakeFile).toMatchObject({
+        name: 'fileName.ext',
+        id: 'id1',
+        type: 'directory'
+      })
     })
   })
 })


### PR DESCRIPTION
**Context** : Après une redirection suite à l'acceptation d'un partage, s'il y a de la latence, on affiche un spinner à la place du shortcut, avant que le fichier partagé arrive chez les destinataires.

**Préalablement**, pour faire ça, on vérifiait simplement s'il y avait un partage dans le context de partage, pour remplacer les shortcut par des spinner. Or on faisait ça quelque soit l'id du partage. Donc tous les shortcuts étaient remplacés par des spinner, même ceux qui n'était pas en relation avec le partage actuel.

**Maintenant** on ne remplace que le shortcut relatif au partage actuel en vérifiant pour chaque fichier, s'ils sont référencés par un partage qui est bien présent dans le contexte de partage.