### PR TITLE
Public toolbar and banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "cozy-scripts": "5.1.1",
     "cozy-sharing": "3.2.0",
     "cozy-stack-client": "17.6.1",
-    "cozy-ui": "47.0.0",
+    "cozy-ui": "47.3.0",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/src/components/sharing/PublicBanner.jsx
+++ b/src/components/sharing/PublicBanner.jsx
@@ -4,9 +4,12 @@ import snarkdown from 'snarkdown'
 
 import { useClient } from 'cozy-client'
 import Banner from 'cozy-ui/transpiled/react/Banner'
-import Button from 'cozy-ui/transpiled/react/Button'
+import Button, { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import palette from 'cozy-ui/transpiled/react/palette'
 import { useI18n } from 'cozy-ui/transpiled/react'
+
+import CozyHomeLinkIcon from 'components/Button/CozyHomeLinkIcon'
+import getHomeLinkHref from 'components/Button/getHomeLinkHref'
 
 import styles from './publicBanner.styl'
 
@@ -127,6 +130,7 @@ const SharingBannerByLinkText = () => {
     </span>
   )
 }
+
 const SharingBannerByLink = ({ onClose }) => {
   const { t } = useI18n()
   return (
@@ -134,6 +138,14 @@ const SharingBannerByLink = ({ onClose }) => {
       bgcolor={palette['paleGrey']}
       text={<SharingBannerByLinkText />}
       buttonOne={
+        <ButtonLink
+          theme="text"
+          label={t('Share.create-cozy')}
+          icon={CozyHomeLinkIcon}
+          href={getHomeLinkHref('sharing-drive')}
+        />
+      }
+      buttonTwo={
         <Button
           theme="text"
           label={t('Share.banner.close')}

--- a/src/drive/web/modules/drive/Toolbar/components/UploadButtonItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/UploadButtonItem.jsx
@@ -7,12 +7,13 @@ import { compose } from 'redux'
 
 import toolbarContainer from '../toolbar'
 
-const UploadButtonItem = ({ t, displayedFolder, isDisabled }) => (
+const UploadButtonItem = ({ t, displayedFolder, isDisabled, onUploaded }) => (
   <UploadButton
     disabled={isDisabled}
     displayedFolder={displayedFolder}
     label={t('toolbar.item_upload')}
     className={classNames(styles['c-btn'], 'u-hide--mob')}
+    onUploaded={onUploaded}
   />
 )
 

--- a/src/drive/web/modules/public/CozyBarRightMobile.jsx
+++ b/src/drive/web/modules/public/CozyBarRightMobile.jsx
@@ -1,0 +1,18 @@
+/* global cozy */
+const { BarRight } = cozy.bar
+
+import React from 'react'
+
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+const CozyBarRightMobile = ({ children }) => {
+  const { isMobile } = useBreakpoints()
+
+  if (isMobile) {
+    return <BarRight>{children}</BarRight>
+  }
+
+  return <>{children}</>
+}
+
+export default CozyBarRightMobile

--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -1,16 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import PublicToolbar from './PublicToolbar'
 import Viewer from 'drive/web/modules/viewer/PublicViewer'
 import SharingBanner from 'drive/web/modules/public/SharingBanner'
 
 import styles from 'drive/web/modules/viewer/barviewer.styl'
 
-const LightFileViewer = ({ files, isFile }) => (
+const LightFileViewer = ({ files }) => (
   <div className={styles['viewer-wrapper-with-bar']}>
     <SharingBanner />
-    <PublicToolbar files={files} isFile={isFile} />
     <div className={'u-pos-relative u-h-100'}>
       <Viewer
         files={files}

--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -3,21 +3,26 @@ import PropTypes from 'prop-types'
 
 import Viewer from 'drive/web/modules/viewer/PublicViewer'
 import SharingBanner from 'drive/web/modules/public/SharingBanner'
+import { useSharingInfos } from 'drive/web/modules/public/useSharingInfos'
 
 import styles from 'drive/web/modules/viewer/barviewer.styl'
 
-const LightFileViewer = ({ files }) => (
-  <div className={styles['viewer-wrapper-with-bar']}>
-    <SharingBanner />
-    <div className={'u-pos-relative u-h-100'}>
-      <Viewer
-        files={files}
-        currentIndex={0}
-        toolbarProps={{ showToolbar: false }}
-      />
+const LightFileViewer = ({ files }) => {
+  const sharingInfos = useSharingInfos()
+
+  return (
+    <div className={styles['viewer-wrapper-with-bar']}>
+      <SharingBanner sharingInfos={sharingInfos} />
+      <div className={'u-pos-relative u-h-100'}>
+        <Viewer
+          files={files}
+          currentIndex={0}
+          toolbarProps={{ showToolbar: false }}
+        />
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 LightFileViewer.propTypes = {
   files: PropTypes.array.isRequired,

--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types'
 
 import PublicToolbar from './PublicToolbar'
 import Viewer from 'drive/web/modules/viewer/PublicViewer'
+import SharingBanner from 'drive/web/modules/public/SharingBanner'
+
 import styles from 'drive/web/modules/viewer/barviewer.styl'
 
 const LightFileViewer = ({ files, isFile }) => (
   <div className={styles['viewer-wrapper-with-bar']}>
+    <SharingBanner />
     <PublicToolbar files={files} isFile={isFile} />
     <div className={'u-pos-relative u-h-100'}>
       <Viewer

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -3,15 +3,20 @@ import PropTypes from 'prop-types'
 
 import PublicToolbarByLink from './PublicToolbarByLink'
 import PublicToolbarCozyToCozy from './PublicToolbarCozyToCozy'
-import { useSharingInfos } from './useSharingInfos'
 
-const PublicToolbar = ({ hasWriteAccess, refreshFolderContent, files }) => {
+const PublicToolbar = ({
+  hasWriteAccess,
+  refreshFolderContent,
+  files,
+  sharingInfos
+}) => {
   const {
     loading,
     discoveryLink,
     sharing,
     isSharingShortcutCreated
-  } = useSharingInfos()
+  } = sharingInfos
+
   return (
     <>
       {loading && null}
@@ -42,7 +47,8 @@ PublicToolbar.propTypes = {
   // hasWriteAccess is only required if we're in a sharing by link
   hasWriteAccess: PropTypes.bool,
   // refreshFolderContent is not required if we're displaying only one file or in a cozy to cozy sharing
-  refreshFolderContent: PropTypes.func
+  refreshFolderContent: PropTypes.func,
+  sharingInfos: PropTypes.object
 }
 
 export default PublicToolbar

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -13,6 +13,7 @@ import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/Selectabl
 import AddFolderItem from 'drive/web/modules/drive/Toolbar/components/AddFolderItem'
 import UploadItem from 'drive/web/modules/drive/Toolbar/components/UploadItem'
 import CreateShortcut from 'drive/web/modules/drive/Toolbar/components/CreateShortcut'
+import UploadButtonItem from 'drive/web/modules/drive/Toolbar/components/UploadButtonItem'
 import { downloadFiles } from 'drive/web/modules/actions/utils'
 import CozyBarRightMobile from 'drive/web/modules/public/CozyBarRightMobile'
 
@@ -108,9 +109,16 @@ const PublicToolbarByLink = ({
     <CozyBarRightMobile>
       <BarContextProvider client={client} t={t} store={client.store}>
         {!isMobile && (
-          <div className="u-m-auto">
-            <DownloadFilesButton files={files} />
-          </div>
+          <>
+            <div className="u-m-auto">
+              {hasWriteAccess && (
+                <UploadButtonItem onUploaded={refreshFolderContent} />
+              )}
+            </div>
+            <div className="u-m-auto">
+              <DownloadFilesButton files={files} />
+            </div>
+          </>
         )}
         {shouldDisplayMoreMenu && (
           <div className="u-m-auto">

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -4,12 +4,11 @@ import { useClient } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import BarContextProvider from 'cozy-ui/transpiled/react/BarContextProvider'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import { Button, ButtonLink, Icon } from 'cozy-ui/transpiled/react'
+import { Button, Icon } from 'cozy-ui/transpiled/react'
 import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
 
 import getHomeLinkHref from 'components/Button/getHomeLinkHref'
-import CozyHomeLinkIcon from 'components/Button/CozyHomeLinkIcon'
 import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/SelectableItem'
 import AddFolderItem from 'drive/web/modules/drive/Toolbar/components/AddFolderItem'
 import UploadItem from 'drive/web/modules/drive/Toolbar/components/UploadItem'
@@ -21,17 +20,6 @@ import { DownloadFilesButton } from './DownloadButton'
 
 const isFilesIsFile = files => files.length === 1 && files[0].type === 'file'
 
-const CreateCozyButton = ({ from, size }) => {
-  const { t } = useI18n()
-  return (
-    <ButtonLink
-      label={t('Share.create-cozy')}
-      icon={CozyHomeLinkIcon}
-      href={getHomeLinkHref(from)}
-      size={size}
-    />
-  )
-}
 const MoreButton = ({ disabled, onClick }) => {
   const { t } = useI18n()
   return (
@@ -120,14 +108,9 @@ const PublicToolbarByLink = ({
     <CozyBarRightMobile>
       <BarContextProvider client={client} t={t} store={client.store}>
         {!isMobile && (
-          <>
-            <div className="u-m-auto">
-              <DownloadFilesButton files={files} />
-            </div>
-            <div className="u-m-auto">
-              <CreateCozyButton from="sharing-drive" />
-            </div>
-          </>
+          <div className="u-m-auto">
+            <DownloadFilesButton files={files} />
+          </div>
         )}
         {shouldDisplayMoreMenu && (
           <div className="u-m-auto">

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -13,7 +13,6 @@ import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
 
 import getHomeLinkHref from 'components/Button/getHomeLinkHref'
 import CozyHomeLinkIcon from 'components/Button/CozyHomeLinkIcon'
-import { SharingBannerByLink } from 'components/sharing/PublicBanner'
 import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/SelectableItem'
 import AddFolderItem from 'drive/web/modules/drive/Toolbar/components/AddFolderItem'
 import UploadItem from 'drive/web/modules/drive/Toolbar/components/UploadItem'
@@ -105,6 +104,7 @@ const MoreMenu = ({
     </>
   )
 }
+
 const PublicToolbarByLink = ({
   files,
   hasWriteAccess,
@@ -117,38 +117,32 @@ const PublicToolbarByLink = ({
 
   const shouldDisplayMoreMenu =
     isMobile || (!isFile && files.length > 0) || hasWriteAccess
-  const [isOpened, setIsOpened] = useState(true)
-  const onClose = useCallback(() => setIsOpened(false), [setIsOpened])
 
   return (
-    <>
-      {isOpened && <SharingBannerByLink onClose={onClose} />}
-
-      <BarRight>
-        <BarContextProvider client={client} t={t} store={client.store}>
-          {!isMobile && (
-            <>
-              <div className="u-m-auto">
-                <DownloadFilesButton files={files} />
-              </div>
-              <div className="u-m-auto">
-                <CreateCozyButton from="sharing-drive" />
-              </div>
-            </>
-          )}
-          {shouldDisplayMoreMenu && (
+    <BarRight>
+      <BarContextProvider client={client} t={t} store={client.store}>
+        {!isMobile && (
+          <>
             <div className="u-m-auto">
-              <MoreMenu
-                hasWriteAccess={hasWriteAccess}
-                refreshFolderContent={refreshFolderContent}
-                isMobile={isMobile}
-                files={files}
-              />
+              <DownloadFilesButton files={files} />
             </div>
-          )}
-        </BarContextProvider>
-      </BarRight>
-    </>
+            <div className="u-m-auto">
+              <CreateCozyButton from="sharing-drive" />
+            </div>
+          </>
+        )}
+        {shouldDisplayMoreMenu && (
+          <div className="u-m-auto">
+            <MoreMenu
+              hasWriteAccess={hasWriteAccess}
+              refreshFolderContent={refreshFolderContent}
+              isMobile={isMobile}
+              files={files}
+            />
+          </div>
+        )}
+      </BarContextProvider>
+    </BarRight>
   )
 }
 

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -1,6 +1,3 @@
-/* global cozy */
-const { BarRight } = cozy.bar
-
 import React, { useCallback, useState } from 'react'
 
 import { useClient } from 'cozy-client'
@@ -18,6 +15,7 @@ import AddFolderItem from 'drive/web/modules/drive/Toolbar/components/AddFolderI
 import UploadItem from 'drive/web/modules/drive/Toolbar/components/UploadItem'
 import CreateShortcut from 'drive/web/modules/drive/Toolbar/components/CreateShortcut'
 import { downloadFiles } from 'drive/web/modules/actions/utils'
+import CozyBarRightMobile from 'drive/web/modules/public/CozyBarRightMobile'
 
 import { DownloadFilesButton } from './DownloadButton'
 
@@ -119,7 +117,7 @@ const PublicToolbarByLink = ({
     isMobile || (!isFile && files.length > 0) || hasWriteAccess
 
   return (
-    <BarRight>
+    <CozyBarRightMobile>
       <BarContextProvider client={client} t={t} store={client.store}>
         {!isMobile && (
           <>
@@ -142,7 +140,7 @@ const PublicToolbarByLink = ({
           </div>
         )}
       </BarContextProvider>
-    </BarRight>
+    </CozyBarRightMobile>
   )
 }
 

--- a/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
+++ b/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
@@ -9,10 +9,8 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 
-import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/SelectableItem'
-
 import { MoreButton } from 'components/Button'
-import { SharingBannerCozyToCozy } from 'components/sharing/PublicBanner'
+import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/SelectableItem'
 import { downloadFiles } from 'drive/web/modules/actions/utils'
 import { DownloadFilesButton } from './DownloadButton'
 
@@ -77,44 +75,30 @@ const MoreMenu = ({
 const PublicToolbarCozyToCozy = ({
   discoveryLink,
   files,
-  isSharingShortcutCreated,
-  sharing
+  isSharingShortcutCreated
 }) => {
   const { t } = useI18n()
   const client = useClient()
   const { isMobile } = useBreakpoints()
 
-  const [isOpened, setIsOpened] = useState(true)
-  const onClose = useCallback(() => setIsOpened(false), [setIsOpened])
-
   return (
-    <>
-      {isOpened && (
-        <SharingBannerCozyToCozy
-          isSharingShortcutCreated={isSharingShortcutCreated}
-          sharing={sharing}
-          discoveryLink={discoveryLink}
-          onClose={onClose}
-        />
-      )}
-      <BarRight>
-        <BarContextProvider client={client} t={t} store={client.store}>
-          {!isMobile && (
-            <div className="u-m-auto">
-              <DownloadFilesButton files={files} />
-            </div>
-          )}
+    <BarRight>
+      <BarContextProvider client={client} t={t} store={client.store}>
+        {!isMobile && (
           <div className="u-m-auto">
-            <MoreMenu
-              files={files}
-              discoveryLink={discoveryLink}
-              isSharingShortcutCreated={isSharingShortcutCreated}
-              isMobile={isMobile}
-            />
+            <DownloadFilesButton files={files} />
           </div>
-        </BarContextProvider>
-      </BarRight>
-    </>
+        )}
+        <div className="u-m-auto">
+          <MoreMenu
+            files={files}
+            discoveryLink={discoveryLink}
+            isSharingShortcutCreated={isSharingShortcutCreated}
+            isMobile={isMobile}
+          />
+        </div>
+      </BarContextProvider>
+    </BarRight>
   )
 }
 

--- a/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
+++ b/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
@@ -1,4 +1,3 @@
-/* global cozy */
 import React, { useState, useCallback } from 'react'
 
 import { useClient } from 'cozy-client'
@@ -12,9 +11,8 @@ import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import { MoreButton } from 'components/Button'
 import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/SelectableItem'
 import { downloadFiles } from 'drive/web/modules/actions/utils'
+import CozyBarRightMobile from 'drive/web/modules/public/CozyBarRightMobile'
 import { DownloadFilesButton } from './DownloadButton'
-
-const { BarRight } = cozy.bar
 
 const openExternalLink = url => (window.location = url)
 
@@ -82,7 +80,7 @@ const PublicToolbarCozyToCozy = ({
   const { isMobile } = useBreakpoints()
 
   return (
-    <BarRight>
+    <CozyBarRightMobile>
       <BarContextProvider client={client} t={t} store={client.store}>
         {!isMobile && (
           <div className="u-m-auto">
@@ -98,7 +96,7 @@ const PublicToolbarCozyToCozy = ({
           />
         </div>
       </BarContextProvider>
-    </BarRight>
+    </CozyBarRightMobile>
   )
 }
 

--- a/src/drive/web/modules/public/SharingBanner.jsx
+++ b/src/drive/web/modules/public/SharingBanner.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
 
 import {
   SharingBannerByLink,
   SharingBannerCozyToCozy
 } from 'components/sharing/PublicBanner'
-import { useSharingInfos } from 'drive/web/modules/public/useSharingInfos'
 
-const SharingBanner = () => {
+const SharingBanner = ({ sharingInfos }) => {
   const [isOpened, setIsOpened] = useState(true)
   const onClose = useCallback(() => setIsOpened(false), [setIsOpened])
 
@@ -15,7 +15,7 @@ const SharingBanner = () => {
     discoveryLink,
     sharing,
     isSharingShortcutCreated
-  } = useSharingInfos()
+  } = sharingInfos
 
   return (
     !loading &&
@@ -31,6 +31,10 @@ const SharingBanner = () => {
       />
     ))
   )
+}
+
+SharingBanner.propTypes = {
+  sharingInfos: PropTypes.object
 }
 
 export default SharingBanner

--- a/src/drive/web/modules/public/SharingBanner.jsx
+++ b/src/drive/web/modules/public/SharingBanner.jsx
@@ -1,0 +1,36 @@
+import React, { useState, useCallback } from 'react'
+
+import {
+  SharingBannerByLink,
+  SharingBannerCozyToCozy
+} from 'components/sharing/PublicBanner'
+import { useSharingInfos } from 'drive/web/modules/public/useSharingInfos'
+
+const SharingBanner = () => {
+  const [isOpened, setIsOpened] = useState(true)
+  const onClose = useCallback(() => setIsOpened(false), [setIsOpened])
+
+  const {
+    loading,
+    discoveryLink,
+    sharing,
+    isSharingShortcutCreated
+  } = useSharingInfos()
+
+  return (
+    !loading &&
+    isOpened &&
+    (!discoveryLink ? (
+      <SharingBannerByLink onClose={onClose} />
+    ) : (
+      <SharingBannerCozyToCozy
+        isSharingShortcutCreated={isSharingShortcutCreated}
+        sharing={sharing}
+        discoveryLink={discoveryLink}
+        onClose={onClose}
+      />
+    ))
+  )
+}
+
+export default SharingBanner

--- a/src/drive/web/modules/public/useSharingInfos.jsx
+++ b/src/drive/web/modules/public/useSharingInfos.jsx
@@ -1,15 +1,17 @@
 import { useState, useEffect } from 'react'
 
-import { useClient, Q, models } from 'cozy-client'
+import { useClient, models } from 'cozy-client'
+import { getQueryParameter } from 'react-cozy-helpers'
 
 import logger from 'lib/logger'
-import { getQueryParameter } from 'react-cozy-helpers'
+import { buildSharingsByIdQuery } from 'drive/web/modules/queries'
 
 const getSharingId = permission => {
   const sourceId = permission.data.attributes.source_id
   const sharingId = sourceId.split('/')[1]
   return sharingId
 }
+
 export const useSharingInfos = () => {
   const client = useClient()
 
@@ -28,6 +30,7 @@ export const useSharingInfos = () => {
           const response = await client
             .collection('io.cozy.permissions')
             .fetchOwnPermissions()
+
           const isSharingShortcutCreated = models.permission.isShortcutCreatedOnTheRecipientCozy(
             response
           )
@@ -37,9 +40,11 @@ export const useSharingInfos = () => {
           const link = client
             .collection('io.cozy.sharings')
             .getDiscoveryLink(sharingId, sharecode)
+          const sharingsByIdQuery = buildSharingsByIdQuery(sharingId)
           const { data: sharing } = await client.query(
-            Q('io.cozy.sharings').getById(sharingId)
+            sharingsByIdQuery.definition
           )
+
           setDiscoveryLink(link)
           setIsSharingSharingcutCreated(isSharingShortcutCreated)
           setSharing(sharing)
@@ -49,6 +54,7 @@ export const useSharingInfos = () => {
           setLoading(false)
         }
       }
+
       if (window.location.pathname === '/preview') {
         loadSharingDiscoveryLink()
       } else {
@@ -57,6 +63,7 @@ export const useSharingInfos = () => {
     },
     [client]
   )
+
   return {
     sharing,
     loading,

--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -283,6 +283,14 @@ export const buildFileWithSpecificMetadataAttributeQuery = ({
   }
 })
 
+export const buildSharingsByIdQuery = sharingId => ({
+  definition: Q('io.cozy.sharings').getById(sharingId),
+  options: {
+    as: `io.cozy.sharings/${sharingId}`,
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
 export {
   buildDriveQuery,
   buildRecentQuery,

--- a/src/drive/web/modules/upload/UploadButton.jsx
+++ b/src/drive/web/modules/upload/UploadButton.jsx
@@ -40,9 +40,12 @@ UploadButton.defaultProps = {
   disabled: false
 }
 
-const mapDispatchToProps = (dispatch, { displayedFolder, sharingState }) => ({
+const mapDispatchToProps = (
+  dispatch,
+  { displayedFolder, sharingState, onUploaded }
+) => ({
   onUpload: files => {
-    dispatch(uploadFiles(files, displayedFolder.id, sharingState))
+    dispatch(uploadFiles(files, displayedFolder.id, sharingState, onUploaded))
   }
 })
 

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -21,6 +21,7 @@ import FolderViewBody from '../Folder/FolderViewBody'
 import FolderViewBreadcrumb from '../Folder/FolderViewBreadcrumb'
 import PublicToolbar from 'drive/web/modules/public/PublicToolbar'
 import SharingBanner from 'drive/web/modules/public/SharingBanner'
+import { useSharingInfos } from 'drive/web/modules/public/useSharingInfos'
 import PublicViewer from 'drive/web/modules/viewer/PublicViewer'
 import {
   getCurrentFolderId,
@@ -66,6 +67,8 @@ const PublicFolderView = ({
 }) => {
   const client = useClient()
   const { isMobile } = useBreakpoints()
+
+  const sharingInfos = useSharingInfos()
 
   const [viewerOpened, setViewerOpened] = useState(false)
   const [currentViewerIndex, setCurrentViewerIndex] = useState(null)
@@ -168,7 +171,7 @@ const PublicFolderView = ({
       <Main isPublic={true}>
         <ModalStack />
         <ModalManager />
-        <SharingBanner />
+        <SharingBanner sharingInfos={sharingInfos} />
         <div className="u-pt-2">
           <FolderViewHeader>
             {currentFolderId && (
@@ -182,6 +185,7 @@ const PublicFolderView = ({
                   files={files}
                   hasWriteAccess={hasWritePermissions}
                   refreshFolderContent={refreshFolderContent}
+                  sharingInfos={sharingInfos}
                 />
               </>
             )}

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -168,20 +168,22 @@ const PublicFolderView = ({
       <Main isPublic={true}>
         <ModalStack />
         <ModalManager />
-        <PublicToolbar
-          files={files}
-          hasWriteAccess={hasWritePermissions}
-          refreshFolderContent={refreshFolderContent}
-        />
         <SharingBanner />
         <div className="u-pt-2">
           <FolderViewHeader>
             {currentFolderId && (
-              <FolderViewBreadcrumb
-                getBreadcrumbPath={geTranslatedBreadcrumbPath}
-                currentFolderId={currentFolderId}
-                navigateToFolder={navigateToFolder}
-              />
+              <>
+                <FolderViewBreadcrumb
+                  getBreadcrumbPath={geTranslatedBreadcrumbPath}
+                  currentFolderId={currentFolderId}
+                  navigateToFolder={navigateToFolder}
+                />
+                <PublicToolbar
+                  files={files}
+                  hasWriteAccess={hasWritePermissions}
+                  refreshFolderContent={refreshFolderContent}
+                />
+              </>
             )}
           </FolderViewHeader>
           <Content>

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -20,17 +20,19 @@ import FolderViewHeader from '../Folder/FolderViewHeader'
 import FolderViewBody from '../Folder/FolderViewBody'
 import FolderViewBreadcrumb from '../Folder/FolderViewBreadcrumb'
 import PublicToolbar from 'drive/web/modules/public/PublicToolbar'
+import SharingBanner from 'drive/web/modules/public/SharingBanner'
 import PublicViewer from 'drive/web/modules/viewer/PublicViewer'
 import {
   getCurrentFolderId,
   getDisplayedFolder,
   getParentFolder
 } from 'drive/web/modules/selectors'
-import usePublicFilesQuery from './usePublicFilesQuery'
-import usePublicWritePermissions from './usePublicWritePermissions'
 import { hasMetadataAttribute } from 'drive/web/modules/drive/files'
 import { useExtraColumns } from 'drive/web/modules/certifications/useExtraColumns'
 import { makeExtraColumnsNamesFromMedia } from 'drive/web/modules/certifications'
+
+import usePublicFilesQuery from './usePublicFilesQuery'
+import usePublicWritePermissions from './usePublicWritePermissions'
 
 const getBreadcrumbPath = (t, displayedFolder, parentFolder) =>
   uniqBy(
@@ -160,6 +162,7 @@ const PublicFolderView = ({
     displayedFolder => getBreadcrumbPath(t, displayedFolder, parentFolder),
     [t, parentFolder]
   )
+
   return (
     <>
       <Main isPublic={true}>
@@ -170,6 +173,7 @@ const PublicFolderView = ({
           hasWriteAccess={hasWritePermissions}
           refreshFolderContent={refreshFolderContent}
         />
+        <SharingBanner />
         <div className="u-pt-2">
           <FolderViewHeader>
             {currentFolderId && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,6 +826,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.2":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -916,6 +923,18 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
+"@emotion/babel-utils@^0.6.4":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"
+  integrity sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==
+  dependencies:
+    "@emotion/hash" "^0.6.6"
+    "@emotion/memoize" "^0.6.6"
+    "@emotion/serialize" "^0.9.1"
+    convert-source-map "^1.5.1"
+    find-root "^1.1.0"
+    source-map "^0.7.2"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -931,10 +950,20 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
+"@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
+  integrity sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
+  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
 
 "@emotion/serialize@^0.11.15":
   version "0.11.16"
@@ -947,6 +976,16 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
+"@emotion/serialize@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.9.1.tgz#a494982a6920730dba6303eb018220a2b629c145"
+  integrity sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==
+  dependencies:
+    "@emotion/hash" "^0.6.6"
+    "@emotion/memoize" "^0.6.6"
+    "@emotion/unitless" "^0.6.7"
+    "@emotion/utils" "^0.8.2"
+
 "@emotion/sheet@0.9.4":
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
@@ -957,15 +996,30 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
+"@emotion/stylis@^0.7.0":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
+  integrity sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==
+
 "@emotion/unitless@0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
+  integrity sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==
+
 "@emotion/utils@0.11.3":
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
+
+"@emotion/utils@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
+  integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
 "@emotion/weak-memoize@0.2.5":
   version "0.2.5"
@@ -1620,6 +1674,11 @@
   version "10.17.40"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.40.tgz#8a50e47daff15fd4a89dc56f5221b3729e506be6"
   integrity sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -2733,6 +2792,24 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-emotion@^9.2.11:
+  version "9.2.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz#319c005a9ee1d15bb447f59fe504c35fd5807728"
+  integrity sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/babel-utils" "^0.6.4"
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.7.0"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    find-root "^1.1.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.7"
+    touch "^2.0.1"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
@@ -2749,6 +2826,15 @@ babel-plugin-jest-hoist@^24.9.0:
   integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-macros@^2.0.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
+  integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    cosmiconfig "^6.0.0"
+    resolve "^1.12.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -2784,6 +2870,11 @@ babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
   integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -4691,7 +4782,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1, convert-source-map@^1.7.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -4966,6 +5057,17 @@ cosmiconfig@^5.0.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
 
 cozy-authentication@^2.0.5:
   version "2.3.2"
@@ -5247,10 +5349,10 @@ cozy-interapp@0.4.9:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.4.9.tgz#5ef68d54755cc99c3e154e5a4646b68cbe5f16fd"
   integrity sha512-skyjrewnMu5zMfST7vTNGl3jsuWae1Iwfdev6pW9RLgb58M7oBSpsIa3ofRANv5tx0XVQDVSEzWvbFQ84WJPSg==
 
-cozy-interapp@0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"
-  integrity sha512-f0UaKpBkRUnIKgAWND0e1IwfTTINjizlgDmfQwX3aMyWp8t9wX0xkNFn53TSyKUoBUnfovrclS3hm9fngjEp7A==
+cozy-interapp@^0.5.4:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.7.tgz#75cafe1732ad660e2caf1ccf412f302594705f39"
+  integrity sha512-laIL/ATYV9oZnmqS+LMoO9qzk8XjJ1v2/YrA1Po2rI8ia/MDgjYO07424x2RuvHhNOBPGjD+JmqwQ0rNDlLW+Q==
 
 cozy-jobs-cli@1.15.9:
   version "1.15.9"
@@ -5474,15 +5576,15 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@47.0.0:
-  version "47.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-47.0.0.tgz#f86e8ffaaad7d43b0b390351213a88181755f77a"
-  integrity sha512-KONTfP33GwwlhRyIRniDqBUmEsC9HJkwmelBCCcUo0dm5eghxIxs4ieAszPe3oXwXQCjks0KzLCNMfez2Lf6hQ==
+cozy-ui@47.3.0:
+  version "47.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-47.3.0.tgz#b53e1c913dc78dafeea88b18c6c55bcab60f3839"
+  integrity sha512-aaTZff+uHXDpcvas31Q7zVipmOsL8KN00KB1aX/RJP5sAnUrTIhrcO6r2wtzn12jDgPsRi7hcaoD9AEKYP7JmA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
     classnames "^2.2.5"
-    cozy-interapp "0.5.4"
+    cozy-interapp "^0.5.4"
     date-fns "^1.28.5"
     hammerjs "^2.0.8"
     intersection-observer "0.11.0"
@@ -5492,8 +5594,8 @@ cozy-ui@47.0.0:
     react-pdf "^4.0.5"
     react-popper "^2.2.3"
     react-remove-scroll "^2.4.0"
-    react-select "2.2.0"
-    react-swipeable-views "0.13.3"
+    react-select "^2.2.0"
+    react-swipeable-views "^0.13.3"
 
 create-ecdh@^4.0.0:
   version "4.0.4"
@@ -5512,6 +5614,19 @@ create-emotion@^10.0.4:
     "@emotion/serialize" "^0.11.15"
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
+
+create-emotion@^9.2.12:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.12.tgz#0fc8e7f92c4f8bb924b0fef6781f66b1d07cb26f"
+  integrity sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==
+  dependencies:
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.7.0"
+    "@emotion/unitless" "^0.6.2"
+    csstype "^2.5.2"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -6468,6 +6583,14 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+emotion@^9.1.2:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
+  integrity sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==
+  dependencies:
+    babel-plugin-emotion "^9.2.11"
+    create-emotion "^9.2.12"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -7606,6 +7729,11 @@ find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -8833,6 +8961,14 @@ import-fresh@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+import-fresh@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -10526,6 +10662,11 @@ lie@3.1.1:
   dependencies:
     immediate "~3.0.5"
 
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
 linux-platform-info@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/linux-platform-info/-/linux-platform-info-0.0.3.tgz#2dae324385e66e3d755bec83f86c7beea61ceb83"
@@ -11006,6 +11147,11 @@ memoize-one@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
   integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
+
+memoize-one@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -11743,6 +11889,13 @@ nopt@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
   integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
   dependencies:
     abbrev "1"
 
@@ -12534,6 +12687,16 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
+
 parse-node-version@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
@@ -12660,6 +12823,11 @@ path-type@^3.0.0:
   integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 pathval@^1.1.0:
   version "1.1.0"
@@ -14012,6 +14180,19 @@ react-select@2.2.0:
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
 
+react-select@^2.2.0:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.4.4.tgz#ba72468ef1060c7d46fbb862b0748f96491f1f73"
+  integrity sha512-C4QPLgy9h42J/KkdrpVxNmkY6p4lb49fsrbDk/hRcZpX7JvZPNb6mGj+c5SzyEtBv1DmQ9oPH4NmhAFvCrg8Jw==
+  dependencies:
+    classnames "^2.2.5"
+    emotion "^9.1.2"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-input-autosize "^2.2.1"
+    react-transition-group "^2.2.1"
+
 react-spring@9.0.0-rc.3:
   version "9.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.0.0-rc.3.tgz#0ad7b1e803f4385b7cbb44fff6d26f5be78884d6"
@@ -14042,7 +14223,7 @@ react-swipeable-views-core@^0.13.1, react-swipeable-views-core@^0.13.7:
     "@babel/runtime" "7.0.0"
     warning "^4.0.1"
 
-react-swipeable-views-utils@^0.13.3:
+react-swipeable-views-utils@^0.13.3, react-swipeable-views-utils@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/react-swipeable-views-utils/-/react-swipeable-views-utils-0.13.9.tgz#a66e98f2f4502d8b00182901f80d13b2f903e10f"
   integrity sha512-QLGxRKrbJCbWz94vkWLzb1Daaa2Y/TZKmsNKQ6WSNrS+chrlfZ3z9tqZ7YUJlW6pRWp3QZdLSY3UE3cN0TXXmw==
@@ -14064,6 +14245,17 @@ react-swipeable-views@0.13.3:
     prop-types "^15.5.4"
     react-swipeable-views-core "^0.13.1"
     react-swipeable-views-utils "^0.13.3"
+    warning "^4.0.1"
+
+react-swipeable-views@^0.13.3:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/react-swipeable-views/-/react-swipeable-views-0.13.9.tgz#d6a6c508bf5288ad55509f9c65916db5df0f2cec"
+  integrity sha512-WXC2FKYvZ9QdJ31v9LjEJEl1bA7E4AcaloTkbW0uU0dYf5uvv4aOpiyxubvOkVl1a5L2UAHmKSif4TmJ9usrSg==
+  dependencies:
+    "@babel/runtime" "7.0.0"
+    prop-types "^15.5.4"
+    react-swipeable-views-core "^0.13.7"
+    react-swipeable-views-utils "^0.13.9"
     warning "^4.0.1"
 
 react-test-renderer@16.13.1:
@@ -15546,7 +15738,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.2, source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -16054,6 +16246,16 @@ stylint@2.0.0:
     strip-json-comments "2.0.1"
     user-home "2.0.0"
     yargs "4.7.1"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 stylus-loader@3.0.2:
   version "3.0.2"
@@ -16654,6 +16856,13 @@ toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
   integrity sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
+
+touch@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
+  integrity sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==
+  dependencies:
+    nopt "~1.0.10"
 
 tough-cookie@2.3.3:
   version "2.3.3"
@@ -17918,6 +18127,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^1.7.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^11.1.1:
   version "11.1.1"


### PR DESCRIPTION
- Sur les pages publiques, on souhaite avoir la toolbar non plus en haut dans la cozybar mais entre le contenu et la banner (comme dans la partie privée)
- La bannière d'info est remaniée au passage, pour récupérer le bouton "créer un cozy" qui était initialement dans la cozybar
- On en profite pour rajouter le bouton "import de fichier" lorsqu'on a les accès écriture