### PR TITLE
fix: Init vault through provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "2.6.0",
     "cozy-harvest-lib": "5.3.1",
-    "cozy-keys-lib": "4.0.0",
+    "cozy-keys-lib": "4.1.0",
     "cozy-logger": "1.6.0",
     "cozy-pouch-link": "23.21.0",
     "cozy-realtime": "3.13.0",

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -7,15 +7,10 @@ import { ThumbnailSizeContextProvider } from 'drive/lib/ThumbnailSizeContext'
 import { ModalContextProvider } from 'drive/lib/ModalContext'
 import { AcceptingSharingProvider } from 'drive/lib/AcceptingSharingContext'
 
-const App = ({ store, client, vaultClient, lang, polyglot, children }) => {
+const App = ({ store, client, lang, polyglot, children }) => {
   return (
     <Provider store={store}>
-      <DriveProvider
-        client={client}
-        vaultClient={vaultClient}
-        lang={lang}
-        polyglot={polyglot}
-      >
+      <DriveProvider client={client} lang={lang} polyglot={polyglot}>
         <AcceptingSharingProvider>
           <ThumbnailSizeContextProvider>
             <ModalContextProvider>{children}</ModalContextProvider>
@@ -30,7 +25,6 @@ App.propTypes = {
   store: PropTypes.object,
   lang: PropTypes.string,
   polyglot: PropTypes.object,
-  client: PropTypes.object,
-  vaultClient: PropTypes.object
+  client: PropTypes.object
 }
 export default App

--- a/src/drive/lib/DriveProvider.jsx
+++ b/src/drive/lib/DriveProvider.jsx
@@ -14,18 +14,11 @@ import FabProvider from 'drive/lib/FabProvider'
 
 import StyledApp from 'drive/web/modules/drive/StyledApp'
 
-const DriveProvider = ({
-  client,
-  vaultClient,
-  lang,
-  polyglot,
-  dictRequire,
-  children
-}) => {
+const DriveProvider = ({ client, lang, polyglot, dictRequire, children }) => {
   return (
     <I18n lang={lang} polyglot={polyglot} dictRequire={dictRequire}>
       <CozyProvider client={client}>
-        <VaultProvider vaultClient={vaultClient}>
+        <VaultProvider cozyClient={client}>
           <VaultUnlockProvider>
             <SharingProvider doctype="io.cozy.files" documentType="Files">
               <BreakpointsProvider>
@@ -44,7 +37,6 @@ const DriveProvider = ({
 
 DriveProvider.propTypes = {
   client: PropTypes.object.isRequired,
-  vaultClient: PropTypes.object.isRequired,
   lang: PropTypes.string.isRequired,
   polyglot: PropTypes.object,
   dictRequire: PropTypes.func

--- a/src/drive/lib/encryption.js
+++ b/src/drive/lib/encryption.js
@@ -88,7 +88,7 @@ export const downloadEncryptedFile = async (
   vaultClient,
   { file, encryptionKey }
 ) => {
-  const blob = await decryptFile(client, vaultClient, file, encryptionKey)
+  const blob = await decryptFile(client, vaultClient, { file, encryptionKey })
   const url = URL.createObjectURL(blob)
   return client.collection(DOCTYPE_FILES).forceFileDownload(url, file.name)
 }

--- a/src/drive/mobile/modules/upload/index.jsx
+++ b/src/drive/mobile/modules/upload/index.jsx
@@ -5,7 +5,8 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
 
-import { Query } from 'cozy-client'
+import { Query, withClient } from 'cozy-client'
+import { withVaultClient } from 'cozy-keys-lib'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { translate } from 'cozy-ui/transpiled/react'
 import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
@@ -50,9 +51,13 @@ export class DumbUpload extends Component {
 
   async uploadFiles() {
     const { items, folderId } = this.state
-    const { router, uploadFilesFromNative } = this.props
+    const { router, uploadFilesFromNative, client, vaultClient } = this.props
+
     const filesForQueue = generateForQueue(items)
-    uploadFilesFromNative(filesForQueue, folderId, this.callbackSuccess)
+    uploadFilesFromNative(filesForQueue, folderId, this.callbackSuccess, {
+      client,
+      vaultClient
+    })
     //just to be sure that first dispatch of uploadFilesFromNative was done
     //we replace the URL to be sure that even with the back button on Android
     //we don't arrive on this component
@@ -164,8 +169,18 @@ DumbUpload.propTypes = {
   uploadFilesFromNative: PropTypes.func.isRequired
 }
 const mapDispatchToProps = dispatch => ({
-  uploadFilesFromNative: (files, folderId, successCallback) =>
-    dispatch(uploadFilesFromNative(files, folderId, successCallback)),
+  uploadFilesFromNative: (
+    files,
+    folderId,
+    successCallback,
+    { client, vaultClient }
+  ) =>
+    dispatch(
+      uploadFilesFromNative(files, folderId, successCallback, {
+        client,
+        vaultClient
+      })
+    ),
   stopMediaBackup: () => dispatch(cancelMediaBackup()),
   startMediaBackup: () => dispatch(startMediaBackup())
 })
@@ -173,6 +188,8 @@ const mapDispatchToProps = dispatch => ({
 export default compose(
   translate(),
   withRouter,
+  withClient,
+  withVaultClient,
   connect(
     null,
     mapDispatchToProps

--- a/src/drive/mobile/modules/upload/index.jsx
+++ b/src/drive/mobile/modules/upload/index.jsx
@@ -40,7 +40,7 @@ export const generateForQueue = files => {
 export class DumbUpload extends Component {
   state = {
     items: [],
-    folderId: ROOT_DIR_ID
+    folder: { _id: ROOT_DIR_ID }
   }
   async componentDidMount() {
     const { stopMediaBackup } = this.props
@@ -50,18 +50,18 @@ export class DumbUpload extends Component {
   }
 
   async uploadFiles() {
-    const { items, folderId } = this.state
+    const { items, folder } = this.state
     const { router, uploadFilesFromNative, client, vaultClient } = this.props
 
     const filesForQueue = generateForQueue(items)
-    uploadFilesFromNative(filesForQueue, folderId, this.callbackSuccess, {
+    uploadFilesFromNative(filesForQueue, folder._id, this.callbackSuccess, {
       client,
       vaultClient
     })
     //just to be sure that first dispatch of uploadFilesFromNative was done
     //we replace the URL to be sure that even with the back button on Android
     //we don't arrive on this component
-    setTimeout(() => router.replace(`/folder/${folderId}`), 50)
+    setTimeout(() => router.replace(`/folder/${folder._id}`), 50)
   }
 
   callbackSuccess = () => {
@@ -73,7 +73,7 @@ export class DumbUpload extends Component {
   }
 
   navigateTo = folder => {
-    this.setState({ folderId: folder.id })
+    this.setState({ folder: folder || { _id: ROOT_DIR_ID } })
   }
 
   onClose = () => {
@@ -85,10 +85,10 @@ export class DumbUpload extends Component {
   }
 
   render() {
-    const { items, folderId, uploadInProgress } = this.state
+    const { items, folder, uploadInProgress } = this.state
     const { t } = this.props
-    const contentQuery = buildMoveOrImportQuery(folderId)
-    const folderQuery = buildOnlyFolderQuery(folderId)
+    const contentQuery = buildMoveOrImportQuery(folder._id)
+    const folderQuery = buildOnlyFolderQuery(folder._id)
 
     return (
       <FixedDialog
@@ -107,7 +107,7 @@ export class DumbUpload extends Component {
               query={folderQuery.definition()}
               fetchPolicy={folderQuery.options.fetchPolicy}
               as={folderQuery.options.as}
-              key={`breadcrumb-${folderId}`}
+              key={`breadcrumb-${folder._id}`}
             >
               {({ data, fetchStatus }) => (
                 <Topbar
@@ -121,7 +121,7 @@ export class DumbUpload extends Component {
         }
         content={
           <Query
-            key={`content-${folderId}`}
+            key={`content-${folder._id}`}
             query={contentQuery.definition()}
             fetchPolicy={contentQuery.options.fetchPolicy}
             as={contentQuery.options.as}
@@ -135,6 +135,7 @@ export class DumbUpload extends Component {
                   >
                     <div>
                       <FileList
+                        folder={folder}
                         files={data}
                         targets={items}
                         navigateTo={this.navigateTo}
@@ -152,7 +153,7 @@ export class DumbUpload extends Component {
             onConfirm={() => this.uploadFiles()}
             onClose={this.onClose}
             targets={items}
-            currentDirId={folderId}
+            currentDirId={folder._id}
             isMoving={uploadInProgress}
             primaryTextAction={t('ImportToDrive.action')}
             secondaryTextAction={t('ImportToDrive.cancel')}

--- a/src/drive/mobile/modules/upload/index.spec.js
+++ b/src/drive/mobile/modules/upload/index.spec.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import { DumbUpload, generateForQueue } from './'
-import CozyClient from 'cozy-client'
 
+jest.mock('cozy-keys-lib', () => ({
+  withVaultClient: jest.fn().mockReturnValue({})
+}))
 jest.mock('cozy-ui/transpiled/react/utils/color', () => ({
   getCssVariableValue: () => '#fff'
 }))
 
 const tSpy = jest.fn()
 const uploadFilesFromNativeSpy = jest.fn()
-
-const cozyClient = new CozyClient({})
 
 describe('OpenWith component Modal', () => {
   afterEach(() => {
@@ -22,7 +22,8 @@ describe('OpenWith component Modal', () => {
 
   const setupComponent = () => {
     const props = {
-      client: cozyClient,
+      client: {},
+      vaultClient: {},
       t: tSpy,
       uploadFilesFromNative: uploadFilesFromNativeSpy
     }
@@ -41,7 +42,7 @@ describe('OpenWith component Modal', () => {
     it('should call uploadFileFromNative with the right arguments', async () => {
       const component = setupComponent()
       const folderId = 'io.cozy.root'
-      component.setState({ items: defaultItems, folderId })
+      component.setState({ items: defaultItems, folder: { _id: folderId } })
 
       component.instance().callbackSuccess = jest.fn()
       await component.instance().uploadFiles()
@@ -49,7 +50,8 @@ describe('OpenWith component Modal', () => {
       expect(uploadFilesFromNativeSpy).toHaveBeenCalledWith(
         genetaredForQueue,
         folderId,
-        component.instance().callbackSuccess
+        component.instance().callbackSuccess,
+        { client: {}, vaultClient: {} }
       )
     })
   })

--- a/src/drive/store/configureStore.js
+++ b/src/drive/store/configureStore.js
@@ -26,11 +26,9 @@ import { connectStoreToHistory } from './connectedRouter'
  * @return {ReduxStore}
  */
 const configureStore = options => {
-  const { client, vaultClient, t, initialState = {}, history } = options
+  const { client, t, initialState = {}, history } = options
 
-  const middlewares = [
-    thunkMiddleware.withExtraArgument({ client, vaultClient, t })
-  ]
+  const middlewares = [thunkMiddleware.withExtraArgument({ client, t })]
   if (__TARGET__ === 'mobile' && !__DEVELOPMENT__) {
     middlewares.push(RavenMiddleWare(ANALYTICS_URL, getReporterConfiguration()))
   }

--- a/src/drive/targets/browser/index.jsx
+++ b/src/drive/targets/browser/index.jsx
@@ -30,22 +30,13 @@ const AppComponent = props => (
 )
 
 const init = () => {
-  const {
-    locale,
-    polyglot,
-    client,
-    vaultClient,
-    history,
-    store,
-    root
-  } = setupApp()
+  const { locale, polyglot, client, history, store, root } = setupApp()
 
   render(
     <AppComponent
       lang={locale}
       polyglot={polyglot}
       client={client}
-      vaultClient={vaultClient}
       history={history}
       store={store}
     />,

--- a/src/drive/targets/browser/setupAppContext.js
+++ b/src/drive/targets/browser/setupAppContext.js
@@ -3,7 +3,6 @@
 import memoize from 'lodash/memoize'
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import CozyClient from 'cozy-client'
-import { WebVaultClient } from 'cozy-keys-lib'
 import {
   shouldEnableTracking,
   getTracker
@@ -37,8 +36,6 @@ const setupApp = memoize(() => {
   if (!Document.cozyClient) {
     Document.registerClient(client)
   }
-  const vaultClient = new WebVaultClient(cozyUrl)
-
   const locale = data.locale
   registerClientPlugins(client)
   const polyglot = initTranslation(locale, lang =>
@@ -48,7 +45,6 @@ const setupApp = memoize(() => {
 
   const store = configureStore({
     client,
-    vaultClient,
     t: polyglot.t.bind(polyglot),
     history
   })
@@ -74,7 +70,7 @@ const setupApp = memoize(() => {
     history = trackerInstance.connectToHistory(hashHistory)
     trackerInstance.track(hashHistory.getCurrentLocation()) // when using a hash history, the initial visit is not tracked by piwik react router
   }
-  return { locale, polyglot, client, vaultClient, history, store, root }
+  return { locale, polyglot, client, history, store, root }
 })
 
 export default setupApp

--- a/src/drive/targets/intents/index.jsx
+++ b/src/drive/targets/intents/index.jsx
@@ -14,7 +14,6 @@ import registerClientPlugins from 'drive/lib/registerClientPlugins'
 import { schema } from 'drive/lib/doctypes'
 import appMetadata from 'drive/appMetadata'
 import IntentHandler from 'drive/web/modules/services'
-import { WebVaultClient } from 'cozy-keys-lib'
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.getElementById('main')
@@ -32,8 +31,6 @@ document.addEventListener('DOMContentLoaded', () => {
     schema
   })
 
-  const vaultClient = new WebVaultClient(cozyUrl)
-
   cozy.client.init({
     cozyURL: cozyUrl,
     token: data.token
@@ -43,7 +40,6 @@ document.addEventListener('DOMContentLoaded', () => {
   render(
     <DriveProvider
       client={client}
-      vaultClient={vaultClient}
       lang={data.locale}
       dictRequire={lang => require(`drive/locales/${lang}`)}
     >

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -113,12 +113,6 @@ class InitAppMobile {
     return this.client
   }
 
-  /*getVaultClient = async () => {
-    if (this.vaultClient) return this.vaultClient
-    this.vaultClient = new WebVaultClient(cozyURL)
-    return this.vaultClient
-  }*/
-
   getPolyglot = () => {
     if (!this.polyglot) {
       this.polyglot = initTranslation(getLang(), lang =>
@@ -263,8 +257,6 @@ class InitAppMobile {
     const client = await this.getClient(cozyURL)
     const store = await this.getStore()
 
-    //const vaultClient = await this.getVaultClient()
-
     registerClientPlugins(client)
     const polyglot = await this.getPolyglot()
     //needed to migrate from cozy-drive auth to cozy-authenticate.
@@ -280,7 +272,6 @@ class InitAppMobile {
     if (isAnalyticsOn(store.getState())) {
       startTracker(getServerUrl(store.getState()))
     }
-    console.log('go to app')
     const root = document.querySelector('[role=application]')
 
     render(

--- a/src/drive/targets/mobile/InitAppMobile.jsx
+++ b/src/drive/targets/mobile/InitAppMobile.jsx
@@ -11,7 +11,6 @@ import { isIOSApp } from 'cozy-device-helper'
 import { Document } from 'cozy-doctypes'
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
-import { WebVaultClient } from 'cozy-keys-lib'
 
 import { saveState, loadState } from 'drive/store/persistedState'
 import configureStore from 'drive/store/configureStore'
@@ -114,12 +113,11 @@ class InitAppMobile {
     return this.client
   }
 
-  getVaultClient = async () => {
+  /*getVaultClient = async () => {
     if (this.vaultClient) return this.vaultClient
-    const cozyURL = await this.getCozyURL()
     this.vaultClient = new WebVaultClient(cozyURL)
     return this.vaultClient
-  }
+  }*/
 
   getPolyglot = () => {
     if (!this.polyglot) {
@@ -133,12 +131,10 @@ class InitAppMobile {
   getStore = async () => {
     if (this.store) return this.store
     const client = this.client || (await this.getClient())
-    const vaultClient = this.vaultClient || (await this.getVaultClient())
     const polyglot = this.getPolyglot()
     const persistedState = await this.getPersistedState()
     this.store = configureStore({
       client,
-      vaultClient,
       t: polyglot.t.bind(polyglot),
       initialState: persistedState,
       history: hashHistory
@@ -265,8 +261,9 @@ class InitAppMobile {
 
     const cozyURL = await this.getCozyURL()
     const client = await this.getClient(cozyURL)
-    const vaultClient = await this.getVaultClient()
     const store = await this.getStore()
+
+    //const vaultClient = await this.getVaultClient()
 
     registerClientPlugins(client)
     const polyglot = await this.getPolyglot()
@@ -283,17 +280,11 @@ class InitAppMobile {
     if (isAnalyticsOn(store.getState())) {
       startTracker(getServerUrl(store.getState()))
     }
-
+    console.log('go to app')
     const root = document.querySelector('[role=application]')
 
     render(
-      <App
-        lang={getLang()}
-        polyglot={polyglot}
-        client={client}
-        store={store}
-        vaultClient={vaultClient}
-      >
+      <App lang={getLang()} polyglot={polyglot} client={client} store={store}>
         <DriveMobileRouter history={hashHistory} />
       </App>,
       root,

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -9,7 +9,6 @@ import 'cozy-ui/transpiled/react/stylesheet.css'
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 import { getQueryParameter } from 'react-cozy-helpers'
 import CozyClient, { models } from 'cozy-client'
-import { WebVaultClient } from 'cozy-keys-lib'
 import { Document } from 'cozy-doctypes'
 import { I18n, initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -85,8 +84,6 @@ const init = async () => {
   if (!Document.cozyClient) {
     Document.registerClient(client)
   }
-  const vaultClient = new WebVaultClient(cozyUrl)
-
   configureReporter()
   setCozyUrl(cozyUrl)
   // we still need cozy-client-js for opening a folder
@@ -99,7 +96,6 @@ const init = async () => {
   )
 
   const store = configureStore({
-    vaultClient,
     client,
     t: polyglot.t.bind(polyglot),
     history: hashHistory
@@ -126,13 +122,7 @@ const init = async () => {
     } else {
       initCozyBar(dataset, client)
       render(
-        <App
-          lang={lang}
-          polyglot={polyglot}
-          client={client}
-          vaultClient={vaultClient}
-          store={store}
-        >
+        <App lang={lang} polyglot={polyglot} client={client} store={store}>
           <Router history={hashHistory}>
             <Route component={PublicLayout}>
               {isOnlyOfficeEnabled() && (

--- a/src/drive/web/modules/drive/Toolbar/components/UploadItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/UploadItem.jsx
@@ -2,6 +2,9 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 
+import { useClient } from 'cozy-client'
+import { useVaultClient } from 'cozy-keys-lib'
+
 import withSharingState from 'cozy-sharing/dist/hoc/withSharingState'
 import { translate } from 'cozy-ui/transpiled/react'
 import { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
@@ -12,32 +15,41 @@ import UploadIcon from 'cozy-ui/transpiled/react/Icons/Upload'
 import { uploadFiles } from 'drive/web/modules/navigation/duck'
 import toolbarContainer from '../toolbar'
 
-const UploadItem = ({ t, isDisabled, onUpload }) => (
-  <FileInput
-    label={t('toolbar.menu_upload')}
-    disabled={isDisabled}
-    multiple
-    onChange={onUpload}
-    data-test-id="upload-btn"
-    value={[]}
-    // FileInput needs to stay rendered until the onChange event, so we prevent the event from bubbling
-    onClick={e => e.stopPropagation()}
-  >
-    <ActionMenuItem
-      left={<Icon icon={UploadIcon} />}
+const UploadItem = ({ t, isDisabled, onUpload }) => {
+  const client = useClient()
+  const vaultClient = useVaultClient()
+  return (
+    <FileInput
+      label={t('toolbar.menu_upload')}
+      disabled={isDisabled}
+      multiple
+      onChange={files => onUpload(client, vaultClient, files)}
+      data-test-id="upload-btn"
+      value={[]}
+      // FileInput needs to stay rendered until the onChange event, so we prevent the event from bubbling
       onClick={e => e.stopPropagation()}
     >
-      {t('toolbar.menu_upload')}
-    </ActionMenuItem>
-  </FileInput>
-)
+      <ActionMenuItem
+        left={<Icon icon={UploadIcon} />}
+        onClick={e => e.stopPropagation()}
+      >
+        {t('toolbar.menu_upload')}
+      </ActionMenuItem>
+    </FileInput>
+  )
+}
 
 const mapDispatchToProps = (
   dispatch,
   { displayedFolder, sharingState, onUploaded }
 ) => ({
-  onUpload: files => {
-    dispatch(uploadFiles(files, displayedFolder.id, sharingState, onUploaded))
+  onUpload: (client, vaultClient, files) => {
+    dispatch(
+      uploadFiles(files, displayedFolder.id, sharingState, onUploaded, {
+        client,
+        vaultClient
+      })
+    )
   }
 })
 

--- a/src/drive/web/modules/move/FileList.jsx
+++ b/src/drive/web/modules/move/FileList.jsx
@@ -1,6 +1,13 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { DumbFile as File } from 'drive/web/modules/filelist/File'
+import { VaultUnlocker } from 'cozy-keys-lib'
+import { ROOT_DIR_ID } from 'drive/constants/config'
+import { hasEncryptionRef } from 'drive/lib/encryption'
+
+const isEncryptedFolder = folder => {
+  return hasEncryptionRef(folder)
+}
 
 const isInvalidMoveTarget = (subjects, target) => {
   const isASubject = subjects.find(subject => subject._id === target._id)
@@ -9,31 +16,49 @@ const isInvalidMoveTarget = (subjects, target) => {
   return isAFile || isASubject
 }
 
-const FileList = ({ targets, files, navigateTo }) => (
-  <>
-    {files.map(file => (
-      <File
-        key={file.id}
-        disabled={isInvalidMoveTarget(targets, file)}
-        styleDisabled={isInvalidMoveTarget(targets, file)}
-        attributes={file}
-        displayedFolder={null}
-        actions={null}
-        isRenaming={false}
-        onFolderOpen={id => navigateTo(files.find(f => f.id === id))}
-        onFileOpen={null}
-        withSelectionCheckbox={false}
-        withFilePath={false}
-        withSharedBadge
+const FileList = ({ targets, files, folder, navigateTo }) => {
+  const [shouldUnlock, setShouldUnlock] = useState(true)
+  const isEncFolder = isEncryptedFolder(folder)
+
+  if (isEncFolder && shouldUnlock) {
+    return (
+      <VaultUnlocker
+        onDismiss={() => {
+          setShouldUnlock(false)
+          return navigateTo(ROOT_DIR_ID)
+        }}
+        onUnlock={() => setShouldUnlock(false)}
       />
-    ))}
-  </>
-)
+    )
+  } else {
+    return (
+      <>
+        {files.map(file => (
+          <File
+            key={file.id}
+            disabled={isInvalidMoveTarget(targets, file)}
+            styleDisabled={isInvalidMoveTarget(targets, file)}
+            attributes={file}
+            displayedFolder={null}
+            actions={null}
+            isRenaming={false}
+            onFolderOpen={id => navigateTo(files.find(f => f.id === id))}
+            onFileOpen={null}
+            withSelectionCheckbox={false}
+            withFilePath={false}
+            withSharedBadge
+          />
+        ))}
+      </>
+    )
+  }
+}
 
 FileList.propTypes = {
   targets: PropTypes.array.isRequired,
   files: PropTypes.array.isRequired,
-  navigateTo: PropTypes.func.isRequired
+  navigateTo: PropTypes.func.isRequired,
+  folder: PropTypes.object
 }
 
 export default FileList

--- a/src/drive/web/modules/move/Topbar.jsx
+++ b/src/drive/web/modules/move/Topbar.jsx
@@ -12,24 +12,24 @@ const getBreadcrumbPath = (t, displayedFolder) =>
   uniqBy(
     [
       {
-        id: ROOT_DIR_ID
+        _id: ROOT_DIR_ID
       },
       {
-        id: get(displayedFolder, 'dir_id')
+        _id: get(displayedFolder, 'dir_id')
       },
       {
-        id: displayedFolder.id,
+        _id: displayedFolder._id,
         name: displayedFolder.name
       }
     ],
-    'id'
+    '_id'
   )
-    .filter(({ id }) => Boolean(id))
+    .filter(({ _id }) => Boolean(_id))
     .map(breadcrumb => ({
-      id: breadcrumb.id,
+      _id: breadcrumb._id,
       name:
         breadcrumb.name ||
-        (breadcrumb.id === ROOT_DIR_ID ? t('breadcrumb.title_drive') : '…')
+        (breadcrumb._id === ROOT_DIR_ID ? t('breadcrumb.title_drive') : '…')
     }))
 
 const MoveTopbar = (

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -1,4 +1,8 @@
 /* global __TARGET__ */
+jest.mock('cozy-keys-lib', () => ({
+  withVaultClient: jest.fn().mockReturnValue({}),
+  useVaultClient: jest.fn()
+}))
 import React from 'react'
 import { Route, IndexRoute, Redirect } from 'react-router'
 
@@ -25,6 +29,7 @@ import OnlyOfficeView from '../views/OnlyOffice'
 import OnlyOfficeCreateView from '../views/OnlyOffice/Create'
 
 import FilesViewerRecent from '../views/Recent/FilesViewerRecent'
+
 // To keep in sync with AppRoute below, used to extract params
 // in the "router" redux slice. Innermost routes should be
 // first

--- a/src/drive/web/modules/navigation/duck/actions.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.jsx
@@ -39,7 +39,8 @@ export const uploadFiles = (
   files,
   dirId,
   sharingState,
-  fileUploadedCallback = () => null
+  fileUploadedCallback = () => null,
+  { client, vaultClient }
 ) => dispatch => {
   dispatch(
     addToUploadQueue(
@@ -57,7 +58,8 @@ export const uploadFiles = (
             errors,
             updated
           )
-        )
+        ),
+      { client, vaultClient }
     )
   )
 }

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -150,8 +150,9 @@ export const processNextFile = (
   fileUploadedCallback,
   queueCompletedCallback,
   dirID,
-  sharingState
-) => async (dispatch, getState, { client, vaultClient }) => {
+  sharingState,
+  { client, vaultClient }
+) => async (dispatch, getState) => {
   let error = null
   if (!client) {
     throw new Error(
@@ -237,7 +238,8 @@ export const processNextFile = (
       fileUploadedCallback,
       queueCompletedCallback,
       dirID,
-      sharingState
+      sharingState,
+      { client, vaultClient }
     )
   )
 }
@@ -359,8 +361,9 @@ export const overwriteFile = async (client, file, path, options = {}) => {
 export const uploadFilesFromNative = (
   files,
   folderId,
-  uploadFilesSuccessCallback
-) => async (dispatch, _, { client, vaultClient }) => {
+  uploadFilesSuccessCallback,
+  { client, vaultClient }
+) => async dispatch => {
   dispatch({
     type: ADD_TO_UPLOAD_QUEUE,
     files: files
@@ -410,7 +413,8 @@ export const addToUploadQueue = (
   dirID,
   sharingState,
   fileUploadedCallback,
-  queueCompletedCallback
+  queueCompletedCallback,
+  { client, vaultClient }
 ) => async dispatch => {
   dispatch({
     type: ADD_TO_UPLOAD_QUEUE,
@@ -421,7 +425,8 @@ export const addToUploadQueue = (
       fileUploadedCallback,
       queueCompletedCallback,
       dirID,
-      sharingState
+      sharingState,
+      { client, vaultClient }
     )
   )
 }

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -81,7 +81,8 @@ describe('uploadFilesFromNative function', () => {
     const uploadProcess = uploadFilesFromNative(
       filesToUpload,
       folderID,
-      successCallBack
+      successCallBack,
+      { client: fakeClient, vaultClient: fakeVaultClient }
     )
     doMobileUpload.mockResolvedValue({ message: 'ok' })
 
@@ -116,7 +117,8 @@ describe('uploadFilesFromNative function', () => {
     const uploadProcess = uploadFilesFromNative(
       filesToUpload,
       folderID,
-      successCallBack
+      successCallBack,
+      { client: fakeClient, vaultClient: fakeVaultClient }
     )
     getEncryptionKeyFromDirId.mockResolvedValue('encryption-key')
     fakeVaultClient.encryptFile.mockResolvedValue('encrypted-file')
@@ -154,6 +156,7 @@ describe('processNextFile function', () => {
   })
 
   beforeEach(() => {
+    getEncryptionKeyFromDirId.mockResolvedValue(null)
     flag.mockReturnValue(true)
   })
 
@@ -167,7 +170,8 @@ describe('processNextFile function', () => {
       fileUploadedCallbackSpy,
       queueCompletedCallbackSpy,
       dirId,
-      sharingState
+      sharingState,
+      { client: fakeClient, vaultClient: fakeVaultClient }
     )
     const result = await asyncProcess(dispatchSpy, getState, {
       client: fakeClient
@@ -205,9 +209,10 @@ describe('processNextFile function', () => {
       fileUploadedCallbackSpy,
       queueCompletedCallbackSpy,
       dirId,
-      sharingState
+      sharingState,
+      { client: fakeClient, vaultClient: fakeVaultClient }
     )
-    await asyncProcess(dispatchSpy, getState, { client: fakeClient })
+    await asyncProcess(dispatchSpy, getState)
     expect(dispatchSpy).toHaveBeenCalledWith({
       type: 'UPLOAD_FILE',
       file
@@ -251,9 +256,10 @@ describe('processNextFile function', () => {
       fileUploadedCallbackSpy,
       queueCompletedCallbackSpy,
       dirId,
-      sharingState
+      sharingState,
+      { client: fakeClient, vaultClient: fakeVaultClient }
     )
-    await asyncProcess(dispatchSpy, getState, { client: fakeClient })
+    await asyncProcess(dispatchSpy, getState)
 
     expect(dispatchSpy).toHaveBeenNthCalledWith(1, {
       type: 'UPLOAD_FILE',
@@ -313,7 +319,8 @@ describe('processNextFile function', () => {
       fileUploadedCallbackSpy,
       queueCompletedCallbackSpy,
       dirId,
-      sharingState
+      sharingState,
+      { client: fakeClient, vaultClient: fakeVaultClient }
     )
     await asyncProcess(dispatchSpy, getState, { client: fakeClient })
 
@@ -350,7 +357,8 @@ describe('processNextFile function', () => {
       fileUploadedCallbackSpy,
       queueCompletedCallbackSpy,
       dirId,
-      sharingState
+      sharingState,
+      { client: fakeClient, vaultClient: fakeVaultClient }
     )
     await asyncProcess(dispatchSpy, getState, { client: fakeClient })
 

--- a/src/drive/web/modules/views/Trash/TrashFolderView.spec.jsx
+++ b/src/drive/web/modules/views/Trash/TrashFolderView.spec.jsx
@@ -13,9 +13,6 @@ import FolderViewBody from '../Folder/FolderViewBody'
 
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 jest.mock('components/pushClient')
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
 
 describe('TrashFolderView', () => {
   const mockClient = () => {

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -53,13 +53,12 @@ const AppLike = ({
   children,
   store,
   client,
-  vaultClient,
   sharingContextValue,
   routerContextValue,
   modalContextValue
 }) => (
   <Provider store={(client && client.store) || store || mockStore}>
-    <CozyProvider client={client} vaultClient={vaultClient}>
+    <CozyProvider client={client}>
       <TestI18n>
         <SharingContext.Provider
           value={sharingContextValue || mockSharingContextValue}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5379,10 +5379,10 @@ cozy-jobs-cli@1.15.9:
     pretty "2.0.0"
     strip-json-comments "3.1.1"
 
-cozy-keys-lib@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-4.0.0.tgz#9d1e64f90e27f7f909965e171646384935418f10"
-  integrity sha512-F2XviyVgzL6aoRavUa0MOFu3IbbwfN+BEdMZ5simPMGYtyU41tEHGXczMhXVjSLWiERoSShpmS4gvlG7hygaSQ==
+cozy-keys-lib@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-4.1.0.tgz#b71e4eb8df0dfea4d5bfa0585c7e64105bb18ea8"
+  integrity sha512-qmbcK/Ifj3OgIdPLRdtcRihOkSiGc67h4BqAVqu4gNPBBOTcKYjD6TiR9nqLViQfhqfk19QK1bHYCkZB+wc7dQ==
   dependencies:
     "@aspnet/signalr" "^1.1.4"
     "@aspnet/signalr-protocol-msgpack" "^1.1.0"
@@ -11372,6 +11372,13 @@ mini-css-extract-plugin@0.5.0:
 minilog@3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
+  dependencies:
+    microee "0.0.6"
+
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  uid "6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
+  resolved "git+https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
   dependencies:
     microee "0.0.6"
 
@@ -18332,6 +18339,7 @@ yargs@^3.8.0:
     string-width "^1.0.1"
     window-size "^0.1.4"
     y18n "^3.2.0"
+
 yup@^0.29.1:
   version "0.29.3"
   resolved "https://registry.yarnpkg.com/yup/-/yup-0.29.3.tgz#69a30fd3f1c19f5d9e31b1cf1c2b851ce8045fea"
@@ -18344,8 +18352,8 @@ yup@^0.29.1:
     property-expr "^2.0.2"
     synchronous-promise "^2.0.13"
     toposort "^2.0.2"
+
 zxcvbn@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
   integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=
-


### PR DESCRIPTION
We used to init the vault by manually creating a WebVaultClient
instance. However, this requires a URI, which is not set in mobile
context, when the user is not onboarded. This was causing a crash on the
first launch.
We fix this by using the VaultProvider, which is now capable to
automatically set the URI thanks to the given cozy-client instance.