### PR TITLE
feat: Select the full filename if we rename a folder

### DIFF
--- a/src/drive/web/modules/filelist/FilenameInput.jsx
+++ b/src/drive/web/modules/filelist/FilenameInput.jsx
@@ -111,14 +111,17 @@ class FilenameInput extends Component {
   }
 
   handleFocus() {
-    const { name } = this.props
+    const { name, file } = this.props
 
     const { filename } = CozyFile.splitFilename({ name, type: 'file' })
     //Since we're mounting the component and focusing it at the same time
     // let's add a small timeout to be sure the ref is populated
     setTimeout(() => {
       if (this.textInput.current)
-        this.textInput.current.setSelectionRange(0, filename.length)
+        this.textInput.current.setSelectionRange(
+          0,
+          isDirectory(file) ? name.length : filename.length
+        )
     }, 5)
   }
 


### PR DESCRIPTION
Previously we were splitting the filename on the latest do,
to prevent extension change.

It works well for file but not for folder. If it's a folder,
let's select the full filename