### PR TITLE
Fix conditions to show the sharing banner on Only Office files

### DIFF
--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -155,11 +155,15 @@ const init = async () => {
                   <Route path="file/:fileId/revision" component={FileHistory} />
                 </Route>
                 {isOnlyOfficeEnabled() && (
-                  // Used to open an only office file inside a folder shared by link
+                  // Used to open an only office file inside a shared folder
                   <Route
                     path="onlyoffice/:fileId"
                     component={props => (
-                      <OnlyOfficeView {...props} isPublic={true} />
+                      <OnlyOfficeView
+                        {...props}
+                        isPublic={true}
+                        isInSharedFolder={true}
+                      />
                     )}
                   />
                 )}

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 
 import { DialogTitle } from 'cozy-ui/transpiled/react/Dialog'
@@ -7,6 +7,7 @@ import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import SharingBanner from 'drive/web/modules/public/SharingBanner'
 import { useSharingInfos } from 'drive/web/modules/public/useSharingInfos'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
+import { showSharingBanner } from 'drive/web/modules/views/OnlyOffice/helpers'
 import Toolbar from 'drive/web/modules/views/OnlyOffice/Toolbar'
 
 const useStyles = makeStyles(() => ({
@@ -17,15 +18,21 @@ const useStyles = makeStyles(() => ({
 }))
 
 const Title = () => {
-  const { isPublic, isFromSharing } = useContext(OnlyOfficeContext)
+  const { isPublic, isFromSharing, isInSharedFolder } = useContext(
+    OnlyOfficeContext
+  )
   const sharingInfos = useSharingInfos()
   const styles = useStyles()
 
-  // The sharing banner need to be shown only on the first arrival
-  // and not after browsing inside a folder
-  // When it comes from sharing, we don't want the banner at all
-  const showSharingBanner =
-    !isFromSharing && isPublic && window.history.length <= 1
+  const showBanner = useMemo(
+    () =>
+      showSharingBanner({
+        isPublic,
+        isFromSharing,
+        isInSharedFolder
+      }),
+    [isPublic, isFromSharing, isInSharedFolder]
+  )
 
   return (
     <>
@@ -38,9 +45,9 @@ const Title = () => {
         <Toolbar />
       </DialogTitle>
       <Divider />
-      {showSharingBanner && <SharingBanner sharingInfos={sharingInfos} />}
+      {showBanner && <SharingBanner sharingInfos={sharingInfos} />}
     </>
   )
 }
 
-export default Title
+export default React.memo(Title)

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -70,3 +70,18 @@ export const makeMimeByClass = fileClass => {
 
   return mimeByClass[fileClass]
 }
+
+// The sharing banner need to be shown only on the first arrival
+// and not after browsing inside a folder
+// When it comes from cozy to cozy sharing, we don't want the banner at all
+export const showSharingBanner = ({
+  isFromSharing,
+  isPublic,
+  isInSharedFolder
+}) => {
+  return (
+    !isFromSharing &&
+    isPublic &&
+    (isInSharedFolder ? window.history.length <= 1 : window.history.length <= 2)
+  )
+}

--- a/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
@@ -1,0 +1,101 @@
+import { showSharingBanner } from 'drive/web/modules/views/OnlyOffice/helpers'
+
+describe('showSharingBanner', () => {
+  describe('for 1 entry in history', () => {
+    it('should not show the banner when it comes from a synchronized cozy to cozy sharing', () => {
+      expect(window.history.length).toBe(1)
+
+      expect(
+        showSharingBanner({
+          isFromSharing: true,
+          isPublic: false,
+          isInSharedFolder: false
+        })
+      ).toBe(false)
+    })
+
+    it('should show the banner - preview for cozy to cozy sharing - coming from mail', () => {
+      expect(window.history.length).toBe(1)
+
+      expect(
+        showSharingBanner({
+          isFromSharing: false,
+          isPublic: true,
+          isInSharedFolder: false
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('for 2 entries in history', () => {
+    beforeAll(() => {
+      window.history.pushState('data', 'title', 'url')
+    })
+
+    it('should not show the banner when it comes from a synchronized cozy to cozy sharing', () => {
+      expect(window.history.length).toBe(2)
+
+      expect(
+        showSharingBanner({
+          isFromSharing: true,
+          isPublic: false,
+          isInSharedFolder: false
+        })
+      ).toBe(false)
+    })
+
+    it('should show the banner - preview for sharing by link, or cozy to cozy coming from shortcut', () => {
+      expect(window.history.length).toBe(2)
+
+      expect(
+        showSharingBanner({
+          isFromSharing: false,
+          isPublic: true,
+          isInSharedFolder: false
+        })
+      ).toBe(true)
+    })
+
+    it('should not show the banner - preview for cozy to cozy shared folder - coming from mail', () => {
+      expect(window.history.length).toBe(2)
+
+      expect(
+        showSharingBanner({
+          isFromSharing: false,
+          isPublic: true,
+          isInSharedFolder: true
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('for 3 entries in history', () => {
+    beforeAll(() => {
+      window.history.pushState('data', 'title', 'url')
+    })
+
+    it('should not show the banner when it comes from a synchronized cozy to cozy sharing', () => {
+      expect(window.history.length).toBe(3)
+
+      expect(
+        showSharingBanner({
+          isFromSharing: true,
+          isPublic: false,
+          isInSharedFolder: false
+        })
+      ).toBe(false)
+    })
+
+    it('should not show the banner - preview for cozy to cozy shared folder coming from shortcut, or for a folder shared by link', () => {
+      expect(window.history.length).toBe(3)
+
+      expect(
+        showSharingBanner({
+          isFromSharing: false,
+          isPublic: true,
+          isInSharedFolder: true
+        })
+      ).toBe(false)
+    })
+  })
+})

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -6,7 +6,13 @@ import Editor from 'drive/web/modules/views/OnlyOffice/Editor'
 
 export const OnlyOfficeContext = createContext()
 
-const OnlyOfficeProvider = ({ fileId, isPublic, isFromSharing, children }) => {
+const OnlyOfficeProvider = ({
+  fileId,
+  isPublic,
+  isFromSharing,
+  isInSharedFolder,
+  children
+}) => {
   const [isEditorReadOnly, setIsEditorReadOnly] = useState()
   const [isEditorReady, setIsEditorReady] = useState(false)
 
@@ -16,6 +22,7 @@ const OnlyOfficeProvider = ({ fileId, isPublic, isFromSharing, children }) => {
         fileId,
         isPublic,
         isFromSharing,
+        isInSharedFolder,
         isEditorReadOnly,
         setIsEditorReadOnly,
         isEditorReady,
@@ -27,13 +34,19 @@ const OnlyOfficeProvider = ({ fileId, isPublic, isFromSharing, children }) => {
   )
 }
 
-const OnlyOffice = ({ params: { fileId }, isPublic, isFromSharing }) => {
+const OnlyOffice = ({
+  params: { fileId },
+  isPublic,
+  isFromSharing,
+  isInSharedFolder
+}) => {
   return (
     <Dialog open={true} fullScreen transitionDuration={0}>
       <OnlyOfficeProvider
         fileId={fileId}
         isPublic={isPublic}
         isFromSharing={isFromSharing}
+        isInSharedFolder={isInSharedFolder}
       >
         <Editor />
       </OnlyOfficeProvider>


### PR DESCRIPTION
On ne se basait initialement que sur le fait que le document soit public ou synchronisé. Or il est important de savoir si le document partagé est un dossier ou non.
Les tests aident à comprendre les différents cas. J'ai également mis tous ces cas dans un tableau dans le paper du partage.