### PR TITLE
feat: Add sharing avatars and button in Only Office toolbar

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/share/ShareButton.jsx
+++ b/src/drive/web/modules/drive/Toolbar/share/ShareButton.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { ShareButton } from 'cozy-sharing'
 import cx from 'classnames'
 
-import styles from './styles.styl'
+import { ShareButton } from 'cozy-sharing'
+
 import shareContainer from './share'
+import styles from './styles.styl'
+
 const ShareButtonWithProps = ({ displayedFolder, share, isDisabled }) => {
   return (
     <ShareButton

--- a/src/drive/web/modules/drive/Toolbar/share/share.jsx
+++ b/src/drive/web/modules/drive/Toolbar/share/share.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { connect } from 'react-redux'
+
 import { showModal } from 'react-cozy-helpers'
 import { ShareModal } from 'cozy-sharing'
+
 import toolbarContainer from '../toolbar'
 
 const mapDispatchToProps = dispatch => ({

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/ReadOnly.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/ReadOnly.jsx
@@ -11,7 +11,7 @@ const ReadOnly = () => {
 
   return (
     <Tooltip title={t('OnlyOffice.readOnly.tooltip')}>
-      <span className="u-flex">
+      <span className="u-flex u-mr-1">
         <Icon
           icon={LockIcon}
           className="u-mr-half"

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/Sharing.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/Sharing.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useCallback } from 'react'
+
+import { ShareButton, ShareModal, SharedRecipients } from 'cozy-sharing'
+
+const _Sharing = ({ fileWithPath }) => {
+  const [showShareModal, setShowShareModal] = useState(false)
+
+  const toggleShareModal = useCallback(() => setShowShareModal(v => !v), [
+    setShowShareModal
+  ])
+
+  return (
+    <>
+      <SharedRecipients
+        docId={fileWithPath.id}
+        size={32}
+        onClick={toggleShareModal}
+      />
+      <ShareButton docId={fileWithPath.id} onClick={toggleShareModal} />
+      {showShareModal && (
+        <ShareModal
+          document={fileWithPath}
+          documentType="Files"
+          sharingDesc={fileWithPath.name}
+          onClose={toggleShareModal}
+        />
+      )}
+    </>
+  )
+}
+
+const Sharing = React.memo(_Sharing)
+
+export default Sharing

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -13,6 +13,7 @@ import BackButton from 'drive/web/modules/views/OnlyOffice/Toolbar/BackButton'
 import FileIcon from 'drive/web/modules/views/OnlyOffice/Toolbar/FileIcon'
 import FileName from 'drive/web/modules/views/OnlyOffice/Toolbar/FileName'
 import ReadOnly from 'drive/web/modules/views/OnlyOffice/Toolbar/ReadOnly'
+import Sharing from 'drive/web/modules/views/OnlyOffice/Toolbar/Sharing'
 
 const Toolbar = () => {
   const { isMobile } = useBreakpoints()
@@ -58,6 +59,7 @@ const Toolbar = () => {
         <FileName fileWithPath={data} />
       </div>
       {!isMobile && isReadOnly && <ReadOnly />}
+      <Sharing fileWithPath={data} />
     </>
   )
 }

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -24,10 +24,14 @@ const setup = ({
         router: { location: { pathname } },
         history: jest.fn()
       }}
+      sharingContextValue={{
+        byDocId: { '123': {} },
+        documentType: 'Files'
+      }}
     >
       <OnlyOfficeContext.Provider
         value={{
-          fileId: '123',
+          fileId: officeDocParam.id,
           isPublic: 'false',
           isReadOnly,
           setIsReadOnly: jest.fn()


### PR DESCRIPTION
On souhaite avoir accès au partage (bouton de partage + avatars) directement dans la toolbar de l'éditeur only office