### PR TITLE
fix: Do not update files in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 1.38.0
+
+## 🐛 Bug Fixes
+* Do not update files in parallel in the qualification migration service, as it might fail in nsjail for too many files
+
 ## 🔧 Tech
 * Use `<SharingBannerPlugin />` and `useSharingInfos()` from `cozy-sharing` instead of internal components
 

--- a/src/drive/lib/migration/qualification.js
+++ b/src/drive/lib/migration/qualification.js
@@ -255,16 +255,20 @@ export const getFileRequalification = file => {
  * @returns {Array} The saved files
  */
 export const migrateQualifiedFiles = async (client, files) => {
-  return Promise.all(
-    files.map(async file => {
-      const newQualification = getFileRequalification(file)
-      if (newQualification) {
-        const cleanedFile = removeOldQualificationAttributes(file)
-        return saveFileQualification(client, cleanedFile, newQualification)
-      } else {
-        log('warn', `No migration case found for the file ${file._id}`)
-        return null
-      }
-    })
-  )
+  let updatedFiles = []
+  for (const file of files) {
+    const newQualification = getFileRequalification(file)
+    if (newQualification) {
+      const cleanedFile = removeOldQualificationAttributes(file)
+      const newFile = await saveFileQualification(
+        client,
+        cleanedFile,
+        newQualification
+      )
+      updatedFiles.push(newFile)
+    } else {
+      log('warn', `No migration case found for the file ${file._id}`)
+    }
+  }
+  return updatedFiles
 }


### PR DESCRIPTION
Trying to update all files in parallel might cause issues with nsjail
because of internal restrictions, if we try to udpate too many files at
once: we experienced failures in production in some cases.
As performances are not critical for this service, we simply remove the
parallelism.