### PR TITLE
fix: Public Route declaration

### DIFF
--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -120,7 +120,7 @@ const init = async () => {
         Alerter.error('alert.offline')
       }
     } else {
-      initCozyBar(dataset)
+      initCozyBar(dataset, client)
       render(
         <App lang={lang} polyglot={polyglot} client={client} store={store}>
           <Router history={hashHistory}>

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -175,16 +175,12 @@ const init = async () => {
                       component={FileHistory}
                     />
                   </Route>
+
+                  <Route path="external/:fileId" component={ExternalRedirect} />
+                  <Redirect from="/*" to={`folder/${sharedDocumentId}`} />
                 </>
               )}
             </Route>
-
-            {!isFile && (
-              <>
-                <Route path="external/:fileId" component={ExternalRedirect} />
-                <Redirect from="/*" to={`folder/${sharedDocumentId}`} />
-              </>
-            )}
           </Router>
         </App>,
         root


### PR DESCRIPTION
Since our last refacto, we created 2 conditions for the same thing. It
resulted to have wrong kind of children for `<Router />`