### PR TITLE
fix: Use a more specific guard in FileOpener

### DIFF
--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -42,9 +42,8 @@ const enableTouchEvents = ev => {
     return false
   }
 
-  // We need to filter here, is the event target the FileOpener or a link INSIDE the FileOpener?
-  // Assuming the FileOpener itself will never be inside an anchor, we can use the following guard
-  if (ev.srcEvent.target.closest('a')) return false
+  // Check if the clicked element is a file path, in that case the FileOpener has nothing to handle
+  if (ev.srcEvent.target.closest('[class^="fil-file-path"]')) return false
 
   return true
 }

--- a/src/drive/web/modules/filelist/cells/FileName.jsx
+++ b/src/drive/web/modules/filelist/cells/FileName.jsx
@@ -129,6 +129,7 @@ const FileName = ({
             ) : (
               <Link
                 to={`/folder/${attributes.dir_id}`}
+                // Please do not modify the className as it is used in event handling, see FileOpener#46
                 className={styles['fil-file-path']}
               >
                 <MidEllipsis text={attributes.displayedPath} />


### PR DESCRIPTION
I was wrong, FileOpener can indeed be rendered inside a link in some cases I wasn't aware of (OpenOffice sharing for instance).

To fix that, I changed the guard in FileOpener to not block at every parent link, but only at file-path parent links. It's more fragile because it's linked to the css class of the link. 