### PR TITLE
Add offline migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "cozy-authentication": "^2.0.5",
     "cozy-bar": "7.16.0",
     "cozy-ci": "0.4.1",
-    "cozy-client": "22.0.0",
+    "cozy-client": "23.0.0",
     "cozy-client-js": "0.19.0",
     "cozy-device-helper": "1.11.0",
     "cozy-doctypes": "1.78.0",

--- a/src/drive/lib/RealTimeQueries.jsx
+++ b/src/drive/lib/RealTimeQueries.jsx
@@ -9,7 +9,7 @@ const dispatchChange = (document, mutationDefinitionCreator, client) => {
   const options = {}
   client.dispatch(
     receiveMutationResult(
-      client.generateId(),
+      client.generateRandomId(),
       response,
       options,
       mutationDefinitionCreator(document)

--- a/src/drive/mobile/modules/offline/duck.js
+++ b/src/drive/mobile/modules/offline/duck.js
@@ -1,3 +1,5 @@
+import localforage from 'localforage'
+
 import {
   saveFileWithCordova,
   openOfflineFile,
@@ -27,7 +29,7 @@ export default (state = [], action = {}) => {
 }
 
 const markAsAvailableOffline = id => ({ type: MAKE_AVAILABLE_OFFLINE, id })
-const markAsUnavailableOffline = id => ({
+export const markAsUnavailableOffline = id => ({
   type: UNDO_MAKE_AVAILABLE_OFFLINE,
   id
 })
@@ -58,7 +60,7 @@ const makeAvailableOffline = (file, client) => async dispatch => {
   dispatch(markAsAvailableOffline(file.id))
 }
 
-const saveOfflineFileCopy = async (file, client) => {
+export const saveOfflineFileCopy = async (file, client) => {
   if (!isMobileApp() || !window.cordova.file) {
     return
   }
@@ -109,4 +111,9 @@ export const updateOfflineFileCopyIfNecessary = (
   ) {
     await saveOfflineFileCopy(file, client)
   }
+}
+
+export const addFileIdToLocalStorageItem = async (key, value) => {
+  const oldValue = (await localforage.getItem(key)) || []
+  await localforage.setItem(key, [...oldValue, value])
 }

--- a/src/drive/mobile/modules/offline/duck.js
+++ b/src/drive/mobile/modules/offline/duck.js
@@ -62,10 +62,11 @@ const saveOfflineFileCopy = async (file, client) => {
   if (!isMobileApp() || !window.cordova.file) {
     return
   }
+
   try {
     const response = await client
       .collection('io.cozy.files')
-      .fetchFileContent(file.id)
+      .fetchFileContentById(file.id)
     const blob = await response.blob()
     const filename = file.id
     saveFileWithCordova(blob, filename)

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -141,17 +141,22 @@ class InitAppMobile {
     if (this.isStarting === true) {
       return
     }
-    this.isStarting = true
-    const store = await this.getStore()
-    this.startApplication()
-    await this.appReady
-    this.getPolyglot()
-    this.openWith()
-    if (isBackgroundServiceParameter()) {
-      startBackgroundService()
+
+    try {
+      this.isStarting = true
+      const store = await this.getStore()
+      this.startApplication()
+      await this.appReady
+      this.getPolyglot()
+      this.openWith()
+      if (isBackgroundServiceParameter()) {
+        startBackgroundService()
+      }
+      store.dispatch(backupImages())
+      if (navigator && navigator.splashscreen) navigator.splashscreen.hide()
+    } catch (e) {
+      logger.error(`onDeviceReady catches : ${e}`)
     }
-    store.dispatch(backupImages())
-    if (navigator && navigator.splashscreen) navigator.splashscreen.hide()
   }
 
   onResume = async () => {

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -1,20 +1,20 @@
 /* global __DEVELOPMENT__, cordova */
 
 import 'whatwg-fetch'
+
 import React from 'react'
 import { render } from 'react-dom'
 import { hashHistory } from 'react-router'
 import localforage from 'localforage'
-import { saveState } from 'drive/store/persistedState'
 
-import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import { isIOSApp } from 'cozy-device-helper'
 import { Document } from 'cozy-doctypes'
+import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 
-import logger from 'lib/logger'
+import { saveState, loadState } from 'drive/store/persistedState'
 import configureStore from 'drive/store/configureStore'
-import { loadState } from 'drive/store/persistedState'
+import logger from 'lib/logger'
 import { startBackgroundService } from 'drive/mobile/lib/background'
 import { configureReporter, logException } from 'drive/lib/reporter'
 import {

--- a/src/drive/targets/mobile/InitAppMobile.spec.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.spec.jsx
@@ -15,6 +15,7 @@ jest.mock('drive/mobile/lib/cozy-helper', () => {
 })
 jest.mock('drive/lib/registerClientPlugins', () => jest.fn())
 jest.mock('drive/store/configureStore')
+jest.mock('drive/store/persistedState')
 jest.mock('drive/lib/reporter')
 jest.mock(
   'drive/mobile/modules/authorization/DriveMobileRouter',
@@ -54,6 +55,7 @@ describe('App initialize', () => {
     await appStarting
     expect(startApplicationSpy).toHaveBeenCalled()
   })
+
   it('should inform us when the app is started', async () => {
     const app = new InitAppMobile()
     const appStarting = app.initialize()
@@ -61,6 +63,7 @@ describe('App initialize', () => {
     const result = await appStarting
     expect(result).toBe(true)
   })
+
   it('should not restart the app while its starting', async () => {
     const app = new InitAppMobile()
     const startApplicationSpy = jest.spyOn(app, 'startApplication')
@@ -75,6 +78,7 @@ describe('App initialize', () => {
     await appStarting
     expect(startApplicationSpy).toHaveBeenCalledTimes(1)
   })
+
   it('should only start the app once', async () => {
     const app = new InitAppMobile()
 
@@ -88,6 +92,7 @@ describe('App initialize', () => {
     await app.startApplication()
     expect(render).toHaveBeenCalledTimes(1)
   })
+
   describe('openWith', () => {
     it('should call removeItem and not setItem when intent is empty', async () => {
       const app = new InitAppMobile()

--- a/src/drive/targets/mobile/InitAppMobile.spec.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.spec.jsx
@@ -16,7 +16,6 @@ jest.mock('drive/mobile/lib/cozy-helper', () => {
 jest.mock('drive/lib/registerClientPlugins', () => jest.fn())
 jest.mock('drive/store/configureStore')
 jest.mock('drive/store/persistedState')
-jest.mock('drive/lib/reporter')
 jest.mock(
   'drive/mobile/modules/authorization/DriveMobileRouter',
   () => () => {}

--- a/src/drive/targets/mobile/config.xml
+++ b/src/drive/targets/mobile/config.xml
@@ -16,7 +16,7 @@
     <platform name="android">
         <preference name="android-minSdkVersion" value="21" />
         <preference name="StatusBarBackgroundColor" value="#D6D8DA" />
-        <preference name="AndroidPersistentFileLocation" value="Compatibility" />
+        <preference name="AndroidPersistentFileLocation" value="Internal" />
         <preference name="AndroidLaunchMode" value="singleTask" />
         <allow-intent href="market:*" />
         <custom-config-file parent="./application/activity/[@android:name='MainActivity']" target="AndroidManifest.xml">

--- a/src/drive/targets/mobile/migrations/migrationOfflineFiles.js
+++ b/src/drive/targets/mobile/migrations/migrationOfflineFiles.js
@@ -1,0 +1,83 @@
+import localforage from 'localforage'
+
+import { Q } from 'cozy-client/dist/queries/dsl'
+
+import logger from 'lib/logger'
+import {
+  getAvailableOfflineIds,
+  saveOfflineFileCopy,
+  markAsUnavailableOffline,
+  addFileIdToLocalStorageItem
+} from 'drive/mobile/modules/offline/duck'
+import {
+  startMediaBackup,
+  cancelMediaBackup
+} from 'drive/mobile/modules/mediaBackup/duck'
+import { isWifi } from 'drive/mobile/lib/network'
+
+const migrateOfflineFiles = async (client) => {
+  try {
+    const alreadyMigrated = await localforage.getItem(
+      'offlineFilesMigration-finished'
+    )
+    if (alreadyMigrated || !isWifi()) return
+
+    const availableOfflineIds = getAvailableOfflineIds(client.store.getState())
+    if (!availableOfflineIds || availableOfflineIds.length < 1) {
+      await localforage.setItem('offlineFilesMigration-finished', true)
+      return
+    }
+
+    // stop media backup
+    client.store.dispatch(cancelMediaBackup())
+
+    let error = false
+
+    for (const fileId of availableOfflineIds) {
+      try {
+        const { data } = await client.query(
+          Q('io.cozy.files').getById(fileId)
+        )
+        await saveOfflineFileCopy(data, client)
+        await addFileIdToLocalStorageItem(
+          'offlineFilesMigration-migratedFileIds',
+          fileId
+        )
+      } catch (e) {
+        error = true
+        logger.error(`migrateOfflineFiles error : ${e}`)
+
+        client.store.dispatch(markAsUnavailableOffline(fileId))
+        await addFileIdToLocalStorageItem(
+          'offlineFilesMigration-notMigratedFileIds',
+          fileId
+        )
+      }
+    }
+
+    // restart media backup
+    client.store.dispatch(startMediaBackup())
+
+    if (error) {
+      const migratedFileIds =
+        (await localforage.getItem(
+          'offlineFilesMigration-migratedFileIds'
+        )) || []
+      const notMigratedFileIds =
+        (await localforage.getItem(
+          'offlineFilesMigration-notMigratedFileIds'
+        )) || []
+
+      throw new Error(
+        `${migratedFileIds.length} of ${notMigratedFileIds.length +
+          migratedFileIds.length} files have been migrated successfully. The files with these ids have not been migrated: ${notMigratedFileIds}`
+      )
+    }
+  } catch (e) {
+    logger.error(`migrateOfflineFiles finished with error : ${e}`)
+  }
+
+  await localforage.setItem('offlineFilesMigration-finished', true)
+}
+
+export default migrateOfflineFiles

--- a/src/drive/targets/mobile/migrations/migrationOfflineFiles.spec.js
+++ b/src/drive/targets/mobile/migrations/migrationOfflineFiles.spec.js
@@ -1,0 +1,216 @@
+import localforage from 'localforage'
+
+import migrateOfflineFiles from 'drive/targets/mobile/migrations/migrationOfflineFiles'
+import { isWifi } from 'drive/mobile/lib/network'
+import {
+  getAvailableOfflineIds,
+  saveOfflineFileCopy,
+  addFileIdToLocalStorageItem,
+  markAsUnavailableOffline
+} from 'drive/mobile/modules/offline/duck'
+import {
+  startMediaBackup,
+  cancelMediaBackup
+} from 'drive/mobile/modules/mediaBackup/duck'
+import logger from 'lib/logger'
+
+logger.error = jest.fn()
+
+jest.mock('drive/mobile/modules/offline/duck', () => ({
+  ...jest.requireActual('drive/mobile/modules/offline/duck'),
+  getAvailableOfflineIds: jest.fn(({ availableOffline }) => availableOffline),
+  saveOfflineFileCopy: jest.fn(),
+  addFileIdToLocalStorageItem: jest.fn(),
+  markAsUnavailableOffline: jest.fn()
+}))
+
+jest.mock('drive/mobile/modules/mediaBackup/duck', () => ({
+  ...jest.requireActual('drive/mobile/modules/mediaBackup/duck'),
+  startMediaBackup: jest.fn(),
+  cancelMediaBackup: jest.fn()
+}))
+
+jest.mock('localforage')
+
+jest.mock('drive/mobile/lib/network', () => ({
+  isWifi: jest.fn()
+}))
+
+jest.mock('drive/mobile/lib/cozy-helper', () => {
+  return {
+    getLang: () => 'en',
+    initClient: jest.fn()
+  }
+})
+
+describe('migrateOfflineFiles', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const setup = async ({
+    isWifiEnabled = true,
+    isAlreadyMigrated = false,
+    availableOfflineFileIds
+  }) => {
+    const alreadyMigrated = localforage.getItem.mockResolvedValueOnce
+    alreadyMigrated(isAlreadyMigrated)
+    isWifi.mockReturnValue(isWifiEnabled)
+
+    const client = {
+      query: jest.fn(() => ({ data: { data: { id: '123' } } })),
+      store: {
+        getState: jest.fn(() => ({
+          availableOffline: availableOfflineFileIds
+        })),
+        dispatch: jest.fn()
+      }
+    }
+
+    await migrateOfflineFiles(client)
+
+    return { client }
+  }
+
+  it('should migrate offline files and set informations in localStorage', async () => {
+    const availableOfflineFileIds = ['123', '456']
+    const { client } = await setup({ availableOfflineFileIds })
+
+    expect(localforage.getItem).toHaveBeenCalledWith(
+      'offlineFilesMigration-finished'
+    )
+    expect(getAvailableOfflineIds).toHaveBeenCalledWith(client.store.getState())
+    expect(client.store.dispatch).toHaveBeenNthCalledWith(1, cancelMediaBackup())
+
+    for (const fileId of availableOfflineFileIds) {
+      expect(client.query).toHaveBeenCalled()
+      expect(saveOfflineFileCopy).toHaveBeenCalled()
+      expect(addFileIdToLocalStorageItem).toHaveBeenCalledWith(
+        'offlineFilesMigration-migratedFileIds',
+        fileId
+      )
+    }
+
+    expect(client.store.dispatch).toHaveBeenNthCalledWith(2, startMediaBackup())
+    expect(localforage.setItem).toHaveBeenCalledWith(
+      'offlineFilesMigration-finished',
+      true
+    )
+  })
+
+  it('should do nothing if not in wifi', async () => {
+    const availableOfflineFileIds = ['123', '456']
+    const { client } = await setup({
+      isWifiEnabled: false,
+      availableOfflineFileIds
+    })
+
+    expect(localforage.getItem).toHaveBeenCalledWith(
+      'offlineFilesMigration-finished'
+    )
+    expect(getAvailableOfflineIds).not.toHaveBeenCalled()
+    expect(client.store.dispatch).not.toHaveBeenCalled()
+
+    availableOfflineFileIds.forEach(() => {
+      expect(client.query).not.toHaveBeenCalled()
+      expect(saveOfflineFileCopy).not.toHaveBeenCalled()
+      expect(addFileIdToLocalStorageItem).not.toHaveBeenCalled()
+    })
+
+    expect(localforage.setItem).not.toHaveBeenCalledWith(
+      'offlineFilesMigration-finished',
+      true
+    )
+  })
+
+  it('should do nothing if offline files are already migrated', async () => {
+    const availableOfflineFileIds = ['123', '456']
+    const { client } = await setup({
+      isAlreadyMigrated: true,
+      availableOfflineFileIds
+    })
+
+    expect(localforage.getItem).toHaveBeenCalledWith(
+      'offlineFilesMigration-finished'
+    )
+    expect(getAvailableOfflineIds).not.toHaveBeenCalled()
+    expect(client.store.dispatch).not.toHaveBeenCalled()
+
+    availableOfflineFileIds.forEach(() => {
+      expect(client.query).not.toHaveBeenCalled()
+      expect(saveOfflineFileCopy).not.toHaveBeenCalled()
+      expect(addFileIdToLocalStorageItem).not.toHaveBeenCalled()
+    })
+
+    expect(localforage.setItem).not.toHaveBeenCalledWith(
+      'offlineFilesMigration-finished',
+      true
+    )
+  })
+
+  it('should not migates file and set migration finished if no offline file', async () => {
+    const availableOfflineFileIds = []
+    const { client } = await setup({
+      availableOfflineFileIds
+    })
+
+    expect(localforage.getItem).toHaveBeenCalledWith(
+      'offlineFilesMigration-finished'
+    )
+    expect(getAvailableOfflineIds).toHaveBeenCalled()
+    expect(client.store.dispatch).not.toHaveBeenCalled()
+
+    availableOfflineFileIds.forEach(() => {
+      expect(client.query).not.toHaveBeenCalled()
+      expect(saveOfflineFileCopy).not.toHaveBeenCalled()
+      expect(addFileIdToLocalStorageItem).not.toHaveBeenCalled()
+    })
+
+    expect(localforage.setItem).toHaveBeenCalledWith(
+      'offlineFilesMigration-finished',
+      true
+    )
+  })
+
+  it('should mark as unavailable offline, update not migrated local storage key and log error when something goes wrong on a file', async () => {
+    const availableOfflineFileIds = ['123', '456']
+    // simulate error when saving the first file
+    saveOfflineFileCopy.mockRejectedValueOnce({
+      message: 'failed to save file'
+    })
+    localforage.getItem.mockResolvedValue(availableOfflineFileIds)
+
+    const { client } = await setup({
+      availableOfflineFileIds
+    })
+
+    expect(client.store.dispatch).toHaveBeenNthCalledWith(1, cancelMediaBackup())
+
+    availableOfflineFileIds.forEach((fileId, index) => {
+      if (index === 0) {
+        expect(client.store.dispatch).toHaveBeenNthCalledWith(
+          2,
+          markAsUnavailableOffline()
+        )
+        expect(addFileIdToLocalStorageItem).toHaveBeenCalledWith(
+          'offlineFilesMigration-notMigratedFileIds',
+          fileId
+        )
+      } else {
+        expect(addFileIdToLocalStorageItem).toHaveBeenCalledWith(
+          'offlineFilesMigration-migratedFileIds',
+          fileId
+        )
+      }
+    })
+
+    expect(client.store.dispatch).toHaveBeenNthCalledWith(3, startMediaBackup())
+    expect(logger.error).toHaveBeenCalledWith(
+      'migrateOfflineFiles finished with error : Error: 2 of 4 files have been migrated successfully. The files with these ids have not been migrated: 123,456'
+    )
+    expect(localforage.setItem).toHaveBeenCalledWith(
+      'offlineFilesMigration-finished',
+      true
+    )
+  })
+})

--- a/src/drive/web/modules/actions/utils.js
+++ b/src/drive/web/modules/actions/utils.js
@@ -123,7 +123,7 @@ export const exportFilesNative = async (client, files, filename) => {
   const downloadAllFiles = files.map(async file => {
     const response = await client
       .collection('io.cozy.files')
-      .fetchFileContent(file.id)
+      .fetchFileContentById(file.id)
 
     const blob = await response.blob()
     const filenameToUse = filename ? filename : file.name
@@ -182,7 +182,7 @@ export const openFileWith = async (client, file) => {
     try {
       fileData = await client
         .collection('io.cozy.files')
-        .fetchFileContent(file.id)
+        .fetchFileContentById(file.id)
     } catch (error) {
       Alerter.error(openFileDownloadError(error))
       throw error

--- a/src/drive/web/modules/actions/utils.spec.js
+++ b/src/drive/web/modules/actions/utils.spec.js
@@ -175,7 +175,7 @@ describe('openFileWith', () => {
     isMobileApp.mockReturnValue(true)
 
     mockClient.collection = jest.fn().mockReturnValue(mockClient)
-    mockClient.fetchFileContent = jest.fn().mockReturnValue({
+    mockClient.fetchFileContentById = jest.fn().mockReturnValue({
       blob: blobMock
     })
 
@@ -190,7 +190,7 @@ describe('openFileWith', () => {
   it('opens the file with cordova', async () => {
     blobMock.mockReturnValue('fake file blob')
     await openFileWith(mockClient, file)
-    expect(mockClient.fetchFileContent).toHaveBeenCalledWith(file.id)
+    expect(mockClient.fetchFileContentById).toHaveBeenCalledWith(file.id)
     expect(saveAndOpenWithCordova).toHaveBeenCalledWith('fake file blob', file)
   })
 
@@ -205,7 +205,7 @@ describe('openFileWith', () => {
 
   it('errors when it fails to download the file', async () => {
     expect.assertions(2)
-    mockClient.fetchFileContent = jest.fn().mockRejectedValue('nope')
+    mockClient.fetchFileContentById = jest.fn().mockRejectedValue('nope')
     try {
       await openFileWith(mockClient, file)
     } catch (e) {
@@ -234,7 +234,7 @@ describe('exportFilesNative', () => {
     jest.resetAllMocks()
 
     mockClient.collection = jest.fn().mockReturnValue(mockClient)
-    mockClient.fetchFileContent = jest.fn().mockReturnValue({
+    mockClient.fetchFileContentById = jest.fn().mockReturnValue({
       blob: jest.fn().mockReturnValue()
     })
     saveFileWithCordova.mockReturnValue({
@@ -253,13 +253,13 @@ describe('exportFilesNative', () => {
     await exportFilesNative(mockClient, files, 'files.zip')
 
     files.forEach(file =>
-      expect(mockClient.fetchFileContent).toHaveBeenCalledWith(file.id)
+      expect(mockClient.fetchFileContentById).toHaveBeenCalledWith(file.id)
     )
     expect(exportMock).toHaveBeenCalled()
   })
 
   it('reports an error', async () => {
-    mockClient.fetchFileContent.mockRejectedValue('nope')
+    mockClient.fetchFileContentById.mockRejectedValue('nope')
     await exportFilesNative(mockClient, files, 'files.zip')
     expect(Alerter.error).toHaveBeenCalled()
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5192,17 +5192,18 @@ cozy-client@16.10.2:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@22.0.0, cozy-client@^22.0.0:
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-22.0.0.tgz#423f0717b8263168fa1d98d67c80de45afc5f8f8"
-  integrity sha512-TwN2QSmCtaCyz56NNrOt4v42HWgrguCp7DJWdvRLXzpkdLkKhaHHAu5nNm3f00n3DgaghG57q7CZVvzj+fqOGg==
+cozy-client@23.0.0:
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-23.0.0.tgz#d6a268a7428bde15a50e3dd9b9af3b7cac534225"
+  integrity sha512-lD3Rd5Eb2M2WW5Md6+3YqGDPY3seIu9B6oKV8FoO7ulouoQ8fXQOmvU6b0BkubdMPfYNUpTsS1p0GRpbZoVrQQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     btoa "^1.2.1"
     cozy-device-helper "^1.12.0"
+    cozy-flags "2.7.1"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^22.0.0"
+    cozy-stack-client "^23.0.0"
     lodash "^4.17.13"
     microee "^0.0.6"
     node-fetch "^2.6.1"
@@ -5232,6 +5233,29 @@ cozy-client@^16.10.2:
     prop-types "^15.6.2"
     react-redux "^7.2.0"
     redux "^3.7.2"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
+cozy-client@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-22.0.0.tgz#423f0717b8263168fa1d98d67c80de45afc5f8f8"
+  integrity sha512-TwN2QSmCtaCyz56NNrOt4v42HWgrguCp7DJWdvRLXzpkdLkKhaHHAu5nNm3f00n3DgaghG57q7CZVvzj+fqOGg==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@types/jest" "^26.0.20"
+    btoa "^1.2.1"
+    cozy-device-helper "^1.12.0"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^22.0.0"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    open "^7.0.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
     redux-thunk "^2.3.0"
     server-destroy "^1.0.1"
     sift "^6.0.0"
@@ -5313,6 +5337,13 @@ cozy-flags@2.6.0, cozy-flags@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.6.0.tgz#c336b154ef94723c151f26ef2782a4d0650b4593"
   integrity sha512-8Jsdct51bZaUsp5aPbfb/4ZLmktWk/gWMM7uxQPcTpatBHqkFgCRdC7Shn7cYoGDoZ+SUPLk7dVsb5AKydb6EA==
+  dependencies:
+    microee "^0.0.6"
+
+cozy-flags@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.7.1.tgz#f37251fee248ef9bef079a22bc52954f1a892dfc"
+  integrity sha512-TtVhuyMSRADRr4q5LSaRjq6u03S5m1zkZRc8n3q8bfad86FizqGC02m3e/Zh4kWTwnsO0pVW+mzeVSsBqDVT/g==
   dependencies:
     microee "^0.0.6"
 
@@ -5543,6 +5574,16 @@ cozy-stack-client@^16.19.0, cozy-stack-client@^16.8.0:
   integrity sha512-TyexZQdqvEsa7THvMnvgszQ2Ndo9bZ4XOiy6W8FzTq2wPuTLC8JK6WBVlBG7e+GCVcncdDMH3QuOywQZqDvolQ==
   dependencies:
     cozy-flags "^2.5.0"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^23.0.0:
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-23.0.0.tgz#8df777901c8af62efdbccccc03c981d04b83d297"
+  integrity sha512-ucZaKdYEoUjdMiG0Yh1+OjMg+16TXPQAFMCsnLmOmLr/GK1vm6V9/HAIk1dkDMWoeaqSXsH1REgXvxUc36Q+qw==
+  dependencies:
+    cozy-flags "2.7.1"
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"


### PR DESCRIPTION
Avec la sortie de Android 11, l'emplacement des fichiers sauvegardé à changé.

La config du plugin file de Cordova `<preference name="AndroidPersistentFileLocation" value="Compatibility" />` doit être remplacé par `<preference name="AndroidPersistentFileLocation" value="Internal" />`

On souhaite également gérer les fichiers qui étaient déjà pris en charge par le offline. Ces fichiers doivent être re-téléchargés dans le nouvel emplacement afin que la migration soit transparente pour l'utilisateur.