### PR TITLE
fix: GET https://xxx/files/%5Bobject%20Object%5D 404 in useFileWithPath

### DIFF
--- a/src/drive/web/modules/views/hooks.js
+++ b/src/drive/web/modules/views/hooks.js
@@ -39,13 +39,18 @@ export const useFilesQueryWithPath = query => {
   }
 }
 
+// TODO: when https://github.com/cozy/cozy-client/pull/947 is merged
+// remove the [] tricks on dirId and Array.isArray(dirId) on parentQuery
+// and use enabled param instead in parentResult query
 export const useFileWithPath = fileId => {
   const fileQuery = buildFileByIdQuery(fileId)
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
   const resultData = fileResult.data
-  const dirId = resultData ? resultData.dir_id : {}
+  const dirId = resultData ? resultData.dir_id : []
 
-  const parentQuery = buildFileByIdQuery(dirId)
+  const parentQuery = Array.isArray(dirId)
+    ? buildParentsByIdsQuery(dirId)
+    : buildFileByIdQuery(dirId)
   const parentResult = useQuery(parentQuery.definition, parentQuery.options)
   const parentData = parentResult.data
 


### PR DESCRIPTION
We use here the same way as in useFilesQueryWithPath : while we don't have the folder id, we use Q('io.cozy.files').getByIds([]) query (that didn't trigger any error) instead of Q('io.cozy.files').getById({})