### PR TITLE
fix(thumbnail): don't render fallback when link is available

### DIFF
--- a/src/components/Image/ImageLoader.jsx
+++ b/src/components/Image/ImageLoader.jsx
@@ -23,7 +23,7 @@ class ImageLoader extends React.Component {
       props.file.links[props.size] &&
       props.client.getStackClient().uri
         ? {
-            status: LOADED,
+            status: PENDING,
             src:
               props.client.getStackClient().uri + props.file.links[props.size]
           }

--- a/src/components/Image/ImageLoader.jsx
+++ b/src/components/Image/ImageLoader.jsx
@@ -14,9 +14,23 @@ const LOADED = 'LOADED'
 const FAILED = 'FAILED'
 
 class ImageLoader extends React.Component {
-  state = {
-    status: PENDING,
-    src: null
+  constructor(props) {
+    super(props)
+    this.state =
+      props.file &&
+      props.file.links &&
+      props.size &&
+      props.file.links[props.size] &&
+      props.client.getStackClient().uri
+        ? {
+            status: LOADED,
+            src:
+              props.client.getStackClient().uri + props.file.links[props.size]
+          }
+        : {
+            status: PENDING,
+            src: null
+          }
   }
 
   _mounted = false


### PR DESCRIPTION
- [ ] need to test on a branch
- [ ] maybe we need to call checkImageSource in componentDidMount in case the link is expired.
- [ ] test needed
- [ ] checkImageSource has 2 cleanImageLoader. Why?

=> pushed on git://github.com/cozy/cozy-drive.git#pierre 
=> https://trollepierre-drivebranch.mycozy.cloud/public?sharecode=0zGcnNUNGt4H#/folder/413309e481fb2264d66039ed220bd40f