### PR TITLE
feat: Add Fab on mobile to switch between read-only or write mode on only office editor

### DIFF
--- a/src/drive/web/modules/drive/Fab.jsx
+++ b/src/drive/web/modules/drive/Fab.jsx
@@ -1,11 +1,8 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 
 import UiFab from 'cozy-ui/transpiled/react/Fab'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
-
-import { AddMenuContext } from 'drive/web/modules/drive/AddMenu/AddMenuProvider'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -16,31 +13,14 @@ const useStyles = makeStyles(() => ({
   }
 }))
 
-export const Fab = ({ noSidebar }) => {
+// TODO: should be in cozy-ui
+const Fab = ({ noSidebar, icon, ...rest }) => {
   const styles = useStyles({ noSidebar })
-  const {
-    anchorRef,
-    handleToggle,
-    isDisabled,
-    handleOfflineClick,
-    isOffline
-  } = useContext(AddMenuContext)
 
   return (
-    <div
-      ref={anchorRef}
-      className={styles.root}
-      onClick={isOffline ? handleOfflineClick : undefined}
-    >
-      <UiFab
-        color="primary"
-        aria-label="add"
-        onClick={handleToggle}
-        disabled={isDisabled || isOffline}
-      >
-        <Icon icon={PlusIcon} />
-      </UiFab>
-    </div>
+    <UiFab className={styles.root} {...rest}>
+      <Icon icon={icon} />
+    </UiFab>
   )
 }
 

--- a/src/drive/web/modules/drive/FabWithMenuContext.jsx
+++ b/src/drive/web/modules/drive/FabWithMenuContext.jsx
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react'
+
+import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
+
+import Fab from 'drive/web/modules/drive/Fab'
+import { AddMenuContext } from 'drive/web/modules/drive/AddMenu/AddMenuProvider'
+
+const FabWithMenuContext = ({ noSidebar }) => {
+  const {
+    anchorRef,
+    handleToggle,
+    isDisabled,
+    handleOfflineClick,
+    isOffline
+  } = useContext(AddMenuContext)
+
+  return (
+    <div
+      ref={anchorRef ? anchorRef : undefined}
+      onClick={isOffline ? handleOfflineClick : undefined}
+    >
+      <Fab
+        noSidebar={noSidebar}
+        aria-label="add"
+        disabled={isDisabled || isOffline}
+        icon={PlusIcon}
+        color="primary"
+        onClick={handleToggle}
+      />
+    </div>
+  )
+}
+
+export default React.memo(FabWithMenuContext)

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -48,7 +48,7 @@ import FolderViewHeader from 'drive/web/modules/views/Folder/FolderViewHeader'
 import FolderViewBody from 'drive/web/modules/views/Folder/FolderViewBody'
 import FolderViewBreadcrumb from 'drive/web/modules/views/Folder/FolderViewBreadcrumb'
 import { useTrashRedirect } from 'drive/web/modules/views/Drive/useTrashRedirect'
-import Fab from 'drive/web/modules/drive/Fab'
+import FabWithMenuContext from 'drive/web/modules/drive/FabWithMenuContext'
 import AddMenuProvider from 'drive/web/modules/drive/AddMenu/AddMenuProvider'
 
 const getBreadcrumbPath = (t, displayedFolder) =>
@@ -239,7 +239,7 @@ const DriveView = ({
             canUpload={true}
             disabled={isLoading || isInError || isPending}
           >
-            <Fab />
+            <FabWithMenuContext />
           </AddMenuProvider>
         )}
         {children}

--- a/src/drive/web/modules/views/OnlyOffice/Editor.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.jsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useContext } from 'react'
 
+import flag from 'cozy-flags'
 import { DialogContent } from 'cozy-ui/transpiled/react/Dialog'
 
+import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import useConfig from 'drive/web/modules/views/OnlyOffice/useConfig'
-
 import View from 'drive/web/modules/views/OnlyOffice/View'
 import Error from 'drive/web/modules/views/OnlyOffice/Error'
 import Loading from 'drive/web/modules/views/OnlyOffice/Loading'
@@ -11,16 +12,32 @@ import Title from 'drive/web/modules/views/OnlyOffice/Title'
 
 export const Editor = () => {
   const { config, status } = useConfig()
+  const { isEditorForcedReadOnly } = useContext(OnlyOfficeContext)
 
   if (status === 'error') return <Error />
   if (status !== 'loaded' || !config) return <Loading />
 
   const { serverUrl, apiUrl, docEditorConfig } = config
 
+  const editorToolbarHeight = Number.isInteger(
+    flag('drive.onlyoffice.editorToolbarHeight')
+  )
+    ? flag('drive.onlyoffice.editorToolbarHeight')
+    : 68
+
   return (
     <>
       <Title />
-      <DialogContent className="u-flex u-flex-column u-p-0">
+      <DialogContent
+        style={
+          isEditorForcedReadOnly
+            ? {
+                marginTop: `-${editorToolbarHeight}px`
+              }
+            : undefined
+        }
+        className="u-flex u-flex-column u-p-0"
+      >
         <View
           id={new URL(serverUrl).hostname}
           apiUrl={apiUrl}

--- a/src/drive/web/modules/views/OnlyOffice/Editor.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.jsx
@@ -9,6 +9,7 @@ import View from 'drive/web/modules/views/OnlyOffice/View'
 import Error from 'drive/web/modules/views/OnlyOffice/Error'
 import Loading from 'drive/web/modules/views/OnlyOffice/Loading'
 import Title from 'drive/web/modules/views/OnlyOffice/Title'
+import { DEFAULT_EDITOR_TOOLBAR_HEIGHT } from 'drive/web/modules/views/OnlyOffice/config'
 
 export const Editor = () => {
   const { config, status } = useConfig()
@@ -23,7 +24,7 @@ export const Editor = () => {
     flag('drive.onlyoffice.editorToolbarHeight')
   )
     ? flag('drive.onlyoffice.editorToolbarHeight')
-    : 68
+    : DEFAULT_EDITOR_TOOLBAR_HEIGHT
 
   return (
     <>

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -37,7 +37,11 @@ jest.mock('cozy-flags')
 
 const client = createMockClient({})
 
-const setup = ({ isMobile = false, forceReadOnlyOnDesktop = false } = {}) => {
+const setup = ({
+  isMobile = false,
+  forceReadOnlyOnDesktop = false,
+  isEditorForcedReadOnly = false
+} = {}) => {
   useBreakpoints.mockReturnValue({ isMobile })
   flag.mockReturnValue(forceReadOnlyOnDesktop)
 
@@ -59,7 +63,7 @@ const setup = ({ isMobile = false, forceReadOnlyOnDesktop = false } = {}) => {
           isEditorReadOnly: false,
           setIsEditorReadOnly: jest.fn(),
           isEditorReady: true,
-          isEditorForcedReadOnly: false
+          isEditorForcedReadOnly
         }}
       >
         <Editor />
@@ -99,7 +103,7 @@ describe('Editor', () => {
     expect(getAllByText('Download')).toBeTruthy()
   })
 
-  it('should show the title and the container view', () => {
+  it('should show the title and the container view if the only office server is installed', () => {
     useFetchJSON.mockReturnValue({
       fetchStatus: 'loaded',
       data: officeDocParam
@@ -107,47 +111,12 @@ describe('Editor', () => {
     useQuery.mockReturnValue(officeDocParam)
     isOnlyOfficeEnabled.mockReturnValue(true)
 
-    const { root } = setup({ isMobile: false })
+    const { root } = setup()
     const { container, queryByTestId } = root
 
     expect(queryByTestId('onlyoffice-content-spinner')).toBeFalsy()
     expect(queryByTestId('onlyoffice-title')).toBeTruthy()
     expect(container.querySelector('#onlyOfficeEditor')).toBeTruthy()
-    expect(queryByTestId('onlyoffice-readonlyfab')).toBeFalsy()
-  })
-
-  it('should show the readOnlyFab on mobile', () => {
-    useFetchJSON.mockReturnValue({
-      fetchStatus: 'loaded',
-      data: officeDocParam
-    })
-    useQuery.mockReturnValue(officeDocParam)
-    isOnlyOfficeEnabled.mockReturnValue(true)
-
-    const { root } = setup({ isMobile: true })
-    const { container, queryByTestId } = root
-
-    expect(queryByTestId('onlyoffice-content-spinner')).toBeFalsy()
-    expect(queryByTestId('onlyoffice-title')).toBeTruthy()
-    expect(container.querySelector('#onlyOfficeEditor')).toBeTruthy()
-    expect(queryByTestId('onlyoffice-readonlyfab')).toBeTruthy()
-  })
-
-  it('should show the readOnlyFab on desktop if forceReadOnlyOnDesktop is true', () => {
-    useFetchJSON.mockReturnValue({
-      fetchStatus: 'loaded',
-      data: officeDocParam
-    })
-    useQuery.mockReturnValue(officeDocParam)
-    isOnlyOfficeEnabled.mockReturnValue(true)
-
-    const { root } = setup({ isMobile: false, forceReadOnlyOnDesktop: true })
-    const { container, queryByTestId } = root
-
-    expect(queryByTestId('onlyoffice-content-spinner')).toBeFalsy()
-    expect(queryByTestId('onlyoffice-title')).toBeTruthy()
-    expect(container.querySelector('#onlyOfficeEditor')).toBeTruthy()
-    expect(queryByTestId('onlyoffice-readonlyfab')).toBeTruthy()
   })
 
   it('should show the CozyUi Viewer if the only office server is not installed', () => {
@@ -165,5 +134,199 @@ describe('Editor', () => {
     expect(queryByTestId('onlyoffice-title')).toBeFalsy()
     expect(queryByTestId('viewer-toolbar')).toBeTruthy()
     expect(getAllByText('Download')).toBeTruthy()
+  })
+
+  describe('Title', () => {
+    describe('on mobile', () => {
+      it('should hide title for forceReadOnlyOnDesktop false and isEditorForcedReadOnly false', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: true,
+          forceReadOnlyOnDesktop: false,
+          isEditorForcedReadOnly: false
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeFalsy()
+      })
+
+      it('should hide title for forceReadOnlyOnDesktop true and isEditorForcedReadOnly false', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: true,
+          forceReadOnlyOnDesktop: true,
+          isEditorForcedReadOnly: false
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeFalsy()
+      })
+
+      it('should show title for forceReadOnlyOnDesktop false and isEditorForcedReadOnly true', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: true,
+          forceReadOnlyOnDesktop: false,
+          isEditorForcedReadOnly: true
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeTruthy()
+      })
+
+      it('should show title for forceReadOnlyOnDesktop true and isEditorForcedReadOnly true', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: true,
+          forceReadOnlyOnDesktop: true,
+          isEditorForcedReadOnly: true
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeTruthy()
+      })
+    })
+
+    describe('on desktop', () => {
+      it('should hide title for forceReadOnlyOnDesktop true and isEditorForcedReadOnly false', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: false,
+          forceReadOnlyOnDesktop: true,
+          isEditorForcedReadOnly: false
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeFalsy()
+      })
+
+      it('should show title for forceReadOnlyOnDesktop true and isEditorForcedReadOnly true', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: false,
+          forceReadOnlyOnDesktop: true,
+          isEditorForcedReadOnly: true
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeTruthy()
+      })
+
+      it('should show title for forceReadOnlyOnDesktop false and isEditorForcedReadOnly true', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: false,
+          forceReadOnlyOnDesktop: false,
+          isEditorForcedReadOnly: true
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeTruthy()
+      })
+
+      it('should show title for forceReadOnlyOnDesktop false and isEditorForcedReadOnly false', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOnlyOfficeEnabled.mockReturnValue(true)
+
+        const { root } = setup({
+          isMobile: false,
+          forceReadOnlyOnDesktop: false,
+          isEditorForcedReadOnly: false
+        })
+        const { queryByTestId } = root
+
+        expect(queryByTestId('onlyoffice-title')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('ReadOnlyFab', () => {
+    it('should show the readOnlyFab on mobile', () => {
+      useFetchJSON.mockReturnValue({
+        fetchStatus: 'loaded',
+        data: officeDocParam
+      })
+      useQuery.mockReturnValue(officeDocParam)
+      isOnlyOfficeEnabled.mockReturnValue(true)
+
+      const { root } = setup({ isMobile: true })
+      const { queryByTestId } = root
+
+      expect(queryByTestId('onlyoffice-readonlyfab')).toBeTruthy()
+    })
+
+    it('should not show the readOnlyFab on desktop', () => {
+      useFetchJSON.mockReturnValue({
+        fetchStatus: 'loaded',
+        data: officeDocParam
+      })
+      useQuery.mockReturnValue(officeDocParam)
+      isOnlyOfficeEnabled.mockReturnValue(true)
+
+      const { root } = setup({ isMobile: false, forceReadOnlyOnDesktop: false })
+      const { queryByTestId } = root
+
+      expect(queryByTestId('onlyoffice-readonlyfab')).toBeFalsy()
+    })
+
+    it('should show the readOnlyFab on desktop if forceReadOnlyOnDesktop is true', () => {
+      useFetchJSON.mockReturnValue({
+        fetchStatus: 'loaded',
+        data: officeDocParam
+      })
+      useQuery.mockReturnValue(officeDocParam)
+      isOnlyOfficeEnabled.mockReturnValue(true)
+
+      const { root } = setup({ isMobile: false, forceReadOnlyOnDesktop: true })
+      const { queryByTestId } = root
+
+      expect(queryByTestId('onlyoffice-readonlyfab')).toBeTruthy()
+    })
   })
 })

--- a/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
@@ -1,0 +1,43 @@
+import React, { useContext, useCallback } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+
+import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
+import CheckIcon from 'cozy-ui/transpiled/react/Icons/Check'
+
+import Fab from 'drive/web/modules/drive/Fab'
+import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    backgroundColor: theme.palette.background.paper,
+    '&:hover': {
+      backgroundColor: theme.palette.background.paper
+    }
+  }
+}))
+
+const ReadOnlyFab = () => {
+  const styles = useStyles()
+  const { isEditorForcedReadOnly, setIsEditorForcedReadOnly } = useContext(
+    OnlyOfficeContext
+  )
+
+  const handleClick = useCallback(
+    () => {
+      setIsEditorForcedReadOnly(v => !v)
+    },
+    [setIsEditorForcedReadOnly]
+  )
+
+  return (
+    <Fab
+      data-testid="onlyoffice-readonlyfab"
+      classes={{ root: styles.root }}
+      noSidebar={true}
+      icon={isEditorForcedReadOnly ? RenameIcon : CheckIcon}
+      onClick={handleClick}
+    />
+  )
+}
+
+export default React.memo(ReadOnlyFab)

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -1,6 +1,8 @@
 import React, { useContext, useMemo } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 
+import flag from 'cozy-flags'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { DialogTitle } from 'cozy-ui/transpiled/react/Dialog'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 
@@ -19,11 +21,15 @@ const useStyles = makeStyles(theme => ({
 }))
 
 const Title = () => {
-  const { isPublic, isFromSharing, isInSharedFolder } = useContext(
-    OnlyOfficeContext
-  )
+  const {
+    isPublic,
+    isFromSharing,
+    isInSharedFolder,
+    isEditorForcedReadOnly
+  } = useContext(OnlyOfficeContext)
   const sharingInfos = useSharingInfos()
   const styles = useStyles()
+  const { isMobile } = useBreakpoints()
 
   const showBanner = useMemo(
     () =>
@@ -35,17 +41,25 @@ const Title = () => {
     [isPublic, isFromSharing, isInSharedFolder]
   )
 
+  const hideToolbar =
+    (isMobile || flag('drive.onlyoffice.forceReadOnlyOnDesktop')) &&
+    !isEditorForcedReadOnly
+
   return (
     <div style={{ zIndex: '1' }}>
-      <DialogTitle
-        data-testid="onlyoffice-title"
-        disableTypography
-        className="u-ellipsis u-flex u-flex-items-center u-p-0 u-pr-1"
-        classes={styles}
-      >
-        <Toolbar />
-      </DialogTitle>
-      <Divider />
+      {!hideToolbar && (
+        <>
+          <DialogTitle
+            data-testid="onlyoffice-title"
+            disableTypography
+            className="u-ellipsis u-flex u-flex-items-center u-p-0 u-pr-1"
+            classes={styles}
+          >
+            <Toolbar />
+          </DialogTitle>
+          <Divider />
+        </>
+      )}
       {showBanner && <SharingBanner sharingInfos={sharingInfos} />}
     </div>
   )

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -41,13 +41,13 @@ const Title = () => {
     [isPublic, isFromSharing, isInSharedFolder]
   )
 
-  const hideToolbar =
+  const hideDialogToolbar =
     (isMobile || flag('drive.onlyoffice.forceReadOnlyOnDesktop')) &&
     !isEditorForcedReadOnly
 
   return (
-    <div style={{ zIndex: '1' }}>
-      {!hideToolbar && (
+    <div style={{ zIndex: 'var(--zIndex-nav)' }}>
+      {!hideDialogToolbar && (
         <>
           <DialogTitle
             data-testid="onlyoffice-title"

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -10,10 +10,11 @@ import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import { showSharingBanner } from 'drive/web/modules/views/OnlyOffice/helpers'
 import Toolbar from 'drive/web/modules/views/OnlyOffice/Toolbar'
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(theme => ({
   root: {
     width: 'calc(100% - 1rem)',
-    height: '3.5rem'
+    height: '3.5rem',
+    backgroundColor: theme.palette.background.paper
   }
 }))
 
@@ -35,7 +36,7 @@ const Title = () => {
   )
 
   return (
-    <>
+    <div style={{ zIndex: '1' }}>
       <DialogTitle
         data-testid="onlyoffice-title"
         disableTypography
@@ -46,7 +47,7 @@ const Title = () => {
       </DialogTitle>
       <Divider />
       {showBanner && <SharingBanner sharingInfos={sharingInfos} />}
-    </>
+    </div>
   )
 }
 

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -62,7 +62,7 @@ const FileName = ({ fileWithPath }) => {
           })}
           variant="h6"
           noWrap
-          onClick={!isEditorReadOnly && onRename}
+          onClick={!isEditorReadOnly ? onRename : undefined}
         >
           {fileWithPath.name}
         </Typography>

--- a/src/drive/web/modules/views/OnlyOffice/View.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/View.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useCallback, useState, useContext } from 'react'
 import PropTypes from 'prop-types'
 
+import flag from 'cozy-flags'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import Error from 'drive/web/modules/views/OnlyOffice/Error'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
+import ReadOnlyFab from 'drive/web/modules/views/OnlyOffice/ReadOnlyFab'
 
 const forceIframeHeight = value => {
   const iframe = document.getElementsByName('frameEditor')[0]
@@ -13,7 +16,8 @@ const forceIframeHeight = value => {
 
 const View = ({ id, apiUrl, docEditorConfig }) => {
   const [isError, setIsError] = useState(false)
-  const { isEditorReady } = useContext(OnlyOfficeContext)
+  const { isEditorReady, isEditorReadOnly } = useContext(OnlyOfficeContext)
+  const { isMobile } = useBreakpoints()
 
   const initEditor = useCallback(
     () => {
@@ -58,6 +62,11 @@ const View = ({ id, apiUrl, docEditorConfig }) => {
     [isEditorReady]
   )
 
+  const showReadOnlyFab =
+    isEditorReady &&
+    !isEditorReadOnly &&
+    (isMobile || flag('drive.onlyoffice.forceReadOnlyOnDesktop'))
+
   if (isError) return <Error />
 
   return (
@@ -69,6 +78,7 @@ const View = ({ id, apiUrl, docEditorConfig }) => {
         />
       )}
       <div id="onlyOfficeEditor" />
+      {showReadOnlyFab && <ReadOnlyFab />}
     </>
   )
 }

--- a/src/drive/web/modules/views/OnlyOffice/View.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/View.jsx
@@ -6,12 +6,9 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Error from 'drive/web/modules/views/OnlyOffice/Error'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 
-const forceIframesHeight = value => {
-  const iframes = document.getElementsByTagName('iframe')
-
-  for (const iframe of iframes) {
-    iframe.style.height = value
-  }
+const forceIframeHeight = value => {
+  const iframe = document.getElementsByName('frameEditor')[0]
+  if (iframe) iframe.style.height = value
 }
 
 const View = ({ id, apiUrl, docEditorConfig }) => {
@@ -21,7 +18,7 @@ const View = ({ id, apiUrl, docEditorConfig }) => {
   const initEditor = useCallback(
     () => {
       new window.DocsAPI.DocEditor('onlyOfficeEditor', docEditorConfig)
-      forceIframesHeight('0')
+      forceIframeHeight('0')
     },
     [docEditorConfig]
   )
@@ -54,7 +51,9 @@ const View = ({ id, apiUrl, docEditorConfig }) => {
 
   useEffect(
     () => {
-      isEditorReady && forceIframesHeight('100%')
+      if (isEditorReady) {
+        forceIframeHeight('100%')
+      }
     },
     [isEditorReady]
   )

--- a/src/drive/web/modules/views/OnlyOffice/View.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/View.jsx
@@ -8,9 +8,10 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Error from 'drive/web/modules/views/OnlyOffice/Error'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import ReadOnlyFab from 'drive/web/modules/views/OnlyOffice/ReadOnlyFab'
+import { FRAME_EDITOR_NAME } from 'drive/web/modules/views/OnlyOffice/config'
 
 const forceIframeHeight = value => {
-  const iframe = document.getElementsByName('frameEditor')[0]
+  const iframe = document.getElementsByName(FRAME_EDITOR_NAME)[0]
   if (iframe) iframe.style.height = value
 }
 

--- a/src/drive/web/modules/views/OnlyOffice/config.js
+++ b/src/drive/web/modules/views/OnlyOffice/config.js
@@ -1,0 +1,3 @@
+export const FRAME_EDITOR_NAME = 'frameEditor'
+
+export const DEFAULT_EDITOR_TOOLBAR_HEIGHT = 68

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -20,23 +20,6 @@ export const isOnlyOfficeReadOnly = ({ data }) =>
 export const shouldBeOpenedOnOtherInstance = ({ data }) =>
   data.attributes.sharecode
 
-export const makeConfig = ({ data }, options) => {
-  const onlyOffice = data.attributes.onlyoffice
-  const serverUrl = onlyOffice.url
-  const apiUrl = `${serverUrl}/web-apps/apps/api/documents/api.js`
-
-  // complete config doc : https://api.onlyoffice.com/editors/advanced
-  const docEditorConfig = {
-    document: onlyOffice.document,
-    editorConfig: onlyOffice.editor,
-    token: onlyOffice.token,
-    documentType: onlyOffice.documentType,
-    ...options
-  }
-
-  return { serverUrl, apiUrl, docEditorConfig }
-}
-
 export const makeOnlyOfficeIconByClass = fileClass => {
   const iconByClass = {
     spreadsheet: FileTypeSheetIcon,

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -1,5 +1,7 @@
 import React, { createContext, useState } from 'react'
 
+import flag from 'cozy-flags'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
 
 import Editor from 'drive/web/modules/views/OnlyOffice/Editor'
@@ -13,8 +15,12 @@ const OnlyOfficeProvider = ({
   isInSharedFolder,
   children
 }) => {
+  const { isMobile } = useBreakpoints()
   const [isEditorReadOnly, setIsEditorReadOnly] = useState()
   const [isEditorReady, setIsEditorReady] = useState(false)
+  const [isEditorForcedReadOnly, setIsEditorForcedReadOnly] = useState(
+    isMobile || flag('drive.onlyoffice.forceReadOnlyOnDesktop')
+  )
 
   return (
     <OnlyOfficeContext.Provider
@@ -26,7 +32,9 @@ const OnlyOfficeProvider = ({
         isEditorReadOnly,
         setIsEditorReadOnly,
         isEditorReady,
-        setIsEditorReady
+        setIsEditorReady,
+        isEditorForcedReadOnly,
+        setIsEditorForcedReadOnly
       }}
     >
       {children}

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -6,7 +6,6 @@ import { generateWebLink } from 'cozy-client'
 
 import {
   isOnlyOfficeReadOnly,
-  makeConfig,
   shouldBeOpenedOnOtherInstance,
   isOnlyOfficeEnabled
 } from 'drive/web/modules/views/OnlyOffice/helpers'
@@ -63,13 +62,21 @@ const useConfig = () => {
             setIsEditorReadOnly(isOnlyOfficeReadOnly(data))
           }
 
-          setConfig(
-            makeConfig(data, {
-              events: {
-                onAppReady: () => setIsEditorReady(true)
-              }
-            })
-          )
+          const onlyOffice = data.data.attributes.onlyoffice
+          const serverUrl = onlyOffice.url
+          const apiUrl = `${serverUrl}web-apps/apps/api/documents/api.js`
+          const docEditorConfig = {
+            // complete config doc : https://api.onlyoffice.com/editors/advanced
+            document: onlyOffice.document,
+            editorConfig: onlyOffice.editor,
+            token: onlyOffice.token,
+            documentType: onlyOffice.documentType,
+            events: {
+              onAppReady: () => setIsEditorReady(true)
+            }
+          }
+
+          setConfig({ serverUrl, apiUrl, docEditorConfig })
         } else {
           setStatus('error')
         }

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -17,7 +17,8 @@ const useConfig = () => {
     isEditorReadOnly,
     setIsEditorReadOnly,
     setIsEditorReady,
-    isPublic
+    isPublic,
+    isEditorForcedReadOnly
   } = useContext(OnlyOfficeContext)
   const [config, setConfig] = useState()
   const [status, setStatus] = useState('loading')
@@ -30,6 +31,13 @@ const useConfig = () => {
       setStatus(fetchStatus)
     },
     [fetchStatus]
+  )
+
+  useEffect(
+    () => {
+      setConfig()
+    },
+    [isEditorForcedReadOnly]
   )
 
   useEffect(
@@ -68,7 +76,10 @@ const useConfig = () => {
           const docEditorConfig = {
             // complete config doc : https://api.onlyoffice.com/editors/advanced
             document: onlyOffice.document,
-            editorConfig: onlyOffice.editor,
+            editorConfig: {
+              ...onlyOffice.editor,
+              mode: isEditorForcedReadOnly ? 'view' : onlyOffice.editor.mode
+            },
             token: onlyOffice.token,
             documentType: onlyOffice.documentType,
             events: {
@@ -91,7 +102,8 @@ const useConfig = () => {
       config,
       setConfig,
       setIsEditorReady,
-      isPublic
+      isPublic,
+      isEditorForcedReadOnly
     ]
   )
 

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -31,7 +31,7 @@ import {
 } from 'drive/web/modules/selectors'
 import { useExtraColumns } from 'drive/web/modules/certifications/useExtraColumns'
 import { makeExtraColumnsNamesFromMedia } from 'drive/web/modules/certifications'
-import Fab from 'drive/web/modules/drive/Fab'
+import FabWithMenuContext from 'drive/web/modules/drive/FabWithMenuContext'
 import AddMenuProvider from 'drive/web/modules/drive/AddMenu/AddMenuProvider'
 import { FabContext } from 'drive/lib/FabProvider'
 
@@ -225,7 +225,7 @@ const PublicFolderView = ({
                 canUpload={hasWritePermissions}
                 refreshFolderContent={refreshFolderContent}
               >
-                <Fab noSidebar={true} />
+                <FabWithMenuContext noSidebar={true} />
               </AddMenuProvider>
             )}
             {viewerOpened &&

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -23,4 +23,5 @@ const flagsList = () => {
   flag('viewer-bottomSheet-friction')
   flag('viewer-bottomSheet-clamp')
   flag('drive.onlyoffice.forceReadOnlyOnDesktop')
+  flag('drive.onlyoffice.editorToolbarHeight')
 }

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -22,4 +22,5 @@ const flagsList = () => {
   flag('viewer-bottomSheet-tension')
   flag('viewer-bottomSheet-friction')
   flag('viewer-bottomSheet-clamp')
+  flag('drive.onlyoffice.forceReadOnlyOnDesktop')
 }


### PR DESCRIPTION
Sur mobile on souhaite avoir l'editeur only office en "lecture" par défaut. Dans ce mode, la toolbar de l'éditeur only office est masqué.
On ajoute également un Fab qui permet de passer en mode "écriture", ce qui remplace notre toolbar par celle d'only office.

Ce comportement est également sur desktop si le flag associé est à true.

Enfin, on a ajouté un flag qui permet de définir la hauteur de la toolbar de l'éditeur only office à masquer.