### PR TITLE
feat: Use partial index for negative queries

### DIFF
--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -41,9 +41,13 @@ const buildDriveQuery = ({
     Q('io.cozy.files')
       .where({
         dir_id: currentFolderId,
-        _id: { $ne: TRASH_DIR_ID },
         type,
         [sortAttribute]: { $gt: null }
+      })
+      .partialIndex({
+        _id: {
+          $ne: TRASH_DIR_ID
+        }
       })
       .indexFields(['dir_id', 'type', sortAttribute])
       .sortBy([
@@ -190,11 +194,13 @@ export const buildMoveOrImportQuery = (client, dirId) => ({
     Q('io.cozy.files')
       .where({
         dir_id: dirId,
-        _id: {
-          $ne: TRASH_DIR_ID
-        },
         type: { $gt: null },
         name: { $gt: null }
+      })
+      .partialIndex({
+        _id: {
+          $ne: TRASH_DIR_ID
+        }
       })
       .indexFields(['dir_id', 'type', 'name'])
       .sortBy([{ dir_id: 'asc' }, { type: 'asc' }, { name: 'asc' }])

--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -187,8 +187,7 @@ const buildTrashQuery = ({
 
 export const buildMoveOrImportQuery = (client, dirId) => ({
   definition: () =>
-    client
-      .find('io.cozy.files')
+    Q('io.cozy.files')
       .where({
         dir_id: dirId,
         _id: {


### PR DESCRIPTION
As recommended
[here](https://docs.cozy.io/en/tutorials/data/advanced/#partial-indexes),
we use partial indexes for negative queries. This is notably better to
have lighter indexes (the _id is not indexed anymore) and thus, more
efficient queries.