### PR TITLE
feat: Upload encrypted files and open them, on mobile

### DIFF
--- a/src/drive/mobile/modules/offline/duck.js
+++ b/src/drive/mobile/modules/offline/duck.js
@@ -119,7 +119,7 @@ export const openLocalFileCopy = (client, file, { vaultClient }) => async (
   if (isAvailableOffline(getState(), file.id)) {
     return openOfflineFile(fileWithMime)
   }
-  return openFileWith(client, fileWithMime, { vaultClient })
+  return openFileWith(client, file, { vaultClient })
 }
 
 export const updateOfflineFileCopyIfNecessary = (

--- a/src/drive/web/modules/actions/utils.js
+++ b/src/drive/web/modules/actions/utils.js
@@ -203,6 +203,7 @@ export const exportFilesNative = async (
 export const openFileWith = async (client, file, { vaultClient } = {}) => {
   if (isMobileApp() && window.cordova.plugins.fileOpener2) {
     let blob
+    let originalMime = file.mime
     try {
       if (isEncryptedFile(file)) {
         const encryptionKey = await getEncryptionKeyFromDirId(
@@ -210,6 +211,9 @@ export const openFileWith = async (client, file, { vaultClient } = {}) => {
           file.dir_id
         )
         blob = await decryptFile(client, vaultClient, { file, encryptionKey })
+        originalMime = client
+          .collection(DOCTYPE_FILES)
+          .getFileTypeFromName(file.name)
       } else {
         const response = await client
           .collection(DOCTYPE_FILES)
@@ -222,7 +226,7 @@ export const openFileWith = async (client, file, { vaultClient } = {}) => {
       throw error
     }
     try {
-      await saveAndOpenWithCordova(blob, file)
+      await saveAndOpenWithCordova(blob, { ...file, mime: originalMime })
     } catch (error) {
       Alerter.info('mobile.error.open_with.noapp', { fileMime: file.mime })
     }

--- a/src/drive/web/modules/actions/utils.spec.js
+++ b/src/drive/web/modules/actions/utils.spec.js
@@ -235,6 +235,7 @@ describe('openFileWith', () => {
     mockClient.fetchFileContentById = jest.fn().mockReturnValue({
       blob: blobMock
     })
+    mockClient.getFileTypeFromName = jest.fn().mockReturnValue('fake-mime')
 
     cordovaBackup = window.cordova
     window.cordova = { plugins: { fileOpener2: {} } }
@@ -263,10 +264,10 @@ describe('openFileWith', () => {
         encryptionKey: 'encryption-key'
       }
     )
-    expect(saveAndOpenWithCordova).toHaveBeenCalledWith(
-      'fake file blob',
-      encryptedFile
-    )
+    expect(saveAndOpenWithCordova).toHaveBeenCalledWith('fake file blob', {
+      ...encryptedFile,
+      mime: 'fake-mime'
+    })
   })
 
   it('errors when the plugin is not present', async () => {


### PR DESCRIPTION
From the mobile app, we are now able to upload encrypted files. It is
also now possible to visualize them through the cordova `open`.
Note the direct display through the Viewer is not possible at this
moment because it requires changes in cozy-ui.

This also uses the mobile upload methods moved in cozy-client in https://github.com/cozy/cozy-client/pull/1051 instead of using the one in cozy-scanner.