### PR TITLE
fix: Import UI's style for react component

### DIFF
--- a/src/drive/targets/mobile/index.jsx
+++ b/src/drive/targets/mobile/index.jsx
@@ -1,4 +1,5 @@
 import 'cozy-ui/dist/cozy-ui.utils.min.css'
+import 'cozy-ui/transpiled/react/stylesheet.css'
 import mobileStyles from 'drive/styles/mobile.styl'
 
 import 'whatwg-fetch'


### PR DESCRIPTION
Since https://github.com/cozy/cozy-drive/pull/2216 we've changed
the way we import UI's style. But we forgot to import the CSS
for the mobile build.


I was pretty sure to check carefully #2216 but it seems not... 🤦‍♂️ 