### PR TITLE
test: Fix sharingContext in only office editor

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -27,6 +27,10 @@ const setup = () => {
       routerContextValue={{
         router: { location: { pathname: '/onlyoffice/fileId' } }
       }}
+      sharingContextValue={{
+        byDocId: {},
+        documentType: 'Files'
+      }}
     >
       <OnlyOfficeContext.Provider
         value={{


### PR DESCRIPTION
oublie dans https://github.com/cozy/cozy-drive/pull/2338 je ne sais pas pourquoi la CI était verte pour autant...