### PR TITLE
fix: CozyBar init

### DIFF
--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -120,7 +120,7 @@ const init = async () => {
         Alerter.error('alert.offline')
       }
     } else {
-      initCozyBar(dataset)
+      initCozyBar(dataset, client)
       render(
         <App lang={lang} polyglot={polyglot} client={client} store={store}>
           <Router history={hashHistory}>


### PR DESCRIPTION
Previously we were relying on the "auto init" cozyclient from the bar.
But since we're not using data-cozy-token in our templates but data-cozy
this mechanism didn't work anymore.

So let's be explicit and pass the cozy client instance directly.