### PR TITLE
fix: Pass the right arguments to the cozy-bar

### DIFF
--- a/src/drive/targets/browser/setupAppContext.js
+++ b/src/drive/targets/browser/setupAppContext.js
@@ -60,7 +60,9 @@ const setupApp = memoize(() => {
     cozyClient: client,
     iconPath: data.app.icon,
     lang: data.locale,
-    replaceTitleOnMobile: false
+    replaceTitleOnMobile: false,
+    appSlug: data.app.slug,
+    appNamePrefix: data.app.prefix
   })
 
   if (shouldEnableTracking() && getTracker()) {

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -41,7 +41,9 @@ const initCozyBar = (data, client) => {
       iconPath: data.app.icon,
       lang: data.locale,
       replaceTitleOnMobile: true,
-      isPublic: true
+      isPublic: true,
+      appSlug: data.app.slug,
+      appNamePrefix: data.app.prefix
     })
   }
 }

--- a/src/photos/targets/browser/index.jsx
+++ b/src/photos/targets/browser/index.jsx
@@ -81,7 +81,9 @@ const setupAppContext = memoize(() => {
     cozyClient: client,
     iconPath: data.app.icon,
     lang: lang,
-    replaceTitleOnMobile: true
+    replaceTitleOnMobile: true,
+    appSlug: data.app.slug,
+    appNamePrefix: data.app.prefix
   })
   return { store, locale, client, history, root }
 })

--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -66,7 +66,9 @@ async function init() {
       iconPath: data.app.icon,
       lang: data.locale,
       replaceTitleOnMobile: true,
-      isPublic: true
+      isPublic: true,
+      appSlug: data.app.slug,
+      appNamePrefix: data.app.prefix
     })
   }
   try {


### PR DESCRIPTION
We decided to use data-cozy={{}} to get access to
the variables injected by the cozy-stack.

By removing data-cozy-*, cozy-bar was lost since
the bar will look into cozy-data-appslug to detect
the slug of the app. Since the bar can't do that
anymore, we need to pass all the args during the
init phase.