### PR TITLE
feat: Adjust PublicFileViewer on tablet according to the new viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "cozy-scripts": "5.1.1",
     "cozy-sharing": "3.2.0",
     "cozy-stack-client": "17.6.1",
-    "cozy-ui": "47.5.1",
+    "cozy-ui": "47.6.0",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -12,17 +12,21 @@ import styles from 'drive/web/modules/viewer/barviewer.styl'
 
 const LightFileViewer = ({ files }) => {
   const sharingInfos = useSharingInfos()
-  const { isMobile } = useBreakpoints()
+  const { isDesktop } = useBreakpoints()
 
   return (
     <div className={styles['viewer-wrapper-with-bar']}>
       <SharingBanner sharingInfos={sharingInfos} />
-      {isMobile && <PublicToolbar files={files} sharingInfos={sharingInfos} />}
+      {!isDesktop && (
+        <div className="u-mt-1 u-mr-1">
+          <PublicToolbar files={files} sharingInfos={sharingInfos} />
+        </div>
+      )}
       <div className={'u-pos-relative u-h-100'}>
         <Viewer
           files={files}
           currentIndex={0}
-          toolbarProps={{ showToolbar: !isMobile }}
+          toolbarProps={{ showToolbar: isDesktop }}
         />
       </div>
     </div>

--- a/src/drive/web/modules/public/LightFileViewer.spec.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.spec.jsx
@@ -26,9 +26,9 @@ const setup = () => {
 }
 
 describe('LightFileViewer', () => {
-  describe('on Mobile', () => {
+  describe('on Mobile and Tablet', () => {
     beforeAll(() => {
-      useBreakpoints.mockReturnValue({ isMobile: true })
+      useBreakpoints.mockReturnValue({ isDesktop: false })
     })
 
     it('should have the sharing banner and public toolbar but no viewer toolbar', () => {
@@ -43,7 +43,7 @@ describe('LightFileViewer', () => {
 
   describe('on Desktop', () => {
     beforeAll(() => {
-      useBreakpoints.mockReturnValue({ isMobile: false })
+      useBreakpoints.mockReturnValue({ isDesktop: true })
     })
 
     it('should have the sharing banner and viewer toolbar but no public toolbar', () => {

--- a/src/drive/web/modules/public/PublicToolbar.jsx
+++ b/src/drive/web/modules/public/PublicToolbar.jsx
@@ -19,7 +19,7 @@ const PublicToolbar = ({
 
   if (loading) return null
   return (
-    <div data-testid="public-toolbar">
+    <div className="u-flex u-flex-justify-end" data-testid="public-toolbar">
       {!discoveryLink ? (
         <PublicToolbarByLink
           files={files}

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -19,7 +19,8 @@ import CozyBarRightMobile from 'drive/web/modules/public/CozyBarRightMobile'
 
 import { DownloadFilesButton } from './DownloadButton'
 
-const isFilesIsFile = files => files.length === 1 && files[0].type === 'file'
+export const isFilesIsFile = files =>
+  files.length === 1 && files[0].type === 'file'
 
 const MoreButton = ({ disabled, onClick }) => {
   const { t } = useI18n()
@@ -110,25 +111,19 @@ const PublicToolbarByLink = ({
       <BarContextProvider client={client} t={t} store={client.store}>
         {!isMobile && (
           <>
-            <div className="u-m-auto">
-              {hasWriteAccess && (
-                <UploadButtonItem onUploaded={refreshFolderContent} />
-              )}
-            </div>
-            <div className="u-m-auto">
-              <DownloadFilesButton files={files} />
-            </div>
+            {hasWriteAccess && (
+              <UploadButtonItem onUploaded={refreshFolderContent} />
+            )}
+            <DownloadFilesButton files={files} />
           </>
         )}
         {shouldDisplayMoreMenu && (
-          <div className="u-m-auto">
-            <MoreMenu
-              hasWriteAccess={hasWriteAccess}
-              refreshFolderContent={refreshFolderContent}
-              isMobile={isMobile}
-              files={files}
-            />
-          </div>
+          <MoreMenu
+            hasWriteAccess={hasWriteAccess}
+            refreshFolderContent={refreshFolderContent}
+            isMobile={isMobile}
+            files={files}
+          />
         )}
       </BarContextProvider>
     </CozyBarRightMobile>

--- a/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
+++ b/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
@@ -13,6 +13,7 @@ import SelectableItem from 'drive/web/modules/drive/Toolbar/selectable/Selectabl
 import { downloadFiles } from 'drive/web/modules/actions/utils'
 import CozyBarRightMobile from 'drive/web/modules/public/CozyBarRightMobile'
 import { DownloadFilesButton } from './DownloadButton'
+import { isFilesIsFile } from './PublicToolbarByLink'
 
 const openExternalLink = url => (window.location = url)
 
@@ -76,25 +77,24 @@ const PublicToolbarCozyToCozy = ({
   isSharingShortcutCreated
 }) => {
   const { t } = useI18n()
+  const isFile = isFilesIsFile(files)
   const client = useClient()
   const { isMobile } = useBreakpoints()
+
+  const shouldDisplayMoreMenu = isMobile || (!isFile && files.length > 0)
 
   return (
     <CozyBarRightMobile>
       <BarContextProvider client={client} t={t} store={client.store}>
-        {!isMobile && (
-          <div className="u-m-auto">
-            <DownloadFilesButton files={files} />
-          </div>
-        )}
-        <div className="u-m-auto">
+        {!isMobile && <DownloadFilesButton files={files} />}
+        {shouldDisplayMoreMenu && (
           <MoreMenu
             files={files}
             discoveryLink={discoveryLink}
             isSharingShortcutCreated={isSharingShortcutCreated}
             isMobile={isMobile}
           />
-        </div>
+        )}
       </BarContextProvider>
     </CozyBarRightMobile>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5619,10 +5619,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@47.5.1:
-  version "47.5.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-47.5.1.tgz#a8bfd3d1f66eb70d7792d973b5b509c2361fe9ca"
-  integrity sha512-16ibaqTpIWdwBkGYq8SCjLnH01IW/H/DqSQroi7RH8lGusb/gzzPtEnaqHVu8wF5kT4wUN9LVUknsrEZaXg/pA==
+cozy-ui@47.6.0:
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-47.6.0.tgz#982612cf232f152e32f4dbd5bca15bd7c13e4f40"
+  integrity sha512-FIkrpFhxM4QvrB/misL1oIqHmxImvRFB69rmM0u73rOKecvuHspeawJvD8pLE6Ebx2XeYLJVUINiS5N8QklF+Q==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
⚠️ **update UI first**

suite à https://github.com/cozy/cozy-ui/pull/1784 on répercute ici les changements pour avoir un page publique avec le même comportement : à savoir une version tablette qui agit comme une version mobile.

A l'exception de la toolbar qui ne se retrouve pas en haut dans la cozy-bar, mais entre la bannière et le contenu comme sur desktop.

De plus, suite à l'ajout d'un div autour de la public toolbar, le style était cassé.