### PR TITLE
feat: Remove Pouch adapter migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## ✨ Features
 
 * Add multiple import at once for Android
+* Remove Pouch adapter migration
 
 ## 🐛 Bug Fixes
 

--- a/src/drive/mobile/lib/cozy-helper.js
+++ b/src/drive/mobile/lib/cozy-helper.js
@@ -76,7 +76,7 @@ export const pickAdapter = async () => {
 
 export const initClient = async url => {
   const stackLink = new StackLink()
-  const adapter = await pickAdapter()
+  const adapter = getOldAdapterName()
 
   const pouchLinkOptions = {
     doctypes: [DOCTYPE_FILES],

--- a/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
+++ b/src/drive/mobile/modules/authorization/DriveMobileRouter.jsx
@@ -15,8 +15,7 @@ import {
   restoreCozyClientJs,
   initBar,
   getOldAdapterName,
-  getAdapterPlugin,
-  shouldMigrateAdapter
+  getAdapterPlugin
 } from 'drive/mobile/lib/cozy-helper'
 import { unlink } from './duck/index'
 import { saveCredentials } from './sagas'
@@ -36,11 +35,7 @@ class DriveMobileRouter extends Component {
   async componentDidMount() {
     // Wait for the app to be booted to avoid race condition between cordova & JS
     await appBooted
-    const shouldMigrate = await shouldMigrateAdapter()
-    this.setState({
-      isAppBooted: true,
-      shouldDisplayMigrate: shouldMigrate
-    })
+    this.setState({ isAppBooted: true })
   }
 
   initClientAndBar = async client => {


### PR DESCRIPTION
La migration (introduite ici https://github.com/cozy/cozy-drive/pull/2399 ) entraine des cas qui ont échoué sans qu'on arrive trop à comprendre pourquoi, ce qui donne parfois des comportements étranges sur les requêtes.
Côté Pouch il semble que indexedDB ne soit pas encore prod ready

Afin de publier une version mobile de Drive, on préfère pour l'instant désactiver cette feature.