### PR TITLE
fix: Wrap Error in StyledApp

### DIFF
--- a/src/components/Error/ErrorShare.jsx
+++ b/src/components/Error/ErrorShare.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Empty } from 'cozy-ui/transpiled/react'
 import EmptyIcon from 'components/icons/icon-cloud-wrong.svg'
 
-export const ErrorShare = ({ t, errorType }) => {
+export const ErrorShare = ({ errorType }) => {
+  const { t } = useI18n()
   return (
     <Empty
       data-test-id="empty-share"
@@ -14,4 +15,4 @@ export const ErrorShare = ({ t, errorType }) => {
   )
 }
 
-export default translate()(ErrorShare)
+export default ErrorShare

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -34,6 +34,7 @@ import logger from 'lib/logger'
 
 import App from 'components/App/App'
 import ExternalRedirect from 'drive/web/modules/navigation/ExternalRedirect'
+import StyledApp from 'drive/web/modules/drive/StyledApp'
 
 const initCozyBar = (data, client) => {
   if (
@@ -57,7 +58,9 @@ const initCozyBar = (data, client) => {
 const renderError = (lang, root) =>
   render(
     <I18n lang={lang} dictRequire={lang => require(`drive/locales/${lang}`)}>
-      <ErrorShare errorType={`public_unshared`} />
+      <StyledApp>
+        <ErrorShare errorType={`public_unshared`} />
+      </StyledApp>
     </I18n>,
     root
   )

--- a/src/photos/components/__snapshots__/ErrorUnshared.spec.js.snap
+++ b/src/photos/components/__snapshots__/ErrorUnshared.spec.js.snap
@@ -8,7 +8,7 @@ exports[`ErrorUnshared should match the snapshot 1`] = `
   <Main
     className="u-pt-1-half"
   >
-    <withI18n(ErrorShare)
+    <ErrorShare
       errorType="public_album_unshared"
     />
   </Main>


### PR DESCRIPTION
Sharing error was not wrapped in `styledapp`. So the style (font & size) wasn't right.
Refactor: useI18n() instead of translate()