### PR TITLE
fix: OnlyOffice file should not be renamable if doc is read only

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -63,7 +63,7 @@ describe('Editor', () => {
     expect(getByText('Something goes wrong')).toBeTruthy()
   })
 
-  it('should show the title and the container view if the doc is undefined', () => {
+  it('should show the title and the container view', () => {
     useFetchJSON.mockReturnValue({
       fetchStatus: 'loaded',
       data: officeDocParam

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 import { makeStyles } from '@material-ui/core/styles'
@@ -7,6 +7,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
 
+import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import { RenameInput } from 'drive/web/modules/drive/RenameInput'
 
 import filelistStyles from 'drive/styles/filelist.styl'
@@ -21,7 +22,9 @@ const useStyles = makeStyles(() => ({
 const FileName = ({ fileWithPath }) => {
   const muiStyles = useStyles()
   const { isMobile } = useBreakpoints()
+  const { isReadOnly } = useContext(OnlyOfficeContext)
   const [isRenaming, setIsRenaming] = useState(false)
+  const isRenamable = !isMobile && !isReadOnly
 
   return (
     <div className={`${styles['fileName']} u-ml-1 u-ml-half-s u-ellipsis`}>
@@ -40,7 +43,7 @@ const FileName = ({ fileWithPath }) => {
           className={muiStyles.name}
           variant="h6"
           noWrap
-          {...!isMobile && { onClick: () => setIsRenaming(true) }}
+          {...isRenamable && { onClick: () => setIsRenaming(true) }}
         >
           {fileWithPath.name}
         </Typography>

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import { createMockClient, useQuery } from 'cozy-client'
+
+import AppLike from 'test/components/AppLike'
+import { officeDocParam } from 'test/data'
+
+import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
+import Toolbar from 'drive/web/modules/views/OnlyOffice/Toolbar'
+
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+
+const client = createMockClient({})
+
+const setup = ({ isReadOnly = false } = {}) => {
+  const root = render(
+    <AppLike client={client}>
+      <OnlyOfficeContext.Provider
+        value={{
+          fileId: '123',
+          isPublic: 'false',
+          isReadOnly,
+          setIsReadOnly: jest.fn()
+        }}
+      >
+        <Toolbar />
+      </OnlyOfficeContext.Provider>
+    </AppLike>
+  )
+
+  return { root }
+}
+
+describe('Toolbar', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should be able to rename the file if not in readOnly mode', () => {
+    useQuery.mockReturnValue(officeDocParam)
+
+    const { root } = setup({ isReadOnly: false })
+    const { getByText, getByRole } = root
+
+    fireEvent.click(getByText(officeDocParam.data.name))
+    expect(getByRole('textbox').value).toBe(officeDocParam.data.name)
+  })
+
+  it('should not be able to rename the file in readOnly mode', () => {
+    useQuery.mockReturnValue(officeDocParam)
+
+    const { root } = setup({ isReadOnly: true })
+    const { getByText, queryByRole } = root
+
+    fireEvent.click(getByText(officeDocParam.data.name))
+    expect(queryByRole('textbox')).toBeFalsy()
+  })
+})

--- a/test/data.js
+++ b/test/data.js
@@ -131,6 +131,8 @@ export const officeDocParam = {
   data: {
     type: 'io.cozy.office.url',
     id: '32e07d806f9b0139c541543d7eb8149c',
+    class: 'text',
+    name: 'Letter.docx',
     attributes: {
       document_id: '32e07d806f9b0139c541543d7eb8149c',
       subdomain: 'flat',


### PR DESCRIPTION
see commit message

J'ai créé un nouveau fichier de test spécifique à la Toolbar pour éviter de devoir mocker ou gérer des cas inutiles liés à d'autres éléments du composant OnlyOffice, comme la vue, l'éditeur, l'instanciation du script js de l'éditeur etc.