### PR TITLE
feat(add): Log sentry exception on click on add menu when offline

### DIFF
--- a/src/drive/web/modules/drive/AddMenu/AddMenuProvider.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenuProvider.jsx
@@ -6,6 +6,7 @@ import React, {
   createContext
 } from 'react'
 import { useSelector } from 'react-redux'
+import { logException } from 'drive/lib/reporter'
 
 import useBrowserOffline from 'cozy-ui/transpiled/react/hooks/useBrowserOffline'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -50,6 +51,9 @@ const AddMenuProvider = ({
   const handleOfflineClick = useCallback(e => {
     e.stopPropagation()
     Alerter.error('alert.offline')
+    logException(
+      `Offline click on AddMenu button detected. Here is the value of window.navigator.onLine: ${window.navigator.onLine}`
+    )
   }, [])
 
   return (

--- a/src/drive/web/modules/drive/AddMenu/AddMenuProvider.spec.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenuProvider.spec.jsx
@@ -1,0 +1,41 @@
+import React, { useContext } from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import AddMenuProvider, { AddMenuContext } from './AddMenuProvider'
+import { logException } from 'drive/lib/reporter'
+
+jest.mock(
+  'drive/web/modules/drive/Toolbar/components/ScanWrapper',
+  // eslint-disable-next-line react/display-name
+  () => () => <div />
+)
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn()
+}))
+jest.mock('drive/lib/reporter', () => ({
+  logException: jest.fn()
+}))
+
+describe('AddMenuContext', () => {
+  it('should log exception on click offline on add button', () => {
+    // Given
+    const Component = () => {
+      const { handleOfflineClick } = useContext(AddMenuContext)
+      return <button data-testid="button" onClick={handleOfflineClick} />
+    }
+    const { container, getByTestId } = render(
+      <AddMenuProvider>
+        <Component />
+      </AddMenuProvider>
+    )
+
+    // When
+    fireEvent.click(getByTestId('button'))
+    fireEvent.click(container)
+
+    // Then
+    expect(logException).toHaveBeenCalledWith(
+      'Offline click on AddMenu button detected. Here is the value of window.navigator.onLine: true'
+    )
+  })
+})


### PR DESCRIPTION
Plenty of users complains because AddMenu button appears offline, but they are not.

We want to log exception to keep eyes on that bug.