### PR TITLE
fix: Revert optim query since there is a bug in CozyClient

### DIFF
--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -23,25 +23,17 @@ const TIMELINE_QUERY = client =>
     .find(FILES_DOCTYPE)
     .where({
       class: 'image',
-      'metadata.datetime': {
-        $gt: null
-      }
-    })
-    .partialIndex({
       trashed: false
     })
-    .indexFields(['class', 'metadata.datetime'])
     .select(['dir_id', 'name', 'size', 'updated_at', 'metadata'])
     .sortBy([
-      {
-        class: 'desc'
-      },
       {
         'metadata.datetime': 'desc'
       }
     ])
     .include(['albums'])
 
+    
 const TIMELINE_MUTATIONS = client => ({
   uploadPhoto: async (file, dirId) => {
     return client.mutate({


### PR DESCRIPTION
We have an issue in CozyClient with this new query when using client.destroy() on this query. I don't know if it's related to partialIndex or indexFields or the selector. 

I'll create the issue on the CozyClient's side 

