### PR TITLE
Fix mobile dataset

### DIFF
--- a/src/drive/targets/mobile/index.ejs
+++ b/src/drive/targets/mobile/index.ejs
@@ -31,16 +31,6 @@
   </head>
   <div
     role="application"
-    data-cozy-token="{{.Token}}"
-    data-cozy-domain="{{.Domain}}"
-    data-cozy-locale="{{.Locale}}"
-    data-cozy-app-name="{{.AppName}}"
-    data-cozy-app-name-prefix="{{.AppNamePrefix}}"
-    data-cozy-app-editor="{{.AppEditor}}"
-    data-cozy-app-slug="{{.AppSlug}}"
-    data-cozy-tracking="{{.Tracking}}"
-    data-cozy-icon-path="{{.IconPath}}"
-    data-cozy-subdomain-type="{{.SubDomain}}"
   ></div>
   <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
   <script src="<%- file %>"></script>


### PR DESCRIPTION
Les dataset sont habituellement injecté par la stack. Ce qui n'est pas le cas sur mobile et fait que les `data-cozy-*="{{.Xxxxx}}"` reste telque et ne sont pas remplacé comme il devrait.
Et cela fait planter le `JSON.parse()` de https://github.com/cozy/cozy-ui/blob/master/react/helpers/appDataset.js#L37 `return value === undefined ? undefined : value === '' || JSON.parse(value)` car `value` vaut `{{.Xxxxx}}` dans le cas présent.
