### PR TITLE
feat(breadcrumbs): Fetch parents id & name to build breadcrumbs

### DIFF
--- a/src/drive/web/modules/views/Folder/FolderViewBreadcrumb.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBreadcrumb.jsx
@@ -1,32 +1,22 @@
 import React, { useCallback } from 'react'
-import { useQuery } from 'cozy-client'
-import get from 'lodash/get'
-import { MobileAwareBreadcrumb as Breadcrumb } from 'drive/web/modules/navigation/Breadcrumb/MobileAwareBreadcrumb'
-import { buildFolderQuery } from 'drive/web/modules/queries'
+import { useBreadcrumbPath } from '../useBreadcrumbPath.jsx'
+import { default as BreadcrumbMui } from '@material-ui/core/Breadcrumbs'
 
-const FolderViewBreadcrumb = ({
-  currentFolderId,
-  getBreadcrumbPath,
-  navigateToFolder
-}) => {
-  const currentFolderQuery = buildFolderQuery(currentFolderId)
-  const currentFolderQueryResults = useQuery(
-    currentFolderQuery.definition,
-    currentFolderQuery.options
-  )
-  const currentFolder = get(currentFolderQueryResults, 'data[0]')
-  const path = currentFolder ? getBreadcrumbPath(currentFolder) : []
+const FolderViewBreadcrumb = ({ currentFolderId, navigateToFolder }) => {
+  const paths = useBreadcrumbPath({ currentFolderId })
 
   const onBreadcrumbClick = useCallback(({ id }) => navigateToFolder(id), [
     navigateToFolder
   ])
 
-  return currentFolder ? (
-    <Breadcrumb
-      path={path}
-      onBreadcrumbClick={onBreadcrumbClick}
-      opening={false}
-    />
+  return paths ? (
+    <BreadcrumbMui>
+      {paths.map(item => (
+        <a key={item.name} color="inherit" href="#" onClick={onBreadcrumbClick}>
+          {item.name}
+        </a>
+      ))}
+    </BreadcrumbMui>
   ) : null
 }
 

--- a/src/drive/web/modules/views/useBreadcrumbPath.jsx
+++ b/src/drive/web/modules/views/useBreadcrumbPath.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+import get from 'lodash/get'
+import { useClient } from 'cozy-client'
+import { buildFolderQuery } from 'drive/web/modules/queries'
+import { ROOT_DIR_ID } from '../../../constants/config'
+
+export const useBreadcrumbPath = ({ currentFolderId }) => {
+  const client = useClient()
+  const [paths, setPaths] = useState([])
+
+  useEffect(
+    () => {
+      let isSubscribed = true
+
+      const fetchFolder = async ({ client, folderId }) => {
+        const folderQuery = buildFolderQuery(folderId)
+        const { options, definition } = folderQuery
+        const folderQueryResults = await client.query(definition(), options)
+        return get(folderQueryResults, 'data')
+      }
+
+      // How to use async functions in useEffect:
+      // https://devtrium.com/posts/async-functions-useeffect#write-the-asynchronous-function-inside-the-useeffect
+      const fetchBreadcrumbs = async () => {
+        let idParentFolder = currentFolderId
+        let STAY = true
+        let returnedPaths = []
+        while (idParentFolder !== ROOT_DIR_ID && !!idParentFolder && STAY) {
+          let folder = await fetchFolder({ client, folderId: idParentFolder })
+          if (!folder) {
+            folder = await fetchFolder({ client, folderId: idParentFolder })
+            if (!folder) {
+              STAY = false
+            }
+            if (idParentFolder) {
+              throw new Error(
+                `je ne comprends pas pourquoi Cozy Client n' arrive pas à fetch le folder id: ${idParentFolder}`
+              )
+            }
+          }
+          let { id, name, dir_id } = folder
+
+          const path = {
+            name,
+            id
+          }
+          returnedPaths.push(path) // find a way to push before
+          idParentFolder = dir_id
+        }
+
+        if (isSubscribed) {
+          returnedPaths.push({
+            name: 'ROOT',
+            id: ROOT_DIR_ID
+          })
+          setPaths(returnedPaths)
+        }
+      }
+
+      fetchBreadcrumbs().catch(console.error) // eslint-disable-line no-console
+
+      return () => {
+        isSubscribed = false
+      }
+    },
+    [currentFolderId, client]
+  )
+
+  return paths
+}


### PR DESCRIPTION
- TODO: use BreadcrumbsMUI from cozy-ui
- TODO: fetching folder query not working while navigation
- TODO: paths array order to reverse

On page load, the path is fully build:

<img width="421" alt="Capture d’écran 2021-12-21 à 15 19 41" src="https://user-images.githubusercontent.com/8363334/146945029-81e4518a-4317-4136-bf78-a8d0fe09be2d.png">


Comparison of logs from fetchFolder() method from useBreadcrumbsPath : 
- on navigation, query results is empty.

<img width="1277" alt="Capture d’écran 2021-12-21 à 14 37 00" src="https://user-images.githubusercontent.com/8363334/146944617-65d7cc0f-6446-4ad6-9184-9d835c9a886c.png">

