### PR TITLE
feat: Add fallback when only office editor returns 404

### DIFF
--- a/src/components/Error/Oops.jsx
+++ b/src/components/Error/Oops.jsx
@@ -1,22 +1,34 @@
 import React from 'react'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import Button from 'cozy-ui/transpiled/react/Button'
+
 import EmptyIcon from '../../drive/assets/icons/icon-folder-broken.svg'
+
 import styles from './oops.styl'
 
 const reload = () => {
   window.location.reload()
 }
 
-const Oops = ({ t }) => (
-  <Empty
-    title={t('error.open_folder')}
-    icon={EmptyIcon}
-    className={styles['oops']}
-  >
-    <Button onClick={reload} label={t('error.button.reload')} />
-  </Empty>
-)
+const Oops = ({ title }) => {
+  const { t } = useI18n()
 
-export default translate()(Oops)
+  return (
+    <Empty
+      title={title ? title : t('error.open_folder')}
+      icon={EmptyIcon}
+      className={styles['oops']}
+    >
+      <Button onClick={reload} label={t('error.button.reload')} />
+    </Empty>
+  )
+}
+
+Oops.propTypes = {
+  title: PropTypes.string
+}
+
+export default Oops

--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -295,6 +295,7 @@
   },
   "error": {
     "open_folder": "Something went wrong when opening the folder.",
+    "open_file": "Something went wrong when opening the file.",
     "button": {
       "reload": "Refresh now"
     },

--- a/src/drive/web/modules/views/OnlyOffice/Error.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Error.jsx
@@ -5,7 +5,9 @@ import { isQueryLoading, useQuery } from 'cozy-client'
 import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import Viewer from 'cozy-ui/transpiled/react/Viewer'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
+import Oops from 'components/Error/Oops'
 import { showPanel } from 'drive/web/modules/viewer/helpers'
 import PanelContent from 'drive/web/modules/viewer/Panel/PanelContent'
 import FooterContent from 'drive/web/modules/viewer/Footer/FooterContent'
@@ -13,6 +15,7 @@ import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import { buildFileByIdQuery } from 'drive/web/modules/queries'
 
 const Error = () => {
+  const { t } = useI18n()
   const { fileId } = useContext(OnlyOfficeContext)
   const handleOnClose = useCallback(() => window.history.back(), [])
 
@@ -27,6 +30,10 @@ const Error = () => {
         size="xxlarge"
       />
     )
+  }
+
+  if (fileResult.fetchStatus === 'failed') {
+    return <Oops title={t('error.open_file')} />
   }
 
   return (


### PR DESCRIPTION
Si `GET /onlyoffice/fileId` return 404, on souhaite afficher une page d'erreur