### PR TITLE
Add certification icons after filepath on mobile

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -231,24 +231,43 @@ column-width-thumbnail-bigger = 7rem
         display table-cell
         white-space nowrap
 
-.fil-file-path
-.fil-file-infos
-    flex 0 0 1rem
-    color var(--coolGrey)
-    font-size .75rem
-    position relative
-    overflow hidden
-    text-overflow ellipsis
-    white-space nowrap
-    text-decoration none
+.fil-file-description
+    display flex
+    justify-content flex-start
+    align-items baseline
 
-    &:hover,
-    &:focus
-        text-decoration underline
+    &--path
+        display contents !important // to take content width
+
+.fil-file-certifications
+    flex-shrink 0
+    color var(--coolGrey)
+
+    &--separator
+        margin-left 0.25rem
 
     &--icon
         width rem(10)
         height rem(10)
+
+.fil-file-path
+.fil-file-infos
+.fil-file-description--path
+    color var(--coolGrey)
+    font-size .75rem
+    text-decoration none
+
+.fil-file-path
+.fil-file-infos
+    flex 0 0 1rem
+    position relative
+    overflow hidden
+    text-overflow ellipsis
+    white-space nowrap
+
+    &:hover,
+    &:focus
+        text-decoration underline
 
 .fil-file-infos
     display none
@@ -397,7 +416,7 @@ column-width-thumbnail-bigger = 7rem
             opacity 0
 
     .fil-file-infos
-        display block
+        display flex
 
     .fil-file-path
         &:hover,

--- a/src/drive/web/modules/filelist/cells/FileName.jsx
+++ b/src/drive/web/modules/filelist/cells/FileName.jsx
@@ -20,27 +20,31 @@ const CertificationsIcons = ({ attributes }) => {
   const isElectronicSafe = get(attributes, 'metadata.electronicSafe')
 
   return (
-    <>
-      {(isCarbonCopy || isElectronicSafe) && ' - '}
+    <div className={styles['fil-file-certifications']}>
+      {(isCarbonCopy || isElectronicSafe) && (
+        <span className={styles['fil-file-certifications--separator']}>
+          {' - '}
+        </span>
+      )}
       {isCarbonCopy &&
         (isElectronicSafe ? (
           <Icon
             icon={CarbonCopyIcon}
-            className={`u-mr-half ${styles['fil-file-infos--icon']}`}
+            className={`u-mr-half ${styles['fil-file-certifications--icon']}`}
           />
         ) : (
           <AppIcon
             app={attributes.cozyMetadata.uploadedBy.slug}
-            className={styles['fil-file-infos--icon']}
+            className={styles['fil-file-certifications--icon']}
           />
         ))}
       {isElectronicSafe && (
         <AppIcon
           app={attributes.cozyMetadata.uploadedBy.slug}
-          className={styles['fil-file-infos--icon']}
+          className={styles['fil-file-certifications--icon']}
         />
       )}
-    </>
+    </div>
   )
 }
 
@@ -88,10 +92,13 @@ const FileName = ({
           {withFilePath &&
             attributes.displayedPath &&
             (isMobile ? (
-              <MidEllipsis
-                className={styles['fil-file-path']}
-                text={attributes.displayedPath}
-              />
+              <div className={styles['fil-file-description']}>
+                <MidEllipsis
+                  className={styles['fil-file-description--path']}
+                  text={attributes.displayedPath}
+                />
+                <CertificationsIcons attributes={attributes} />
+              </div>
             ) : (
               <Link
                 to={`/folder/${attributes.dir_id}`}
@@ -106,7 +113,7 @@ const FileName = ({
                 {`${formattedUpdatedAt}${
                   formattedSize ? ` - ${formattedSize}` : ''
                 }`}
-                <CertificationsIcons attributes={attributes} />
+                {isMobile && <CertificationsIcons attributes={attributes} />}
               </div>
             ))}
         </div>


### PR DESCRIPTION
Les icones de certifications doivent apparaître sur mobile à côté du filepath ou de la description du fichier (date et poids)