### PR TITLE
fix: Table head size on Safari

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -364,6 +364,7 @@ column-width-thumbnail-bigger = 7rem
 
     .fil-content-mobile-head
         display flex
+        flex-basis auto
 
     .fil-content-mobile-header.fil-content-header-sortasc
     .fil-content-mobile-header.fil-content-header-sortdesc


### PR DESCRIPTION
see "a-z" section :

![image](https://user-images.githubusercontent.com/67680939/105368295-aa7d6780-5c01-11eb-8632-d666b4e4fe34.png)

fixed to : 

![image](https://user-images.githubusercontent.com/67680939/105368432-d0a30780-5c01-11eb-830a-781a01af4c9d.png)

