### PR TITLE
fix: Remove double saving when creating directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 * Fixed an error on mobile that was preventing users to long tap in order to trigger multiple files selection
 * Fixed an error in directory tree names appearing under filenames where sometimes, the path appeared scrambled
+* Fixed an error where creating a directory sent two save actions instead of one

--- a/src/drive/web/modules/filelist/FilenameInput.jsx
+++ b/src/drive/web/modules/filelist/FilenameInput.jsx
@@ -67,7 +67,7 @@ class FilenameInput extends Component {
     const { value } = this.state
     const { file } = this.props
     this.setState({ working: true, error: false })
-    if (!this.fileNameOnMount) this.save()
+    if (!this.fileNameOnMount) return this.save()
     if (file && !isDirectory(file)) {
       const previousExtension = CozyFile.splitFilename({
         name: this.fileNameOnMount,


### PR DESCRIPTION
Related to https://trello.com/c/W6b1eknd/1505-%F0%9F%93%81-drive-r%C3%A9gression-1-erreur-%C3%A0-la-cr%C3%A9ation-dun-dossier

Issue: creating a directory triggered a "this folder already exists error"

Bug: FilenameInput launches two save() action if a file has no name => directory never has a name when creating one, so it will always be saved twice creating dupe error

Resolution: return the save action if the component has no name

