### PR TITLE
Fix/move bread crumb

### DIFF
--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -65,7 +65,7 @@ export class MoveModal extends React.Component {
   }
 
   navigateTo = folder => {
-    this.setState({ folderId: folder.id })
+    this.setState({ folderId: folder._id })
   }
 
   registerCancelable = promise => {

--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -38,6 +38,8 @@ const styles = theme => ({
     '& .MuiDialogTitle-root': {
       padding: '0',
       [theme.breakpoints.down('sm')]: {
+        width: '100%',
+        overflow: 'visible',
         // back button
         '& .MuiButtonBase-root': {
           display: 'none'


### PR DESCRIPTION
In responsive mode (mobile), we an issue:
- The breadcrumb was not well displayed
![Capture d’écran 2022-01-07 à 09 05 31](https://user-images.githubusercontent.com/1107936/148512632-af81ff34-60ad-4d1f-8a9e-1bc9b94c0f50.png)
(we should have displayed Drive and "...") 
(now 
<img width="603" alt="Capture d’écran 2022-01-07 à 09 09 23" src="https://user-images.githubusercontent.com/1107936/148512819-013ae3d0-5f9d-4bc8-af08-1c4e58d177dd.png">
)

In both mode (desktop / mobile)
- The navigation was not working. Every time we clicked on a folder, we got a blank screen since we're setting the dirId to `id` which doesn't not exist. Using `_id` makes it works :) 