### PR TITLE
Fix certification icon width on firefox

### DIFF
--- a/src/drive/web/modules/certifications/CertificationTooltip.jsx
+++ b/src/drive/web/modules/certifications/CertificationTooltip.jsx
@@ -15,7 +15,7 @@ const CertificationTooltip = ({ body, caption, content }) => {
         </div>
       }
     >
-      <span>{content}</span>
+      <span className="u-w-100">{content}</span>
     </Tooltip>
   )
 }


### PR DESCRIPTION
Certification icon has width 0 on firefox. The span is needed to make the tooltip working.