### PR TITLE
feat: Use title to display the filename

### DIFF
--- a/src/drive/web/modules/filelist/cells/FileName.jsx
+++ b/src/drive/web/modules/filelist/cells/FileName.jsx
@@ -108,6 +108,7 @@ const FileName = ({
               <div
                 data-test-id="fil-file-filename-and-ext"
                 className={styles['fil-file-filename-and-ext']}
+                title={filename + extension}
               >
                 {filename}
                 {extension && (
@@ -119,7 +120,10 @@ const FileName = ({
           {withFilePath &&
             attributes.displayedPath &&
             (isMobile ? (
-              <div className={styles['fil-file-description']}>
+              <div
+                className={styles['fil-file-description']}
+                title={filename + extension}
+              >
                 <MidEllipsis
                   className={styles['fil-file-description--path']}
                   text={attributes.displayedPath}


### PR DESCRIPTION
Useful when we've a long filename and not enough space
to display it

<img width="607" alt="Capture d’écran 2022-01-07 à 08 39 42" src="https://user-images.githubusercontent.com/1107936/148509172-b1b81485-d71c-4be2-80dc-f4d80c55bb15.png">
.