### PR TITLE
feat: Action menu openWith, forwardTo and sendTo label/icon

### DIFF
--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -238,12 +238,14 @@
     "rename": "Rename",
     "restore": "Restore",
     "close": "Close",
+    "openWith": "Open with...",
+    "applePreview": "Apple preview",
     "forward": "Forward",
+    "forwardTo": "Forward to...",
     "moveto": "Move to…",
     "phone-download": "Make available offline",
     "qualify": "Categorize",
-    "history": "History",
-    "sendto": "Send to..."
+    "history": "History"
   },
   "deleteconfirmation": {
     "title": "Delete this element? |||| Delete these elements?",

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { models } from 'cozy-client'
 import { ShareModal } from 'cozy-sharing'
-import { isIOSApp, isMobileApp, isIOS } from 'cozy-device-helper'
+import { isIOSApp, isMobileApp } from 'cozy-device-helper'
 import { EditDocumentQualification } from 'cozy-scanner'
 import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
 import { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
@@ -16,6 +16,8 @@ import HistoryIcon from 'cozy-ui/transpiled/react/Icons/History'
 import RestoreIcon from 'cozy-ui/transpiled/react/Icons/Restore'
 import ReplyIcon from 'cozy-ui/transpiled/react/Icons/Reply'
 import ShareIosIcon from 'cozy-ui/transpiled/react/Icons/ShareIos'
+import LinkOutIcon from 'cozy-ui/transpiled/react/Icons/LinkOut'
+import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
 
 import DeleteConfirm from 'drive/web/modules/drive/DeleteConfirm'
 import MoveModal from 'drive/web/modules/move/MoveModal'
@@ -24,7 +26,6 @@ import MakeAvailableOfflineMenuItem from 'drive/web/modules/drive/MakeAvailableO
 import DestroyConfirm from 'drive/web/modules/trash/components/DestroyConfirm'
 import { startRenamingAsync } from 'drive/web/modules/drive/rename'
 
-const ForwardIcon = isIOS() ? ShareIosIcon : ReplyIcon
 const { file: fileModel } = models
 const { isFile } = fileModel
 
@@ -68,7 +69,7 @@ export const download = ({ client }) => {
           )
         },
         action: files => exportFilesNative(client, files),
-        label: 'sendto',
+        label: 'forwardTo',
         Component: function Download(props) {
           const { t } = useI18n()
           return (
@@ -76,9 +77,9 @@ export const download = ({ client }) => {
               onClick={() => {
                 return exportFilesNative(client, props.files)
               }}
-              left={<Icon icon={DownloadIcon} />}
+              left={<Icon icon={isIOSApp() ? ShareIosIcon : ReplyIcon} />}
             >
-              {t('SelectionBar.sendto')}
+              {t('SelectionBar.forwardTo')}
             </ActionMenuItem>
           )
         }
@@ -162,9 +163,11 @@ export const open = ({ client }) => {
       return (
         <ActionMenuItem
           onClick={() => openFileWith(client, props.files[0])}
-          left={<Icon icon={ForwardIcon} />}
+          left={<Icon icon={isIOSApp() ? EyeIcon : LinkOutIcon} />}
         >
-          {t('SelectionBar.forward')}
+          {isIOSApp()
+            ? t('SelectionBar.applePreview')
+            : t('SelectionBar.openWith')}
         </ActionMenuItem>
       )
     }

--- a/src/drive/web/modules/actions/useActions.spec.jsx
+++ b/src/drive/web/modules/actions/useActions.spec.jsx
@@ -222,7 +222,7 @@ describe('useActions', () => {
 
       it('is visible for a single file on iOS', () => {
         global.window.cordova = { platformId: 'ios' }
-        const downloadAction = getAction('sendto')
+        const downloadAction = getAction('forwardTo')
         expect(
           downloadAction.displayCondition([{ id: 'abc', type: 'file' }])
         ).toBe(true)
@@ -245,7 +245,7 @@ describe('useActions', () => {
 
       it('is visible if only files are selected on android', () => {
         global.window.cordova = { platformId: 'android' }
-        const downloadAction = getAction('sendto')
+        const downloadAction = getAction('forwardTo')
         expect(
           downloadAction.displayCondition([
             { id: 'abc', type: 'file' },
@@ -261,7 +261,7 @@ describe('useActions', () => {
       })
 
       it('export files to the device when activated', () => {
-        const downloadAction = getAction('sendto')
+        const downloadAction = getAction('forwardTo')
         const mockDocuments = [
           { id: 'abc', name: 'my-file.md' },
           { id: 'def', name: 'my-file-2.md' }


### PR DESCRIPTION
On souhaite avoir ce comportement : 
- Le 'ouvrir avec... ' reste 'ouvrir avec...' et 'open with...' pour Android dans le menu d'action (et garde le même comportement). Idéalement c'est "Aperçu apple" pour iOS.
- Le 'send to ...' devient 'transférer vers...' / 'forward to...' dans le menu d'action (avec idéalement une icône en fonction de l'OS: android ou iOS)
- Le bouton 'dans le viewer prend alors le comportement du "send to" renommer 'transférer vers ...'/ 'forward to...' avec comme texte pour ce bouton "Transférer" et "Forward" (pour des raisons de place)