### PR TITLE
Fix redirection and sharing in only office Public view

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/HomeLinker.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/HomeLinker.jsx
@@ -7,24 +7,7 @@ import {
   buildAppsQuery,
   buildSettingsByIdQuery
 } from 'drive/web/modules/queries'
-
-// TODO: use this method from cozy-client instead
-const computeHomeApp = ({ apps, context }) => {
-  const defaultRedirection =
-    context && context.attributes && context.attributes.default_redirection
-  let homeApp = null
-
-  if (!defaultRedirection) {
-    homeApp = apps.find(app => app.slug === 'home')
-  } else {
-    const slugRegexp = /^([^/]+)\/.*/
-    const matches = defaultRedirection.match(slugRegexp)
-    const defaultAppSlug = matches && matches[1]
-    homeApp = apps.find(app => app.slug === defaultAppSlug)
-  }
-
-  return homeApp
-}
+import { computeHomeApp } from 'drive/web/modules/views/OnlyOffice/Toolbar/helpers'
 
 const HomeLinker = ({ children }) => {
   const client = useClient()

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/Sharing.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/Sharing.jsx
@@ -16,7 +16,11 @@ const Sharing = ({ fileWithPath }) => {
         size={32}
         onClick={toggleShareModal}
       />
-      <ShareButton docId={fileWithPath.id} onClick={toggleShareModal} />
+      <ShareButton
+        data-testid="onlyoffice-sharing-button"
+        docId={fileWithPath.id}
+        onClick={toggleShareModal}
+      />
       {showShareModal && (
         <ShareModal
           document={fileWithPath}

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/helpers.js
@@ -1,0 +1,17 @@
+// TODO: use this method from cozy-client instead
+export const computeHomeApp = ({ apps, context }) => {
+  const defaultRedirection =
+    context && context.attributes && context.attributes.default_redirection
+  let homeApp = null
+
+  if (!defaultRedirection) {
+    homeApp = apps.find(app => app.slug === 'home')
+  } else {
+    const slugRegexp = /^([^/]+)\/.*/
+    const matches = defaultRedirection.match(slugRegexp)
+    const defaultAppSlug = matches && matches[1]
+    homeApp = apps.find(app => app.slug === defaultAppSlug)
+  }
+
+  return homeApp
+}

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -57,7 +57,7 @@ const Toolbar = () => {
         <FileName fileWithPath={fileWithPath} />
       </div>
       {!isMobile && isEditorReadOnly && <ReadOnly />}
-      {isEditorReady && <Sharing fileWithPath={fileWithPath} />}
+      {!isPublic && isEditorReady && <Sharing fileWithPath={fileWithPath} />}
     </>
   )
 }

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -16,7 +16,8 @@ const useConfig = () => {
     fileId,
     isEditorReadOnly,
     setIsEditorReadOnly,
-    setIsEditorReady
+    setIsEditorReady,
+    isPublic
   } = useContext(OnlyOfficeContext)
   const [config, setConfig] = useState()
 
@@ -26,7 +27,7 @@ const useConfig = () => {
   useEffect(
     () => {
       if (!isQueryLoading(queryResult) && fetchStatus !== 'error' && !config) {
-        if (isSharedWithMe(data)) {
+        if (!isPublic && isSharedWithMe(data)) {
           const {
             protocol,
             instance,
@@ -66,7 +67,8 @@ const useConfig = () => {
       setIsEditorReadOnly,
       config,
       setConfig,
-      setIsEditorReady
+      setIsEditorReady,
+      isPublic
     ]
   )
 


### PR DESCRIPTION
Lors de l'accès à une page publique, suite à un partage, on était redirigé comme s'il s'agissait d'un partage de cozy à cozy.

De plus, il y avait les boutons et avatars de partage sur les pages publiques, ce qu'on ne souhaite pas faire.