### PR TITLE
fix: Only office username for cozy to cozy shared document

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -73,10 +73,11 @@ export const showSharingBanner = ({
  * Make username to use in the Only office editor in order to show the name
  * when adding comment or moving the cursor for example
  * @param {object} params - Params
- * @param {boolean} params.isPublic - Whether  the route is public (like /preview)
+ * @param {boolean} params.isPublic - Whether the route is public (like /public)
+ * @param {boolean} params.isFromSharing - Whether the doc is shared from cozy to cozy
  * @param {string} params.username - The name of the sharing recipient
  * @param {string} params.public_name - The name of the owner
  * @returns {string|undefined}
  */
-export const makeName = ({ isPublic, username, public_name }) =>
-  isPublic ? undefined : username ? username : public_name
+export const makeName = ({ isPublic, isFromSharing, username, public_name }) =>
+  isPublic && !isFromSharing ? undefined : username ? username : public_name

--- a/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
@@ -4,41 +4,75 @@ import {
 } from 'drive/web/modules/views/OnlyOffice/helpers'
 
 describe('makeName', () => {
-  it('should return undefined public route', () => {
-    expect(
-      makeName({
-        isPublic: true,
-        username: 'bob',
-        public_name: 'alice'
-      })
-    ).toBe(undefined)
-    expect(
-      makeName({
-        isPublic: true,
-        username: undefined,
-        public_name: 'alice'
-      })
-    ).toBe(undefined)
-    expect(
-      makeName({
-        isPublic: true,
-        username: 'bob',
-        public_name: undefined
-      })
-    ).toBe(undefined)
-    expect(
-      makeName({
-        isPublic: true,
-        username: undefined,
-        public_name: undefined
-      })
-    ).toBe(undefined)
+  describe('for public route', () => {
+    it('should return undefined if it is not an accepted document from cozy to cozy sharing', () => {
+      expect(
+        makeName({
+          isPublic: true,
+          isFromSharing: false,
+          username: 'bob',
+          public_name: 'alice'
+        })
+      ).toBe(undefined)
+      expect(
+        makeName({
+          isPublic: true,
+          isFromSharing: false,
+          username: undefined,
+          public_name: 'alice'
+        })
+      ).toBe(undefined)
+      expect(
+        makeName({
+          isPublic: true,
+          isFromSharing: false,
+          username: 'bob',
+          public_name: undefined
+        })
+      ).toBe(undefined)
+      expect(
+        makeName({
+          isPublic: true,
+          isFromSharing: false,
+          username: undefined,
+          public_name: undefined
+        })
+      ).toBe(undefined)
+    })
+
+    it('should return the name of the sharing recipient for a document shared from cozy to cozy', () => {
+      expect(
+        makeName({
+          isPublic: true,
+          isFromSharing: true,
+          username: 'bob',
+          public_name: 'alice'
+        })
+      ).toBe('bob')
+      expect(
+        makeName({
+          isPublic: true,
+          isFromSharing: true,
+          username: 'bob',
+          public_name: undefined
+        })
+      ).toBe('bob')
+      expect(
+        makeName({
+          isPublic: true,
+          isFromSharing: true,
+          username: undefined,
+          public_name: undefined
+        })
+      ).toBe(undefined)
+    })
   })
 
   it('should return the public name if no sharing recipient', () => {
     expect(
       makeName({
         isPublic: false,
+        isFromSharing: false,
         username: undefined,
         public_name: undefined
       })
@@ -46,6 +80,7 @@ describe('makeName', () => {
     expect(
       makeName({
         isPublic: false,
+        isFromSharing: false,
         username: undefined,
         public_name: 'alice'
       })
@@ -56,6 +91,7 @@ describe('makeName', () => {
     expect(
       makeName({
         isPublic: false,
+        isFromSharing: false,
         username: 'bob',
         public_name: 'alice'
       })
@@ -63,6 +99,7 @@ describe('makeName', () => {
     expect(
       makeName({
         isPublic: false,
+        isFromSharing: false,
         username: 'bob',
         public_name: undefined
       })

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -20,7 +20,8 @@ const useConfig = () => {
     setIsEditorReady,
     isPublic,
     username,
-    isEditorForcedReadOnly
+    isEditorForcedReadOnly,
+    isFromSharing
   } = useContext(OnlyOfficeContext)
   const [config, setConfig] = useState()
   const [status, setStatus] = useState('loading')
@@ -78,6 +79,7 @@ const useConfig = () => {
           const { onlyoffice, public_name } = attributes
           const name = makeName({
             isPublic,
+            isFromSharing,
             username,
             public_name
           })
@@ -116,7 +118,8 @@ const useConfig = () => {
       setIsEditorReady,
       isPublic,
       isEditorForcedReadOnly,
-      username
+      username,
+      isFromSharing
     ]
   )
 


### PR DESCRIPTION
in this case, isPublic is true because the recipient use the public access of the host to get the document. So this is not the only param to check, we need `isFromSharing` too.