### PR TITLE
Fix route for sharing only office from cozy to cozy

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "cozy-realtime": "3.13.0",
     "cozy-scanner": "1.1.1",
     "cozy-scripts": "5.1.1",
-    "cozy-sharing": "3.3.3",
+    "cozy-sharing": "3.4.0",
     "cozy-stack-client": "23.0.0",
     "cozy-ui": "50.2.0",
     "date-fns": "1.30.1",

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -65,6 +65,7 @@ const FileOpener = ({
   isRenaming,
   isShared,
   isSharedWithMe,
+  hasSharedParent,
   children
 }) => {
   const rowRef = useRef()
@@ -105,7 +106,14 @@ const FileOpener = ({
     ]
   )
 
-  if (isOnlyOfficeEditorSupported({ file, isShared, isSharedWithMe })) {
+  if (
+    isOnlyOfficeEditorSupported({
+      file,
+      isShared,
+      isSharedWithMe,
+      hasSharedParent
+    })
+  ) {
     return (
       <a
         data-testid="onlyoffice-link"

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -42,8 +42,6 @@ export const routes = [
   '/trash/:folderId/file/:fileId',
   '/trash/:folderId',
   '/file/:fileId',
-  '/onlyoffice/:fileId',
-  '/onlyoffice/:fileId/fromSharing',
   '/onlyoffice/:fileId/fromCreate',
   '/onlyoffice/create/:folderId/:fileClass'
 ]
@@ -103,7 +101,6 @@ const AppRoute = (
       </Route>
 
       <Route path="onlyoffice/:fileId" component={OnlyOfficeView} />
-      <Route path="onlyoffice/:fileId/fromSharing" component={OnlyOfficeView} />
       <Route path="onlyoffice/:fileId/fromCreate" component={OnlyOfficeView} />
       <Route
         path="onlyoffice/create/:folderId/:fileClass"

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -65,7 +65,14 @@ const FolderViewBody = ({
   const dispatch = useDispatch()
 
   const handleFileOpen = useCallback(
-    ({ event, file, isAvailableOffline, isShared, isSharedWithMe }) => {
+    ({
+      event,
+      file,
+      isAvailableOffline,
+      isShared,
+      isSharedWithMe,
+      hasSharedParent
+    }) => {
       return createFileOpeningHandler({
         client,
         isFlatDomain,
@@ -74,7 +81,14 @@ const FolderViewBody = ({
         replaceCurrentUrl: url => (window.location.href = url),
         openInNewTab: url => window.open(url, '_blank'),
         routeTo: url => router.push(url)
-      })({ event, file, isAvailableOffline, isShared, isSharedWithMe })
+      })({
+        event,
+        file,
+        isAvailableOffline,
+        isShared,
+        isSharedWithMe,
+        hasSharedParent
+      })
     },
     [client, dispatch, navigateToFile, isFlatDomain, router]
   )

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -17,7 +17,14 @@ const createFileOpeningHandler = ({
   replaceCurrentUrl,
   openInNewTab,
   routeTo
-}) => async ({ event, file, availableOffline, isShared, isSharedWithMe }) => {
+}) => async ({
+  event,
+  file,
+  availableOffline,
+  isShared,
+  isSharedWithMe,
+  hasSharedParent
+}) => {
   if (availableOffline) {
     return dispatch(openLocalFile(file))
   }
@@ -27,7 +34,8 @@ const createFileOpeningHandler = ({
   const isOnlyOffice = isOnlyOfficeEditorSupported({
     file,
     isShared,
-    isSharedWithMe
+    isSharedWithMe,
+    hasSharedParent
   })
 
   if (isShortcut) {

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -4,7 +4,6 @@ import { makeStyles } from '@material-ui/core/styles'
 import { DialogTitle } from 'cozy-ui/transpiled/react/Dialog'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 
-import { useRouter } from 'drive/lib/RouterContext'
 import SharingBanner from 'drive/web/modules/public/SharingBanner'
 import { useSharingInfos } from 'drive/web/modules/public/useSharingInfos'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
@@ -18,19 +17,15 @@ const useStyles = makeStyles(() => ({
 }))
 
 const Title = () => {
-  const { isPublic } = useContext(OnlyOfficeContext)
+  const { isPublic, isFromSharing } = useContext(OnlyOfficeContext)
   const sharingInfos = useSharingInfos()
   const styles = useStyles()
-  const { router } = useRouter()
-
-  const isFromSharing = router.location.pathname.endsWith('/fromSharing')
 
   // The sharing banner need to be shown only on the first arrival
   // and not after browsing inside a folder
-  // When it comes from sharing, we add two entries in the history (one for the doc, one for the redirection)
+  // When it comes from sharing, we don't want the banner at all
   const showSharingBanner =
-    (isPublic && window.history.length <= 1) ||
-    (isFromSharing && window.history.length <= 3)
+    !isFromSharing && isPublic && window.history.length <= 1
 
   return (
     <>

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -16,16 +16,16 @@ import Sharing from 'drive/web/modules/views/OnlyOffice/Toolbar/Sharing'
 
 const Toolbar = () => {
   const { isMobile } = useBreakpoints()
-  const { fileId, isPublic, isEditorReadOnly, isEditorReady } = useContext(
-    OnlyOfficeContext
-  )
+  const {
+    fileId,
+    isPublic,
+    isFromSharing,
+    isEditorReadOnly,
+    isEditorReady
+  } = useContext(OnlyOfficeContext)
   const { data: fileWithPath } = useFileWithPath(fileId)
   const { router } = useRouter()
 
-  const isFromSharing = useMemo(
-    () => router.location.pathname.endsWith('/fromSharing'),
-    [router]
-  )
   const isFromCreate = useMemo(
     () => router.location.pathname.endsWith('/fromCreate'),
     [router]
@@ -34,7 +34,6 @@ const Toolbar = () => {
     isFromSharing,
     isFromCreate
   ])
-
   // The condition is different in the case of a only office file that has been shared with us.
   // In this case there is a double redirection (one to know that the file is a share, the other
   // to open it on the host instance), so there is an additional entry in the history.

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -20,14 +20,14 @@ client.stackClient.uri = 'http://cozy.tools'
 
 const setup = ({
   isEditorReadOnly = false,
-  pathname = '/onlyoffice/fileId',
-  isPublic = false
+  isPublic = false,
+  isFromSharing = false
 } = {}) => {
   const root = render(
     <AppLike
       client={client}
       routerContextValue={{
-        router: { location: { pathname } },
+        router: { location: { pathname: `/onlyoffice/${officeDocParam.id}` } },
         history: jest.fn()
       }}
       sharingContextValue={{
@@ -39,6 +39,7 @@ const setup = ({
         value={{
           fileId: officeDocParam.id,
           isPublic,
+          isFromSharing,
           isEditorReadOnly,
           setIsEditorReadOnly: jest.fn(),
           isEditorReady: true
@@ -114,7 +115,7 @@ describe('Toolbar', () => {
       it('should not show the back button in sharing from cozy to cozy', () => {
         useQuery.mockReturnValue(officeDocParam)
 
-        const { root } = setup({ pathname: '/onlyoffice/fileId/fromSharing' })
+        const { root } = setup({ isFromSharing: true })
         const { queryByTestId } = root
 
         expect(window.history.length).toBe(1)
@@ -140,7 +141,7 @@ describe('Toolbar', () => {
       it('should not show the back button in sharing from cozy to cozy', () => {
         useQuery.mockReturnValue(officeDocParam)
 
-        const { root } = setup({ pathname: '/onlyoffice/fileId/fromSharing' })
+        const { root } = setup({ isFromSharing: true })
         const { queryByTestId } = root
 
         expect(window.history.length).toBe(2)
@@ -166,7 +167,7 @@ describe('Toolbar', () => {
       it('should show the back button in sharing from cozy to cozy', () => {
         useQuery.mockReturnValue(officeDocParam)
 
-        const { root } = setup({ pathname: '/onlyoffice/fileId/fromSharing' })
+        const { root } = setup({ isFromSharing: true })
         const { queryByTestId } = root
 
         expect(window.history.length).toBe(3)

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -15,10 +15,12 @@ export const isOnlyOfficeReadOnly = ({ data }) =>
 export const isOnlyOfficeEditorSupported = ({
   file,
   isShared,
-  isSharedWithMe
+  isSharedWithMe,
+  hasSharedParent
 }) =>
   models.file.shouldBeOpenedByOnlyOffice(file) &&
   (isSharedWithMe ||
+    hasSharedParent ||
     (isShared && !isSharedWithMe && helpers.isOnlyOfficeEnabled()) ||
     (!isShared && helpers.isOnlyOfficeEnabled()))
 

--- a/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
@@ -1,5 +1,47 @@
 import helpers, { isOnlyOfficeEditorSupported } from './helpers'
 
+const casesToTest = [
+  {
+    // the doc is not shared
+    isShared: false,
+    isSharedWithMe: false,
+    hasSharedParent: false
+  },
+  {
+    // the doc is shared by being the owner
+    isShared: true,
+    isSharedWithMe: false,
+    hasSharedParent: false
+  },
+  {
+    // the doc is shared but without being the owner
+    isShared: true,
+    isSharedWithMe: true,
+    hasSharedParent: false
+  },
+  {
+    // the doc is inside a shared folder
+    isShared: false,
+    isSharedWithMe: false,
+    hasSharedParent: true
+  }
+]
+
+const executeTests = (file, expectations) => {
+  casesToTest.forEach(
+    ({ isShared, isSharedWithMe, hasSharedParent }, index) => {
+      expect(
+        isOnlyOfficeEditorSupported({
+          file,
+          isShared,
+          isSharedWithMe,
+          hasSharedParent
+        })
+      ).toBe(expectations[index])
+    }
+  )
+}
+
 describe('isOnlyOfficeEditorSupported', () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -9,133 +51,33 @@ describe('isOnlyOfficeEditorSupported', () => {
     const file = { type: 'file', class: 'image', name: 'doc.png' }
 
     it('should return false no matter if it is shared', () => {
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: false,
-          isSharedWithMe: false
-        })
-      ).toBeFalsy()
-
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: false
-        })
-      ).toBeFalsy()
-
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: true
-        })
-      ).toBeFalsy()
+      const expectations = [false, false, false, false]
+      executeTests(file, expectations)
     })
 
     it('should return false no matter if an only office server is configured', () => {
       jest.spyOn(helpers, 'isOnlyOfficeEnabled').mockReturnValue(true)
 
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: false,
-          isSharedWithMe: false
-        })
-      ).toBeFalsy()
-
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: false
-        })
-      ).toBeFalsy()
-
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: true
-        })
-      ).toBeFalsy()
+      const expectations = [false, false, false, false]
+      executeTests(file, expectations)
     })
   })
 
-  describe('For an only office doc, without any only office server configured', () => {
+  describe('For an only office doc', () => {
     const file = { type: 'file', class: 'slide', name: 'doc.pptx' }
 
-    beforeEach(() => {
+    it('should return the expectation without any only office server configured', () => {
       jest.spyOn(helpers, 'isOnlyOfficeEnabled').mockReturnValue(false)
+
+      const expectations = [false, false, true, true]
+      executeTests(file, expectations)
     })
 
-    it('should return false if the doc is not shared', () => {
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: false,
-          isSharedWithMe: false
-        })
-      ).toBeFalsy()
-    })
-
-    it('should return false if the doc is shared by being the owner', () => {
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: false
-        })
-      ).toBeFalsy()
-    })
-
-    it('should return true if the doc is shared but without being the owner', () => {
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: true
-        })
-      ).toBeTruthy()
-    })
-  })
-
-  describe('For an only office doc, with an only office server configured', () => {
-    const file = { type: 'file', class: 'slide', name: 'doc.pptx' }
-
-    beforeEach(() => {
+    it('should return the expectation with an only office server configured', () => {
       jest.spyOn(helpers, 'isOnlyOfficeEnabled').mockReturnValue(true)
-    })
 
-    it('should return true if the doc is not shared', () => {
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: false,
-          isSharedWithMe: false
-        })
-      ).toBeTruthy()
-    })
-
-    it('should return true if the doc is shared by being the owner', () => {
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: false
-        })
-      ).toBeTruthy()
-    })
-
-    it('should return true if the doc is shared but without being the owner', () => {
-      expect(
-        isOnlyOfficeEditorSupported({
-          file,
-          isShared: true,
-          isSharedWithMe: true
-        })
-      ).toBeTruthy()
+      const expectations = [true, true, true, true]
+      executeTests(file, expectations)
     })
   })
 })

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -6,7 +6,7 @@ import Editor from 'drive/web/modules/views/OnlyOffice/Editor'
 
 export const OnlyOfficeContext = createContext()
 
-const OnlyOfficeProvider = ({ fileId, isPublic, children }) => {
+const OnlyOfficeProvider = ({ fileId, isPublic, isFromSharing, children }) => {
   const [isEditorReadOnly, setIsEditorReadOnly] = useState()
   const [isEditorReady, setIsEditorReady] = useState(false)
 
@@ -15,6 +15,7 @@ const OnlyOfficeProvider = ({ fileId, isPublic, children }) => {
       value={{
         fileId,
         isPublic,
+        isFromSharing,
         isEditorReadOnly,
         setIsEditorReadOnly,
         isEditorReady,
@@ -26,10 +27,14 @@ const OnlyOfficeProvider = ({ fileId, isPublic, children }) => {
   )
 }
 
-const OnlyOffice = ({ params: { fileId }, isPublic }) => {
+const OnlyOffice = ({ params: { fileId }, isPublic, isFromSharing }) => {
   return (
     <Dialog open={true} fullScreen transitionDuration={0}>
-      <OnlyOfficeProvider fileId={fileId} isPublic={isPublic}>
+      <OnlyOfficeProvider
+        fileId={fileId}
+        isPublic={isPublic}
+        isFromSharing={isFromSharing}
+      >
         <Editor />
       </OnlyOfficeProvider>
     </Dialog>

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -32,31 +32,36 @@ const useConfig = () => {
             protocol,
             instance,
             document_id,
-            subdomain
+            subdomain,
+            sharecode
           } = data.data.attributes
+
+          const searchParams = [['sharecode', sharecode]]
+          searchParams.push(['isOnlyOfficeDocShared', true])
+          searchParams.push(['onlyOfficeDocId', document_id])
 
           const link = generateWebLink({
             cozyUrl: `${protocol}://${instance}`,
-            pathname: '',
-            hash: `/onlyoffice/${document_id}/fromSharing`,
+            searchParams,
+            pathname: '/public/',
             slug: 'drive',
             subDomainType: subdomain
           })
 
-          return (window.location = link)
-        }
+          window.location = link
+        } else {
+          if (isEditorReadOnly !== isOnlyOfficeReadOnly(data)) {
+            setIsEditorReadOnly(isOnlyOfficeReadOnly(data))
+          }
 
-        if (isEditorReadOnly !== isOnlyOfficeReadOnly(data)) {
-          setIsEditorReadOnly(isOnlyOfficeReadOnly(data))
+          setConfig(
+            makeConfig(data, {
+              events: {
+                onAppReady: () => setIsEditorReady(true)
+              }
+            })
+          )
         }
-
-        setConfig(
-          makeConfig(data, {
-            events: {
-              onAppReady: () => setIsEditorReady(true)
-            }
-          })
-        )
       }
     },
     [

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -19,6 +19,7 @@ const mockStore = createStore(() => ({
     url: 'cozy-url://'
   }
 }))
+
 export const TestI18n = ({ children }) => {
   return (
     <I18n lang={'en'} dictRequire={() => langEn}>
@@ -31,7 +32,8 @@ const mockSharingContextValue = {
   refresh: jest.fn(),
   hasWriteAccess: jest.fn(),
   getRecipients: jest.fn(),
-  getSharingLink: jest.fn()
+  getSharingLink: jest.fn(),
+  hasSharedParent: jest.fn()
 }
 
 const mockRouterContextValue = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5285,6 +5285,17 @@ cozy-doctypes@^1.81.0:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
+cozy-doctypes@^1.82.2:
+  version "1.82.2"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.82.2.tgz#7c7d6f44e3aaee18ba51253468e84d2d1a70fde6"
+  integrity sha512-NWbQ6rKj2a+Rq19MX9uNa8GNlzwdlye9pxiC1V3jd+76T5fQMQN+tjHr9jK468V/NJvC/oQowAcWsRoMaB5A+Q==
+  dependencies:
+    cozy-logger "^1.7.0"
+    date-fns "^1.30.1"
+    es6-promise-pool "^2.5.0"
+    lodash "^4.17.19"
+    prop-types "^15.7.2"
+
 cozy-flags@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.6.0.tgz#c336b154ef94723c151f26ef2782a4d0650b4593"
@@ -5487,16 +5498,16 @@ cozy-scripts@5.1.1:
     webpack-dev-server "3.10.3"
     webpack-merge "4.2.2"
 
-cozy-sharing@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-3.3.3.tgz#cc9e82b59a4c35c4134c6dcdbd9a1ebfc7db0890"
-  integrity sha512-oYzpgdoy5Ba+ZYb/sajm8W/pI0czdJPSX/sxpucnmbxcJ3s+no0aukOcdPNppOFE5Q3Pd54Sqoi7eelKBwArjQ==
+cozy-sharing@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-3.4.0.tgz#8e0c596d5bc74d0fe439e8e850d5431858997537"
+  integrity sha512-8FuMUdBmnpKq9c+DmywT6ipUHBiDgkM+OiF8KMpwcz9DgH48TFzfbwm5QcKX8kz7/JSROjNqDEy0eA8Wff/Z3g==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.2.6"
     copy-text-to-clipboard "^2.1.1"
     cozy-device-helper "^1.12.0"
-    cozy-doctypes "^1.81.0"
+    cozy-doctypes "^1.82.2"
     lodash "^4.17.19"
     react-autosuggest "^9.4.3"
     react-tooltip "^3.11.1"


### PR DESCRIPTION
Lors d'un partage de cozy à cozy on reroutait en partie privée de Drive, ce qui posait des problèmes d'authentification lors de l'ouverture du document only office par le receveur d'un partage. Pour rappel, dans ce cas (partage d'un doc only office de Alice à Bob), Bob est renvoyé sur l'instance d'Alice pour ouvrir le doc, et utiliser son serveur only office.

On a également gérer le cas d'un partage d'un dossier contenant un document only office