### PR TITLE
fix: Missing last execution timestamp

### DIFF
--- a/src/photos/ducks/clustering/files.js
+++ b/src/photos/ducks/clustering/files.js
@@ -12,6 +12,7 @@ export const getFilesFromDate = async (client, date, { limit = 0 } = {}) => {
     .partialIndex({
       trashed: false
     })
+    .indexFields(['class', 'cozyMetadata.createdAt'])
     .sortBy([{ class: 'asc' }, { 'cozyMetadata.createdAt': 'asc' }])
     .limitBy(limit)
 
@@ -31,8 +32,7 @@ export const getAllPhotos = async client => {
 
 export const getFilesByAutoAlbum = async (client, album) => {
   let allPhotos = []
-  const query = client
-    .find(DOCTYPE_ALBUMS)
+  const query = Q(DOCTYPE_ALBUMS)
     .getById(album._id)
     .include(['photos'])
   const resp = await client.query(query)

--- a/src/photos/ducks/clustering/settings.js
+++ b/src/photos/ducks/clustering/settings.js
@@ -117,9 +117,10 @@ export const updateParamsPeriod = async (client, setting, params, photos) => {
 }
 
 export const shouldReleaseLock = setting => {
+  const lastUpdatedDate = new Date(setting.cozyMetadata.updatedAt).getTime()
   return (
     setting.jobStatus === 'running' &&
-    isDurationMoreThan24Hours(setting.lastExecution, Date.now())
+    isDurationMoreThan24Hours(lastUpdatedDate, Date.now())
   )
 }
 

--- a/src/photos/targets/services/onPhotoUpload.js
+++ b/src/photos/targets/services/onPhotoUpload.js
@@ -206,9 +206,10 @@ export const onPhotoUpload = async () => {
     }
     log('warn', 'The job status is marked as running for too long.')
   } else if (setting.jobStatus === 'postponed') {
-    const duration = convertDurationInMilliseconds(TRIGGER_ELAPSED)
+    const lastUpdatedDate = new Date(setting.cozyMetadata.updatedAt).getTime()
+    const elapsedDuration = convertDurationInMilliseconds(TRIGGER_ELAPSED)
     // Stop if a trigger is planned later
-    if (setting.lastExecution + duration > Date.now()) {
+    if (lastUpdatedDate + elapsedDuration > Date.now()) {
       log('info', 'The service is already planned later. Abort.')
       return
     }
@@ -270,8 +271,7 @@ export const onPhotoUpload = async () => {
         .create(attrs)
       await client.save({
         ...newSetting,
-        jobStatus: 'postponed',
-        lastExecution: Date.now()
+        jobStatus: 'postponed'
       })
       log('info', `The service will be run again in ${TRIGGER_ELAPSED}`)
     } else {

--- a/src/photos/targets/services/onPhotoUpload.spec.js
+++ b/src/photos/targets/services/onPhotoUpload.spec.js
@@ -29,7 +29,12 @@ describe('onPhotoUpload', () => {
   })
 
   it('Should stop if other execution is running', async () => {
-    readSetting.mockReturnValueOnce({ jobStatus: 'running' })
+    readSetting.mockReturnValueOnce({
+      jobStatus: 'running',
+      cozyMetadata: {
+        updatedAt: 500
+      }
+    })
     await onPhotoUpload()
     expect(client.save).toHaveBeenCalledTimes(0)
   })
@@ -37,7 +42,9 @@ describe('onPhotoUpload', () => {
   it('Should stop if execution is postponed', async () => {
     readSetting.mockReturnValueOnce({
       jobStatus: 'postponed',
-      lastExecution: 500
+      cozyMetadata: {
+        updatedAt: 500
+      }
     })
     convertDurationInMilliseconds.mockReturnValueOnce(600)
     await onPhotoUpload()
@@ -53,7 +60,9 @@ describe('onPhotoUpload', () => {
     ]
     readSetting.mockReturnValueOnce({
       jobStatus: 'running',
-      lastExecution: 0,
+      cozyMetadata: {
+        updatedAt: 0
+      },
       parameters: params
     })
     await onPhotoUpload()


### PR DESCRIPTION
We used to store a timestamp of the last execution of the service,
which is useful to know if the service should actually be run, depending on the 'running' and 'postponed' status.
However, this timestamp was not always set, leading to missing
information.
Therefore, we prefer to remove this timestamp and now use the
`cozyMetadata.udpatedAt` field, that we are sure is always set, as the
photo settings are updated at the beggining of the execution.

Note the doctype format should be updated accordingly: https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.photos.md#clustering-settings