### PR TITLE
fix: Viewer in public view doesn't need any toolbar

### DIFF
--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -9,7 +9,11 @@ const LightFileViewer = ({ files, isFile }) => (
   <div className={styles['viewer-wrapper-with-bar']}>
     <PublicToolbar files={files} isFile={isFile} />
     <div className={'u-pos-relative u-h-100'}>
-      <Viewer files={files} currentIndex={0} dark={false} showToolbar={false} />
+      <Viewer
+        files={files}
+        currentIndex={0}
+        toolbarProps={{ showToolbar: false }}
+      />
     </div>
   </div>
 )

--- a/src/drive/web/modules/public/LightFileViewer.spec.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.spec.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { createMockClient } from 'cozy-client'
+
+import LightFileViewer from './LightFileViewer'
+import AppLike from 'test/components/AppLike'
+
+const client = new createMockClient({})
+
+describe('LightFileViewer', () => {
+  it('should not have toolbar in the viewer', () => {
+    const { queryByRole } = render(
+      <AppLike client={client}>
+        <LightFileViewer files={[{ id: '01' }]} isFile={true} />
+      </AppLike>
+    )
+
+    expect(queryByRole('viewer-toolbar')).toBeFalsy()
+  })
+})


### PR DESCRIPTION
Remove toolbar in public viewer