### PR TITLE
feat: Add DACC service, to send anonymized measures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Stylint with Cozy config each .styl files in src
 
+## ✨ Features
+
+* DACC service to send anonymized measures about the file sizes grouped by app/konnector
+
 # 1.38.0
 
 ## ✨ Features

--- a/src/drive/lib/dacc/dacc.js
+++ b/src/drive/lib/dacc/dacc.js
@@ -1,0 +1,104 @@
+import { queryFilesByDate } from 'drive/lib/dacc/query'
+import log from 'cozy-logger'
+
+const sendMeasureToDACC = async (client, remoteDoctype, measure) => {
+  try {
+    await client
+      .getStackClient()
+      .fetchJSON('POST', `/remote/${remoteDoctype}`, {
+        data: JSON.stringify(measure)
+      })
+  } catch (error) {
+    log(
+      'error',
+      `Error while sending measure to remote doctype: ${error.message}`
+    )
+    throw error
+  }
+}
+
+/**
+ * Send measures to a remote doctype
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {string} remoteDoctype - The remote doctype to use
+ * @param {object} sizesBySlug - The hash table of values by slug
+ * @param {{startDate, measureName}} params - The measure params
+ */
+export const sendToRemoteDoctype = async (
+  client,
+  remoteDoctype,
+  sizesBySlug,
+  { startDate, measureName }
+) => {
+  const slugs = Object.keys(sizesBySlug)
+  log(
+    'info',
+    `Send ${slugs.length} measures ${measureName} on ${startDate} to ${remoteDoctype}...`
+  )
+  for (const slug of slugs) {
+    const measure = {
+      createdBy: 'drive',
+      measureName,
+      startDate,
+      value: sizesBySlug[slug],
+      group1: { slug: slug }
+    }
+    await sendMeasureToDACC(client, remoteDoctype, measure)
+  }
+}
+
+const convertFileSizeInMB = file => {
+  // The size is converted in MB to avoid too large values
+  return parseInt(file.size) / (1024 * 1024) // Size in MB
+}
+
+/**
+ * Aggregate values by slug
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {string} endDate - The max file date to query
+ * @returns {object} The hash table of values by slug
+ */
+export const aggregateFilesSize = async (client, endDate) => {
+  let hasNext = true
+  let bookmark
+  const sizesBySlug = {}
+  while (hasNext) {
+    const resp = await queryFilesByDate(client, endDate, bookmark)
+    for (const file of resp.data) {
+      const slug = file.cozyMetadata.createdByApp
+      if (!slug) {
+        continue
+      }
+      if (slug in sizesBySlug) {
+        sizesBySlug[slug] += convertFileSizeInMB(file)
+      } else {
+        sizesBySlug[slug] = convertFileSizeInMB(file)
+      }
+    }
+
+    if (!resp || !resp.next) {
+      hasNext = false
+    }
+    bookmark = resp.bookmark
+  }
+
+  return sizesBySlug
+}
+
+/**
+ * Aggregate all values except for excluded slug
+ *
+ * @param {object} sizesBySlug - The hash table of values by slug
+ * @param {string} exclusionSlug - The slug to exclude
+ */
+export const aggregateNonExcludedSlugs = (sizesBySlug, exclusionSlug) => {
+  let totalSize = 0
+  for (const slug of Object.keys(sizesBySlug)) {
+    if (!slug.includes(exclusionSlug)) {
+      totalSize += sizesBySlug[slug]
+    }
+  }
+  return totalSize
+}

--- a/src/drive/lib/dacc/dacc.spec.js
+++ b/src/drive/lib/dacc/dacc.spec.js
@@ -1,0 +1,74 @@
+import {
+  aggregateFilesSize,
+  aggregateNonExcludedSlugs
+} from 'drive/lib/dacc/dacc'
+import { queryFilesByDate } from 'drive/lib/dacc/query'
+
+jest.mock('drive/lib/dacc/query')
+
+const mockedFilesQueryResponse = {
+  data: [
+    {
+      size: 1048576,
+      cozyMetadata: {
+        createdByApp: 'drive'
+      }
+    },
+    {
+      size: 3145728,
+      cozyMetadata: {
+        createdByApp: 'drive'
+      }
+    },
+    {
+      size: 2097152,
+      cozyMetadata: {
+        createdByApp: 'edf'
+      }
+    },
+    {
+      size: 8388608,
+      cozyMetadata: {
+        createdByApp: 'maif'
+      }
+    },
+    {
+      size: 6291456,
+      cozyMetadata: {
+        createdByApp: 'maif-vie'
+      }
+    }
+  ],
+  next: false
+}
+
+describe('dacc service', () => {
+  beforeEach(() => {
+    queryFilesByDate.mockResolvedValue(mockedFilesQueryResponse)
+  })
+  it('should aggregate sizes by slug', async () => {
+    const sizesBySlug = await aggregateFilesSize(null, '2022-01-01')
+    expect(Object.keys(sizesBySlug)).toEqual([
+      'drive',
+      'edf',
+      'maif',
+      'maif-vie'
+    ])
+    expect(sizesBySlug['drive']).toEqual(4)
+    expect(sizesBySlug['edf']).toEqual(2)
+    expect(sizesBySlug['maif']).toEqual(8)
+    expect(sizesBySlug['maif-vie']).toEqual(6)
+  })
+
+  it('should aggregate all sizes but excluded slug', async () => {
+    const sizesBySlug = await aggregateFilesSize(null, '2022-01-01')
+    const totalSize = aggregateNonExcludedSlugs(sizesBySlug, 'maif')
+    expect(totalSize).toEqual(sizesBySlug['drive'] + sizesBySlug['edf'])
+  })
+
+  it('should aggregate nothing when excluded slug is empty', async () => {
+    const sizesBySlug = await aggregateFilesSize(null, '2022-01-01')
+    const totalSize = aggregateNonExcludedSlugs(sizesBySlug, '')
+    expect(totalSize).toEqual(0)
+  })
+})

--- a/src/drive/lib/dacc/query.js
+++ b/src/drive/lib/dacc/query.js
@@ -1,0 +1,31 @@
+import { DOCTYPE_FILES } from 'drive/lib/doctypes'
+
+/**
+ * Query files by created_at
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {string} endDate - The max file date to query
+ * @param {string} bookmark - The query bookmark
+ * @returns {Array} The files sorted by (createdByApp, created_at)
+ */
+export const queryFilesByDate = async (client, endDate, bookmark = '') => {
+  const selector = {
+    'cozyMetadata.createdByApp': {
+      $gt: null
+    },
+    created_at: { $lte: endDate }
+  }
+  const options = {
+    partialFilter: {
+      type: 'file',
+      trashed: false
+    },
+    fields: ['cozyMetadata.createdByApp', 'size'],
+    indexedFields: ['cozyMetadata.createdByApp', 'created_at'],
+    sort: [{ 'cozyMetadata.createdByApp': 'asc' }, { created_at: 'asc' }],
+    limit: 1000,
+    bookmark
+  }
+  // We directly use the collection to avoid using the store for nothing.
+  return client.collection(DOCTYPE_FILES).find(selector, options)
+}

--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -97,6 +97,11 @@
       "file": "services/qualificationMigration/drive.js",
       "trigger": "@event io.cozy.files:CREATED,UPDATED",
       "debounce": "24h"
+    },
+    "dacc": {
+      "type": "node",
+      "file": "services/dacc/drive.js",
+      "trigger": "@every 720h"
     }
   },
   "permissions": {
@@ -169,6 +174,11 @@
       "description": "Required to display additional information in the viewer for files automatically retrieved by services",
       "type": "io.cozy.triggers",
       "verbs": ["GET"]
+    },
+    "dacc": {
+      "type": "cc.cozycloud.dacc",
+      "verbs": ["POST"],
+      "description": "Remote-doctype required to send anonymized measures to the Cozy's DACC"
     }
   }
 }

--- a/src/drive/targets/services/dacc.js
+++ b/src/drive/targets/services/dacc.js
@@ -1,0 +1,63 @@
+import log from 'cozy-logger'
+import CozyClient from 'cozy-client'
+import { schema } from 'drive/lib/doctypes'
+import flag from 'cozy-flags'
+import { endOfMonth, startOfMonth, format, subMonths } from 'date-fns'
+import fetch from 'node-fetch'
+global.fetch = fetch
+
+import {
+  aggregateFilesSize,
+  aggregateNonExcludedSlugs,
+  sendToRemoteDoctype
+} from 'drive/lib/dacc/dacc'
+
+/**
+ * This service aggregates files size by createdByApps slug and send them to the DACC.
+ * See https://github.com/cozy/DACC for more insights about the DACC.
+ * The service relies on a flag that contains the following information:
+ *   - measureName: the name of the dacc measure
+ *   - remoteDoctype: the remote doctype to use
+ *   - nonExcludedGroupLabel: when set, it is used to aggregate all the slugs not maching the excludedSlug
+ *   - excludedSlug: used to exclude a slug from the total aggregation
+ */
+export const run = async () => {
+  log('info', 'Start dacc service')
+
+  const client = CozyClient.fromEnv(process.env, { schema })
+
+  await flag.initialize(client)
+  const daccFileSizeFlag = flag('drive.dacc-files-size-by-slug')
+  if (!daccFileSizeFlag) {
+    return
+  }
+  const {
+    excludedSlug,
+    nonExcludedGroupLabel,
+    measureName,
+    remoteDoctype
+  } = daccFileSizeFlag
+  const aggregationDate = endOfMonth(subMonths(new Date(), 1))
+
+  const sizesBySlug = await aggregateFilesSize(client, aggregationDate)
+
+  if (excludedSlug && nonExcludedGroupLabel) {
+    const totalNonExcluded = aggregateNonExcludedSlugs(
+      sizesBySlug,
+      excludedSlug
+    )
+    sizesBySlug[nonExcludedGroupLabel] = totalNonExcluded
+  }
+
+  const startDateMeasure = format(startOfMonth(aggregationDate), 'YYYY-MM-DD')
+
+  await sendToRemoteDoctype(client, remoteDoctype, sizesBySlug, {
+    measureName,
+    startDate: startDateMeasure
+  })
+}
+
+run().catch(e => {
+  log('critical', e)
+  process.exit(1)
+})


### PR DESCRIPTION
This service aggregates the file size by grouping them by the app/konnector
that created them.
It then sends all the measures to the DACC, an external service used to
aggregate anonymized measures, which require new remote doctype
permissions.
Note this feature is yet restricted by a flag.