### PR TITLE
fix: Inject cozy-ui css earlier in code to prevent invalid var call

### DIFF
--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -1,4 +1,6 @@
 /* global __DEVELOPMENT__ */
+
+import 'cozy-ui/transpiled/react/stylesheet.css'
 // eslint-disable-next-line no-unused-vars
 import mainStyles from 'drive/styles/main.styl'
 

--- a/src/drive/targets/intents/index.jsx
+++ b/src/drive/targets/intents/index.jsx
@@ -1,5 +1,7 @@
 /* global cozy */
 
+import 'cozy-ui/transpiled/react/stylesheet.css'
+
 import 'whatwg-fetch'
 
 import React from 'react'

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -4,6 +4,8 @@ import 'whatwg-fetch'
 import React from 'react'
 import { render } from 'react-dom'
 
+import 'cozy-ui/transpiled/react/stylesheet.css'
+
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 import CozyClient, { models } from 'cozy-client'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'

--- a/src/drive/web/modules/drive/StyledApp.jsx
+++ b/src/drive/web/modules/drive/StyledApp.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import 'cozy-ui/transpiled/react/stylesheet.css'
+
 import 'cozy-sharing/dist/stylesheet.css'
 //eslint-disable-next-line
 import mainStyles from 'drive/styles/main.styl'

--- a/src/photos/components/StyledApp.jsx
+++ b/src/photos/components/StyledApp.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'photos/styles/main.styl'
 import 'cozy-sharing/dist/stylesheet.css'
 

--- a/src/photos/targets/browser/index.jsx
+++ b/src/photos/targets/browser/index.jsx
@@ -1,5 +1,7 @@
 /* global cozy __DEVELOPMENT__ */
 
+import 'cozy-ui/transpiled/react/stylesheet.css'
+
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'

--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -1,4 +1,7 @@
 /* global cozy */
+
+import 'cozy-ui/transpiled/react/stylesheet.css'
+
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'


### PR DESCRIPTION
Problème : l'utilisation de variable css cozy-ui se fait avant le chargement de la feuille de style de cozy-ui, ce qui génère une erreur et plante l'application. 

Solution : Charger la feuille de style plus tôt.

Je n'ai pas réussi à corriger le problème simplement en déplaçant les appels à `styleApp` (qui mutualise tous les chargement de feuille de style) plus tôt dans l'app. J'ai donc sorti l'appel à la feuille de style cozy-ui de `styleApp` pour le mettre plus tôt, dans tous les endroits qui faisait appel à `styleApp`.