### PR TITLE
fix: Allow users without OO to navigate to OO file

### DIFF
--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -25,6 +25,7 @@ import { TRASH_DIR_ID } from 'drive/constants/config'
 import createFileOpeningHandler from 'drive/web/modules/views/Folder/createFileOpeningHandler'
 import { useSyncingFakeFile } from './useSyncingFakeFile'
 import { isReferencedByShareInSharingContext } from 'drive/web/modules/views/Folder/syncHelpers'
+import { isOnlyOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
 
 // TODO: extraColumns is then passed to 'FileListHeader', 'AddFolder',
 // and 'File' (this one from a 'syncingFakeFile' and a normal file).
@@ -73,7 +74,8 @@ const FolderViewBody = ({
         navigateToFile,
         replaceCurrentUrl: url => (window.location.href = url),
         openInNewTab: url => window.open(url, '_blank'),
-        routeTo: url => router.push(url)
+        routeTo: url => router.push(url),
+        isOnlyOfficeEnabled: isOnlyOfficeEnabled()
       })({
         event,
         file,

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -13,7 +13,8 @@ const createFileOpeningHandler = ({
   navigateToFile,
   replaceCurrentUrl,
   openInNewTab,
-  routeTo
+  routeTo,
+  isOnlyOfficeEnabled
 }) => async ({ event, file, isAvailableOffline }) => {
   if (isAvailableOffline) {
     return dispatch(openLocalFile(file))
@@ -43,7 +44,7 @@ const createFileOpeningHandler = ({
     } catch (e) {
       Alerter.error('alert.offline')
     }
-  } else if (isOnlyOffice) {
+  } else if (isOnlyOffice && isOnlyOfficeEnabled) {
     if (event.ctrlKey || event.metaKey || event.shiftKey) {
       openInNewTab(makeOnlyOfficeFileRoute(file))
     } else {

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.spec.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.spec.js
@@ -54,7 +54,7 @@ describe('createFileOpeningHandler', () => {
   const onlyofficeFile = generateFile({ i: 3 })
   onlyofficeFile.class = 'slide'
 
-  const setup = () =>
+  const setup = ({ isOnlyOfficeEnabled } = { isOnlyOfficeEnabled: true }) =>
     createFileOpeningHandler({
       client,
       isFlatDomain,
@@ -62,7 +62,8 @@ describe('createFileOpeningHandler', () => {
       navigateToFile,
       replaceCurrentUrl,
       openInNewTab,
-      routeTo
+      routeTo,
+      isOnlyOfficeEnabled
     })
 
   afterEach(() => {
@@ -120,6 +121,13 @@ describe('createFileOpeningHandler', () => {
     expect(replaceCurrentUrl).not.toHaveBeenCalled()
     expect(routeTo).toHaveBeenCalledWith(`/onlyoffice/${onlyofficeFile.id}`)
     expect(navigateToFile).not.toHaveBeenCalled()
+  })
+
+  it('should redirect to the file for an onlyoffice document with onlyoffice deactivated', async () => {
+    shouldBeOpenedByOnlyOffice.mockReturnValue(true)
+    const handler = setup({ isOnlyOfficeEnabled: false })
+    await handler({ file: onlyofficeFile, isAvailableOffline: false })
+    expect(navigateToFile).toHaveBeenCalledWith(onlyofficeFile)
   })
 
   it('should open the onlyoffice file in a new tab with onlyoffice activated and key pressed when clicking the link', async () => {


### PR DESCRIPTION
- **Issue**: Shared folder with OnlyOffice files. The user doesn't have OnlyOffice installed => Link to download the file in FileViewer is broken.
- **Bug**: missing `isOnlyOfficeEnabled()` check in `createFileOpeningHandler()`
- **Resolution**: add `isOnlyOfficeEnabled()` check as a boolean argument to `createFileOpeningHandler()` function.