### PR TITLE
Enhanced Only Office toolbar on mobile

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/BackButton.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/BackButton.jsx
@@ -4,14 +4,17 @@ import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
 
-const _BackButton = ({ onClick }) => {
+const BackButton = ({ onClick }) => {
+  // TODO: remove u-ml-half-s when https://github.com/cozy/cozy-ui/issues/1808 is fixed
   return (
-    <IconButton onClick={onClick} data-testid="onlyoffice-backButton">
+    <IconButton
+      data-testid="onlyoffice-backButton"
+      className="u-ml-half-s"
+      onClick={onClick}
+    >
       <Icon icon={PreviousIcon} />
     </IconButton>
   )
 }
 
-const BackButton = React.memo(_BackButton)
-
-export default BackButton
+export default React.memo(BackButton)

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -59,16 +59,18 @@ const FileName = ({ fileWithPath }) => {
           {fileWithPath.name}
         </Typography>
       )}
-      {fileWithPath.displayedPath && (
-        <Link
-          to={`/folder/${fileWithPath.dir_id}`}
-          className={filelistStyles['fil-file-path']}
-        >
-          <Typography variant="caption">
-            <MidEllipsis text={fileWithPath.displayedPath} />
-          </Typography>
-        </Link>
-      )}
+      {fileWithPath.displayedPath &&
+        !isMobile && (
+          <Link
+            data-testid="onlyoffice-filename-path"
+            to={`/folder/${fileWithPath.dir_id}`}
+            className={filelistStyles['fil-file-path']}
+          >
+            <Typography variant="caption">
+              <MidEllipsis text={fileWithPath.displayedPath} />
+            </Typography>
+          </Link>
+        )}
     </div>
   )
 }

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react'
+import React, { useState, useContext, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 import { makeStyles } from '@material-ui/core/styles'
@@ -35,6 +35,11 @@ const FileName = ({ fileWithPath }) => {
   const [isRenaming, setIsRenaming] = useState(false)
   const isRenamable = !isMobile && !isEditorReadOnly
 
+  const onRename = useCallback(() => setIsRenaming(true), [setIsRenaming])
+  const onRenameFinished = useCallback(() => setIsRenaming(false), [
+    setIsRenaming
+  ])
+
   return (
     <div className={`${styles['fileName']} u-ml-1 u-ml-half-s u-ellipsis`}>
       {isRenaming ? (
@@ -43,8 +48,8 @@ const FileName = ({ fileWithPath }) => {
             className={styles['filename-renameInput']}
             file={fileWithPath}
             withoutExtension
-            refreshFolderContent={() => setIsRenaming(false)}
-            onAbort={() => setIsRenaming(false)}
+            refreshFolderContent={onRenameFinished}
+            onAbort={onRenameFinished}
           />
         </Typography>
       ) : (
@@ -54,7 +59,7 @@ const FileName = ({ fileWithPath }) => {
           })}
           variant="h6"
           noWrap
-          {...isRenamable && { onClick: () => setIsRenaming(true) }}
+          onClick={isRenamable && onRename}
         >
           {fileWithPath.name}
         </Typography>
@@ -79,4 +84,4 @@ FileName.propTypes = {
   fileWithPath: PropTypes.object.isRequired
 }
 
-export default FileName
+export default React.memo(FileName)

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -33,7 +33,6 @@ const FileName = ({ fileWithPath }) => {
   const { isMobile } = useBreakpoints()
   const { isEditorReadOnly } = useContext(OnlyOfficeContext)
   const [isRenaming, setIsRenaming] = useState(false)
-  const isRenamable = !isMobile && !isEditorReadOnly
 
   const onRename = useCallback(() => setIsRenaming(true), [setIsRenaming])
   const onRenameFinished = useCallback(() => setIsRenaming(false), [
@@ -41,7 +40,11 @@ const FileName = ({ fileWithPath }) => {
   ])
 
   return (
-    <div className={`${styles['fileName']} u-ml-1 u-ml-half-s u-ellipsis`}>
+    <div
+      className={`${
+        styles['fileName']
+      } u-mh-1 u-mh-half-s u-ellipsis u-flex-grow-1`}
+    >
       {isRenaming ? (
         <Typography variant="h6" noWrap>
           <RenameInput
@@ -55,11 +58,11 @@ const FileName = ({ fileWithPath }) => {
       ) : (
         <Typography
           className={cx(muiStyles.name, {
-            [`${muiStyles.renamable}`]: isRenamable
+            [`${muiStyles.renamable}`]: !isEditorReadOnly
           })}
           variant="h6"
           noWrap
-          onClick={isRenamable && onRename}
+          onClick={!isEditorReadOnly && onRename}
         >
           {fileWithPath.name}
         </Typography>

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/ReadOnly.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/ReadOnly.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import LockIcon from 'cozy-ui/transpiled/react/Icons/Lock'
@@ -8,16 +9,30 @@ import Tooltip from 'cozy-ui/transpiled/react/Tooltip'
 
 const ReadOnly = () => {
   const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
+
+  if (isMobile)
+    return (
+      <div className="u-flex u-mr-1">
+        <Icon
+          data-testid="onlyoffice-readonly-icon-only"
+          icon={LockIcon}
+          color="var(--secondaryTextColor)"
+        />
+      </div>
+    )
 
   return (
     <Tooltip title={t('OnlyOffice.readOnly.tooltip')}>
       <span className="u-flex u-mr-1">
         <Icon
+          data-testid="onlyoffice-readonly-icon"
           icon={LockIcon}
           className="u-mr-half"
           color="var(--secondaryTextColor)"
         />
         <Typography
+          data-testid="onlyoffice-readonly-text"
           variant="body1"
           color="textSecondary"
           className="u-c-default"

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/Sharing.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/Sharing.jsx
@@ -1,9 +1,14 @@
 import React, { useState, useCallback } from 'react'
 
 import { ShareButton, ShareModal, SharedRecipients } from 'cozy-sharing'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 
 const Sharing = ({ fileWithPath }) => {
   const [showShareModal, setShowShareModal] = useState(false)
+  const { isMobile } = useBreakpoints()
 
   const toggleShareModal = useCallback(() => setShowShareModal(v => !v), [
     setShowShareModal
@@ -11,16 +16,27 @@ const Sharing = ({ fileWithPath }) => {
 
   return (
     <>
-      <SharedRecipients
-        docId={fileWithPath.id}
-        size={32}
-        onClick={toggleShareModal}
-      />
-      <ShareButton
-        data-testid="onlyoffice-sharing-button"
-        docId={fileWithPath.id}
-        onClick={toggleShareModal}
-      />
+      {isMobile ? (
+        <IconButton
+          data-testid="onlyoffice-sharing-icon"
+          onClick={toggleShareModal}
+        >
+          <Icon icon={ShareIcon} />
+        </IconButton>
+      ) : (
+        <>
+          <SharedRecipients
+            docId={fileWithPath.id}
+            size={32}
+            onClick={toggleShareModal}
+          />
+          <ShareButton
+            data-testid="onlyoffice-sharing-button"
+            docId={fileWithPath.id}
+            onClick={toggleShareModal}
+          />
+        </>
+      )}
       {showShareModal && (
         <ShareModal
           document={fileWithPath}

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -70,7 +70,7 @@ const Toolbar = () => {
           fileWithPath.class && <FileIcon fileClass={fileWithPath.class} />}
         <FileName fileWithPath={fileWithPath} />
       </div>
-      {!isMobile && isEditorReadOnly && <ReadOnly />}
+      {isEditorReadOnly && <ReadOnly />}
       {!isPublic && isEditorReady && <Sharing fileWithPath={fileWithPath} />}
     </>
   )

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -112,6 +112,18 @@ describe('Toolbar', () => {
       fireEvent.click(getByText(officeDocParam.data.name))
       expect(queryByRole('textbox')).toBeFalsy()
     })
+
+    describe('Renaming on mobile', () => {
+      it('should be able to rename the file if not in readOnly mode', () => {
+        useQuery.mockReturnValue(officeDocParam)
+
+        const { root } = setup({ isEditorReadOnly: false, isMobile: true })
+        const { getByText, getByRole } = root
+
+        fireEvent.click(getByText(officeDocParam.data.name))
+        expect(getByRole('textbox').value).toBe(officeDocParam.data.name)
+      })
+    })
   })
 
   describe('Sharing', () => {

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -68,6 +68,30 @@ describe('Toolbar', () => {
     jest.clearAllMocks()
   })
 
+  describe('FileName', () => {
+    it('should show the path', () => {
+      useQuery
+        .mockReturnValueOnce(officeDocParam)
+        .mockReturnValue({ ...officeDocParam, data: { path: '/path' } })
+
+      const { root } = setup({ isMobile: false })
+      const { queryByTestId } = root
+
+      expect(queryByTestId('onlyoffice-filename-path')).toBeTruthy()
+    })
+
+    it('should not show the path on mobile', () => {
+      useQuery
+        .mockReturnValueOnce(officeDocParam)
+        .mockReturnValue({ ...officeDocParam, data: { path: '/path' } })
+
+      const { root } = setup({ isMobile: true })
+      const { queryByTestId } = root
+
+      expect(queryByTestId('onlyoffice-filename-path')).toBeFalsy()
+    })
+  })
+
   describe('Renaming', () => {
     it('should be able to rename the file if not in readOnly mode', () => {
       useQuery.mockReturnValue(officeDocParam)

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -122,6 +122,50 @@ describe('Toolbar', () => {
     })
   })
 
+  describe('Read only', () => {
+    it('should show text and icon if editor is read only', () => {
+      useQuery.mockReturnValue(officeDocParam)
+
+      const { root } = setup({ isEditorReadOnly: true, isMobile: false })
+      const { queryByTestId } = root
+
+      expect(queryByTestId('onlyoffice-readonly-icon')).toBeTruthy()
+      expect(queryByTestId('onlyoffice-readonly-text')).toBeTruthy()
+    })
+
+    it('should not show text and icon if editor is not read only', () => {
+      useQuery.mockReturnValue(officeDocParam)
+
+      const { root } = setup({ isEditorReadOnly: false, isMobile: false })
+      const { queryByTestId } = root
+
+      expect(queryByTestId('onlyoffice-readonly-icon')).toBeFalsy()
+      expect(queryByTestId('onlyoffice-readonly-text')).toBeFalsy()
+    })
+
+    describe('Read only on mobile', () => {
+      it('should show only icon if editor is read only', () => {
+        useQuery.mockReturnValue(officeDocParam)
+
+        const { root } = setup({ isEditorReadOnly: true, isMobile: true })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-readonly-icon-only')).toBeTruthy()
+        expect(queryByTestId('onlyoffice-readonly-text')).toBeFalsy()
+      })
+
+      it('should not show text and icon if editor is not read only', () => {
+        useQuery.mockReturnValue(officeDocParam)
+
+        const { root } = setup({ isEditorReadOnly: false, isMobile: true })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-readonly-icon')).toBeFalsy()
+        expect(queryByTestId('onlyoffice-readonly-text')).toBeFalsy()
+      })
+    })
+  })
+
   describe('Back Button', () => {
     describe('with default history', () => {
       it('should not show the back button', () => {

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
 import { createMockClient, useQuery } from 'cozy-client'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import AppLike from 'test/components/AppLike'
 import { officeDocParam } from 'test/data'
@@ -9,6 +10,12 @@ import { officeDocParam } from 'test/data'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import Toolbar from 'drive/web/modules/views/OnlyOffice/Toolbar'
 
+jest.mock('cozy-ui/transpiled/react/hooks/useBreakpoints', () => ({
+  ...jest.requireActual('cozy-ui/transpiled/react/hooks/useBreakpoints'),
+  __esModule: true,
+  default: jest.fn(),
+  useBreakpoints: jest.fn()
+}))
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 jest.mock('drive/web/modules/views/OnlyOffice/Toolbar/helpers', () => ({
   ...jest.requireActual('drive/web/modules/views/OnlyOffice/Toolbar/helpers'),
@@ -21,8 +28,11 @@ client.stackClient.uri = 'http://cozy.tools'
 const setup = ({
   isEditorReadOnly = false,
   isPublic = false,
-  isFromSharing = false
+  isFromSharing = false,
+  isMobile = false
 } = {}) => {
+  useBreakpoints.mockReturnValue({ isMobile })
+
   const root = render(
     <AppLike
       client={client}
@@ -97,6 +107,18 @@ describe('Toolbar', () => {
       const { queryByTestId } = root
 
       expect(queryByTestId('onlyoffice-sharing-button')).toBeFalsy()
+    })
+
+    describe('Sharing on mobile', () => {
+      it('should show only sharing icon on mobile', () => {
+        useQuery.mockReturnValue(officeDocParam)
+
+        const { root } = setup({ isPublic: false, isMobile: true })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-sharing-button')).toBeFalsy()
+        expect(queryByTestId('onlyoffice-sharing-icon')).toBeTruthy()
+      })
     })
   })
 


### PR DESCRIPTION
- suppression de l'icone home, de l'avatar et de l'icone fichier
- suppression du chemin du fichier
- nom éditable
- icone de partage à la place des avatars et bouton de partage
- cadenas simple sans texte pour une document readOnly