### PR TITLE
Wait for only office editor initialisation

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Editor.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.jsx
@@ -20,7 +20,7 @@ export const Editor = () => {
   return (
     <>
       <Title />
-      <DialogContent className="u-p-0">
+      <DialogContent className="u-flex u-flex-column u-p-0">
         <View
           id={new URL(serverUrl).hostname}
           apiUrl={apiUrl}

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -36,8 +36,8 @@ const setup = () => {
         value={{
           fileId: '123',
           isPublic: 'false',
-          isReadOnly: false,
-          setIsReadOnly: jest.fn()
+          isEditorReadOnly: false,
+          setIsEditorReadOnly: jest.fn()
         }}
       >
         <Editor />

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -31,9 +31,9 @@ const useStyles = makeStyles(theme => ({
 const FileName = ({ fileWithPath }) => {
   const muiStyles = useStyles()
   const { isMobile } = useBreakpoints()
-  const { isReadOnly } = useContext(OnlyOfficeContext)
+  const { isEditorReadOnly } = useContext(OnlyOfficeContext)
   const [isRenaming, setIsRenaming] = useState(false)
-  const isRenamable = !isMobile && !isReadOnly
+  const isRenamable = !isMobile && !isEditorReadOnly
 
   return (
     <div className={`${styles['fileName']} u-ml-1 u-ml-half-s u-ellipsis`}>

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -16,7 +16,7 @@ import Sharing from 'drive/web/modules/views/OnlyOffice/Toolbar/Sharing'
 
 const Toolbar = () => {
   const { isMobile } = useBreakpoints()
-  const { fileId, isPublic, isReadOnly, isEditorReady } = useContext(
+  const { fileId, isPublic, isEditorReadOnly, isEditorReady } = useContext(
     OnlyOfficeContext
   )
   const { data: fileWithPath } = useFileWithPath(fileId)
@@ -56,7 +56,7 @@ const Toolbar = () => {
           fileWithPath.class && <FileIcon fileClass={fileWithPath.class} />}
         <FileName fileWithPath={fileWithPath} />
       </div>
-      {!isMobile && isReadOnly && <ReadOnly />}
+      {!isMobile && isEditorReadOnly && <ReadOnly />}
       {isEditorReady && <Sharing fileWithPath={fileWithPath} />}
     </>
   )

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -16,7 +16,9 @@ import Sharing from 'drive/web/modules/views/OnlyOffice/Toolbar/Sharing'
 
 const Toolbar = () => {
   const { isMobile } = useBreakpoints()
-  const { fileId, isPublic, isReadOnly } = useContext(OnlyOfficeContext)
+  const { fileId, isPublic, isReadOnly, isEditorReady } = useContext(
+    OnlyOfficeContext
+  )
   const { data: fileWithPath } = useFileWithPath(fileId)
   const { router } = useRouter()
 
@@ -55,7 +57,7 @@ const Toolbar = () => {
         <FileName fileWithPath={fileWithPath} />
       </div>
       {!isMobile && isReadOnly && <ReadOnly />}
-      <Sharing fileWithPath={fileWithPath} />
+      {isEditorReady && <Sharing fileWithPath={fileWithPath} />}
     </>
   )
 }

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -14,7 +14,7 @@ jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 const client = createMockClient({})
 
 const setup = ({
-  isReadOnly = false,
+  isEditorReadOnly = false,
   pathname = '/onlyoffice/fileId'
 } = {}) => {
   const root = render(
@@ -33,8 +33,8 @@ const setup = ({
         value={{
           fileId: officeDocParam.id,
           isPublic: 'false',
-          isReadOnly,
-          setIsReadOnly: jest.fn()
+          isEditorReadOnly,
+          setIsEditorReadOnly: jest.fn()
         }}
       >
         <Toolbar />
@@ -54,7 +54,7 @@ describe('Toolbar', () => {
     it('should be able to rename the file if not in readOnly mode', () => {
       useQuery.mockReturnValue(officeDocParam)
 
-      const { root } = setup({ isReadOnly: false })
+      const { root } = setup({ isEditorReadOnly: false })
       const { getByText, getByRole } = root
 
       fireEvent.click(getByText(officeDocParam.data.name))
@@ -64,7 +64,7 @@ describe('Toolbar', () => {
     it('should not be able to rename the file in readOnly mode', () => {
       useQuery.mockReturnValue(officeDocParam)
 
-      const { root } = setup({ isReadOnly: true })
+      const { root } = setup({ isEditorReadOnly: true })
       const { getByText, queryByRole } = root
 
       fireEvent.click(getByText(officeDocParam.data.name))

--- a/src/drive/web/modules/views/OnlyOffice/View.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/View.jsx
@@ -1,14 +1,28 @@
-import React, { useEffect, useCallback, useState } from 'react'
+import React, { useEffect, useCallback, useState, useContext } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
+
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import Error from 'drive/web/modules/views/OnlyOffice/Error'
+import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
+
+const forceIframesHeight = value => {
+  const iframes = document.getElementsByTagName('iframe')
+
+  for (const iframe of iframes) {
+    iframe.style.height = value
+  }
+}
 
 const View = ({ id, apiUrl, docEditorConfig }) => {
   const [isError, setIsError] = useState(false)
+  const { isEditorReady } = useContext(OnlyOfficeContext)
 
   const initEditor = useCallback(
     () => {
       new window.DocsAPI.DocEditor('onlyOfficeEditor', docEditorConfig)
+      forceIframesHeight('0')
     },
     [docEditorConfig]
   )
@@ -39,7 +53,28 @@ const View = ({ id, apiUrl, docEditorConfig }) => {
     [id, apiUrl, initEditor, handleError]
   )
 
-  return isError ? <Error /> : <div id="onlyOfficeEditor" />
+  useEffect(
+    () => {
+      isEditorReady && forceIframesHeight('100%')
+    },
+    [isEditorReady]
+  )
+
+  if (isError) return <Error />
+
+  return (
+    <>
+      {!isEditorReady && (
+        <Spinner
+          className={cx(
+            'u-flex u-flex-items-center u-flex-justify-center u-flex-grow-1'
+          )}
+          size="xxlarge"
+        />
+      )}
+      <div id="onlyOfficeEditor" />
+    </>
+  )
 }
 
 View.propTypes = {

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -28,7 +28,7 @@ export const isOnlyOfficeEditorSupported = ({
  */
 export const isSharedWithMe = ({ data }) => data.attributes.sharecode
 
-export const makeConfig = ({ data }) => {
+export const makeConfig = ({ data }, options) => {
   const onlyOffice = data.attributes.onlyoffice
   const serverUrl = onlyOffice.url
   const apiUrl = `${serverUrl}/web-apps/apps/api/documents/api.js`
@@ -38,7 +38,8 @@ export const makeConfig = ({ data }) => {
     document: onlyOffice.document,
     editorConfig: onlyOffice.editor,
     token: onlyOffice.token,
-    documentType: onlyOffice.documentType
+    documentType: onlyOffice.documentType,
+    ...options
   }
 
   return { serverUrl, apiUrl, docEditorConfig }

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -7,7 +7,7 @@ import Editor from 'drive/web/modules/views/OnlyOffice/Editor'
 export const OnlyOfficeContext = createContext()
 
 const OnlyOfficeProvider = ({ fileId, isPublic, children }) => {
-  const [isReadOnly, setIsReadOnly] = useState()
+  const [isEditorReadOnly, setIsEditorReadOnly] = useState()
   const [isEditorReady, setIsEditorReady] = useState(false)
 
   return (
@@ -15,8 +15,8 @@ const OnlyOfficeProvider = ({ fileId, isPublic, children }) => {
       value={{
         fileId,
         isPublic,
-        isReadOnly,
-        setIsReadOnly,
+        isEditorReadOnly,
+        setIsEditorReadOnly,
         isEditorReady,
         setIsEditorReady
       }}

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -8,10 +8,18 @@ export const OnlyOfficeContext = createContext()
 
 const OnlyOfficeProvider = ({ fileId, isPublic, children }) => {
   const [isReadOnly, setIsReadOnly] = useState()
+  const [isEditorReady, setIsEditorReady] = useState(false)
 
   return (
     <OnlyOfficeContext.Provider
-      value={{ fileId, isPublic, isReadOnly, setIsReadOnly }}
+      value={{
+        fileId,
+        isPublic,
+        isReadOnly,
+        setIsReadOnly,
+        isEditorReady,
+        setIsEditorReady
+      }}
     >
       {children}
     </OnlyOfficeContext.Provider>

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -12,7 +12,9 @@ import {
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 
 const useConfig = () => {
-  const { fileId, isReadOnly, setIsReadOnly } = useContext(OnlyOfficeContext)
+  const { fileId, isReadOnly, setIsReadOnly, setIsEditorReady } = useContext(
+    OnlyOfficeContext
+  )
   const [config, setConfig] = useState()
 
   const queryResult = useFetchJSON('GET', `/office/${fileId}/open`)
@@ -44,7 +46,13 @@ const useConfig = () => {
           setIsReadOnly(isOnlyOfficeReadOnly(data))
         }
 
-        setConfig(makeConfig(data))
+        setConfig(
+          makeConfig(data, {
+            events: {
+              onAppReady: () => setIsEditorReady(true)
+            }
+          })
+        )
       }
     },
     [
@@ -54,7 +62,8 @@ const useConfig = () => {
       isReadOnly,
       setIsReadOnly,
       config,
-      setConfig
+      setConfig,
+      setIsEditorReady
     ]
   )
 

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -12,9 +12,12 @@ import {
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 
 const useConfig = () => {
-  const { fileId, isReadOnly, setIsReadOnly, setIsEditorReady } = useContext(
-    OnlyOfficeContext
-  )
+  const {
+    fileId,
+    isEditorReadOnly,
+    setIsEditorReadOnly,
+    setIsEditorReady
+  } = useContext(OnlyOfficeContext)
   const [config, setConfig] = useState()
 
   const queryResult = useFetchJSON('GET', `/office/${fileId}/open`)
@@ -42,8 +45,8 @@ const useConfig = () => {
           return (window.location = link)
         }
 
-        if (isReadOnly !== isOnlyOfficeReadOnly(data)) {
-          setIsReadOnly(isOnlyOfficeReadOnly(data))
+        if (isEditorReadOnly !== isOnlyOfficeReadOnly(data)) {
+          setIsEditorReadOnly(isOnlyOfficeReadOnly(data))
         }
 
         setConfig(
@@ -59,8 +62,8 @@ const useConfig = () => {
       queryResult,
       fetchStatus,
       data,
-      isReadOnly,
-      setIsReadOnly,
+      isEditorReadOnly,
+      setIsEditorReadOnly,
       config,
       setConfig,
       setIsEditorReady

--- a/src/drive/web/modules/views/hooks.js
+++ b/src/drive/web/modules/views/hooks.js
@@ -50,6 +50,7 @@ export const useFileWithPath = fileId => {
   const parentData = parentResult.data
 
   return {
+    ...fileResult,
     data: {
       ...resultData,
       displayedPath: parentData ? parentData.path : undefined


### PR DESCRIPTION
On récupère dans le contexte le fait que l'éditeur a terminé son initialisation. Cela permet de charger certains éléments seulement après.