### PR TITLE
Viewer : add certifications panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "cozy-scripts": "5.1.1",
     "cozy-sharing": "2.8.2",
     "cozy-stack-client": "16.4.0",
-    "cozy-ui": "44.0.5",
+    "cozy-ui": "44.1.1",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -532,6 +532,9 @@
       "noapp": "No application found to handle this file.",
       "generic": "An error occurred when opening this file, please try again.",
       "noNetwork": "You're currently offline."
+    },
+    "panel": {
+      "title": "Useful information"
     }
   },
   "Move": {

--- a/src/drive/web/modules/viewer/FilesViewer.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.jsx
@@ -11,6 +11,8 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 import palette from 'cozy-ui/transpiled/react/palette'
 
 import Fallback from 'drive/web/modules/viewer/Fallback'
+import { isInfoPanel } from './helpers'
+import PanelContent from './Panel/PanelContent'
 
 export const FilesViewerLoading = () => (
   <Overlay>
@@ -136,6 +138,12 @@ class FilesViewer extends Component {
             onChangeRequest={this.onChange}
             onCloseRequest={this.onClose}
             renderFallbackExtraContent={file => <Fallback file={file} t={t} />}
+            panelInfoProps={{
+              showPanel: ({ currentFile }) => isInfoPanel(currentFile),
+              PanelContent: ({ currentFile }) => (
+                <PanelContent file={currentFile} />
+              )
+            }}
           />
         </Overlay>
       )

--- a/src/drive/web/modules/viewer/FilesViewer.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.jsx
@@ -1,15 +1,16 @@
 import React, { Component } from 'react'
-
 import compose from 'lodash/flowRight'
+
 import { withClient } from 'cozy-client'
-import { Overlay, Spinner, Viewer } from 'cozy-ui/transpiled/react'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
-
 import { isIOSApp } from 'cozy-device-helper'
-
 import logger from 'lib/logger'
-import Fallback from 'drive/web/modules/viewer/Fallback'
+import Overlay from 'cozy-ui/transpiled/react/Overlay'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import Viewer from 'cozy-ui/transpiled/react/Viewer'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import palette from 'cozy-ui/transpiled/react/palette'
+
+import Fallback from 'drive/web/modules/viewer/Fallback'
 
 export const FilesViewerLoading = () => (
   <Overlay>

--- a/src/drive/web/modules/viewer/Panel/Certifications.jsx
+++ b/src/drive/web/modules/viewer/Panel/Certifications.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import has from 'lodash/has'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
+import Icon, { iconPropType } from 'cozy-ui/transpiled/react/Icon'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import CarbonCopyIcon from 'cozy-ui/transpiled/react/Icons/CarbonCopy'
+import SafeIcon from 'cozy-ui/transpiled/react/Icons/Safe'
+
+const Certification = ({ icon, title, caption }) => {
+  return (
+    <div className="u-mb-1-half">
+      <Media className="u-mb-half" align="top">
+        <Img className="u-mr-half">
+          <Icon icon={icon} />
+        </Img>
+        <Bd>
+          <Typography variant="body1">{title}</Typography>
+        </Bd>
+      </Media>
+      <Typography variant="caption">{caption}</Typography>
+    </div>
+  )
+}
+
+Certification.propTypes = {
+  icon: iconPropType.isRequired,
+  title: PropTypes.string.isRequired,
+  caption: PropTypes.string.isRequired
+}
+
+const Certifications = ({ file }) => {
+  const { t } = useI18n()
+
+  const hasCarbonCopy = has(file, 'metadata.carbonCopy')
+  const hasElectronicSafe = has(file, 'metadata.electronicSafe')
+
+  return (
+    <>
+      {hasCarbonCopy && (
+        <Certification
+          icon={CarbonCopyIcon}
+          title={t('table.tooltip.carbonCopy.title')}
+          caption={t('table.tooltip.carbonCopy.caption')}
+        />
+      )}
+      {hasElectronicSafe && (
+        <Certification
+          icon={SafeIcon}
+          title={t('table.tooltip.electronicSafe.title')}
+          caption={t('table.tooltip.electronicSafe.caption')}
+        />
+      )}
+    </>
+  )
+}
+
+Certifications.propTypes = {
+  file: PropTypes.object.isRequired
+}
+
+export default Certifications

--- a/src/drive/web/modules/viewer/Panel/PanelContent.jsx
+++ b/src/drive/web/modules/viewer/Panel/PanelContent.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Stack from 'cozy-ui/transpiled/react/Stack'
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import getPanelBlocks, { panelBlocksSpecs } from './getPanelBlocks'
+
+const PanelContent = ({ file }) => {
+  const { t } = useI18n()
+  const panelBlocks = getPanelBlocks({ panelBlocksSpecs, file })
+
+  return (
+    <Stack spacing="s" className={cx('u-flex u-flex-column u-h-100')}>
+      <Paper
+        className={'u-ph-2 u-flex u-flex-items-center u-h-3'}
+        elevation={2}
+        square
+      >
+        <Typography variant="h4">{t('Viewer.panel.title')}</Typography>
+      </Paper>
+      {panelBlocks.map((PanelBlock, index) => (
+        <Paper
+          key={index}
+          className={cx('u-ph-2 u-pv-1-half', {
+            'u-flex-grow-1': index === panelBlocks.length - 1
+          })}
+          elevation={2}
+          square
+        >
+          <Typography variant="h4">
+            <PanelBlock file={file} />
+          </Typography>
+        </Paper>
+      ))}
+    </Stack>
+  )
+}
+
+PanelContent.propTypes = {
+  file: PropTypes.object.isRequired
+}
+
+export default PanelContent

--- a/src/drive/web/modules/viewer/Panel/getPanelBlocks.jsx
+++ b/src/drive/web/modules/viewer/Panel/getPanelBlocks.jsx
@@ -1,0 +1,22 @@
+import { hasCertifications } from 'drive/web/modules/viewer/helpers'
+import Certifications from './Certifications'
+
+// TODO add connector block
+export const panelBlocksSpecs = {
+  certifications: {
+    condition: hasCertifications,
+    component: Certifications
+  }
+}
+
+const getPanelBlocks = ({ panelBlocksSpecs, file }) => {
+  const panelBlocks = []
+
+  Object.values(panelBlocksSpecs).forEach(panelBlock => {
+    panelBlock.condition({ file }) && panelBlocks.push(panelBlock.component)
+  })
+
+  return panelBlocks
+}
+
+export default getPanelBlocks

--- a/src/drive/web/modules/viewer/Panel/getPanelBlocks.spec.jsx
+++ b/src/drive/web/modules/viewer/Panel/getPanelBlocks.spec.jsx
@@ -1,0 +1,59 @@
+import getPanelBlocks from './getPanelBlocks'
+
+const block1Component = jest.fn()
+const block2Component = jest.fn()
+
+describe('getPanelBlocks', () => {
+  it('should return only blocks with truthy condition', () => {
+    // with two truthy component
+    expect(
+      getPanelBlocks({
+        panelBlocksSpecs: {
+          block1: {
+            condition: () => true,
+            component: block1Component
+          },
+          block2: {
+            condition: () => true,
+            component: block2Component
+          }
+        }
+      })
+    ).toMatchObject([block1Component, block2Component])
+
+    // with one truthy component
+    expect(
+      getPanelBlocks({
+        panelBlocksSpecs: {
+          block1: {
+            condition: () => false,
+            component: block1Component
+          },
+          block2: {
+            condition: () => true,
+            component: block2Component
+          }
+        }
+      })
+    ).toMatchObject([block2Component])
+
+    // with no truthy component
+    expect(
+      getPanelBlocks({
+        panelBlocksSpecs: {
+          block1: {
+            condition: () => false,
+            component: block1Component
+          },
+          block2: {
+            condition: () => false,
+            component: block2Component
+          }
+        }
+      })
+    ).toMatchObject([])
+
+    // with no specs
+    expect(getPanelBlocks({ panelBlocksSpecs: {} })).toMatchObject([])
+  })
+})

--- a/src/drive/web/modules/viewer/helpers.js
+++ b/src/drive/web/modules/viewer/helpers.js
@@ -1,0 +1,11 @@
+import has from 'lodash/has'
+
+export const hasCertifications = ({ file }) =>
+  has(file, 'metadata.carbonCopy') || has(file, 'metadata.electronicSafe')
+
+export const isInfoPanel = file => {
+  // TODO add rules for connectors
+
+  // for now we just need to return result for certifications
+  return hasCertifications({ file })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5262,10 +5262,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@44.0.5:
-  version "44.0.5"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-44.0.5.tgz#7c6c2e39bca8b383437fdedd76f06b00017e447c"
-  integrity sha512-12JF0ZJDOQoOvjTRtqVPkcmdxInqXqQNt/LJ/vQJqIqBA37jINxSwHuDHVw1qaj+xoxdNRuvmSA6wemXeB/Gbg==
+cozy-ui@44.1.1:
+  version "44.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-44.1.1.tgz#f98a3265afcba43de9205d62e40fee6471dd7a41"
+  integrity sha512-tNigfTEPTWDLVNfp2stXfWo0/+X1FwYvophsQ31/PtiwIgxmW7aCJwLCAQGGI3tVkg28k0hgR/fhc8OfuqGG+Q==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
Première étape de l'utilisation du Viewer augmenté dans Drive. On souhaite afficher des informations relatives aux certifications si le fichier visualisé est certifié.

Pour l'instant on ne gère que les certifications sur les fichiers. L'étape suivante consistera à gérer les informations relatives au connecteur.
