### PR TITLE
fix: Few fixes on public page

### DIFF
--- a/src/drive/web/modules/drive/AddMenu/AddMenu.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenu.jsx
@@ -18,7 +18,8 @@ export const ActionMenuContent = ({
   isDisabled,
   canCreateFolder,
   canUpload,
-  refreshFolderContent
+  refreshFolderContent,
+  isPublic
 }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -34,7 +35,7 @@ export const ActionMenuContent = ({
         </>
       )}
       {canCreateFolder && <AddFolderItem />}
-      <CreateNoteItem />
+      {!isPublic && <CreateNoteItem />}
       {canUpload &&
         isOnlyOfficeEnabled() && (
           <>
@@ -59,7 +60,8 @@ const AddMenu = ({
   isDisabled,
   canCreateFolder,
   canUpload,
-  refreshFolderContent
+  refreshFolderContent,
+  isPublic
 }) => {
   return (
     <ActionMenu
@@ -75,6 +77,7 @@ const AddMenu = ({
         canCreateFolder={canCreateFolder}
         canUpload={canUpload}
         refreshFolderContent={refreshFolderContent}
+        isPublic={isPublic}
       />
     </ActionMenu>
   )

--- a/src/drive/web/modules/drive/AddMenu/AddMenuProvider.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenuProvider.jsx
@@ -25,7 +25,8 @@ const AddMenuProvider = ({
   canCreateFolder,
   canUpload,
   refreshFolderContent,
-  children
+  children,
+  isPublic
 }) => {
   const [menuIsVisible, setMenuVisible] = useState(false)
   const selectionModeActive = useSelector(isSelectionBarVisible)
@@ -58,7 +59,8 @@ const AddMenuProvider = ({
         handleToggle,
         isDisabled,
         isOffline,
-        handleOfflineClick
+        handleOfflineClick,
+        isPublic
       }}
     >
       {children}
@@ -70,6 +72,7 @@ const AddMenuProvider = ({
             canCreateFolder={canCreateFolder}
             canUpload={canUpload}
             refreshFolderContent={refreshFolderContent}
+            isPublic={isPublic}
           />
         )}
       </ScanWrapper>

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -108,7 +108,7 @@ const PublicToolbarByLink = ({
                 <AddButton />
               </AddMenuProvider>
             )}
-            <DownloadFilesButton files={files} />
+            {files.length > 0 && <DownloadFilesButton files={files} />}
           </>
         )}
         {shouldDisplayMoreMenu && (

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -104,6 +104,7 @@ const PublicToolbarByLink = ({
                 canCreateFolder={true}
                 canUpload={true}
                 refreshFolderContent={refreshFolderContent}
+                isPublic={true}
               >
                 <AddButton />
               </AddMenuProvider>

--- a/src/drive/web/modules/public/PublicToolbarByLink.jsx
+++ b/src/drive/web/modules/public/PublicToolbarByLink.jsx
@@ -91,8 +91,7 @@ const PublicToolbarByLink = ({
   const client = useClient()
   const { isMobile } = useBreakpoints()
 
-  const shouldDisplayMoreMenu =
-    isMobile || (!isFile && files.length > 0) || hasWriteAccess
+  const shouldDisplayMoreMenu = isMobile || (!isFile && files.length > 0)
 
   return (
     <CozyBarRightMobile>

--- a/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
+++ b/src/drive/web/modules/public/PublicToolbarCozyToCozy.jsx
@@ -56,14 +56,15 @@ const MoreMenu = ({
               : t('toolbar.add_to_mine')}
           </ActionMenuItem>
 
-          {isMobile && (
-            <ActionMenuItem
-              onClick={() => downloadFiles(client, files)}
-              left={<Icon icon={'download'} />}
-            >
-              {t('toolbar.menu_download')}
-            </ActionMenuItem>
-          )}
+          {isMobile &&
+            files.length > 0 && (
+              <ActionMenuItem
+                onClick={() => downloadFiles(client, files)}
+                left={<Icon icon={'download'} />}
+              >
+                {t('toolbar.menu_download')}
+              </ActionMenuItem>
+            )}
           {files.length > 1 && <SelectableItem />}
         </ActionMenu>
       )}
@@ -86,7 +87,7 @@ const PublicToolbarCozyToCozy = ({
   return (
     <CozyBarRightMobile>
       <BarContextProvider client={client} t={t} store={client.store}>
-        {!isMobile && <DownloadFilesButton files={files} />}
+        {!isMobile && files.length > 0 && <DownloadFilesButton files={files} />}
         {shouldDisplayMoreMenu && (
           <MoreMenu
             files={files}

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -224,6 +224,7 @@ const PublicFolderView = ({
                 canCreateFolder={hasWritePermissions}
                 canUpload={hasWritePermissions}
                 refreshFolderContent={refreshFolderContent}
+                isPublic={true}
               >
                 <FabWithMenuContext noSidebar={true} />
               </AddMenuProvider>


### PR DESCRIPTION
- We hide the CreateNote button 
- We don't display the MoreMenu if the is no file in the folder (since the only action within the menu is "Select file" and this action is not display when there is no file...) 
- We hide the download button if there is no file to download 
