### PR TITLE
fix(dropzone): invalid prop were shouting errors instead of uploading file

### DIFF
--- a/src/drive/web/modules/upload/Dropzone.jsx
+++ b/src/drive/web/modules/upload/Dropzone.jsx
@@ -34,17 +34,11 @@ export class Dropzone extends Component {
 
   render() {
     const { dropzoneActive } = this.state
-    const {
-      displayedFolder,
-      children,
-      /* don't pass these props to UIDropzone */
-      sharingState, // eslint-disable-line no-unused-vars
-      uploadFiles, // eslint-disable-line no-unused-vars
-      ...rest
-    } = this.props
+    const { displayedFolder, children, disabled, role } = this.props
     return (
       <UIDropzone
-        {...rest}
+        disabled={disabled}
+        role={role}
         className={dropzoneActive ? styles['fil-dropzone-active'] : ''}
         disableClick
         style={{}}

--- a/src/drive/web/modules/upload/Dropzone.spec.jsx
+++ b/src/drive/web/modules/upload/Dropzone.spec.jsx
@@ -6,8 +6,24 @@ import AppLike from 'test/components/AppLike'
 import { render } from '@testing-library/react'
 
 jest.mock('react-dropzone', () => {
-  const Component = ({ onDrop }) => (
+  const Component = ({
+    onDrop,
+    disabled,
+    role,
+    className,
+    disableClick,
+    style,
+    onDropEnter, // eslint-disable-line no-unused-vars
+    onDropLeave, // eslint-disable-line no-unused-vars
+    ...rest
+  }) => (
     <button
+      {...rest}
+      disabled={disabled}
+      role={role}
+      className={className}
+      data-disable-click={disableClick}
+      style={style}
       data-test-id="drop-button"
       onClick={() => onDrop(['files'], '_', { dataTransfer: { items: [] } })}
     />


### PR DESCRIPTION
When uploading file, we used to have
![Capture d’écran 2022-01-19 à 16 00 20](https://user-images.githubusercontent.com/8363334/150167950-11393fed-c58c-4f0a-aa83-bb5b5f2d5b45.png)
 