### PR TITLE
Fix/color

### DIFF
--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -144,7 +144,7 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
               />
             )
           }
-          left={<Icon icon={TrashIcon} className="u-error" />}
+          left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
         >
           <span className="u-error">{t('SelectionBar.trash')}</span>
         </ActionMenuItem>
@@ -343,7 +343,7 @@ export const destroy = ({ pushModal, popModal }) => {
           onClick={() =>
             pushModal(<DestroyConfirm files={props.files} onClose={popModal} />)
           }
-          left={<Icon icon={TrashIcon} className="u-error" />}
+          left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
         >
           <span className="u-error">{t('SelectionBar.destroy')}</span>
         </ActionMenuItem>

--- a/src/drive/web/modules/drive/Toolbar/delete/DeleteItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/delete/DeleteItem.jsx
@@ -19,7 +19,7 @@ const DeleteItem = ({
   isSharedWithMe ? (
     <ActionMenuItem
       data-test-id="fil-action-delete"
-      left={<Icon icon={TrashIcon} color="var(--pomegranate)" />}
+      left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
       onClick={() =>
         onLeave(displayedFolder).then(() => trashFolder(displayedFolder))
       }
@@ -29,7 +29,7 @@ const DeleteItem = ({
   ) : (
     <ActionMenuItem
       data-test-id="fil-action-delete"
-      left={<Icon icon={TrashIcon} color="var(--pomegranate)" />}
+      left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
       onClick={() => {
         trashFolder(displayedFolder)
       }}

--- a/src/drive/web/modules/trash/Toolbar.jsx
+++ b/src/drive/web/modules/trash/Toolbar.jsx
@@ -66,11 +66,9 @@ export const Toolbar = ({
             <>
               <ActionMenuItem
                 onClick={onEmptyTrash}
-                left={<Icon icon={TrashIcon} color="var(--pomegranate)" />}
+                left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
               >
-                <span className="u-pomegranate">
-                  {t('toolbar.empty_trash')}
-                </span>
+                <span className="u-error">{t('toolbar.empty_trash')}</span>
               </ActionMenuItem>
               <hr />
             </>


### PR DESCRIPTION
With this commit https://github.com/cozy/cozy-drive/commit/e1b6eb269ebf8b81e1702bba91e5004ec40c6692 we remplace the use of `color` by `className` but it's wrong. The `u-color` uses `color` property, but we can't use that for an SVG. We need to use `fill`. In order to do that, we have to use `color` instead of classname.

Now the `Delete` action item is now red again! 


Also replace the use of `pomegranate` on that particular Icon.