### PR TITLE
Refactor conditional onClick

### DIFF
--- a/src/drive/web/modules/drive/Fab.jsx
+++ b/src/drive/web/modules/drive/Fab.jsx
@@ -30,7 +30,7 @@ export const Fab = ({ noSidebar }) => {
     <div
       ref={anchorRef}
       className={styles.root}
-      onClick={isOffline && handleOfflineClick}
+      onClick={isOffline ? handleOfflineClick : undefined}
     >
       <UiFab
         color="primary"

--- a/src/drive/web/modules/drive/Toolbar/components/AddButton.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/AddButton.jsx
@@ -17,7 +17,7 @@ export const AddButton = () => {
   } = useContext(AddMenuContext)
 
   return (
-    <div ref={anchorRef} onClick={isOffline && handleOfflineClick}>
+    <div ref={anchorRef} onClick={isOffline ? handleOfflineClick : undefined}>
       <Button
         onClick={handleToggle}
         disabled={isDisabled || isOffline}


### PR DESCRIPTION
Précédemment on avait `{...isOffline && { onClick: handleOfflineClick }}` qu'on a remplacé par `onClick={isOffline && handleOfflineClick}`.

Sauf qu'en fait avec cette approche, si la condition (ici `isOffline`) et la valeur (ici `handleOfflineClick`) sont des bool (false par exemple) toutes les deux, on se retrouve avec un `onClick={false}`.

Du coup il est préférable d'utiliser `onClick={isOffline ? handleOfflineClick : undefined}`