### PR TITLE
test: add clearMocks in jest.config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     '^cozy-client$': 'cozy-client/dist/index.js',
     '^react-redux': '<rootDir>/node_modules/react-redux'
   },
+  clearMocks: true,
   snapshotSerializers: ['enzyme-to-json/serializer'],
   transform: {
     '^.+\\.jsx?$': 'babel-jest',

--- a/jestHelpers/ConsoleUsageReporter.js
+++ b/jestHelpers/ConsoleUsageReporter.js
@@ -117,9 +117,7 @@ ${reset(formatConsoleCalls(consoleCalls))}
 If calling the console is normal in your test case, consider mocking the \
 console as is:
 
-  const consoleSpy = jest.spyOn(console, 'method').mockImplementation();
-  [...]
-  consoleSpy.mockRestore();
+  jest.spyOn(console, 'method').mockImplementation();
 `)
         )
       }

--- a/src/components/pushClient/index.spec.js
+++ b/src/components/pushClient/index.spec.js
@@ -2,9 +2,6 @@ import { isClientAlreadyInstalled, DESKTOP_SOFTWARE_ID } from './index'
 import CozyClient from 'cozy-client'
 
 describe('isClientAlreadyInstalled', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
   test('isClientAlreadyInstalled is true', async () => {
     const client = new CozyClient({})
     client.query = jest.fn().mockResolvedValue({

--- a/src/drive/mobile/modules/mediaBackup/duck/fixBackupFolderNamesBug.spec.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/fixBackupFolderNamesBug.spec.js
@@ -24,10 +24,6 @@ jest.mock('folder-references', () => ({
   getOrCreateFolderWithReference: jest.fn()
 }))
 describe('bugFix fix', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
-
   it('should fix the default scenario', async () => {
     /** 1er scénario :
      * - /Photos sans référence + /Photos/Uploadées par Cozy Photos/Photo1.jpg

--- a/src/drive/mobile/modules/mediaBackup/duck/index.spec.js
+++ b/src/drive/mobile/modules/mediaBackup/duck/index.spec.js
@@ -50,7 +50,6 @@ describe('StartMediaBackup', () => {
   const uploadDirPath = '/upload'
 
   beforeEach(() => {
-    jest.resetAllMocks()
     getUploadDir.mockResolvedValue({
       _id: uploadDirIr,
       attributes: {

--- a/src/drive/mobile/modules/settings/components/__snapshots__/Unlink.spec.jsx.snap
+++ b/src/drive/mobile/modules/settings/components/__snapshots__/Unlink.spec.jsx.snap
@@ -17,35 +17,7 @@ exports[`Unlink should render the Component 1`] = `
       "data": "foo",
     }
   }
-  t={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          "mobile.settings.unlink.title",
-        ],
-        Array [
-          "mobile.settings.unlink.description",
-        ],
-        Array [
-          "mobile.settings.unlink.button",
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": "mobile.settings.unlink.title",
-        },
-        Object {
-          "type": "return",
-          "value": "mobile.settings.unlink.description",
-        },
-        Object {
-          "type": "return",
-          "value": "mobile.settings.unlink.button",
-        },
-      ],
-    }
-  }
+  t={[MockFunction]}
   unlink={[MockFunction]}
 >
   <div>

--- a/src/drive/mobile/modules/upload/index.spec.js
+++ b/src/drive/mobile/modules/upload/index.spec.js
@@ -11,10 +11,6 @@ const tSpy = jest.fn()
 const uploadFilesFromNativeSpy = jest.fn()
 
 describe('OpenWith component Modal', () => {
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   const defaultItems = [{ name: 'File1.pdf' }]
 
   const setupComponent = () => {

--- a/src/drive/targets/mobile/migrations/migrationOfflineFiles.js
+++ b/src/drive/targets/mobile/migrations/migrationOfflineFiles.js
@@ -23,6 +23,7 @@ const migrateOfflineFiles = async (client) => {
     if (alreadyMigrated || !isWifi()) return
 
     const availableOfflineIds = getAvailableOfflineIds(client.store.getState())
+
     if (!availableOfflineIds || availableOfflineIds.length < 1) {
       await localforage.setItem('offlineFilesMigration-finished', true)
       return

--- a/src/drive/web/modules/actions/utils.spec.js
+++ b/src/drive/web/modules/actions/utils.spec.js
@@ -201,7 +201,7 @@ describe('downloadFiles', () => {
       {
         id: 'folder-id-1',
         name: 'encrypted-folder',
-        type: 'folder',
+        type: 'directory',
         referenced_by: [
           {
             id: 'encryption-key-id',

--- a/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/MoreMenu.spec.jsx
@@ -40,14 +40,12 @@ describe('MoreMenu', () => {
   describe('DownloadButton', () => {
     it('download files', async () => {
       // TODO: remove it when DeleteItem get props
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+      jest.spyOn(console, 'error').mockImplementation()
 
       const { getByText } = await setup()
 
       fireEvent.click(getByText('Download folder'))
       expect(downloadFiles).toHaveBeenCalled()
-
-      consoleSpy.mockRestore()
     })
   })
 })

--- a/src/drive/web/modules/filelist/FileOpener.spec.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.spec.jsx
@@ -29,10 +29,6 @@ const setup = ({ file }) => {
 }
 
 describe('FileOpener', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('should show a link to onlyoffice document if Only Office is supported', () => {
     shouldBeOpenedByOnlyOffice.mockReturnValue(true)
 

--- a/src/drive/web/modules/move/MoveModal.spec.jsx
+++ b/src/drive/web/modules/move/MoveModal.spec.jsx
@@ -33,10 +33,6 @@ const cozyClient = new CozyClient({
 })
 
 describe('MoveModal component', () => {
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   const defaultEntries = [
     { _id: 'bill_201901', dir_id: 'bills', name: 'bill_201901.pdf' },
     { _id: 'bill_201902', dir_id: 'bills', name: 'bill_201902.pdf' },
@@ -119,9 +115,6 @@ describe('MoveModal component', () => {
   })
 
   describe('cancelMove', () => {
-    afterEach(() => {
-      jest.restoreAllMocks()
-    })
     it('should move items back to their previous location', async () => {
       const component = setupComponent()
       const callback = jest.fn()

--- a/src/drive/web/modules/navigation/Breadcrumb/Breadcrumb.spec.jsx
+++ b/src/drive/web/modules/navigation/Breadcrumb/Breadcrumb.spec.jsx
@@ -6,10 +6,6 @@ import { dummyBreadcrumbPath } from 'test/dummies/dummyBreadcrumbPath'
 describe('Breadcrumbs', () => {
   const path = dummyBreadcrumbPath()
 
-  beforeEach(() => {
-    jest.restoreAllMocks()
-  })
-
   describe('template', () => {
     it('should match snapshot', () => {
       // When

--- a/src/drive/web/modules/navigation/Index.spec.js
+++ b/src/drive/web/modules/navigation/Index.spec.js
@@ -46,10 +46,6 @@ const setup = async ({ sharingId, withReferencedFiles, withShortcut } = {}) => {
  * As for the redirection, it is done according to whether there is a reference file or not.
  */
 describe('fetchSharing', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('should redirect to /folder and store nothing in context, if no sharing id', async () => {
     await setup()
 

--- a/src/drive/web/modules/public/LightFileViewer.spec.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.spec.jsx
@@ -35,7 +35,7 @@ describe('LightFileViewer', () => {
     })
 
     it('should have the sharing banner and public toolbar but no viewer toolbar', () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation() // to be removed with https://github.com/cozy/cozy-libs/pull/1457
+      jest.spyOn(console, 'error').mockImplementation() // TODO: to be removed with https://github.com/cozy/cozy-libs/pull/1457
 
       const { root } = setup()
       const { queryByTestId, queryAllByRole } = root
@@ -45,8 +45,6 @@ describe('LightFileViewer', () => {
       ) // This is the sharing banner
       expect(queryByTestId('public-toolbar')).toBeTruthy()
       expect(queryByTestId('viewer-toolbar')).toBeFalsy()
-
-      consoleSpy.mockRestore()
     })
   })
 

--- a/src/drive/web/modules/selectors.spec.js
+++ b/src/drive/web/modules/selectors.spec.js
@@ -63,7 +63,7 @@ const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
 describe('getCurrentViewFetchStatus', () => {
   it('should return the fetch status', async () => {
     // TODO: Warning: An update to %s inside a test was not wrapped in act(...).
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    jest.spyOn(console, 'error').mockImplementation()
 
     const folderId = 'directory-foobar0'
     const initialStoreState = {
@@ -95,8 +95,6 @@ describe('getCurrentViewFetchStatus', () => {
     const state2 = store.getState()
     const status2 = getCurrentViewFetchStatus(state2)
     expect(status2).toEqual('loaded')
-
-    consoleSpy.mockRestore()
   })
 })
 describe('getCurrentFolderId', () => {

--- a/src/drive/web/modules/trash/Toolbar.spec.jsx
+++ b/src/drive/web/modules/trash/Toolbar.spec.jsx
@@ -16,7 +16,7 @@ describe('Toolbar', () => {
     // TODO: Warning: You called act(async () => ...) without await. This could lead to unexpected testing behaviour,
     //  interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);
     // However the above resolution makes test failing
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    jest.spyOn(console, 'error').mockImplementation()
 
     const { getByText } = render(
       <AppLike client={client}>
@@ -45,7 +45,5 @@ describe('Toolbar', () => {
 
     expect(client.emptyTrash).toHaveBeenCalled()
     await waitForElementToBeRemoved(() => getByText('Delete all'))
-
-    consoleSpy.mockRestore()
   })
 })

--- a/src/drive/web/modules/upload/Dropzone.spec.jsx
+++ b/src/drive/web/modules/upload/Dropzone.spec.jsx
@@ -42,7 +42,7 @@ mockCozyClientRequestQuery()
 describe('Dropzone', () => {
   it('should match snapshot', async () => {
     // Given
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    jest.spyOn(console, 'error').mockImplementation()
 
     const displayedFolder = {
       id: 'directory-foobar0'
@@ -62,9 +62,6 @@ describe('Dropzone', () => {
 
     // Then
     expect(root).toMatchSnapshot()
-
-    // After
-    consoleSpy.mockRestore()
   })
 
   it('should dispatch the uploadFiles action', () => {

--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -50,10 +50,6 @@ const fakeVaultClient = {
 CozyFile.getFullpath.mockResolvedValue('/my-dir/mydoc.odt')
 
 describe('uploadFilesFromNative function', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('should upload files from native and put items to the queue', async () => {
     const filesToUpload = [
       {
@@ -148,10 +144,6 @@ describe('processNextFile function', () => {
     sharedPaths: []
   }
   fakeClient.query.mockResolvedValueOnce(null)
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
 
   beforeEach(() => {
     getEncryptionKeyFromDirId.mockResolvedValue(null)
@@ -677,10 +669,6 @@ describe('queue reducer', () => {
 })
 
 describe('overwriteFile function', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('should update the io.cozy.files', async () => {
     updateFileSpy.mockResolvedValue({
       data: {

--- a/src/drive/web/modules/viewer/Footer/FooterContent.spec.jsx
+++ b/src/drive/web/modules/viewer/Footer/FooterContent.spec.jsx
@@ -57,15 +57,13 @@ describe('FooterContent', () => {
   it('should show download button if not in mobile app', () => {
     // TODO: Warning: Invalid values for props %s on <%s> tag. Either remove them from the element, or pass a string or number value to keep them in the DOM.
     //  For details, see https://fb.me/react-attribute-behavior%s `t`, `f` button in button (created by BaseButton)
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    jest.spyOn(console, 'error').mockImplementation()
 
     const { root } = setup()
     const { getByText, queryByText } = root
 
     expect(getByText('Download'))
     expect(queryByText('Forward')).toBeFalsy()
-
-    consoleSpy.mockRestore()
   })
 
   it('should show forward button if in mobile app', () => {

--- a/src/drive/web/modules/viewer/Footer/FooterContent.spec.jsx
+++ b/src/drive/web/modules/viewer/Footer/FooterContent.spec.jsx
@@ -54,10 +54,6 @@ const setup = ({
 }
 
 describe('FooterContent', () => {
-  beforeEach(() => {
-    jest.resetAllMocks()
-  })
-
   it('should show download button if not in mobile app', () => {
     // TODO: Warning: Invalid values for props %s on <%s> tag. Either remove them from the element, or pass a string or number value to keep them in the DOM.
     //  For details, see https://fb.me/react-attribute-behavior%s `t`, `f` button in button (created by BaseButton)

--- a/src/drive/web/modules/views/Drive/index.spec.jsx
+++ b/src/drive/web/modules/views/Drive/index.spec.jsx
@@ -54,7 +54,7 @@ describe('Drive View', () => {
   }
 
   it('should use FolderViewBreadcrumb with correct rootBreadcrumbPath', async () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation() // to be removed with https://github.com/cozy/cozy-libs/pull/1457
+    jest.spyOn(console, 'error').mockImplementation() // TODO: to be removed with https://github.com/cozy/cozy-libs/pull/1457
 
     let render
 
@@ -70,7 +70,5 @@ describe('Drive View', () => {
     expect(
       getByTestId('FolderViewBreadcrumb').getAttribute('data-folder-id')
     ).toEqual('1234')
-
-    consoleSpy.mockRestore()
   })
 })

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.spec.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.spec.js
@@ -15,59 +15,67 @@ jest.mock('cozy-client/dist/models/file', () => ({
 }))
 
 describe('createFileOpeningHandler', () => {
-  const client = createMockClient({})
-  const dispatch = jest.fn()
-  const navigateToFile = jest.fn()
-  const replaceCurrentUrl = jest.fn()
-  const openInNewTab = jest.fn()
-  const routeTo = jest.fn()
+  let client
+  let dispatch
+  let navigateToFile
+  let replaceCurrentUrl
+  let openInNewTab
+  let routeTo
   const isFlatDomain = true
+  let genericFile
+  let setup
+  let shortcutFile
+  let onlyofficeFile
+  let noteFile
 
-  client.getStackClient = jest.fn(() => client)
-  client.collection = jest.fn(() => client)
-  client.fetchURL = jest.fn()
-  client.uri = 'http://cozy.tools'
-
-  const genericFile = generateFile({ i: 0 })
-  const noteFile = generateFile({
-    prefix: 'my-note-',
-    i: 1,
-    type: 'file',
-    ext: '.cozy-note'
-  })
-
-  noteFile.metadata = {
-    content: '',
-    schema: '',
-    title: '',
-    version: ''
-  }
-
-  const shortcutFile = generateFile({
-    prefix: 'cozy',
-    i: 2,
-    type: 'file',
-    ext: '.url'
-  })
-  shortcutFile.class = 'shortcut'
-
-  const onlyofficeFile = generateFile({ i: 3 })
-  onlyofficeFile.class = 'slide'
-
-  const setup = ({ isOnlyOfficeEnabled } = { isOnlyOfficeEnabled: true }) =>
-    createFileOpeningHandler({
-      client,
-      isFlatDomain,
-      dispatch,
-      navigateToFile,
-      replaceCurrentUrl,
-      openInNewTab,
-      routeTo,
-      isOnlyOfficeEnabled
+  beforeEach(() => {
+    client = createMockClient({})
+    dispatch = jest.fn()
+    navigateToFile = jest.fn()
+    replaceCurrentUrl = jest.fn()
+    openInNewTab = jest.fn()
+    routeTo = jest.fn()
+    client.getStackClient = jest.fn(() => client)
+    client.collection = jest.fn(() => client)
+    client.fetchURL = jest.fn()
+    client.uri = 'http://cozy.tools'
+    genericFile = generateFile({ i: 0 })
+    noteFile = generateFile({
+      prefix: 'my-note-',
+      i: 1,
+      type: 'file',
+      ext: '.cozy-note'
     })
 
-  afterEach(() => {
-    jest.clearAllMocks()
+    noteFile.metadata = {
+      content: '',
+      schema: '',
+      title: '',
+      version: ''
+    }
+
+    shortcutFile = generateFile({
+      prefix: 'cozy',
+      i: 2,
+      type: 'file',
+      ext: '.url'
+    })
+    shortcutFile.class = 'shortcut'
+
+    onlyofficeFile = generateFile({ i: 3 })
+    onlyofficeFile.class = 'slide'
+
+    setup = ({ isOnlyOfficeEnabled } = { isOnlyOfficeEnabled: true }) =>
+      createFileOpeningHandler({
+        client,
+        isFlatDomain,
+        dispatch,
+        navigateToFile,
+        replaceCurrentUrl,
+        openInNewTab,
+        routeTo,
+        isOnlyOfficeEnabled
+      })
   })
 
   it('should open an offline file', async () => {
@@ -146,7 +154,6 @@ describe('createFileOpeningHandler', () => {
       expect(replaceCurrentUrl).not.toHaveBeenCalled()
       expect(routeTo).not.toHaveBeenCalled()
       expect(navigateToFile).not.toHaveBeenCalled()
-      jest.clearAllMocks()
     }
   })
 

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -111,7 +111,7 @@ describe('Editor', () => {
   })
 
   it('should show the title and the container view if the only office server is installed', () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation() // to be removed with https://github.com/cozy/cozy-libs/pull/1457
+    jest.spyOn(console, 'error').mockImplementation() // TODO: to be removed with https://github.com/cozy/cozy-libs/pull/1457
 
     useFetchJSON.mockReturnValue({
       fetchStatus: 'loaded',
@@ -126,8 +126,6 @@ describe('Editor', () => {
     expect(queryByTestId('onlyoffice-content-spinner')).toBeFalsy()
     expect(queryByTestId('onlyoffice-title')).toBeTruthy()
     expect(container.querySelector('#onlyOfficeEditor')).toBeTruthy()
-
-    consoleSpy.mockRestore()
   })
 
   it('should show the CozyUi Viewer if the only office server is not installed', () => {

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -82,7 +82,6 @@ const setup = ({
 
 describe('Editor', () => {
   afterEach(() => {
-    jest.clearAllMocks()
     document.body.innerHTML = '' // used to reset document.getElementById(id) present in View
   })
 

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -70,21 +70,14 @@ const setup = ({
 }
 
 describe('Toolbar', () => {
-  let consoleSpy
-
   beforeEach(() => {
-    consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
-  })
-
-  afterEach(() => {
-    consoleSpy.mockRestore()
-    jest.clearAllMocks()
+    jest.spyOn(console, 'warn').mockImplementation()
   })
 
   describe('FileName', () => {
     it('should show the path', () => {
       // TODO : analyse why BaseButton has incorrect props and remove this consoleSpy
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+      jest.spyOn(console, 'error').mockImplementation()
 
       useQuery
         .mockReturnValueOnce(officeDocParam)
@@ -94,8 +87,6 @@ describe('Toolbar', () => {
       const { queryByTestId } = root
 
       expect(queryByTestId('onlyoffice-filename-path')).toBeTruthy()
-
-      consoleSpy.mockRestore()
     })
 
     it('should not show the path on mobile', () => {

--- a/src/drive/web/modules/views/Public/index.spec.jsx
+++ b/src/drive/web/modules/views/Public/index.spec.jsx
@@ -92,7 +92,7 @@ describe('Public View', () => {
   })
 
   it('renders the public view', async () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation() // to be removed with https://github.com/cozy/cozy-libs/pull/1457
+    jest.spyOn(console, 'error').mockImplementation() // TODO: to be removed with https://github.com/cozy/cozy-libs/pull/1457
 
     const { getByText, findByText } = setup()
     const sleep = duration =>
@@ -119,8 +119,6 @@ describe('Public View', () => {
     fireEvent.click(historyItem)
 
     await expect(findByText('FileHistory stub')).resolves.toBeTruthy()
-
-    consoleSpy.mockRestore()
   })
 
   it('should use FolderViewBreadcrumb with correct rootBreadcrumbPath', async () => {

--- a/src/drive/web/modules/views/Recent/index.spec.jsx
+++ b/src/drive/web/modules/views/Recent/index.spec.jsx
@@ -67,7 +67,7 @@ const setup = () => {
 
 describe('Recent View', () => {
   it('tests the recent view', async () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation() // to be removed with https://github.com/cozy/cozy-libs/pull/1457
+    jest.spyOn(console, 'error').mockImplementation() // TODO: to be removed with https://github.com/cozy/cozy-libs/pull/1457
 
     const nbFiles = 2
     const path = '/test'
@@ -142,7 +142,5 @@ describe('Recent View', () => {
     // Going back to recent view, not file view
     hashHistory.goBack()
     await expect(findByText('Recent')).resolves.toBeTruthy()
-
-    consoleSpy.mockRestore()
   })
 })

--- a/src/drive/web/modules/views/Sharings/index.spec.jsx
+++ b/src/drive/web/modules/views/Sharings/index.spec.jsx
@@ -91,7 +91,7 @@ describe('Sharings View', () => {
   }
 
   it('should display placeholder when all files are not loaded', async () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation() // to be removed with https://github.com/cozy/cozy-libs/pull/1457
+    jest.spyOn(console, 'error').mockImplementation() // TODO: to be removed with https://github.com/cozy/cozy-libs/pull/1457
 
     const { container } = setup(false)
 
@@ -100,8 +100,6 @@ describe('Sharings View', () => {
         container.querySelector('.fil-content-file-placeholder')
       ).not.toBeNull()
     })
-
-    consoleSpy.mockRestore()
   })
 
   it('should not display placeholder when all files are loaded', async () => {

--- a/src/drive/web/modules/views/Trash/TrashFolderView.spec.jsx
+++ b/src/drive/web/modules/views/Trash/TrashFolderView.spec.jsx
@@ -97,7 +97,7 @@ describe('TrashFolderView', () => {
   })
 
   it('renders the empty trash view', async () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation() // to be removed with https://github.com/cozy/cozy-libs/pull/1457
+    jest.spyOn(console, 'error').mockImplementation() // TODO: to be removed with https://github.com/cozy/cozy-libs/pull/1457
 
     useQuery.mockReturnValue({
       data: [],
@@ -111,8 +111,6 @@ describe('TrashFolderView', () => {
       await sleep(100)
     })
     getByText(`You don’t have any deleted files.`)
-
-    consoleSpy.mockRestore()
   })
 
   it('should contain breadcrumb with root path', async () => {

--- a/src/drive/web/modules/views/hooks.spec.js
+++ b/src/drive/web/modules/views/hooks.spec.js
@@ -75,10 +75,6 @@ test('excludeTrashedFiles', () => {
 })
 
 describe('useFileWithPath', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('should return default data while all queries are not finished', () => {
     useQuery
       .mockReturnValueOnce({ data: null, fetchStatus: 'loading' })

--- a/src/photos/ducks/clustering/setting.spec.js
+++ b/src/photos/ducks/clustering/setting.spec.js
@@ -19,9 +19,6 @@ const photos = [
 ]
 
 describe('setting', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
   it('Should update the params period ', async () => {
     const params = [
       {

--- a/src/photos/targets/services/onPhotoUpload.spec.js
+++ b/src/photos/targets/services/onPhotoUpload.spec.js
@@ -30,9 +30,6 @@ describe('onPhotoUpload', () => {
     // TODO: remove this spy by testing correctly the asynchronous actions
     jest.spyOn(console, 'error').mockImplementation()
   })
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
 
   it('Should stop if other execution is running', async () => {
     readSetting.mockReturnValueOnce({


### PR DESCRIPTION
Automatically clear mock calls, instances and results before every test.
Equivalent to calling jest.clearAllMocks() before each test.
This does not remove any mock implementation that may have been provided.

First step before using resetMocks in jest.config

Reply to request from #2502 