### PR TITLE
feat: Re-enable partial index based query optimization 

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "cozy-authentication": "^2.0.5",
     "cozy-bar": "7.16.0",
     "cozy-ci": "0.4.1",
-    "cozy-client": "16.10.0",
+    "cozy-client": "16.10.2",
     "cozy-client-js": "0.17.3",
     "cozy-device-helper": "1.11.0",
     "cozy-doctypes": "1.74.7",

--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -23,10 +23,19 @@ const TIMELINE_QUERY = client =>
     .find(FILES_DOCTYPE)
     .where({
       class: 'image',
+      'metadata.datetime': {
+        $gt: null
+      }
+    })
+    .partialIndex({
       trashed: false
     })
+    .indexFields(['class', 'metadata.datetime'])
     .select(['dir_id', 'name', 'size', 'updated_at', 'metadata'])
     .sortBy([
+      {
+        class: 'desc'
+      },
       {
         'metadata.datetime': 'desc'
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4890,10 +4890,10 @@ cozy-client@13.8.3:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@16.10.0:
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.10.0.tgz#b1a28eaeb21c1eec099e9dac8740439b51dfc7db"
-  integrity sha512-VHvsR9pQ5YZFo7BzJ2EuUu8QPSG2cbauyo+Y5jP6MfqYrk1H+F2feQoCnWvhh0keqjf7FljHqIabY1KR+8xUcw==
+cozy-client@16.10.2:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.10.2.tgz#c13e0911fa88f12be0688ec70acacd23291b2bb5"
+  integrity sha512-yCB8NRtHYnI/n+FTbdnSBYH8KkN6U2kC6khKY+VHUUcW6yk3rzRPM1ibNI+DJTHVm1hxNSjTtOofxAZJ9MteQg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     btoa "^1.2.1"


### PR DESCRIPTION
This query optimization was previously [reverted](https://github.com/cozy/cozy-drive/pull/2200) because of a bug in cozy-client, which is now fixed and tested.
For more details, see the [issue](cozy/cozy-client#845)