### PR TITLE
fix(upload): return average remaining time

### DIFF
--- a/src/drive/web/modules/upload/index.spec.js
+++ b/src/drive/web/modules/upload/index.spec.js
@@ -668,7 +668,6 @@ describe('queue reducer', () => {
 
     it('should handle upload error', () => {
       const result = queue(state, uploadProgress(file, event1, date1))
-      expect(result[0].progress.remainingTime).toBe(null)
       const result2 = queue(result, uploadProgress(file, event2, date2))
       const result3 = queue(result2, { type: 'RECEIVE_UPLOAD_ERROR', file })
       expect(result3[0].progress).toEqual(null)


### PR DESCRIPTION
Instead of slowing Cozy-UI FileUpload component, we calculate an average of the remaining time. And returns it.

This feature is in draft, not tested yet, and in the beta 5 version because I struggle to check on a branch if the new version works. If it's approved, I will go further

Addendum: Friday 18th February
The feature is approved, it is going directly in prod'.

This commit is going to be cherry picked and a PR will come to add missing tests