### PR TITLE
fix: Remove deep dependecies in CertificationsIcons useCallback 

### DIFF
--- a/src/drive/web/modules/filelist/cells/FileName.jsx
+++ b/src/drive/web/modules/filelist/cells/FileName.jsx
@@ -17,9 +17,10 @@ import { CozyFile } from 'models'
 
 import styles from 'drive/styles/filelist.styl'
 
-const CertificationsIcons = ({ attributes }) => {
+export const CertificationsIcons = ({ attributes }) => {
   const isCarbonCopy = get(attributes, 'metadata.carbonCopy')
   const isElectronicSafe = get(attributes, 'metadata.electronicSafe')
+  const slug = get(attributes, 'cozyMetadata.uploadedBy.slug')
   const client = useClient()
 
   //TODO To be removed when UI's AppIcon use getIconURL from Cozy-Client
@@ -28,11 +29,11 @@ const CertificationsIcons = ({ attributes }) => {
     () => {
       return client.getStackClient().getIconURL({
         type: 'konnector',
-        slug: attributes.cozyMetadata.uploadedBy.slug,
+        slug,
         priority: 'registry'
       })
     },
-    [client, attributes.cozyMetadata.uploadedBy.slug]
+    [client, slug]
   )
 
   return (
@@ -44,23 +45,29 @@ const CertificationsIcons = ({ attributes }) => {
       )}
       {isCarbonCopy &&
         (isElectronicSafe ? (
-          <Icon
-            icon={CarbonCopyIcon}
-            className={`u-mr-half ${styles['fil-file-certifications--icon']}`}
-          />
+          <span data-testid="certificationsIcons-carbonCopyIcon">
+            <Icon
+              icon={CarbonCopyIcon}
+              className={`u-mr-half ${styles['fil-file-certifications--icon']}`}
+            />
+          </span>
         ) : (
+          <span data-testid="certificationsIcons-carbonCopyAppIcon">
+            <AppIcon
+              app={slug}
+              className={styles['fil-file-certifications--icon']}
+              fetchIcon={fetchIcon}
+            />
+          </span>
+        ))}
+      {isElectronicSafe && (
+        <span data-testid="certificationsIcons-electronicSafeAppIcon">
           <AppIcon
-            app={attributes.cozyMetadata.uploadedBy.slug}
+            app={slug}
             className={styles['fil-file-certifications--icon']}
             fetchIcon={fetchIcon}
           />
-        ))}
-      {isElectronicSafe && (
-        <AppIcon
-          app={attributes.cozyMetadata.uploadedBy.slug}
-          className={styles['fil-file-certifications--icon']}
-          fetchIcon={fetchIcon}
-        />
+        </span>
       )}
     </div>
   )

--- a/src/drive/web/modules/filelist/cells/FileName.spec.js
+++ b/src/drive/web/modules/filelist/cells/FileName.spec.js
@@ -1,0 +1,97 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { createMockClient } from 'cozy-client'
+
+import AppLike from 'test/components/AppLike'
+import { CertificationsIcons } from './FileName'
+
+const client = new createMockClient({})
+const setup = ({ attributes }) => {
+  const root = render(
+    <AppLike client={client}>
+      <CertificationsIcons attributes={attributes} />
+    </AppLike>
+  )
+
+  return { root }
+}
+
+describe('CertificationsIcons', () => {
+  it('should render only carbon copy app icon', () => {
+    const { root } = setup({
+      attributes: {
+        metadata: { carbonCopy: true, electronicSafe: false },
+        cozyMetadata: { uploadedBy: { slug: 'pajemploi' } }
+      }
+    })
+    const { queryByTestId } = root
+
+    expect(queryByTestId('certificationsIcons-carbonCopyAppIcon')).toBeTruthy()
+    expect(queryByTestId('certificationsIcons-carbonCopyIcon')).toBeFalsy()
+    expect(
+      queryByTestId('certificationsIcons-electronicSafeAppIcon')
+    ).toBeFalsy()
+  })
+
+  it('should render only electronic safe app icon', () => {
+    const { root } = setup({
+      attributes: {
+        metadata: { carbonCopy: false, electronicSafe: true },
+        cozyMetadata: { uploadedBy: { slug: 'pajemploi' } }
+      }
+    })
+    const { queryByTestId } = root
+
+    expect(queryByTestId('certificationsIcons-carbonCopyAppIcon')).toBeFalsy()
+    expect(queryByTestId('certificationsIcons-carbonCopyIcon')).toBeFalsy()
+    expect(
+      queryByTestId('certificationsIcons-electronicSafeAppIcon')
+    ).toBeTruthy()
+  })
+
+  it('should render carbon copy icon and electronic safe app icon', () => {
+    const { root } = setup({
+      attributes: {
+        metadata: { carbonCopy: true, electronicSafe: true },
+        cozyMetadata: { uploadedBy: { slug: 'pajemploi' } }
+      }
+    })
+    const { queryByTestId } = root
+
+    expect(queryByTestId('certificationsIcons-carbonCopyAppIcon')).toBeFalsy()
+    expect(queryByTestId('certificationsIcons-carbonCopyIcon')).toBeTruthy()
+    expect(
+      queryByTestId('certificationsIcons-electronicSafeAppIcon')
+    ).toBeTruthy()
+  })
+
+  it('should render no certifications icon', () => {
+    const { root } = setup({
+      attributes: {
+        metadata: { carbonCopy: false, electronicSafe: false },
+        cozyMetadata: { uploadedBy: { slug: 'pajemploi' } }
+      }
+    })
+    const { queryByTestId } = root
+
+    expect(queryByTestId('certificationsIcons-carbonCopyAppIcon')).toBeFalsy()
+    expect(queryByTestId('certificationsIcons-carbonCopyIcon')).toBeFalsy()
+    expect(
+      queryByTestId('certificationsIcons-electronicSafeAppIcon')
+    ).toBeFalsy()
+  })
+
+  it('should render no certifications icon and not throw error with empty attributes', () => {
+    const { root } = setup({
+      attributes: {}
+    })
+    const { queryByTestId } = root
+
+    expect(queryByTestId('certificationsIcons-carbonCopyAppIcon')).toBeFalsy()
+    expect(queryByTestId('certificationsIcons-carbonCopyIcon')).toBeFalsy()
+    expect(
+      queryByTestId('certificationsIcons-electronicSafeAppIcon')
+    ).toBeFalsy()
+  })
+})


### PR DESCRIPTION
Fix fait sur la branche release/1.32.0 validé et mergé sur la branche, mais non rappatrié sur master.

voir https://github.com/cozy/cozy-drive/commit/66891bd2681e494a3d65f641b7642e84e20a2e5a