### PR TITLE
fix: Allow overwriting a file from a share link

### DIFF
--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -9,6 +9,7 @@ import 'cozy-ui/transpiled/react/stylesheet.css'
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 import { getQueryParameter } from 'react-cozy-helpers'
 import CozyClient, { models } from 'cozy-client'
+import { Document } from 'cozy-doctypes'
 import { I18n, initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import getSharedDocument from 'cozy-sharing/dist/getSharedDocument'
@@ -81,6 +82,10 @@ const init = async () => {
     store: false
   })
   registerClientPlugins(client)
+
+  if (!Document.cozyClient) {
+    Document.registerClient(client)
+  }
 
   configureReporter()
   setCozyUrl(cozyUrl)


### PR DESCRIPTION
Problème initial: En partageant un dossier par lien (avec accès en écriture), la personne ne peut pas uploader un fichier déjà existant dans le dossier (même nom).

Aujourd'hui le processus d'upload, en cas de conflit (409), requière `cozy-doctype`
(cf: https://github.com/cozy/cozy-drive/blob/13ff154da4f2dd71ae765437210e6cb32c40944e/src/drive/web/modules/upload/index.js#L186)

L'index public n'enregistrait pas le client via la méthode `Document.registerClient` de `cozy-doctype` comme il devrait le faire depuis l'ajout/modification du code ci-dessus.