### PR TITLE
feat: Use partial index for auto albums

### DIFF
--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -103,14 +103,19 @@ const removeAutoAlbumReferences = async (client, photos, album) => {
 export const findAutoAlbums = async client => {
   const query = Q(DOCTYPE_ALBUMS)
     .where({
+      name: {
+        $gt: null
+      }
+    })
+    .partialIndex({
       auto: true
     })
+    .indexFields(['name'])
     .sortBy([
       {
         name: 'desc'
       }
     ])
-    .indexFields(['name'])
   const results = await client.queryAll(query)
   return client.hydrateDocuments(DOCTYPE_ALBUMS, results)
 }


### PR DESCRIPTION
This allows a more efficient query to find auto-albums as it avoids to
query on the `auto` non-indexed field