### PR TITLE
fix: Update hammerjs API usage

### DIFF
--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -72,11 +72,11 @@ const FileOpener = ({
 
       const gesturesHandler = propagating(new Hammer(rowRef.current))
 
-      gesturesHandler.on('tap onpress singletap', ev => {
+      gesturesHandler.on('tap press singletap', ev => {
         if (actionMenuVisible || disabled) return
         if (enableTouchEvents(ev)) {
           ev.preventDefault() // prevent a ghost click
-          if (ev.type === 'onpress' || selectionModeActive) {
+          if (ev.type === 'press' || selectionModeActive) {
             ev.srcEvent.stopImmediatePropagation()
             toggle(ev.srcEvent)
           } else {


### PR DESCRIPTION
https://trello.com/c/80mmMpTV/1497-%F0%9F%93%81-drive-mobile-le-clic-long-sur-le-mobile-nenclenche-plus-une-s%C3%A9lection-de-l%C3%A9l%C3%A9ment

The "onpress" event never existed, see: https://hammerjs.github.io/recognizer-press/
It used to work in cozy-drive because "onpress" was a custom event. With the new API, we can simply use the native 'press' event.
