### PR TITLE
Fix clustering

### DIFF
--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -51,30 +51,26 @@ const removeRefs = async (client, ids, album) => {
 
 const addAutoAlbumReferences = async (client, photos, album) => {
   let refCount = 0
-  try {
-    const refsIds = []
-    for (const photo of photos) {
-      if (photo.clusterId === album._id) {
-        continue
-      }
-      if (photo.clusterId && photo.clusterId !== album._id) {
-        // The photo references another album: remove it
-        await removeRefs(client, photo.clusterId, album)
-      }
-      refsIds.push(photo.id)
+  const refsIds = []
+  for (const photo of photos) {
+    if (photo.clusterId === album._id) {
+      continue
     }
-    if (refsIds.length > 0) {
-      await addRefs(client, refsIds, album)
-      log(
-        'info',
-        `${refsIds.length} photos clustered into: ${JSON.stringify(album._id)}`
-      )
-      refCount = refsIds.length
-    } else {
-      log('info', `Nothing to clusterize for ${album._id}`)
+    if (photo.clusterId && photo.clusterId !== album._id) {
+      // The photo references another album: remove it
+      await removeRefs(client, photo.clusterId, album)
     }
-  } catch (e) {
-    log('error', e)
+    refsIds.push(photo.id)
+  }
+  if (refsIds.length > 0) {
+    await addRefs(client, refsIds, album)
+    log(
+      'info',
+      `${refsIds.length} photos clustered into: ${JSON.stringify(album._id)}`
+    )
+    refCount = refsIds.length
+  } else {
+    log('info', `Nothing to clusterize for ${album._id}`)
   }
   return refCount
 }

--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -1,6 +1,7 @@
 import log from 'cozy-logger'
 import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
 import uniq from 'lodash/uniq'
+import { Q } from 'cozy-client'
 
 // An auto album name is the date of the first photo
 const albumName = photos => {
@@ -104,14 +105,16 @@ const removeAutoAlbumReferences = async (client, photos, album) => {
 }
 
 export const findAutoAlbums = async client => {
-  const query = client
-    .find(DOCTYPE_ALBUMS)
-    .where({ auto: true })
+  const query = Q(DOCTYPE_ALBUMS)
+    .where({
+      auto: true
+    })
     .sortBy([
       {
         name: 'desc'
       }
     ])
+    .indexFields(['name'])
   const results = await client.queryAll(query)
   return client.hydrateDocuments(DOCTYPE_ALBUMS, results)
 }

--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -35,7 +35,7 @@ const addRefs = async (client, ids, album) => {
     _id: id,
     _type: 'io.cozy.files'
   }))
-  await client.mutate(album.photos.insertDocuments(relations))
+  await client.mutate(album.photos.addReferences(relations))
 }
 
 //TODO: we should probably use removeById from HasManyFiles. However, it causes
@@ -46,7 +46,7 @@ const removeRefs = async (client, ids, album) => {
     _id: id,
     _type: 'io.cozy.files'
   }))
-  await client.mutate(album.photos.removeDocuments(relations))
+  await client.mutate(album.photos.removeReferences(relations))
 }
 
 const addAutoAlbumReferences = async (client, photos, album) => {

--- a/src/photos/ducks/clustering/albums.spec.js
+++ b/src/photos/ducks/clustering/albums.spec.js
@@ -12,19 +12,19 @@ client.create = jest.fn().mockImplementation((doctype, album) => {
 client.mutate = jest.fn()
 
 describe('album', () => {
-  const photos = [
-    {
-      datetime: '2020-01-01',
-      clusterId: 'fakeAlbumId1',
-      id: '1'
-    },
-    {
-      datetime: '2020-01-01',
-      clusterId: 'fakeAlbumId1',
-      id: '2'
-    }
-  ]
   it('should save clustering if no existing auto-album', async () => {
+    const photos = [
+      {
+        datetime: '2020-01-01',
+        clusterId: 'fakeAlbumId1',
+        id: '1'
+      },
+      {
+        datetime: '2020-01-01',
+        clusterId: 'fakeAlbumId1',
+        id: '2'
+      }
+    ]
     const clusters = [photos]
     const clustered = await saveClustering(client, clusters)
     expect(clustered).toBe(photos.length)

--- a/src/photos/ducks/clustering/albums.spec.js
+++ b/src/photos/ducks/clustering/albums.spec.js
@@ -1,0 +1,74 @@
+import CozyClient from 'cozy-client'
+import { saveClustering } from './albums'
+import doctypes from 'photos/targets/browser/doctypes'
+
+const client = new CozyClient({ schema: doctypes })
+client.save = jest.fn().mockImplementation((doctype, album) => {
+  return { data: { _id: '1', _type: doctype, ...album } }
+})
+client.create = jest.fn().mockImplementation((doctype, album) => {
+  return { data: { _id: '1', _type: doctype, ...album } }
+})
+client.mutate = jest.fn()
+
+describe('album', () => {
+  const photos = [
+    {
+      datetime: '2020-01-01',
+      clusterId: 'fakeAlbumId1',
+      id: '1'
+    },
+    {
+      datetime: '2020-01-01',
+      clusterId: 'fakeAlbumId1',
+      id: '2'
+    }
+  ]
+  it('should save clustering if no existing auto-album', async () => {
+    const clusters = [photos]
+    const clustered = await saveClustering(client, clusters)
+    expect(clustered).toBe(photos.length)
+  })
+
+  it('should save clustering with existing auto-albums', async () => {
+    const photos = [
+      {
+        datetime: '2020-01-02',
+        clusterId: 'fakeAlbumId2',
+        id: '3'
+      },
+      {
+        datetime: '2020-01-03',
+        clusterId: 'fakeAlbumId3',
+        id: '4'
+      }
+    ]
+    const clusters = [photos]
+    const existingAlbums = [
+      {
+        _id: 'fakeAlbumId2',
+        _type: 'io.cozy.photos.albums',
+        name: '2020-01-02',
+        period: {
+          start: '2020-01-02',
+          end: '2020-01-02'
+        }
+      },
+      {
+        _id: 'fakeAlbumId3',
+        _type: 'io.cozy.photos.albums',
+        name: '2020-01-03',
+        period: {
+          start: '2020-01-03',
+          end: '2020-01-03'
+        }
+      }
+    ]
+    const hydratedAlbums = client.hydrateDocuments(
+      'io.cozy.photos.albums',
+      existingAlbums
+    )
+    const clustered = await saveClustering(client, clusters, hydratedAlbums)
+    expect(clustered).toBe(photos.length)
+  })
+})

--- a/src/photos/ducks/clustering/files.js
+++ b/src/photos/ducks/clustering/files.js
@@ -1,5 +1,6 @@
 import log from 'cozy-logger'
 import { DOCTYPE_FILES, DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
+import { Q } from 'cozy-client'
 
 export const getFilesFromDate = async (
   client,
@@ -8,7 +9,7 @@ export const getFilesFromDate = async (
 ) => {
   log('info', `Get files from ${date}`)
   const dateField = indexDateField || 'metadata.datetime'
-  const query = client.find(DOCTYPE_FILES).where({
+  const query = Q(DOCTYPE_FILES).where({
     [dateField]: { $gt: date },
     class: 'image',
     trashed: false
@@ -39,7 +40,7 @@ export const getAllPhotos = async client => {
   // This does not use pagination but is significantly faster as it queries
   // the _all_docs endpoint
   // Note this is only used once, for init
-  const query = client.find(DOCTYPE_FILES).limitBy(null)
+  const query = Q(DOCTYPE_FILES).limitBy(null)
   const results = await client.query(query)
   const files = results.data
   return files.filter(file => file.class === 'image' && !file.trashed)

--- a/src/photos/ducks/clustering/settings.js
+++ b/src/photos/ducks/clustering/settings.js
@@ -1,4 +1,5 @@
 import log from 'cozy-logger'
+import { Q } from 'cozy-client'
 import { DOCTYPE_PHOTOS_SETTINGS } from 'drive/lib/doctypes'
 import {
   SETTING_TYPE,
@@ -20,7 +21,7 @@ export const createSetting = async (client, initParameters) => {
 }
 
 export const readSetting = async client => {
-  const settings = await client.query(client.find(DOCTYPE_PHOTOS_SETTINGS))
+  const settings = await client.query(Q(DOCTYPE_PHOTOS_SETTINGS))
   return settings.data.find(doc => doc.type === SETTING_TYPE)
 }
 


### PR DESCRIPTION
The clustering service is currently broken since a cozy-client upgrade with breaking change in the HasManyFiles relationships: 
* `insertDocuments` becomes `addReferences`
* `removeDocuments` becomes `removeReferences`

This PR:
* Fix the API change
* Add somes tests to avoid such situation in the future
* Improve the error handling to avoid hiding errors and be alerted when the service actually fails
* Fix existing queries