### PR TITLE
 Refactor: Use CozyClient and not old client js

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ yarn install
 
 :pushpin: If you use a node environment wrapper like [nvm] or [ndenv], don't forget to set your local node version `8` before doing a `yarn install`.
 
-:warning: During its early ages, _cozy-drive_ uses beta versions of [cozy-ui] and [cozy-client-js], take a look at the ["living on the edge" note](#living-on-the-edge) below to know hot to install and configure the latest available versions.
+_cozy-drive_ uses [cozy-ui] and [cozy-client], take a look at the ["living on the edge" note](#living-on-the-edge) below to know hot to install and configure the latest available versions.
 
 Cozy's apps use a standard set of _npm scripts_ to run common tasks, like watch, lint, test, build…
 
@@ -97,7 +97,7 @@ yarn link cozy-ui
 
 You can now run the watch task and your project will hot-reload each times a cozy-ui source file is touched.
 
-[Cozy-client-js] is our API library that provides an unified API on top of the cozy-stack. If you need to develop / hack cozy-client-js in parallel of your application, you can use the same trick that we used with [cozy-ui]: yarn linking.
+[Cozy-client] is our API library that provides an unified API on top of the cozy-stack. If you need to develop / hack cozy-client in parallel of your application, you can use the same trick that we used with [cozy-ui]: yarn linking.
 
 
 ### Tests
@@ -156,7 +156,7 @@ Cozy Drive is developed by Cozy Cloud and distributed under the [AGPL v3 license
 [yarn]: https://yarnpkg.com/
 [yarn-install]: https://yarnpkg.com/en/docs/install
 [cozy-ui]: https://github.com/cozy/cozy-ui
-[cozy-client-js]: https://github.com/cozy/cozy-client-js/
+[cozy-client]: https://github.com/cozy/cozy-client/
 [cozy-stack-docker]: https://github.com/cozy/cozy-stack/blob/master/docs/client-app-dev.md#with-docker
 [doctypes]: https://cozy.github.io/cozy-doctypes/
 [bill-doctype]: https://github.com/cozy/cozy-konnector-libs/blob/master/models/bill.js

--- a/jestHelpers/setup.js
+++ b/jestHelpers/setup.js
@@ -1,3 +1,5 @@
+require('jest-fetch-mock').enableMocks()
+
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 global.cozy = {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "husky": "0.14.3",
     "identity-obj-proxy": "3.0.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
+    "jest-fetch-mock": "^3.0.3",
     "npm-run-all": "4.1.5",
     "react-addons-test-utils": "15.6.2",
     "react-test-renderer": "16.14.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "cozy-bar": "7.16.0",
     "cozy-ci": "0.4.1",
     "cozy-client": "23.3.0",
-    "cozy-client-js": "0.19.0",
     "cozy-device-helper": "1.12.0",
     "cozy-doctypes": "1.82.1",
     "cozy-flags": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "cozy-doctypes": "1.82.1",
     "cozy-flags": "2.6.0",
     "cozy-harvest-lib": "5.3.1",
+    "cozy-interapp": "^0.6.2",
     "cozy-logger": "1.6.0",
     "cozy-pouch-link": "23.21.0",
     "cozy-realtime": "3.13.0",

--- a/src/components/Image/ImageLoader.jsx
+++ b/src/components/Image/ImageLoader.jsx
@@ -1,9 +1,8 @@
-/* global cozy */
 import React from 'react'
 import PropTypes from 'prop-types'
 import logger from 'lib/logger'
 
-import { withClient } from 'cozy-client'
+import { withClient, Q } from 'cozy-client'
 
 const TTL = 10000
 
@@ -96,9 +95,9 @@ class ImageLoader extends React.Component {
   async getFileLinks(file) {
     if (file.links) return file.links
     else {
-      const response = await cozy.client.files.statById(
-        this.getFileId(file),
-        false
+      const { client } = this.props
+      const response = await client.query(
+        Q('io.cozy.files').getById(this.getFileId(file))
       )
       if (!response.links) throw new Error('Could not fetch file links')
       return response.links

--- a/src/drive/mobile/lib/__mocks__/cozy-helper.js
+++ b/src/drive/mobile/lib/__mocks__/cozy-helper.js
@@ -9,7 +9,6 @@ const mock = {
     getStackClient: jest.fn(() => mockStackClient)
   })),
   initBar: jest.fn(),
-  restoreCozyClientJs: jest.fn(),
   resetClient: jest.fn(),
   getOauthOptions: jest.fn()
 }

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -1,5 +1,4 @@
 /* global cozy */
-import { LocalStorage as Storage } from 'cozy-client-js'
 import CozyClient, { StackLink } from 'cozy-client'
 import PouchLink from 'cozy-pouch-link'
 import { isMobileApp, isIOSApp, getDeviceName } from 'cozy-device-helper'
@@ -145,41 +144,13 @@ export const initBar = async client => {
   })
 }
 
-export const restoreCozyClientJs = (uri, clientInfos, token) => {
-  const offline = { doctypes: ['io.cozy.files'] }
-  cozy.client.init({
-    cozyURL: uri,
-    oauth: {
-      storage: new Storage(),
-      clientParams: {
-        ...clientInfos,
-        scopes: token.scope
-      }
-    },
-    offline
-  })
-
-  cozy.client.saveCredentials(clientInfos, token)
-}
-
-export function resetClient(client, clientInfo = null) {
-  if (clientInfo && cozy.client.auth.unregisterClient) {
-    cozy.client.auth.unregisterClient(clientInfo)
-  }
+export function resetClient(client) {
   // reset cozy-bar
   if (document.getElementById('coz-bar')) {
     document.getElementById('coz-bar').remove()
   }
-  // reset pouchDB
-  if (cozy.client.offline.destroyAllDatabase) {
-    cozy.client.offline.destroyAllDatabase()
-  }
   // reset cozy-client
   client.getStackClient().resetClient()
-  // reset cozy-client-js
-  if (cozy.client._storage) {
-    cozy.client._storage.clear()
-  }
 
   disableBackgroundService()
 }

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -183,10 +183,3 @@ export function resetClient(client, clientInfo = null) {
 
   disableBackgroundService()
 }
-
-export const getToken = async () => {
-  const credentials = await cozy.client.authorize()
-  return credentials.token.accessToken
-}
-
-export const getClientUrl = () => cozy.client._url

--- a/src/drive/mobile/lib/media.js
+++ b/src/drive/mobile/lib/media.js
@@ -1,4 +1,3 @@
-import { getToken, getClientUrl } from './cozy-helper'
 import { logException } from 'drive/lib/reporter'
 import { isMobileApp } from 'cozy-device-helper'
 import logger from 'lib/logger'
@@ -49,9 +48,10 @@ const generatePayloadForNative = async ({
   uri,
   file,
   method = 'POST',
-  id = undefined
+  id = undefined,
+  client
 }) => {
-  const token = await getToken()
+  const token = client.getStackClient().getAccessToken()
   const payload = {
     id,
     serverUrl: uri,
@@ -90,16 +90,18 @@ export const updateLibraryItem = async (
   previousDocument,
   libraryItem,
   progressCallback,
-  thumbnailCallback
+  thumbnailCallback,
+  client
 ) => {
   if (hasCordovaPlugin()) {
+    const cozyURI = client.getStackClient().uri
     // the cordova plugin is going to do the upload and needs all the infos to make a request to the stack
-    const uri =
-      getClientUrl() + '/files/' + encodeURIComponent(previousDocument._id)
+    const uri = cozyURI + '/files/' + encodeURIComponent(previousDocument._id)
     const payload = await generatePayloadForNative({
       uri,
       file: libraryItem,
-      method: 'PUT'
+      method: 'PUT',
+      client
     })
     return uploadNativeItem(payload, progressCallback, thumbnailCallback)
   }
@@ -109,11 +111,13 @@ export const uploadLibraryItem = async (
   dirID,
   libraryItem,
   progressCallback,
-  thumbnailCallback
+  thumbnailCallback,
+  client
 ) => {
+  const cozyURI = client.getStackClient().uri
   if (hasCordovaPlugin()) {
     const uri =
-      getClientUrl() +
+      cozyURI +
       '/files/' +
       encodeURIComponent(dirID) +
       '?Name=' +
@@ -122,7 +126,8 @@ export const uploadLibraryItem = async (
     const payload = await generatePayloadForNative({
       id: dirID,
       file: libraryItem,
-      uri
+      uri,
+      client
     })
     return uploadNativeItem(payload, progressCallback, thumbnailCallback)
   }

--- a/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
+++ b/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
@@ -12,7 +12,6 @@ import { IconSprite } from 'cozy-ui/transpiled/react/'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
 import { setUrl } from 'drive/mobile/modules/settings/duck'
 import {
-  restoreCozyClientJs,
   initBar,
   getOldAdapterName,
   getAdapterPlugin,
@@ -46,11 +45,6 @@ class DriveMobileRouter extends Component {
   initClientAndBar = async client => {
     const { saveServerUrl, saveCredentials } = this.props
     const accesstoken = client.getStackClient().token
-    restoreCozyClientJs(
-      client.getStackClient().uri,
-      client.getStackClient().oauthOptions,
-      client.getStackClient().token
-    )
     saveCredentials(client.getStackClient().oauthOptions, accesstoken)
     saveServerUrl(client.getStackClient().uri)
     await initBar(client)

--- a/src/drive/mobile/modules/authorization/UserActionRequired.jsx
+++ b/src/drive/mobile/modules/authorization/UserActionRequired.jsx
@@ -11,7 +11,7 @@ import { translate } from 'cozy-ui/transpiled/react'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import { unlink, getClientSettings } from './duck'
+import { unlink } from './duck'
 import tosIcon from 'drive/mobile/assets/icons/icon-tos.svg'
 
 const TosUpdatedModal = translate()(({ t, newTosLink, onAccept, onRefuse }) => {
@@ -128,15 +128,11 @@ class UserActionRequired extends Component {
   }
 }
 
-const mapStateToProps = state => ({
-  clientSettings: getClientSettings(state)
-})
-
 const mapDispatchToProps = dispatch => ({
-  unlink: (client, clientSettings) => dispatch(unlink(client, clientSettings))
+  unlink: client => dispatch(unlink(client))
 })
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps
 )(UserActionRequired)

--- a/src/drive/mobile/modules/authorization/duck/actions.js
+++ b/src/drive/mobile/modules/authorization/duck/actions.js
@@ -11,10 +11,10 @@ export const setToken = token => ({ type: SET_TOKEN, token })
 
 export const revokeClient = () => ({ type: REVOKE })
 
-export const unlink = (client, clientInfo) => async dispatch => {
+export const unlink = client => async dispatch => {
   client.logout()
 
-  resetClient(client, clientInfo)
+  resetClient(client)
 
   await resetPersistedState()
   // This action will be handled by the rootReducer: the store will be restored to its initial state

--- a/src/drive/mobile/modules/mediaBackup/duck/index.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/index.js
@@ -41,7 +41,7 @@ export const startMediaBackup = (isManualBackup = false) => async (
   { client, t }
 ) => {
   dispatch({ type: MEDIA_UPLOAD_START })
-  client.getStackClient().fetchJSON('POST', '/settings/synchronized')
+  await client.getStackClient().fetchJSON('POST', '/settings/synchronized')
   if (!(await isAuthorized())) {
     const promptForPermissions = isManualBackup
     const receivedAuthorisation = await updateValueAfterRequestAuthorization(
@@ -81,7 +81,7 @@ export const startMediaBackup = (isManualBackup = false) => async (
         }
       }
 
-      client.getStackClient().fetchJSON('POST', '/settings/synchronized')
+      await client.getStackClient().fetchJSON('POST', '/settings/synchronized')
     } catch (e) {
       dispatch({ type: MEDIA_UPLOAD_ABORT })
       if (!e.message.match(/Failed to fetch/))

--- a/src/drive/mobile/modules/settings/components/Unlink.jsx
+++ b/src/drive/mobile/modules/settings/components/Unlink.jsx
@@ -5,14 +5,11 @@ import { withClient } from 'cozy-client'
 import { connect } from 'react-redux'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import SettingCategory, { ELEMENT_BUTTON } from './SettingCategory'
-import {
-  unlink,
-  getClientSettings
-} from 'drive/mobile/modules/authorization/duck'
+import { unlink } from 'drive/mobile/modules/authorization/duck'
 
 export class Unlink extends Component {
   render() {
-    const { t, unlink, clientSettings, client } = this.props
+    const { t, unlink, client } = this.props
     return (
       <div>
         <SettingCategory
@@ -23,7 +20,7 @@ export class Unlink extends Component {
               description: t('mobile.settings.unlink.description'),
               text: t('mobile.settings.unlink.button'),
               theme: 'danger-outline',
-              onClick: () => unlink(client, clientSettings)
+              onClick: () => unlink(client)
             }
           ]}
         />
@@ -34,24 +31,19 @@ export class Unlink extends Component {
 Unlink.propTypes = {
   t: PropTypes.func,
   unlink: PropTypes.func,
-  clientSettings: PropTypes.object,
   router: PropTypes.object
 }
 
-const mapStateToProps = state => ({
-  clientSettings: getClientSettings(state)
-})
-
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  unlink: (client, clientSettings) => {
-    dispatch(unlink(client, clientSettings))
+  unlink: client => {
+    dispatch(unlink(client))
     ownProps.router.replace('/onboarding')
   }
 })
 
 export default withRouter(
   connect(
-    mapStateToProps,
+    null,
     mapDispatchToProps
   )(translate()(withClient(Unlink)))
 )

--- a/src/drive/mobile/modules/settings/components/Unlink.spec.jsx
+++ b/src/drive/mobile/modules/settings/components/Unlink.spec.jsx
@@ -18,17 +18,7 @@ describe('Unlink', () => {
 
   const unlink = jest.fn()
   const t = jest.fn(s => s)
-  const clientSettings = {
-    data: 'foo'
-  }
-  const comp = mount(
-    <Unlink
-      t={t}
-      unlink={unlink}
-      clientSettings={clientSettings}
-      client={client}
-    />
-  )
+  const comp = mount(<Unlink t={t} unlink={unlink} client={client} />)
 
   afterEach(() => {
     jest.restoreAllMocks()
@@ -42,6 +32,6 @@ describe('Unlink', () => {
     const button = comp.find('Button')
     button.prop('onClick')()
 
-    expect(unlink).toHaveBeenCalledWith(client, clientSettings)
+    expect(unlink).toHaveBeenCalledWith(client)
   })
 })

--- a/src/drive/mobile/modules/settings/components/__snapshots__/Unlink.spec.jsx.snap
+++ b/src/drive/mobile/modules/settings/components/__snapshots__/Unlink.spec.jsx.snap
@@ -12,11 +12,6 @@ exports[`Unlink should render the Component 1`] = `
       },
     }
   }
-  clientSettings={
-    Object {
-      "data": "foo",
-    }
-  }
   t={
     [MockFunction] {
       "calls": Array [

--- a/src/drive/targets/browser/index.ejs
+++ b/src/drive/targets/browser/index.ejs
@@ -1,44 +1,32 @@
 <!DOCTYPE html>
 <html lang="{{.Locale}}">
-  <head>
-    <meta charset="utf-8" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link
-      rel="icon"
-      type="image/png"
-      href="./favicon-32x32.png"
-      sizes="32x32"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="./favicon-16x16.png"
-      sizes="16x16"
-    />
-    <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
-    <meta name="theme-color" content="#ffffff" />
-    <meta
-      name="viewport"
-      content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover"
-    />
-    <% if (__STACK_ASSETS__) { %>
-    {{.CozyClientJS}}
+
+<head>
+  <meta charset="utf-8" />
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  {{.ThemeCSS}}
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+  <meta name="theme-color" content="#ffffff" />
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover" />
+  <% if (__STACK_ASSETS__) { %>
     {{.CozyBar}}
-    <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
-    <link rel="stylesheet" href="<%- file %>" />
-    <% }); %>
-  </head>
-  <div
-    role="application"
-    data-cozy="{{.CozyData}}"
-  ></div>
-  <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+    <% } %>
+      <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
+        <link rel="stylesheet" href="<%- file %>" />
+        <% }); %>
+</head>
+<div role="application" data-cozy="{{.CozyData}}"></div>
+<% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
   <script src="<%- file %>"></script>
-  <% }); %> <% if (__STACK_ASSETS__ || (__DEVELOPMENT__ && __TARGET__ !==
-  'mobile')) { %>
-  <script src="//{{.Domain}}/assets/js/piwik.js" async></script>
-  <% } %>
+  <% }); %>
+    <% if (__STACK_ASSETS__ || (__DEVELOPMENT__ && __TARGET__ !=='mobile' )) { %>
+      <script src="//{{.Domain}}/assets/js/piwik.js" async></script>
+      <% } %>
+
 </html>

--- a/src/drive/targets/browser/setupAppContext.js
+++ b/src/drive/targets/browser/setupAppContext.js
@@ -1,20 +1,21 @@
 /* global cozy */
-
 import memoize from 'lodash/memoize'
-import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
+import { hashHistory } from 'react-router'
+
 import CozyClient from 'cozy-client'
+import { Document } from 'cozy-doctypes'
+import { Intents } from 'cozy-interapp'
 import {
   shouldEnableTracking,
   getTracker
 } from 'cozy-ui/transpiled/react/helpers/tracker'
+import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
+
 import { configureReporter, setCozyUrl } from 'drive/lib/reporter'
 import registerClientPlugins from 'drive/lib/registerClientPlugins'
-
 import appMetadata from 'drive/appMetadata'
 import configureStore from 'drive/store/configureStore'
 import { schema } from 'drive/lib/doctypes'
-import { Document } from 'cozy-doctypes'
-import { hashHistory } from 'react-router'
 
 const setupApp = memoize(() => {
   const root = document.querySelector('[role=application]')
@@ -64,6 +65,9 @@ const setupApp = memoize(() => {
     appSlug: data.app.slug,
     appNamePrefix: data.app.prefix
   })
+
+  const intents = new Intents({ client })
+  client.intents = intents
 
   if (shouldEnableTracking() && getTracker()) {
     let trackerInstance = getTracker()

--- a/src/drive/targets/browser/setupAppContext.js
+++ b/src/drive/targets/browser/setupAppContext.js
@@ -50,11 +50,6 @@ const setupApp = memoize(() => {
     history
   })
 
-  cozy.client.init({
-    cozyURL: cozyUrl,
-    token: data.token
-  })
-
   cozy.bar.init({
     appName: data.app.name,
     appEditor: data.app.editor,

--- a/src/drive/targets/intents/index.ejs
+++ b/src/drive/targets/intents/index.ejs
@@ -1,44 +1,30 @@
 <!DOCTYPE html>
 <html lang="{{.Locale}}">
-  <head>
-    <meta charset="utf-8" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
-    <% if (__TARGET__ !== 'mobile') { %>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="//{{.Domain}}/assets/fonts/fonts.css"
-    />
+
+<head>
+  <meta charset="utf-8" />
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  {{.ThemeCSS}}
+  <% if (__TARGET__ !=='mobile' ) { %>
+    <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css" />
     <% } %>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link
-      rel="icon"
-      type="image/png"
-      href="./favicon-32x32.png"
-      sizes="32x32"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="./favicon-16x16.png"
-      sizes="16x16"
-    />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
-    <meta name="theme-color" content="#ffffff" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <% if (__STACK_ASSETS__) { %>
-    {{.CozyClientJS}}
-    <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
-      <link rel="stylesheet" href="<%- file %>" />
-    <% }); %>
-  </head>
-  <div
-    id="main"
-    role="application"
-    data-cozy="{{.CozyData}}"
-  ></div>
-  <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
-    <script src="<%- file %>"></script>
+      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+      <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+      <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+      <meta name="theme-color" content="#ffffff" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <% if (__STACK_ASSETS__) { %>
+        <% } %>
+          <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
+            <link rel="stylesheet" href="<%- file %>" />
+            <% }); %>
+</head>
+<div id="main" role="application" data-cozy="{{.CozyData}}"></div>
+<% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+  <script src="<%- file %>"></script>
   <% }); %>
+
 </html>

--- a/src/drive/targets/intents/index.jsx
+++ b/src/drive/targets/intents/index.jsx
@@ -1,5 +1,3 @@
-/* global cozy */
-
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'whatwg-fetch'
 
@@ -31,10 +29,6 @@ document.addEventListener('DOMContentLoaded', () => {
     schema
   })
 
-  cozy.client.init({
-    cozyURL: cozyUrl,
-    token: data.token
-  })
   registerClientPlugins(client)
 
   render(

--- a/src/drive/targets/public/index.ejs
+++ b/src/drive/targets/public/index.ejs
@@ -1,46 +1,38 @@
 <!DOCTYPE html>
 <html lang="{{.Locale}}">
-  <head>
-    <meta charset="utf-8" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
-    <link rel="apple-touch-icon" sizes="180x180" href="/public/apple-touch-icon.png" />
-    <link
-      rel="icon"
-      type="image/png"
-      href="/public/favicon-32x32.png"
-      sizes="32x32"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="/public/favicon-16x16.png"
-      sizes="16x16"
-    />
-    <link rel="mask-icon" href="/public/safari-pinned-tab.svg" color="#5bbad5" />
-    <meta name="theme-color" content="#ffffff" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="robots" content="noindex, nofollow, noimageindex" />
-    <% if (__TARGET__ === 'mobile') { %>
+
+<head>
+  <meta charset="utf-8" />
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  {{.ThemeCSS}}
+  <link rel="apple-touch-icon" sizes="180x180" href="/public/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="/public/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="/public/favicon-16x16.png" sizes="16x16" />
+  <link rel="mask-icon" href="/public/safari-pinned-tab.svg" color="#5bbad5" />
+  <meta name="theme-color" content="#ffffff" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow, noimageindex" />
+  <% if (__TARGET__==='mobile' ) { %>
     <meta name="format-detection" content="telephone=no" />
     <script src="cordova.js" defer></script>
     <% } else if (__STACK_ASSETS__) { %>
-    {{.CozyClientJS}}
-    {{.CozyBar}}
-    <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
-    <link rel="stylesheet" href="<%- file %>" />
-    <% }); %>
-  </head>
-  <body>
-    <div
-      role="application"
-      data-cozy="{{.CozyData}}"
-    ></div>
-    <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+      {{.CozyBar}}
+      <% } %>
+        <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
+          <link rel="stylesheet" href="<%- file %>" />
+          <% }); %>
+</head>
+
+<body>
+  <div role="application" data-cozy="{{.CozyData}}"></div>
+  <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
     <script src="<%- file %>"></script>
-    <% }); %> <% if (__STACK_ASSETS__ || (__DEVELOPMENT__ && __TARGET__ !==
-    'mobile')) { %>
-    <script src="//{{.Domain}}/assets/js/piwik.js" async></script>
-    <% } %>
-  </body>
+    <% }); %>
+      <% if (__STACK_ASSETS__ || (__DEVELOPMENT__ && __TARGET__ !=='mobile' )) { %>
+        <script src="//{{.Domain}}/assets/js/piwik.js" async></script>
+        <% } %>
+</body>
+
 </html>

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -87,11 +87,6 @@ const init = async () => {
 
   configureReporter()
   setCozyUrl(cozyUrl)
-  // we still need cozy-client-js for opening a folder
-  cozy.client.init({
-    cozyURL: cozyUrl,
-    token: sharecode
-  })
 
   const polyglot = initTranslation(dataset.locale, lang =>
     require(`drive/locales/${lang}`)

--- a/src/drive/web/modules/services/components/Intent.jsx
+++ b/src/drive/web/modules/services/components/Intent.jsx
@@ -1,6 +1,8 @@
-/* global cozy */
 import React from 'react'
 import classNames from 'classnames'
+
+import { withClient } from 'cozy-client'
+
 import { Modal, Button } from 'cozy-ui/transpiled/react'
 import styles from 'drive/styles/intentbutton.styl'
 
@@ -51,8 +53,8 @@ class IntentButton extends React.Component {
 
 class Intent extends React.Component {
   componentDidMount() {
-    const { action, docType, data } = this.props
-    cozy.client.intents
+    const { action, docType, data, client } = this.props
+    client.intents
       .create(action, docType, {
         ...data,
         exposeIntentFrameRemoval: true
@@ -72,4 +74,4 @@ class Intent extends React.Component {
 }
 
 export { IntentButton }
-export default Intent
+export default withClient(Intent)

--- a/src/drive/web/modules/services/components/Intent.jsx
+++ b/src/drive/web/modules/services/components/Intent.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { withClient } from 'cozy-client'
+import { Intents } from 'cozy-interapp'
 
 import { Modal, Button } from 'cozy-ui/transpiled/react'
 import styles from 'drive/styles/intentbutton.styl'
@@ -54,7 +55,8 @@ class IntentButton extends React.Component {
 class Intent extends React.Component {
   componentDidMount() {
     const { action, docType, data, client } = this.props
-    client.intents
+    const intents = new Intents({ client })
+    intents
       .create(action, docType, {
         ...data,
         exposeIntentFrameRemoval: true

--- a/src/drive/web/modules/services/components/IntentHandler.jsx
+++ b/src/drive/web/modules/services/components/IntentHandler.jsx
@@ -1,5 +1,6 @@
-/* global cozy */
 import React from 'react'
+
+import { withClient } from 'cozy-client'
 
 import Embeder from './Embeder'
 import URLGetter from './URLGetter'
@@ -21,13 +22,13 @@ class IntentHandler extends React.Component {
   }
 
   async startService() {
-    const { intentId } = this.props
+    const { intentId, client } = this.props
 
     let component
     let service
     let intent
     try {
-      service = await cozy.client.intents.createService(intentId, window)
+      service = await client.intents.createService(intentId, window)
       intent = service.getIntent()
 
       if (
@@ -66,4 +67,4 @@ class IntentHandler extends React.Component {
   }
 }
 
-export default IntentHandler
+export default withClient(IntentHandler)

--- a/src/drive/web/modules/services/components/IntentHandler.jsx
+++ b/src/drive/web/modules/services/components/IntentHandler.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { withClient } from 'cozy-client'
+import { Intents } from 'cozy-interapp'
 
 import Embeder from './Embeder'
 import URLGetter from './URLGetter'
@@ -23,12 +24,12 @@ class IntentHandler extends React.Component {
 
   async startService() {
     const { intentId, client } = this.props
-
     let component
     let service
     let intent
     try {
-      service = await client.intents.createService(intentId, window)
+      const intents = new Intents({ client })
+      service = await intents.createService(intentId, window)
       intent = service.getIntent()
 
       if (

--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -51,9 +51,7 @@ class SuggestionProvider extends React.Component {
     const { client } = this.props
     return new Promise(async resolve => {
       const resp = await client.collection('io.cozy.files').all({ limit: null })
-      const files = resp.rows
-        .filter(row => !row.doc.hasOwnProperty('views'))
-        .map(row => ({ id: row.id, ...row.doc }))
+      const files = resp.data
 
       const folders = files.filter(file => file.type === TYPE_DIRECTORY)
 

--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -1,8 +1,8 @@
-/* global cozy */
 import React from 'react'
+import { withClient, models } from 'cozy-client'
+
 import FuzzyPathSearch from '../FuzzyPathSearch'
 import { getFileMimetype } from 'drive/lib/getFileMimetype'
-import { withClient, models } from 'cozy-client'
 
 const TYPE_DIRECTORY = 'directory'
 
@@ -50,10 +50,7 @@ class SuggestionProvider extends React.Component {
   async indexFiles() {
     const { client } = this.props
     return new Promise(async resolve => {
-      const resp = await cozy.client.fetchJSON(
-        'GET',
-        `/data/io.cozy.files/_all_docs?include_docs=true`
-      )
+      const resp = await client.collection('io.cozy.files').all({ limit: null })
       const files = resp.rows
         .filter(row => !row.doc.hasOwnProperty('views'))
         .map(row => ({ id: row.id, ...row.doc }))

--- a/src/drive/web/modules/services/components/URLGetter.jsx
+++ b/src/drive/web/modules/services/components/URLGetter.jsx
@@ -1,22 +1,18 @@
-/* global cozy */
 import React from 'react'
-
-const getFileDownloadUrl = async id => {
-  const link = await cozy.client.files.getDownloadLinkById(id)
-  return `${cozy.client._url}${link}`
-}
-
+import { withClient } from 'cozy-client'
 class URLGetter extends React.Component {
   componentDidMount() {
     this.getURL()
   }
 
   async getURL() {
-    const { service } = this.props
+    const { service, client } = this.props
 
     try {
       const { id } = service.getData()
-      const url = await getFileDownloadUrl(id)
+      const url = await client
+        .collection('io.cozy.files')
+        .getDownloadLinkById(id)
       service.terminate({ url })
     } catch (error) {
       service.throw(error)
@@ -24,4 +20,4 @@ class URLGetter extends React.Component {
   }
 }
 
-export default URLGetter
+export default withClient(URLGetter)

--- a/src/drive/web/modules/viewer/FileOpenerExternal.jsx
+++ b/src/drive/web/modules/viewer/FileOpenerExternal.jsx
@@ -1,4 +1,3 @@
-/* global cozy */
 /**
  * This component was previously named FileOpener
  * It has been renamed since it is used in :
@@ -12,6 +11,7 @@ import { withRouter } from 'react-router'
 import get from 'lodash/get'
 import { RemoveScroll } from 'react-remove-scroll'
 
+import { withClient, Q } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
@@ -56,9 +56,10 @@ export class FileOpener extends Component {
     }
   }
   async loadFileInfo(id) {
+    const { client } = this.props
     try {
       this.setState({ fileNotFound: false })
-      const resp = await cozy.client.files.statById(id, false)
+      const resp = await client.query(Q('io.cozy.files').getById(id))
       const file = { ...resp, ...resp.attributes, id: resp._id }
       this.setState({ file, loading: false })
     } catch (e) {
@@ -70,7 +71,6 @@ export class FileOpener extends Component {
   render() {
     const { file, loading, fileNotFound } = this.state
     const { t, service, router } = this.props
-
     return (
       <div className="u-pos-absolute u-w-100 u-h-100 u-bg-charcoalGrey">
         {loading && <Spinner size="xxlarge" middle noMargin color="white" />}
@@ -121,4 +121,4 @@ FileOpener.propTypes = {
   fileId: PropTypes.string
 }
 
-export default translate()(withRouter(FileOpener))
+export default translate()(withClient(withRouter(FileOpener)))

--- a/src/drive/web/modules/viewer/FileOpenerExternal.spec.jsx
+++ b/src/drive/web/modules/viewer/FileOpenerExternal.spec.jsx
@@ -1,22 +1,22 @@
-import { shallow } from 'enzyme'
 import React from 'react'
+import { shallow } from 'enzyme'
+import CozyClient from 'cozy-client'
 
 import { FileOpener } from './FileOpenerExternal'
-global.cozy = {
-  client: {
-    files: {
-      statById: jest.fn()
-    }
-  }
-}
+
 const routerMock = {
   push: () => {},
   params: {
     fileId: '1'
   }
 }
+
 describe('FileOpenerExternal', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
   it('should set the id in state', async () => {
+    const client = new CozyClient({})
     const wrapper = shallow(
       <FileOpener
         router={routerMock}
@@ -24,19 +24,25 @@ describe('FileOpenerExternal', () => {
         routeParams={{
           fileId: '123'
         }}
+        client={client}
       />,
       {
         disableLifecycleMethods: true
       }
     )
-    global.cozy.client.files.statById.mockResolvedValue({
+
+    client.query = jest.fn().mockResolvedValue({
       _id: '123'
     })
+
     await wrapper.instance().loadFileInfo('123')
     expect(wrapper.state().file.id).toBe('123')
   })
 
   it('should set the id in state even after a props update', async () => {
+    const client = new CozyClient({})
+
+    client.stackClient.fetchJSON = jest.fn()
     const wrapper = shallow(
       <FileOpener
         router={routerMock}
@@ -44,12 +50,13 @@ describe('FileOpenerExternal', () => {
         routeParams={{
           fileId: '123'
         }}
+        client={client}
       />,
       {
         disableLifecycleMethods: true
       }
     )
-    global.cozy.client.files.statById.mockResolvedValue({
+    client.query = jest.fn().mockResolvedValue({
       _id: '123'
     })
     await wrapper.instance().loadFileInfo('123')
@@ -59,7 +66,7 @@ describe('FileOpenerExternal', () => {
         fileId: '456'
       }
     })
-    global.cozy.client.files.statById.mockResolvedValue({
+    client.query = jest.fn().mockResolvedValue({
       _id: '456'
     })
     await wrapper.instance().loadFileInfo('456')

--- a/src/photos/targets/browser/index.ejs
+++ b/src/photos/targets/browser/index.ejs
@@ -1,31 +1,29 @@
 <!DOCTYPE html>
 <html lang="{{.Locale}}">
-  <head>
-    <meta charset="utf-8" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
-    <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
-    <meta name="theme-color" content="#ffffff" />
-    <meta
-      name="viewport"
-      content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover"
-    />
-    <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
+
+<head>
+  <meta charset="utf-8" />
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  {{.ThemeCSS}}
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
+  <meta name="theme-color" content="#ffffff" />
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover" />
+  <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>" />
-    <% }); %> <% if (__STACK_ASSETS__) { %>
-    {{.CozyClientJS}}
-    {{.CozyBar}}
-    <% } %>
-  </head>
-  <div
-    role="application"
-    data-cozy="{{.CozyData}}"
-  ></div>
-  <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+    <% }); %>
+      <% if (__STACK_ASSETS__) { %>
+        {{.CozyBar}}
+        <% } %>
+</head>
+<div role="application" data-cozy="{{.CozyData}}"></div>
+<% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
   <script src="<%- file %>"></script>
   <% }); %>
-  <script src="//{{.Domain}}/assets/js/piwik.js" async></script>
+    <script src="//{{.Domain}}/assets/js/piwik.js" async></script>
+
 </html>

--- a/src/photos/targets/browser/index.jsx
+++ b/src/photos/targets/browser/index.jsx
@@ -47,11 +47,6 @@ const setupAppContext = memoize(() => {
     store: false
   })
   client.registerPlugin(RealtimePlugin)
-  // We still need to init cozy-client-js for the Uploader
-  cozy.client.init({
-    cozyURL: cozyUrl,
-    token: data.token
-  })
 
   configureReporter()
   setCozyUrl(cozyUrl)

--- a/src/photos/targets/public/index.ejs
+++ b/src/photos/targets/public/index.ejs
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{.Locale}}">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,19 +10,17 @@
   {{.ThemeCSS}}
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>">
-  <% }); %>
-  <% if (__STACK_ASSETS__) { %>
-    {{.CozyClientJS}}
-    {{.CozyBar}}
-  <% } %>
+    <% }); %>
+      <% if (__STACK_ASSETS__) { %>
+        {{.CozyBar}}
+        <% } %>
 </head>
+
 <body>
-  <div
-    role="application"
-    data-cozy="{{.CozyData}}"
-  >
-  <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
-    <script src="<%- file %>"></script>
-  <% }); %>
+  <div role="application" data-cozy="{{.CozyData}}">
+    <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+      <script src="<%- file %>"></script>
+      <% }); %>
 </body>
+
 </html>

--- a/test/targets/mobile/test/actions/unlink.spec.js
+++ b/test/targets/mobile/test/actions/unlink.spec.js
@@ -1,6 +1,4 @@
 /* eslint-env jest */
-/* global cozy */
-
 import {
   SHOW_UNLINK_CONFIRMATION,
   HIDE_UNLINK_CONFIRMATION,
@@ -8,12 +6,6 @@ import {
   hideUnlinkConfirmation,
   unlink
 } from '../../../../../src/targets/mobile/actions/unlink'
-
-import client from 'cozy-client-js'
-
-beforeAll(() => {
-  cozy.client = client
-})
 
 describe('ui actions', () => {
   it('should create an action to display unlink confirmation', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5552,6 +5552,13 @@ create-react-class@^15.5.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-fetch@^3.0.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-fetch@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
@@ -9785,6 +9792,14 @@ jest-environment-node@^24.9.0:
     jest-mock "^24.9.0"
     jest-util "^24.9.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -13406,6 +13421,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
+  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
 
 promise-retry@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5264,6 +5264,11 @@ cozy-interapp@^0.5.4:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.7.tgz#75cafe1732ad660e2caf1ccf412f302594705f39"
   integrity sha512-laIL/ATYV9oZnmqS+LMoO9qzk8XjJ1v2/YrA1Po2rI8ia/MDgjYO07424x2RuvHhNOBPGjD+JmqwQ0rNDlLW+Q==
 
+cozy-interapp@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.6.2.tgz#ab0e0062cbaca057023902bbde8825febe5c95a8"
+  integrity sha512-2cz+xGSio+vvgC+MJnOl8/3Pt4IMAnt2jh9/zMU0YgiP8JmPqVRsweRoPOjUmPqhw2xmVvGSWr//IhAfMxi62w==
+
 cozy-jobs-cli@1.15.9:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.15.9.tgz#50bd0eb80c605526374caac215deba39d533056a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5049,16 +5049,6 @@ cozy-ci@0.4.1:
   resolved "https://registry.yarnpkg.com/cozy-ci/-/cozy-ci-0.4.1.tgz#f5991f9acc8fb81480003441e190d4be3a0f8446"
   integrity sha512-SKlFoecbneXe4ctop0Al3jQ6jts8bu5pJij9XU5HjhxwKx4whkzwPOkpJ+F1k5lkgstfNU7k9YQPE+nizp6W9Q==
 
-cozy-client-js@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.19.0.tgz#ccfb0572d6c6f3aa7c187978c23dd89f04caf796"
-  integrity sha512-3EPLxLu7mg/GSmAHauW7rfdVMynCQb9Yj1vHvDO1Rpda/CV0xN04HRH1eq+3HhZiIx1g1L76zSh0jN1shgCknQ==
-  dependencies:
-    core-js "^3.6.5"
-    cross-fetch "^3.0.6"
-    pouchdb-browser "7.0.0"
-    pouchdb-find "7.0.0"
-
 cozy-client-js@^0.17.4:
   version "0.17.4"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.17.4.tgz#58b2b112da2486299c118d5a11480f763b0ce347"


### PR DESCRIPTION
The idea is to remove the reference of the old cozy-client-js to only use cozy-client 