### PR TITLE
feat: Add realtime on only office toolbar

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -36,6 +36,12 @@ jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 jest.mock('cozy-flags')
 
 const client = createMockClient({})
+client.plugins = {
+  realtime: {
+    subscribe: () => {},
+    unsubscribe: () => {}
+  }
+}
 
 const setup = ({
   isMobile = false,

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -1,7 +1,9 @@
 import React, { useContext, useCallback, useMemo } from 'react'
 
+import { RealTimeQueries } from 'cozy-client'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
+import { DOCTYPE_FILES } from 'drive/lib/doctypes'
 import { useRouter } from 'drive/lib/RouterContext'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import { useFileWithPath } from 'drive/web/modules/views/hooks'
@@ -52,6 +54,7 @@ const Toolbar = () => {
 
   return (
     <>
+      <RealTimeQueries doctype={DOCTYPE_FILES} />
       <div className="u-flex u-flex-items-center u-flex-grow-1 u-ellipsis">
         {!isMobile && (
           <>

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -24,6 +24,12 @@ jest.mock('drive/web/modules/views/OnlyOffice/Toolbar/helpers', () => ({
 
 const client = createMockClient({})
 client.stackClient.uri = 'http://cozy.tools'
+client.plugins = {
+  realtime: {
+    subscribe: () => {},
+    unsubscribe: () => {}
+  }
+}
 
 const setup = ({
   isEditorReadOnly = false,


### PR DESCRIPTION
L'éditeur Only Office est "autonome" à savoir qu'après avoir instancié l'app, le routeur de l'app redirige tout de suite sur l'éditeur. Il n'hérite donc d'aucun wrapper/provider de l'app. C'est pourquoi nous avons besoin d'ajouter le `RealTimeQueries` ici.

Due to the limitations of the public page, real time is only effective for the owner of the document. So if the recipient modifies an information, the owner receives the update. However, this is not true in the other direction.