### PR TITLE
fix: Note doesn't have path to compare...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## 🔧 Tech
 * Use `<SharingBannerPlugin />` and `useSharingInfos()` from `cozy-sharing` instead of internal components
+* Fixed an error in Search result when the result contained at least one Cozy Note
+
 
 # 1.37.0
 ## 🐛 Bug Fixes

--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -81,13 +81,11 @@ class SuggestionProvider extends React.Component {
             path = file.path
             url = urlToFolder
           } else {
+            const parentDir = folders.find(folder => folder._id === file.dir_id)
+            path = parentDir && parentDir.path ? parentDir.path : ''
             if (models.file.isNote(file)) {
               url = await models.note.fetchURL(client, file)
             } else {
-              const parentDir = folders.find(
-                folder => folder._id === file.dir_id
-              )
-              path = parentDir && parentDir.path ? parentDir.path : ''
               url = `${urlToFolder}/file/${file._id}`
             }
           }

--- a/src/drive/web/modules/services/components/helpers.js
+++ b/src/drive/web/modules/services/components/helpers.js
@@ -1,0 +1,70 @@
+import { models } from 'cozy-client'
+
+import { getFileMimetype } from 'drive/lib/getFileMimetype'
+import { hasEncryptionRef } from 'drive/lib/encryption'
+
+export const TYPE_DIRECTORY = 'directory'
+
+const iconsContext =
+  typeof require.context === 'undefined' // no require.context in jest
+    ? { keys: () => [] }
+    : require.context('drive/assets/icons/', false, /icon-type-.*.svg$/)
+
+const icons = iconsContext.keys().reduce((acc, item) => {
+  acc[item.replace(/\.\/icon-type-(.*)\.svg/, '$1')] = iconsContext(item)
+  return acc
+}, {})
+
+const getIconUrl = file => {
+  let keyIcon
+  if (file.type === TYPE_DIRECTORY) {
+    if (hasEncryptionRef(file)) {
+      keyIcon = 'encrypted-folder'
+    } else {
+      keyIcon = 'folder'
+    }
+  } else {
+    keyIcon = models.file.isNote(file)
+      ? 'note'
+      : getFileMimetype(icons)(file.mime, file.name) || 'files'
+  }
+  const icon = icons[keyIcon].default
+
+  return `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='${
+    icon.viewBox
+  }'>${icon.content}<use href='#${
+    icon.id
+  }' x='0' y='0' width='32' height='32'/></svg>`.replace(/#/g, '%23')
+}
+
+export const containerForTesting = {
+  getIconUrl
+}
+
+export const makeNormalizedFile = async (client, folders, file) => {
+  const isDir = file.type === TYPE_DIRECTORY
+  const dirId = isDir ? file._id : file.dir_id
+  const urlToFolder = `${window.location.origin}/#/folder/${dirId}`
+
+  let path, url
+  if (isDir) {
+    path = file.path
+    url = urlToFolder
+  } else {
+    const parentDir = folders.find(folder => folder._id === file.dir_id)
+    path = parentDir && parentDir.path ? parentDir.path : ''
+    if (models.file.isNote(file)) {
+      url = await models.note.fetchURL(client, file)
+    } else {
+      url = `${urlToFolder}/file/${file._id}`
+    }
+  }
+
+  return {
+    id: file._id,
+    name: file.name,
+    path,
+    url,
+    icon: containerForTesting.getIconUrl(file)
+  }
+}

--- a/src/drive/web/modules/services/components/helpers.spec.js
+++ b/src/drive/web/modules/services/components/helpers.spec.js
@@ -1,0 +1,83 @@
+import { createMockClient, models } from 'cozy-client'
+
+import {
+  makeNormalizedFile,
+  containerForTesting,
+  TYPE_DIRECTORY
+} from './helpers'
+
+models.note.fetchURL = jest.fn(() => 'noteUrl')
+
+jest.spyOn(containerForTesting, 'getIconUrl').mockReturnValue('mocked')
+
+const client = createMockClient({})
+
+const noteFileProps = {
+  name: 'note.cozy-note',
+  metadata: {
+    content: '',
+    schema: '',
+    title: '',
+    version: ''
+  }
+}
+
+describe('makeNormalizedFile', () => {
+  it('should return correct values for a directory', async () => {
+    const folders = []
+    const file = {
+      _id: 'fileId',
+      type: TYPE_DIRECTORY,
+      path: 'filePath',
+      name: 'fileName'
+    }
+
+    const normalizedFile = await makeNormalizedFile(client, folders, file)
+
+    expect(normalizedFile).toMatchObject({
+      id: 'fileId',
+      name: 'fileName',
+      path: 'filePath',
+      url: 'http://localhost/#/folder/fileId'
+    })
+  })
+
+  it('should return correct values for a file', async () => {
+    const folders = [{ _id: 'folderId', path: 'folderPath' }]
+    const file = {
+      _id: 'fileId',
+      dir_id: 'folderId',
+      type: 'file',
+      name: 'fileName'
+    }
+
+    const normalizedFile = await makeNormalizedFile(client, folders, file)
+
+    expect(normalizedFile).toMatchObject({
+      id: 'fileId',
+      name: 'fileName',
+      path: 'folderPath',
+      url: 'http://localhost/#/folder/folderId/file/fileId'
+    })
+  })
+
+  it('should return correct values for a note', async () => {
+    const folders = [{ _id: 'folderId', path: 'folderPath' }]
+    const file = {
+      _id: 'fileId',
+      dir_id: 'folderId',
+      type: 'file',
+      name: 'fileName',
+      ...noteFileProps
+    }
+
+    const normalizedFile = await makeNormalizedFile(client, folders, file)
+
+    expect(normalizedFile).toMatchObject({
+      id: 'fileId',
+      name: 'note.cozy-note',
+      path: 'folderPath',
+      url: 'noteUrl'
+    })
+  })
+})


### PR DESCRIPTION
We added a special case recently to handle the
Notes in the search response.

We had to make a call in order to calculte the
url when the user clicks on it since we can't pass
an onClick method ATM, but we forgot to add the
path argument resulting of having a JS error
can't read localCompare of undefined

- [ ] test to add