### PR TITLE
fix: Add busy state to delete confirm button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an error on mobile that was preventing users to long tap in order to trigger multiple files selection
 * Fixed an error in directory tree names appearing under filenames where sometimes, the path appeared scrambled
 * Fixed an error where creating a directory sent two save actions instead of one
+* Added a missing loading status on delete confirm modal button
 
 ## 🔧 Tech
 * Add CodeQL in order to scan the code🚫

--- a/src/drive/web/modules/drive/DeleteConfirm.jsx
+++ b/src/drive/web/modules/drive/DeleteConfirm.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useClient } from 'cozy-client'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Button from 'cozy-ui/transpiled/react/Button'
@@ -40,9 +40,11 @@ export const DeleteConfirm = ({
   const { t } = useI18n()
   const fileCount = files.length
   const client = useClient()
+  const [isDeleting, setDeleting] = useState(false)
 
   const onDelete = useCallback(
     async () => {
+      setDeleting(true)
       await trashFiles(client, files)
       afterConfirmation()
       onClose()
@@ -71,6 +73,7 @@ export const DeleteConfirm = ({
             label={t('deleteconfirmation.cancel')}
           />
           <Button
+            busy={isDeleting}
             theme="danger"
             label={t('deleteconfirmation.delete')}
             onClick={onDelete}


### PR DESCRIPTION
Related to https://trello.com/c/Oon3REW1/1500-%F0%9F%93%81-drive-ajouter-un-spinner-dans-la-modale-de-suppression

Bug: no UX feedback when deleting batch of files

Fix: useState in the confirm modal and inject busy state in the button when starting delete process