### PR TITLE
chore: Run bundle size only on PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
         - yarn build:$COZY_APP_SLUG:browser
         - echo -en 'travis_fold:end:build\\r'
         - &downcloud-cert if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then eval "$(ssh-agent -s)" && chmod 600 /tmp/id_rsa_travis_downcloud && ssh-add /tmp/id_rsa_travis_downcloud; fi # Needs to be inlined and not in a script to work.
-        - if [ "${COZY_APP_SLUG}" == "drive" ]; then yarn bundlemon; fi
+        - if [ "${COZY_APP_SLUG}" == "drive" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then yarn bundlemon; fi
         #- echo 'create and deploy' && echo -en 'travis_fold:start:createanddeploy\\r'
         #- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./scripts/create-deploy-test.sh; fi
         #- echo -en 'travis_fold:end:createanddeploy\\r'


### PR DESCRIPTION
We currently run the bundle size for every actions. But for a merge commit, comment will fail (see https://app.travis-ci.com/github/cozy/cozy-drive/jobs/544872465#L624-L627)

So let's run the script only for PR. 