### PR TITLE
fix: Multiples renderers on sharings view

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "cozy-realtime": "3.13.0",
     "cozy-scanner": "1.1.1",
     "cozy-scripts": "5.1.1",
-    "cozy-sharing": "3.4.0",
+    "cozy-sharing": "3.4.2",
     "cozy-stack-client": "23.0.0",
     "cozy-ui": "50.2.0",
     "date-fns": "1.30.1",

--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -118,13 +118,14 @@ const buildParentsByIdsQuery = ids => ({
   }
 })
 
-const buildSharingsQuery = ids => ({
+const buildSharingsQuery = ({ ids, enabled = true }) => ({
   definition: () =>
     Q('io.cozy.files')
       .getByIds(ids)
       .sortBy([{ type: 'asc' }, { name: 'asc' }]),
   options: {
     as: `sharings-by-ids-${ids.join('')}`,
+    enabled,
     fetchPolicy: defaultFetchPolicy
   }
 })

--- a/src/drive/web/modules/views/Sharings/FilesViewerSharings.jsx
+++ b/src/drive/web/modules/views/Sharings/FilesViewerSharings.jsx
@@ -17,7 +17,7 @@ const FilesViewerWithQuery = ({
   currentFolderId,
   ...props
 }) => {
-  const filesQuery = buildSharingsQuery(sharedDocumentIds)
+  const filesQuery = buildSharingsQuery({ ids: sharedDocumentIds })
   const results = useQuery(filesQuery.definition, filesQuery.options)
   const { router } = useRouter()
   if (results.data) {

--- a/src/drive/web/modules/views/Sharings/withSharedDocumentIds.jsx
+++ b/src/drive/web/modules/views/Sharings/withSharedDocumentIds.jsx
@@ -4,8 +4,12 @@ import SharedDocuments from 'cozy-sharing/dist/components/SharedDocuments'
 const withSharedDocumentIds = BaseComponent => {
   const WrapperComponent = props => (
     <SharedDocuments>
-      {({ sharedDocuments }) => (
-        <BaseComponent {...props} sharedDocumentIds={sharedDocuments} />
+      {({ sharedDocuments, allLoaded }) => (
+        <BaseComponent
+          {...props}
+          sharedDocumentIds={sharedDocuments}
+          allLoaded={allLoaded}
+        />
       )}
     </SharedDocuments>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,10 +5498,10 @@ cozy-scripts@5.1.1:
     webpack-dev-server "3.10.3"
     webpack-merge "4.2.2"
 
-cozy-sharing@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-3.4.0.tgz#8e0c596d5bc74d0fe439e8e850d5431858997537"
-  integrity sha512-8FuMUdBmnpKq9c+DmywT6ipUHBiDgkM+OiF8KMpwcz9DgH48TFzfbwm5QcKX8kz7/JSROjNqDEy0eA8Wff/Z3g==
+cozy-sharing@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-3.4.2.tgz#cfb07aa25fd36b70c01e919fc495b09119b6bea6"
+  integrity sha512-isTPwxdDMgu43CgSDLnMGPLVxYZAnfuZ+dhkAGojvbcWUlvWPfDoSmuInZJx5aH3B6rFAzzNFx8gC/V3z9LW5A==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.2.6"


### PR DESCRIPTION
:heavy_exclamation_mark: Cette PR est liée à celle-ci sur cozy-sharing: https://github.com/cozy/cozy-libs/pull/1323

Lorsque l'on rafraichissait la page Partages avec au moins 60 fichiers/dossiers, de multiples rendus étaient effectués car le composant n'attendait pas d'avoir tous les fichiers partagés avant de les lister.

La source du problème vient de cozy-sharing qui retourne par 30 au maximum les fichiers/dossiers.

Avec la propriété `allLoaded` ajoutée à cozy-sharing, le composant peut maintenant attendre pour afficher la liste complète.