### PR TITLE
feat: Do not enable redux-logger by default

### DIFF
--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -35,7 +35,7 @@ const configureStore = options => {
     middlewares.push(createTrackerMiddleware())
   }
 
-  if (options.logger !== false) {
+  if (options.logger === true) {
     middlewares.push(createLogger(loggerOptions()))
   }
 

--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -1,5 +1,6 @@
 /* global __DEVELOPMENT__, __TARGET__ */
 import { compose, createStore, applyMiddleware } from 'redux'
+import flag from 'cozy-flags'
 import { createLogger } from 'redux-logger'
 import RavenMiddleWare from 'redux-raven-middleware'
 import {
@@ -35,7 +36,7 @@ const configureStore = options => {
     middlewares.push(createTrackerMiddleware())
   }
 
-  if (options.logger === true) {
+  if (flag('drive.logger')) {
     middlewares.push(createLogger(loggerOptions()))
   }
 

--- a/src/drive/web/modules/filelist/AddFolder.spec.jsx
+++ b/src/drive/web/modules/filelist/AddFolder.spec.jsx
@@ -5,7 +5,7 @@ import { setupStoreAndClient } from 'test/setup'
 import AddFolder, { AddFolder as DumbAddFolder } from './AddFolder'
 import flag from 'cozy-flags'
 import { createFolder } from 'drive/web/modules/navigation/duck/actions'
-const originalFlag = jest.requireActual('cozy-flags')
+const originalFlag = jest.requireActual('cozy-flags').default
 
 jest.mock('drive/web/modules/navigation/duck/actions', () => ({
   createFolder: jest.fn(() => async () => {})

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -24,4 +24,5 @@ const flagsList = () => {
   flag('viewer-bottomSheet-clamp')
   flag('drive.onlyoffice.forceReadOnlyOnDesktop')
   flag('drive.onlyoffice.editorToolbarHeight')
+  flag('drive.logger')
 }


### PR DESCRIPTION
redux-logger was enabled by default, even in production. This is useful
to debug, but is also quite verbose. Therefore, we disable it by
default. Note one can still use the redux brower extension to get useful
insights.