### PR TITLE
fix: Wrong cozy-keys-lib mock 

### DIFF
--- a/src/drive/mobile/lib/__mocks__/cozy-keys-lib.js
+++ b/src/drive/mobile/lib/__mocks__/cozy-keys-lib.js
@@ -1,0 +1,4 @@
+jest.mock('cozy-keys-lib', () => ({
+  withVaultClient: jest.fn().mockReturnValue({}),
+  useVaultClient: jest.fn()
+}))

--- a/src/drive/web/modules/filelist/AddFolder.spec.jsx
+++ b/src/drive/web/modules/filelist/AddFolder.spec.jsx
@@ -13,7 +13,11 @@ jest.mock('drive/web/modules/navigation/duck/actions', () => ({
 }))
 
 jest.mock('cozy-flags', () => jest.fn())
-
+jest.mock('cozy-keys-lib', () => ({
+  withVaultClient: jest.fn().mockReturnValue({}),
+  useVaultClient: jest.fn(),
+  WebVaultClient: jest.fn().mockReturnValue({})
+}))
 describe('AddFolder', () => {
   const setup = () => {
     const { client, store } = setupStoreAndClient({})

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -1,8 +1,4 @@
 /* global __TARGET__ */
-jest.mock('cozy-keys-lib', () => ({
-  withVaultClient: jest.fn().mockReturnValue({}),
-  useVaultClient: jest.fn()
-}))
 import React from 'react'
 import { Route, IndexRoute, Redirect } from 'react-router'
 

--- a/src/drive/web/modules/navigation/Index.spec.js
+++ b/src/drive/web/modules/navigation/Index.spec.js
@@ -5,6 +5,10 @@ import { SHAREDWITHME_DIR_ID } from 'drive/constants/config'
 
 import { fetchSharing } from './Index'
 
+jest.mock('cozy-keys-lib', () => ({
+  withVaultClient: jest.fn().mockReturnValue({}),
+  useVaultClient: jest.fn()
+}))
 const client = createMockClient({})
 const router = { push: jest.fn() }
 const setSharingsValue = jest.fn()

--- a/src/drive/web/modules/navigation/duck/actions.spec.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.spec.jsx
@@ -6,6 +6,11 @@ import { generateFile, getStoreStateWhenViewingFolder } from 'test/generate'
 
 import { createFolder } from './actions'
 
+jest.mock('cozy-keys-lib', () => ({
+  withVaultClient: jest.fn().mockReturnValue({}),
+  useVaultClient: jest.fn(),
+  WebVaultClient: jest.fn().mockReturnValue({})
+}))
 const vaultClient = new WebVaultClient('http://alice.cozy.cloud')
 
 beforeEach(() => {

--- a/test/setup.jsx
+++ b/test/setup.jsx
@@ -12,6 +12,11 @@ import AppLike from 'test/components/AppLike'
 import FolderContent from 'test/components/FolderContent'
 import { generateFile } from './generate'
 
+jest.mock('cozy-keys-lib', () => ({
+  withVaultClient: jest.fn().mockReturnValue({}),
+  useVaultClient: jest.fn()
+}))
+
 configure({ testIdAttribute: 'data-test-id' })
 
 export const mockCozyClientRequestQuery = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11375,13 +11375,6 @@ minilog@3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   dependencies:
     microee "0.0.6"
 
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid "6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
-  resolved "git+https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
-  dependencies:
-    microee "0.0.6"
-
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"


### PR DESCRIPTION
The c3bd4aa commit broke the app
because of cozy-keys-lib wrongly mocked into the AppRoute component.
Instead, we mock it in the revelant files to make the tests run.