### PR TITLE
fix: ForwardButton now forward the file instead of opening it

### DIFF
--- a/src/drive/web/modules/viewer/Footer/FooterContent.spec.jsx
+++ b/src/drive/web/modules/viewer/Footer/FooterContent.spec.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 
 import { createMockClient } from 'cozy-client'
 import { isMobileApp } from 'cozy-device-helper'
 
 import AppLike from 'test/components/AppLike'
 
+import * as utils from 'drive/web/modules/actions/utils'
 import FooterContent from './FooterContent'
 
 jest.mock('cozy-device-helper', () => ({
@@ -62,6 +63,10 @@ describe('FooterContent', () => {
 
     expect(getByText('Forward'))
     expect(queryByText('Download')).toBeFalsy()
+
+    const spy = jest.spyOn(utils, 'exportFilesNative')
+    fireEvent.click(getByText('Forward'))
+    expect(spy).toHaveBeenCalled()
   })
 
   it('should show "share" if the file is not shared', () => {

--- a/src/drive/web/modules/viewer/Footer/ForwardButton.jsx
+++ b/src/drive/web/modules/viewer/Footer/ForwardButton.jsx
@@ -2,13 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
-import { openFileWith } from 'cozy-client/dist/models/fsnative'
 import { isIOS } from 'cozy-device-helper'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
 import ReplyIcon from 'cozy-ui/transpiled/react/Icons/Reply'
 import ShareIosIcon from 'cozy-ui/transpiled/react/Icons/ShareIos'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
+
+import { exportFilesNative } from 'drive/web/modules/actions/utils'
 
 const ForwardIcon = isIOS() ? ShareIosIcon : ReplyIcon
 
@@ -18,7 +19,7 @@ const ForwardButton = ({ file }) => {
 
   const onFileOpen = async file => {
     try {
-      await openFileWith(client, file)
+      await exportFilesNative(client, [file])
     } catch (error) {
       Alerter.info(`mobile.error.open_with.${error}`, { fileMime: file.mime })
     }


### PR DESCRIPTION
Suite à une incompréhension, il y avait l'action "ouvrir avec" sur le bouton "transférer vers" du footer dans le viewer