### PR TITLE
feat: Window title updates with doc name and path

### DIFF
--- a/src/drive/appMetadata.js
+++ b/src/drive/appMetadata.js
@@ -2,7 +2,9 @@ import manifest from 'drive/targets/manifest.webapp'
 
 const appMetadata = {
   slug: manifest.slug,
-  version: manifest.version
+  version: manifest.version,
+  name: manifest.name,
+  prefix: manifest.name_prefix
 }
 
 export default appMetadata

--- a/src/drive/web/modules/selectors.js
+++ b/src/drive/web/modules/selectors.js
@@ -1,8 +1,10 @@
 import maxBy from 'lodash/maxBy'
 import get from 'lodash/get'
+
 import { getDocumentFromState } from 'cozy-client/dist/store'
-import { getMirrorQueryId, parseFolderQueryId } from './queries'
+
 import { ROOT_DIR_ID, TRASH_DIR_ID } from 'drive/constants/config'
+import { getMirrorQueryId, parseFolderQueryId } from './queries'
 
 export const getCurrentFolderId = rootState => {
   if (get(rootState, 'router.params.folderId')) {

--- a/src/drive/web/modules/viewer/FilesViewer.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.jsx
@@ -10,6 +10,7 @@ import Viewer from 'cozy-ui/transpiled/react/Viewer'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import palette from 'cozy-ui/transpiled/react/palette'
 
+import useUpdateDocumentTitle from 'drive/web/modules/views/useUpdateDocumentTitle'
 import { useRouter } from 'drive/lib/RouterContext'
 import Fallback from 'drive/web/modules/viewer/Fallback'
 import {
@@ -49,6 +50,7 @@ const styleStatusBar = switcher => {
  */
 
 const FilesViewer = ({ filesQuery, files, fileId, onClose, onChange }) => {
+  useUpdateDocumentTitle(fileId)
   const [currentFile, setCurrentFile] = useState(null)
   const [fetchingMore, setFetchingMore] = useState(false)
 

--- a/src/drive/web/modules/views/Folder/FolderView.jsx
+++ b/src/drive/web/modules/views/Folder/FolderView.jsx
@@ -1,11 +1,18 @@
 import React from 'react'
-import { RealTimeQueries } from 'cozy-client'
+import { useSelector } from 'react-redux'
 
+import { RealTimeQueries } from 'cozy-client'
 import { ModalManager } from 'react-cozy-helpers'
+
 import { ModalStack } from 'drive/lib/ModalContext'
 import Main from 'drive/web/modules/layout/Main'
+import { getCurrentFolderId } from 'drive/web/modules/selectors'
+import useUpdateDocumentTitle from 'drive/web/modules/views/useUpdateDocumentTitle'
 
 const FolderView = ({ children }) => {
+  const currentFolderId = useSelector(getCurrentFolderId)
+  useUpdateDocumentTitle(currentFolderId)
+
   return (
     <Main>
       <RealTimeQueries doctype="io.cozy.files" />
@@ -16,4 +23,4 @@ const FolderView = ({ children }) => {
   )
 }
 
-export default FolderView
+export default React.memo(FolderView)

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -13,6 +13,7 @@ import FileIcon from 'drive/web/modules/views/OnlyOffice/Toolbar/FileIcon'
 import FileName from 'drive/web/modules/views/OnlyOffice/Toolbar/FileName'
 import ReadOnly from 'drive/web/modules/views/OnlyOffice/Toolbar/ReadOnly'
 import Sharing from 'drive/web/modules/views/OnlyOffice/Toolbar/Sharing'
+import useUpdateDocumentTitle from 'drive/web/modules/views/useUpdateDocumentTitle'
 
 const Toolbar = () => {
   const { isMobile } = useBreakpoints()
@@ -23,6 +24,7 @@ const Toolbar = () => {
     isEditorReadOnly,
     isEditorReady
   } = useContext(OnlyOfficeContext)
+  useUpdateDocumentTitle(fileId)
   const { data: fileWithPath } = useFileWithPath(fileId)
   const { router } = useRouter()
 

--- a/src/drive/web/modules/views/hooks.js
+++ b/src/drive/web/modules/views/hooks.js
@@ -39,15 +39,22 @@ export const useFilesQueryWithPath = query => {
   }
 }
 
-// TODO: when https://github.com/cozy/cozy-client/pull/947 is merged
-// remove the [] tricks on dirId and Array.isArray(dirId) on parentQuery
-// and use enabled param instead in parentResult query
-export const useFileWithPath = fileId => {
-  const fileQuery = buildFileByIdQuery(fileId)
+// TODO: since https://github.com/cozy/cozy-client/pull/947 is merged
+// remove the tricks on useQueries and use 'enabled' param instead.
+// Be aware for now a query with 'enabled' true remains in 'pending' status
+// so fetchStatus test should be used carefully especially with 'loaded' values
+export const useFileWithPath = docId => {
+  // trick here to get loaded fetchStatus with an undefined docId
+  const fileQuery = docId
+    ? buildFileByIdQuery(docId)
+    : buildParentsByIdsQuery([])
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
   const resultData = fileResult.data
-  const dirId = resultData ? resultData.dir_id : []
 
+  // trick here to return an empty array and use it in buildParentsByIdsQuery if no dirId
+  const dirId = resultData && resultData.dir_id ? resultData.dir_id : []
+
+  // same trick as for fileQuery
   const parentQuery = Array.isArray(dirId)
     ? buildParentsByIdsQuery(dirId)
     : buildFileByIdQuery(dirId)

--- a/src/drive/web/modules/views/hooks.js
+++ b/src/drive/web/modules/views/hooks.js
@@ -56,6 +56,11 @@ export const useFileWithPath = fileId => {
 
   return {
     ...fileResult,
+    fetchStatus:
+      fileResult.fetchStatus === 'loaded' &&
+      (parentResult && parentResult.fetchStatus === 'loaded')
+        ? 'loaded'
+        : 'loading',
     data: {
       ...resultData,
       displayedPath: parentData ? parentData.path : undefined

--- a/src/drive/web/modules/views/useUpdateDocumentTitle.js
+++ b/src/drive/web/modules/views/useUpdateDocumentTitle.js
@@ -1,0 +1,80 @@
+import { useMemo, useEffect } from 'react'
+
+import { useClient, models } from 'cozy-client'
+
+import { useFileWithPath } from 'drive/web/modules/views/hooks'
+import { TRASH_DIR_PATH } from 'drive/constants/config'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+export const makeTitle = (fileWithPath, appFullName, t) => {
+  const fileName =
+    fileWithPath &&
+    fileWithPath.name &&
+    !TRASH_DIR_PATH.includes(fileWithPath.name)
+      ? `${fileWithPath.name} `
+      : ''
+
+  let path = ''
+  if (models.file.isDirectory(fileWithPath)) {
+    if (fileWithPath && fileWithPath.path) {
+      if (fileWithPath.path.startsWith(TRASH_DIR_PATH)) {
+        const trashSubDirectories = fileWithPath.path.split(
+          `${TRASH_DIR_PATH}/`
+        )[1]
+        path = trashSubDirectories
+          ? `(${t('Nav.item_trash')}/${trashSubDirectories}) `
+          : `${t('Nav.item_trash')} `
+      } else if (
+        fileWithPath.path !== '/' &&
+        fileWithPath.path !== `/${fileWithPath.name}`
+      ) {
+        path = `(${fileWithPath.path.substring(1)}) `
+      }
+    }
+  } else {
+    if (fileWithPath && fileWithPath.displayedPath) {
+      if (fileWithPath.displayedPath.startsWith(TRASH_DIR_PATH)) {
+        const trashSubDirectories = fileWithPath.displayedPath.split(
+          `${TRASH_DIR_PATH}/`
+        )[1]
+        path = trashSubDirectories
+          ? `(${t('Nav.item_trash')}/${trashSubDirectories}) `
+          : `(${t('Nav.item_trash')}) `
+      } else {
+        path = `(${fileWithPath.displayedPath.substring(1)}) `
+      }
+    }
+  }
+
+  const separator = fileName || path ? '- ' : ''
+
+  return `${fileName}${path}${separator}${appFullName}`
+}
+
+const useUpdateDocumentTitle = docId => {
+  const { t } = useI18n()
+  const client = useClient()
+  const { data: fileWithPath, fetchStatus } = useFileWithPath(docId)
+
+  const appFullName = useMemo(
+    () => `${client.appMetadata.prefix} ${client.appMetadata.name}`,
+    [client.appMetadata]
+  )
+
+  const title = useMemo(() => makeTitle(fileWithPath, appFullName, t), [
+    fileWithPath,
+    appFullName,
+    t
+  ])
+
+  useEffect(
+    () => {
+      if (fetchStatus === 'loaded' && title !== document.title) {
+        document.title = title
+      }
+    },
+    [fetchStatus, title]
+  )
+}
+
+export default useUpdateDocumentTitle

--- a/src/drive/web/modules/views/useUpdateDocumentTitle.spec.js
+++ b/src/drive/web/modules/views/useUpdateDocumentTitle.spec.js
@@ -1,0 +1,110 @@
+import { makeTitle } from './useUpdateDocumentTitle'
+import { TRASH_DIR_PATH } from 'drive/constants/config'
+import Polyglot from 'node-polyglot'
+import en from 'drive/locales/en.json'
+
+const p = new Polyglot()
+p.extend(en)
+const t = p.t.bind(p)
+
+describe('makeTitle', () => {
+  describe('for files', () => {
+    it('should show only the app name', () => {
+      expect(makeTitle({}, 'Cozy Drive', t)).toBe('Cozy Drive')
+    })
+
+    it('should show the file name and app name', () => {
+      expect(makeTitle({ name: 'file.docx' }, 'Cozy Drive', t)).toBe(
+        'file.docx - Cozy Drive'
+      )
+    })
+
+    it('should show the folder name and app name', () => {
+      expect(
+        makeTitle({ displayedPath: '/folder/subFolder' }, 'Cozy Drive', t)
+      ).toBe('(folder/subFolder) - Cozy Drive')
+    })
+
+    it('should show the file name, folder name and app name', () => {
+      expect(
+        makeTitle(
+          { name: 'file.docx', displayedPath: '/folder/subFolder' },
+          'Cozy Drive',
+          t
+        )
+      ).toBe('file.docx (folder/subFolder) - Cozy Drive')
+    })
+
+    it('should show trash folder with human frendly name', () => {
+      expect(
+        makeTitle(
+          { name: 'file.docx', displayedPath: `${TRASH_DIR_PATH}/folder` },
+          'Cozy Drive',
+          t
+        )
+      ).toBe('file.docx (Trash/folder) - Cozy Drive')
+    })
+
+    it('should show trash folder with human frendly name even if no subdirectory', () => {
+      expect(
+        makeTitle(
+          { name: 'file.docx', displayedPath: TRASH_DIR_PATH },
+          'Cozy Drive',
+          t
+        )
+      ).toBe('file.docx (Trash) - Cozy Drive')
+    })
+  })
+
+  describe('for folders', () => {
+    it('should show trash folder with human frendly name even if no subdirectory', () => {
+      expect(
+        makeTitle(
+          { type: 'directory', name: '.cozy_trash', path: TRASH_DIR_PATH },
+          'Cozy Drive',
+          t
+        )
+      ).toBe('Trash - Cozy Drive')
+    })
+
+    it('should show trash folder with human frendly name', () => {
+      expect(
+        makeTitle(
+          {
+            type: 'directory',
+            name: 'folder',
+            path: `${TRASH_DIR_PATH}/folder`
+          },
+          'Cozy Drive',
+          t
+        )
+      ).toBe('folder (Trash/folder) - Cozy Drive')
+    })
+
+    it('should show folder path and app name', () => {
+      expect(
+        makeTitle(
+          { type: 'directory', name: 'subfolder', path: '/folder/subfolder' },
+          'Cozy Drive',
+          t
+        )
+      ).toBe('subfolder (folder/subfolder) - Cozy Drive')
+    })
+
+    it('should show only app name for root directory', () => {
+      expect(
+        makeTitle({ type: 'directory', name: '', path: '/' }, 'Cozy Drive', t)
+      ).toBe('Cozy Drive')
+    })
+
+    it('should not show the path for first level folders', () => {
+      expect(
+        makeTitle(
+          { type: 'directory', name: 'folder', path: '/folder' },
+          'Cozy Drive',
+          t
+        )
+      ).toBe('folder - Cozy Drive')
+    })
+  })
+})


### PR DESCRIPTION
On souhaite afficher le `<nom de l'élément> (<chemin de l'élément>) - Cozy Drive` dans le titre de la fenêtre/onglet quand on est dans l'éditeur only office.

Idem pour les vues de Drive, pour les dossiers Drive et Trash ainsi que leurs sous-dossiers.

Il reste toujours le TODO sur le hook useFileWithPath relatif à la nouvelle option 'enabled' des useQuery. Ayant déjà passé trop de temps sur cette feature, je n'ai pas réussi à utiliser cette nouvelle approche rapidement et simplement dans ce cas d'utilisation. J'ai donc repris le trick précédemment utilisée. Je compte me dégager du temps semaine prochaine pour m'en occuper.

Par ailleurs une issue est créée https://github.com/cozy/cozy-client/issues/961 par rapport à l'utilisation que j'en ai eu. Idem j'aimerai prendre le temps semaine prochaine de le traiter.

edit : une PR a été ouverte https://github.com/cozy/cozy-client/pull/970 suite à l'issue et quelques tests, et une refacto du hook a été faite en dev, mais il faut au préalable (in)valider la PR sur Client.

Pour cette PR je serai d'avis de laisser le TODO...