### PR TITLE
chore(warnings): Mute warnings during build

### DIFF
--- a/src/drive/web/modules/services/components/helpers.js
+++ b/src/drive/web/modules/services/components/helpers.js
@@ -2,18 +2,17 @@ import { models } from 'cozy-client'
 
 import { getFileMimetype } from 'drive/lib/getFileMimetype'
 import { hasEncryptionRef } from 'drive/lib/encryption'
+import iconsContext from './iconsContext'
 
 export const TYPE_DIRECTORY = 'directory'
 
-const iconsContext =
-  typeof require.context === 'undefined' // no require.context in jest
-    ? { keys: () => [] }
-    : require.context('drive/assets/icons/', false, /icon-type-.*.svg$/)
-
-const icons = iconsContext.keys().reduce((acc, item) => {
-  acc[item.replace(/\.\/icon-type-(.*)\.svg/, '$1')] = iconsContext(item)
-  return acc
-}, {})
+const icons =
+  iconsContext &&
+  iconsContext.keys &&
+  iconsContext.keys().reduce((acc, item) => {
+    acc[item.replace(/\.\/icon-type-(.*)\.svg/, '$1')] = iconsContext(item)
+    return acc
+  }, {})
 
 const getIconUrl = file => {
   let keyIcon

--- a/src/drive/web/modules/services/components/helpers.requirecontext.spec.js
+++ b/src/drive/web/modules/services/components/helpers.requirecontext.spec.js
@@ -1,0 +1,28 @@
+import { createMockClient, models } from 'cozy-client'
+
+require.context = jest.fn()
+import { makeNormalizedFile, containerForTesting } from './helpers'
+
+jest.mock('./iconsContext', () => ({ keys: undefined }))
+
+models.note.fetchURL = jest.fn(() => 'noteUrl')
+jest.spyOn(containerForTesting, 'getIconUrl').mockReturnValue('mocked')
+const client = createMockClient({})
+
+describe('makeNormalizedFile', () => {
+  it('should run without', async () => {
+    const folders = [{ _id: 'folderId', path: 'folderPath' }]
+    const file = {
+      _id: 'fileId',
+      dir_id: 'folderId',
+      type: 'file',
+      name: 'fileName'
+    }
+
+    try {
+      await makeNormalizedFile(client, folders, file)
+    } catch (error) {
+      throw error
+    }
+  })
+})

--- a/src/drive/web/modules/services/components/helpers.spec.js
+++ b/src/drive/web/modules/services/components/helpers.spec.js
@@ -1,15 +1,16 @@
 import { createMockClient, models } from 'cozy-client'
 
+require.context = jest.fn()
 import {
   makeNormalizedFile,
   containerForTesting,
   TYPE_DIRECTORY
 } from './helpers'
 
+jest.mock('./iconsContext', () => ({ keys: () => [] }))
+
 models.note.fetchURL = jest.fn(() => 'noteUrl')
-
 jest.spyOn(containerForTesting, 'getIconUrl').mockReturnValue('mocked')
-
 const client = createMockClient({})
 
 const noteFileProps = {

--- a/src/drive/web/modules/services/components/iconsContext.js
+++ b/src/drive/web/modules/services/components/iconsContext.js
@@ -1,0 +1,9 @@
+const iconsContext = require.context(
+  'drive/assets/icons/',
+  false,
+  /icon-type-.*.svg$/
+)
+
+export default {
+  iconsContext
+}


### PR DESCRIPTION
While building the app, a warning is displayed mentioning webpack cannot require conditionnally. 
This MR fixed that, adds a test on this fix and keep preventing error attached below.