### PR TITLE
fix: Call the hooks in the right order

### DIFF
--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -109,8 +109,8 @@ const PublicFolderView = ({
         Alerter.error('alert.offline')
       }
     } else {
-      setViewerOpened(true)
       showInViewer(file)
+      setViewerOpened(true)
     }
   }
 
@@ -160,7 +160,6 @@ const PublicFolderView = ({
     displayedFolder => getBreadcrumbPath(t, displayedFolder, parentFolder),
     [t, parentFolder]
   )
-
   return (
     <>
       <Main isPublic={true}>


### PR DESCRIPTION
If not, we got undefined for currentIndex when opening
the viewer. Let's set the index before opening it.

Tried to add a test on the component, but I can't
handle it since we've a react-test-lib test but
file-opener is done with HammerJS. Click will not
fire the right event... We should test our
hooks call in order to test the component