### PR TITLE
fix: Query returns docs in data object

### DIFF
--- a/src/drive/targets/services/qualificationMigration.js
+++ b/src/drive/targets/services/qualificationMigration.js
@@ -37,11 +37,12 @@ export const migrateQualifications = async () => {
     lastProcessedFileDate = settings.lastProcessedFileDate
   }
   // Get a batch of sorted files starting from the date
-  const filesByDate = await queryFilesFromDate(
+  const res = await queryFilesFromDate(
     client,
     lastProcessedFileDate,
     BATCH_FILES_LIMIT
   )
+  const filesByDate = res.data
   if (filesByDate.length < 1) {
     log('warn', 'No new file to process')
     return


### PR DESCRIPTION
The returned object is not the same between `.query` and `.queryAll`: there is a `data` object for the former but not for the later. Maybe we should change that to avoid future mistakes like this one?