### PR TITLE
fix: Rename insertDocuments to addReferences

### DIFF
--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -34,7 +34,7 @@ const addRefs = async (client, ids, album) => {
     _id: id,
     _type: 'io.cozy.files'
   }))
-  await client.mutate(album.photos.insertDocuments(relations))
+  await client.mutate(album.photos.addReferences(relations))
 }
 
 //TODO: we should probably use removeById from HasManyFiles. However, it causes


### PR DESCRIPTION
Since https://github.com/cozy/cozy-client/pull/807/files#diff-1f726d94368a619efa8c1839270760a5eeb041e23208fab4c23781eba88d1092L66
we renamed insertDocuments to addReferences.

Todo add a test