### PR TITLE
fix: Update browser navigation on directory links

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed an error in directory tree names appearing under filenames where sometimes, the path appeared scrambled
 * Fixed an error where creating a directory sent two save actions instead of one
 * Added a missing loading status on delete confirm modal button
+* Fixed issues related to recent view not going where it should when navigating back and forth in directory paths
 
 ## 🔧 Tech
 * Add CodeQL in order to scan the code🚫

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-measure": "2.5.0",
     "react-redux": "7.2.0",
     "react-remove-scroll": "^2.4.1",
-    "react-router": "3.2.4",
+    "react-router": "3.2.6",
     "react-tooltip": "3.11.1",
     "redux": "3.7.2",
     "redux-logger": "3.0.6",

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -42,14 +42,9 @@ const enableTouchEvents = ev => {
     return false
   }
 
-  // remove events when they are on the file's path, because it's a different behavior
-  const parentLink = getParentLink(ev.target)
-  if (
-    parentLink &&
-    parentLink.className.indexOf(styles['fil-file-path']) >= 0
-  ) {
-    return false
-  }
+  // We need to filter here, is the event target the FileOpener or a link INSIDE the FileOpener?
+  // Assuming the FileOpener itself will never be inside an anchor, we can use the following guard
+  if (ev.srcEvent.target.closest('a')) return false
 
   return true
 }

--- a/src/drive/web/modules/views/Recent/index.spec.jsx
+++ b/src/drive/web/modules/views/Recent/index.spec.jsx
@@ -33,6 +33,8 @@ jest.mock('drive/web/modules/views/hooks', () => ({
   useFilesQueryWithPath: jest.fn()
 }))
 
+const Folder = () => <div>Folder</div>
+
 const setup = () => {
   const { store, client } = setupStoreAndClient()
 
@@ -48,10 +50,12 @@ const setup = () => {
   const rendered = render(
     <AppLike client={client} store={store}>
       <Router history={hashHistory}>
+        <Redirect from="/folder" to="/folder" />
         <Redirect from="/" to="/recent" />
         <Route path="/recent" component={RecentViewWithProvider}>
           <Route path="file/:fileId/revision" component={FileHistory} />
         </Route>
+        <Route path="/folder/:dirId" component={Folder} />
       </Router>
     </AppLike>
   )
@@ -62,7 +66,7 @@ describe('Recent View', () => {
   it('tests the recent view', async () => {
     const nbFiles = 2
     const path = '/test'
-    const dir_id = 'dirIdParent'
+    const dir_id = '123'
     const updated_at = '2020-05-14T10:33:31.365224+02:00'
 
     const filesFixture = generateFileFixtures({
@@ -122,7 +126,16 @@ describe('Recent View', () => {
     // navigates  to the history view
     const historyItem = getByText('History')
     fireEvent.click(historyItem)
-
     await expect(findByText('FileHistory stub')).resolves.toBeTruthy()
+
+    hashHistory.goBack()
+
+    // Navigate to foldier view, not file view
+    fireEvent.click(linkElement0)
+    await expect(findByText('Folder')).resolves.toBeTruthy()
+
+    // Going back to recent view, not file view
+    hashHistory.goBack()
+    await expect(findByText('Recent')).resolves.toBeTruthy()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8384,11 +8384,6 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
   integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-
 hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -13854,7 +13849,7 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -13972,18 +13967,18 @@ react-remove-scroll@^2.4.0, react-remove-scroll@^2.4.1:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-router@3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.4.tgz#fdd415a062982e0c943f814efde506eae1418d0e"
-  integrity sha512-5kIJXV1Yx+FYk0lDJoPQnt+qFf7HxS6XrIm2aCw0r3XQTxixFd0HSVlHenYRWKmSHlcvSQ7bpYWgdRwJGXWPKw==
+react-router@3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.6.tgz#cad202796a7bba3efc2100da453b3379c9d4aeb4"
+  integrity sha512-nlxtQE8B22hb/JxdaslI1tfZacxFU8x8BJryXOnR2RxB4vc01zuHYAHAIgmBkdk1kzXaA25hZxK6KAH/+CXArw==
   dependencies:
     create-react-class "^15.5.1"
     history "^3.0.0"
-    hoist-non-react-statics "^2.3.1"
+    hoist-non-react-statics "^3.3.2"
     invariant "^2.2.1"
     loose-envify "^1.2.0"
     prop-types "^15.7.2"
-    react-is "^16.8.6"
+    react-is "^16.13.0"
     warning "^3.0.0"
 
 react-select@2.2.0:


### PR DESCRIPTION
Related to: https://trello.com/c/BdnfOXYA/1510-%F0%9F%93%81-drive-le-lien-sur-le-chemin-du-dossier-ne-fonctionne-pas-bien

Issues:
- note directory opens a note instead of its dir
- other files open the dir, but the preview tool when going back

Bugs:

- conflict with FileName onClick() and Link in Dir Name (link inside a link => double routing)

Resolution:
- add a guard on file opening method