### PR TITLE
fix: OO creation

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/useCreateFile.js
+++ b/src/drive/web/modules/views/OnlyOffice/useCreateFile.js
@@ -16,7 +16,7 @@ const useCreateFile = (folderId, fileClass) => {
 
   const fileExt = useMemo(() => makeExtByClass(fileClass), [fileClass])
   const fileMime = useMemo(() => makeMimeByClass(fileClass), [fileClass])
-  const fileUrl = useMemo(() => `/onlyoffice/${fileClass}.${fileExt}`, [
+  const fileUrl = useMemo(() => `/onlyOffice/${fileClass}.${fileExt}`, [
     fileClass,
     fileExt
   ])


### PR DESCRIPTION
Assets are available in /onlyOffice/file.ext, not
in /onlyoffice/file.ext