### PR TITLE
fix: Remove WebviewIntentProvider from tests

### DIFF
--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -13,7 +13,6 @@ import { ModalContext } from 'drive/lib/ModalContext'
 import { RouterContext } from 'drive/lib/RouterContext'
 import { AcceptingSharingProvider } from 'drive/lib/AcceptingSharingContext'
 import FabProvider from 'drive/lib/FabProvider'
-import { WebviewIntentProvider } from 'cozy-intent'
 
 const mockStore = createStore(() => ({
   mobile: {
@@ -58,33 +57,31 @@ const AppLike = ({
   routerContextValue,
   modalContextValue
 }) => (
-  <WebviewIntentProvider>
-    <Provider store={(client && client.store) || store || mockStore}>
-      <CozyProvider client={client}>
-        <TestI18n>
-          <SharingContext.Provider
-            value={sharingContextValue || mockSharingContextValue}
-          >
-            <AcceptingSharingProvider>
-              <RouterContext.Provider
-                value={routerContextValue || mockRouterContextValue}
-              >
-                <ThumbnailSizeContextProvider>
-                  <BreakpointsProvider>
-                    <ModalContext.Provider
-                      value={modalContextValue || mockModalContextValue}
-                    >
-                      <FabProvider>{children}</FabProvider>
-                    </ModalContext.Provider>
-                  </BreakpointsProvider>
-                </ThumbnailSizeContextProvider>
-              </RouterContext.Provider>
-            </AcceptingSharingProvider>
-          </SharingContext.Provider>
-        </TestI18n>
-      </CozyProvider>
-    </Provider>
-  </WebviewIntentProvider>
+  <Provider store={(client && client.store) || store || mockStore}>
+    <CozyProvider client={client}>
+      <TestI18n>
+        <SharingContext.Provider
+          value={sharingContextValue || mockSharingContextValue}
+        >
+          <AcceptingSharingProvider>
+            <RouterContext.Provider
+              value={routerContextValue || mockRouterContextValue}
+            >
+              <ThumbnailSizeContextProvider>
+                <BreakpointsProvider>
+                  <ModalContext.Provider
+                    value={modalContextValue || mockModalContextValue}
+                  >
+                    <FabProvider>{children}</FabProvider>
+                  </ModalContext.Provider>
+                </BreakpointsProvider>
+              </ThumbnailSizeContextProvider>
+            </RouterContext.Provider>
+          </AcceptingSharingProvider>
+        </SharingContext.Provider>
+      </TestI18n>
+    </CozyProvider>
+  </Provider>
 )
 
 export default AppLike


### PR DESCRIPTION
As it uses window.console, it made tests fail.