### PR TITLE
fix: Drag and drop

### DIFF
--- a/src/drive/web/modules/upload/Dropzone.jsx
+++ b/src/drive/web/modules/upload/Dropzone.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import UIDropzone from 'react-dropzone'
 import { compose } from 'redux'
+import { withVaultClient } from 'cozy-keys-lib'
+import { withClient } from 'cozy-client'
 
 import { uploadFiles } from 'drive/web/modules/navigation/duck'
 
@@ -23,11 +25,11 @@ export class Dropzone extends Component {
     this.setState(state => ({ ...state, dropzoneActive: false }))
 
   onDrop = async (files, _, evt) => {
-    const { uploadFiles } = this.props
+    const { uploadFiles, client, vaultClient } = this.props
     this.setState(state => ({ ...state, dropzoneActive: false }))
     if (!canDrop(evt)) return
     const filesToUpload = canHandleFolders(evt) ? evt.dataTransfer.items : files
-    uploadFiles(filesToUpload)
+    uploadFiles(filesToUpload, { client, vaultClient })
   }
 
   render() {
@@ -73,12 +75,19 @@ const canDrop = evt => {
 }
 
 const mapDispatchToProps = (dispatch, { displayedFolder, sharingState }) => ({
-  uploadFiles: files =>
-    dispatch(uploadFiles(files, displayedFolder.id, sharingState))
+  uploadFiles: (files, { client, vaultClient }) =>
+    dispatch(
+      uploadFiles(files, displayedFolder.id, sharingState, () => null, {
+        client,
+        vaultClient
+      })
+    )
 })
 
 export default compose(
   withSharingState,
+  withClient,
+  withVaultClient,
   connect(
     null,
     mapDispatchToProps

--- a/src/drive/web/modules/upload/Dropzone.spec.jsx
+++ b/src/drive/web/modules/upload/Dropzone.spec.jsx
@@ -3,8 +3,18 @@ import { mount } from 'enzyme'
 import { setupFolderContent, mockCozyClientRequestQuery } from 'test/setup'
 import Dropzone, { Dropzone as DumbDropzone } from './Dropzone'
 import AppLike from 'test/components/AppLike'
-import { uploadFiles } from 'drive/web/modules/navigation/duck'
+import { render } from '@testing-library/react'
 
+jest.mock('react-dropzone', () => {
+  const Component = ({ onDrop }) => (
+    <button
+      data-test-id="drop-button"
+      onClick={() => onDrop(['files'], '_', { dataTransfer: { items: [] } })}
+    />
+  )
+  Component.displayName = 'drop-component'
+  return Component
+})
 jest.mock('drive/web/modules/navigation/duck', () => ({
   uploadFiles: jest.fn().mockReturnValue({
     type: 'FAKE_UPLOAD_FILES'
@@ -14,7 +24,10 @@ jest.mock('drive/web/modules/navigation/duck', () => ({
 mockCozyClientRequestQuery()
 
 describe('Dropzone', () => {
-  it('should dispatch the uploadFiles action', async () => {
+  it('should match snapshot', async () => {
+    // Given
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
     const displayedFolder = {
       id: 'directory-foobar0'
     }
@@ -24,21 +37,40 @@ describe('Dropzone', () => {
 
     store.dispatch = jest.fn()
 
+    // When
     const root = mount(
       <AppLike client={client} store={store}>
         <Dropzone displayedFolder={displayedFolder} />
       </AppLike>
     )
 
-    const dropzone = root.find(DumbDropzone)
-    const files = []
-    dropzone.props().uploadFiles(files)
-    expect(uploadFiles).toHaveBeenCalledWith(
-      files,
-      'directory-foobar0',
-      expect.objectContaining({
-        refresh: expect.any(Function)
-      })
+    // Then
+    expect(root).toMatchSnapshot()
+
+    // After
+    consoleSpy.mockRestore()
+  })
+
+  it('should dispatch the uploadFiles action', () => {
+    // Given
+    const uploadFilesMock = jest.fn()
+    const cozyClient = 'cozyClient'
+    const vaultClient = 'vaultClient'
+    const { getByTestId } = render(
+      <DumbDropzone
+        uploadFiles={uploadFilesMock}
+        client={cozyClient}
+        vaultClient={vaultClient}
+      />
     )
+
+    // When
+    getByTestId('drop-button').click()
+
+    // Then
+    expect(uploadFilesMock).toHaveBeenCalledWith(['files'], {
+      client: cozyClient,
+      vaultClient
+    })
   })
 })

--- a/src/drive/web/modules/upload/__snapshots__/Dropzone.spec.jsx.snap
+++ b/src/drive/web/modules/upload/__snapshots__/Dropzone.spec.jsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropzone should match snapshot 1`] = `
+<AppLike
+  client={
+    CozyClient {
+      "uri": undefined,
+    }
+  }
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Provider
+    store={
+      Object {
+        "dispatch": [MockFunction],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <CozyProvider
+      client={
+        CozyClient {
+          "uri": undefined,
+        }
+      }
+    >
+      <TestI18n>
+        <I18n
+          defaultLang="en"
+          dictRequire={[Function]}
+          lang="en"
+        >
+          <AcceptingSharingProvider>
+            <ThumbnailSizeContextProvider>
+              <BreakpointsProvider>
+                <FabProvider>
+                  <WithSharingState(withClient(withVaultClient(Connect(Dropzone))))
+                    displayedFolder={
+                      Object {
+                        "id": "directory-foobar0",
+                      }
+                    }
+                  >
+                    <withClient(withVaultClient(Connect(Dropzone)))
+                      displayedFolder={
+                        Object {
+                          "id": "directory-foobar0",
+                        }
+                      }
+                      sharingState={
+                        Object {
+                          "getRecipients": [MockFunction],
+                          "getSharingLink": [MockFunction],
+                          "hasWriteAccess": [MockFunction],
+                          "refresh": [MockFunction],
+                        }
+                      }
+                    >
+                      <withVaultClient(Connect(Dropzone))
+                        client={
+                          CozyClient {
+                            "uri": undefined,
+                          }
+                        }
+                        displayedFolder={
+                          Object {
+                            "id": "directory-foobar0",
+                          }
+                        }
+                        sharingState={
+                          Object {
+                            "getRecipients": [MockFunction],
+                            "getSharingLink": [MockFunction],
+                            "hasWriteAccess": [MockFunction],
+                            "refresh": [MockFunction],
+                          }
+                        }
+                      />
+                    </withClient(withVaultClient(Connect(Dropzone)))>
+                  </WithSharingState(withClient(withVaultClient(Connect(Dropzone))))>
+                </FabProvider>
+              </BreakpointsProvider>
+            </ThumbnailSizeContextProvider>
+          </AcceptingSharingProvider>
+        </I18n>
+      </TestI18n>
+    </CozyProvider>
+  </Provider>
+</AppLike>
+`;

--- a/test/setup.jsx
+++ b/test/setup.jsx
@@ -14,7 +14,20 @@ import { generateFile } from './generate'
 import { act } from 'react-dom/test-utils'
 
 jest.mock('cozy-keys-lib', () => ({
-  withVaultClient: jest.fn().mockReturnValue({}),
+  withVaultClient: BaseComponent => {
+    const Component = props => (
+      <>
+        {({ vaultClient }) => (
+          <BaseComponent vaultClient={vaultClient} {...props} />
+        )}
+      </>
+    )
+
+    Component.displayName = `withVaultClient(${BaseComponent.displayName ||
+      BaseComponent.name})`
+
+    return Component
+  },
   useVaultClient: jest.fn()
 }))
 
@@ -53,6 +66,7 @@ export const setupStoreAndClient = ({ initialStoreState } = {}) => {
   const client = new CozyClient({
     store: false
   })
+  client.getStackClient().setUri('http://test.cloud')
 
   const store = configureStore({
     client,


### PR DESCRIPTION
Since the changes introduced in #2441, the uploadFiles signature changed
and the DropZone component was not updated accordingly. Hence the drag
and drop feature was broken, which is now fixed.