### PR TITLE
Fixes for clustering service

### DIFF
--- a/src/photos/ducks/clustering/consts.js
+++ b/src/photos/ducks/clustering/consts.js
@@ -13,6 +13,7 @@ export const EVALUATION_THRESHOLD = 500
 export const CHANGES_RUN_LIMIT = 1000
 export const TRIGGER_ELAPSED = '20m'
 export const LOG_ERROR_MSG_LIMIT = 32 * 1024 - 1 // Avoid unreadable logs by the stack
+export const DAY_DURATION_IN_MS = 24 * 60 * 60 * 1000
 
 export const DEFAULT_SETTING = {
   type: SETTING_TYPE,

--- a/src/photos/ducks/clustering/settings.js
+++ b/src/photos/ducks/clustering/settings.js
@@ -11,6 +11,7 @@ import {
   COARSE_COEFFICIENT
 } from './consts'
 import { gradientAngle } from 'photos/ducks/clustering/gradient'
+import { isDurationMoreThan24Hours } from './utils'
 
 export const createSetting = async (client, initParameters) => {
   log('info', 'Create setting')
@@ -113,6 +114,13 @@ export const updateParamsPeriod = async (client, setting, params, photos) => {
 
   const newSetting = await client.save({ ...setting, parameters })
   return newSetting.data
+}
+
+export const shouldReleaseLock = setting => {
+  return (
+    setting.jobStatus === 'running' &&
+    isDurationMoreThan24Hours(setting.lastExecution, Date.now())
+  )
 }
 
 export const updateSettingStatus = async (client, setting, count, lastDate) => {

--- a/src/photos/ducks/clustering/utils.js
+++ b/src/photos/ducks/clustering/utils.js
@@ -1,4 +1,5 @@
 import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
+import { DAY_DURATION_IN_MS } from './consts'
 import get from 'lodash/get'
 
 /**
@@ -72,4 +73,16 @@ export const convertDurationInMilliseconds = duration => {
   const minutes = offsetM > 0 ? duration.substring(offsetH + 1, offsetM) : 0
   const seconds = offsetS > 0 ? duration.substring(offsetM + 1, offsetS) : 0
   return seconds * 1000 + minutes * 60 * 1000 + hours * 3600 * 1000
+}
+
+/**
+ * Check if the duration between the 2 dates is more than 24h
+ * @param {Date} date1 - The first date
+ * @param {Date} date2 - The second date
+ * @returns {bool} Whether or not the duration is more than 24h
+ */
+export const isDurationMoreThan24Hours = (date1, date2) => {
+  const d1 = new Date(date1).getTime()
+  const d2 = new Date(date2).getTime()
+  return Math.abs(d1 - d2) > DAY_DURATION_IN_MS
 }

--- a/src/photos/ducks/clustering/utils.spec.js
+++ b/src/photos/ducks/clustering/utils.spec.js
@@ -1,4 +1,8 @@
-import { averageTime, convertDurationInMilliseconds } from './utils'
+import {
+  averageTime,
+  convertDurationInMilliseconds,
+  isDurationMoreThan24Hours
+} from './utils'
 
 describe('date', () => {
   it('Should compute the mean date', () => {
@@ -25,7 +29,7 @@ describe('date', () => {
   })
 })
 
-describe('convert duration', () => {
+describe('duration', () => {
   it('Should correctly convert duration', () => {
     const d1 = '2h'
     const d2 = '3m'
@@ -37,5 +41,22 @@ describe('convert duration', () => {
     expect(convertDurationInMilliseconds(d3)).toEqual(4000)
     expect(convertDurationInMilliseconds(d4)).toEqual(4215000)
     expect(convertDurationInMilliseconds(d5)).toEqual(0)
+  })
+
+  it('should correctly detect 24h duration', () => {
+    const d1 = new Date('2020-01-01T12:00:00')
+    const d2 = new Date('2020-01-02T12:00:01')
+    expect(isDurationMoreThan24Hours(d1, d2)).toEqual(true)
+    expect(isDurationMoreThan24Hours(d2, d1)).toEqual(true)
+
+    const d3 = new Date('2020-01-01T12:00:00')
+    const d4 = new Date('2020-01-02T12:00:00')
+    expect(isDurationMoreThan24Hours(d3, d4)).toEqual(false)
+    expect(isDurationMoreThan24Hours(d4, d3)).toEqual(false)
+
+    const d5 = new Date('2020-01-01T12:00')
+    const d6 = new Date('2020-01-01T13:00')
+    expect(isDurationMoreThan24Hours(d5, d6)).toEqual(false)
+    expect(isDurationMoreThan24Hours(d6, d5)).toEqual(false)
   })
 })

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -201,14 +201,15 @@ export const onPhotoUpload = async () => {
   if (setting.jobStatus === 'running') {
     // Safeguard to avoid never-released locks
     if (!shouldReleaseLock(setting)) {
-      log('warn', 'The service is already executed. Abort.')
+      log('info', 'The service is already executed. Abort.')
       return
     }
+    log('warn', 'The job status is marked as running for too long.')
   } else if (setting.jobStatus === 'postponed') {
     const duration = convertDurationInMilliseconds(TRIGGER_ELAPSED)
     // Stop if a trigger is planned later
     if (setting.lastExecution + duration > Date.now()) {
-      log('warn', 'The service is already planned later. Abort.')
+      log('info', 'The service is already planned later. Abort.')
       return
     }
   }

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -130,7 +130,6 @@ const recomputeParameters = async (client, setting) => {
 const runClustering = async (client, setting) => {
   const sinceDate = setting.lastDate ? setting.lastDate : 0
   const photos = await getFilesFromDate(client, sinceDate, {
-    indexDateField: 'created_at',
     limit: CHANGES_RUN_LIMIT
   })
   if (photos.length < 1) {
@@ -145,7 +144,8 @@ const runClustering = async (client, setting) => {
   }
 
   log('info', `${result.clusteredCount} photos clustered since ${sinceDate}`)
-  const newLastDate = photos[photos.length - 1].attributes.created_at
+  const newLastDate =
+    photos[photos.length - 1].attributes.cozyMetadata.createdAt
   // The oldest photo in the dataset is older or equal than the last photo used
   // to compute the parameters: do not count this dataset in the evaluation
   // as it has been already used to compute parameters

--- a/src/photos/targets/services/onPhotoUpload.spec.js
+++ b/src/photos/targets/services/onPhotoUpload.spec.js
@@ -1,42 +1,62 @@
 import { onPhotoUpload } from './onPhotoUpload'
 import { readSetting } from 'photos/ducks/clustering/settings'
-import {
-  convertDurationInMilliseconds,
-  isPartOfProgressiveRollout
-} from 'photos/ducks/clustering/utils'
+import { convertDurationInMilliseconds } from 'photos/ducks/clustering/utils'
 import CozyClient from 'cozy-client'
 
-CozyClient.fromEnv = jest.fn()
 jest.mock('photos/ducks/clustering/settings', () => ({
+  ...jest.requireActual('photos/ducks/clustering/settings'),
   readSetting: jest.fn()
 }))
 jest.mock('photos/ducks/clustering/utils', () => ({
-  convertDurationInMilliseconds: jest.fn(),
-  isPartOfProgressiveRollout: jest.fn()
+  ...jest.requireActual('photos/ducks/clustering/utils'),
+  convertDurationInMilliseconds: jest.fn()
 }))
-jest.mock('cozy-client')
+
+jest.mock('photos/ducks/clustering/files', () => ({
+  getFilesFromDate: jest.fn().mockReturnValue([])
+}))
+
 const client = new CozyClient({})
-client.save = jest.fn(() => Promise.resolve({ data: {} }))
+client.save = jest.fn(doc => Promise.resolve({ data: doc }))
+CozyClient.fromEnv = jest.fn().mockReturnValue(client)
 
 describe('onPhotoUpload', () => {
   beforeEach(() => {
     jest.spyOn(Date, 'now').mockImplementation(() => 1000)
-    isPartOfProgressiveRollout.mockReturnValue(true)
   })
   afterEach(() => {
-    jest.restoreAllMocks()
+    jest.clearAllMocks()
   })
 
-  it('Should stop if running', async () => {
+  it('Should stop if other execution is running', async () => {
     readSetting.mockReturnValueOnce({ jobStatus: 'running' })
     await onPhotoUpload()
     expect(client.save).toHaveBeenCalledTimes(0)
   })
 
-  it('Should stop if postponed', async () => {
-    readSetting.mockReturnValueOnce({ jobStatus: 'postponed', lastExec: 500 })
+  it('Should stop if execution is postponed', async () => {
+    readSetting.mockReturnValueOnce({
+      jobStatus: 'postponed',
+      lastExecution: 500
+    })
     convertDurationInMilliseconds.mockReturnValueOnce(600)
     await onPhotoUpload()
     expect(client.save).toHaveBeenCalledTimes(0)
+  })
+
+  it('should continue if lock is set for too long', async () => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 86400001) // 24h + 1
+    const params = [
+      {
+        evaluation: { start: 0, end: 0 }
+      }
+    ]
+    readSetting.mockReturnValueOnce({
+      jobStatus: 'running',
+      lastExecution: 0,
+      parameters: params
+    })
+    await onPhotoUpload()
+    expect(client.save).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
This fixes 2 behaviors with the photos clustering service:

* The query to get the new photos to clusterize was based on `file.created_at`, which is the date from exif data (or the upload date if it does not exist): the photos with a `file.created_at` older than the last execution date were not clusterized. We now use `file.cozyMetadata.createdAt`, to always rely on the upload date.
* When the service is running, a lock is set in order to avoid parallel executions of the service. In some cases, the lock was never released, causing the service to be never run again. We add a safeguard to bypass the lock if it has been set for more than 24h.