### PR TITLE
File openings inside new tab

### DIFF
--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -104,7 +104,9 @@ const File = props => {
     refreshFolderContent,
     isInSyncFromSharing,
     extraColumns,
-    breakpoints: { isExtraLarge, isMobile }
+    breakpoints: { isExtraLarge, isMobile },
+    fileUrlToNavigate,
+    folderUrlToNavigate
   } = props
 
   const isImage = attributes.class === 'image'
@@ -144,6 +146,8 @@ const File = props => {
         open={open}
         toggle={toggle}
         isRenaming={isRenaming}
+        fileUrlToNavigate={fileUrlToNavigate}
+        folderUrlToNavigate={folderUrlToNavigate}
       >
         <FileThumbnail
           file={attributes}
@@ -160,6 +164,7 @@ const File = props => {
           formattedUpdatedAt={formattedUpdatedAt}
           refreshFolderContent={refreshFolderContent}
           isInSyncFromSharing={isInSyncFromSharing}
+          folderUrlToNavigate={folderUrlToNavigate}
         />
         <LastUpdate
           date={updatedAt}

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -65,7 +65,12 @@ const File = props => {
     const { onFolderOpen, onFileOpen, isAvailableOffline } = props
     event.stopPropagation()
     if (isDirectory(attributes)) {
-      onFolderOpen(attributes.id)
+      if (event.ctrlKey || event.metaKey || event.shiftKey) {
+        const openInNewTab = url => window.open(url, '_blank')
+        openInNewTab(`/#/folder/${attributes.id}`)
+      } else {
+        onFolderOpen(attributes.id)
+      }
     } else {
       onFileOpen({
         event,

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -62,6 +62,8 @@ const File = props => {
   }
 
   const open = (event, attributes) => {
+    console.log('open')
+
     const {
       onFolderOpen,
       onFileOpen,
@@ -70,6 +72,8 @@ const File = props => {
     } = props
     event.stopPropagation()
     if (isDirectory(attributes)) {
+      console.log('is directory')
+
       if (event.ctrlKey || event.metaKey || event.shiftKey) {
         const openInNewTab = url => window.open(url, '_blank')
         const folderUrl =
@@ -165,6 +169,7 @@ const File = props => {
           refreshFolderContent={refreshFolderContent}
           isInSyncFromSharing={isInSyncFromSharing}
           folderUrlToNavigate={folderUrlToNavigate}
+          open={open}
         />
         <LastUpdate
           date={updatedAt}

--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -62,12 +62,19 @@ const File = props => {
   }
 
   const open = (event, attributes) => {
-    const { onFolderOpen, onFileOpen, isAvailableOffline } = props
+    const {
+      onFolderOpen,
+      onFileOpen,
+      isAvailableOffline,
+      folderUrlToNavigate
+    } = props
     event.stopPropagation()
     if (isDirectory(attributes)) {
       if (event.ctrlKey || event.metaKey || event.shiftKey) {
         const openInNewTab = url => window.open(url, '_blank')
-        openInNewTab(`/#/folder/${attributes.id}`)
+        const folderUrl =
+          folderUrlToNavigate(attributes.id) || `/folder/${attributes.id}`
+        openInNewTab(`/#${folderUrl}`)
       } else {
         onFolderOpen(attributes.id)
       }

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -66,6 +66,8 @@ const FileOpener = ({
     const gesturesHandler = propagating(new Hammer(rowRef.current))
 
     gesturesHandler.on('tap press singletap', ev => {
+      console.log('tap press singletap')
+
       if (actionMenuVisible || disabled) return
       if (enableTouchEvents(ev)) {
         ev.preventDefault() // prevent a ghost click
@@ -74,6 +76,7 @@ const FileOpener = ({
           toggle(ev.srcEvent)
         } else {
           ev.srcEvent.stopImmediatePropagation()
+          console.log('open')
           if (!isRenaming) open(ev.srcEvent, file)
         }
       }

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -15,18 +15,6 @@ const getParentDiv = element => {
   return getParentDiv(element.parentNode)
 }
 
-export const getParentLink = element => {
-  if (!element) {
-    return null
-  }
-
-  if (element.nodeName.toLowerCase() === 'a') {
-    return element
-  }
-
-  return getParentLink(element.parentNode)
-}
-
 const enableTouchEvents = ev => {
   // remove event when you rename a file
   if (['INPUT', 'BUTTON'].indexOf(ev.target.nodeName) !== -1) {

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -111,7 +111,9 @@ const FileOpener = ({
 
   const isFolder = file =>
     file.attributes && file.attributes.type === 'directory'
-  const isFile = file => file.attributes && file.attributes.type === 'file'
+  const isFile = file =>
+    (file.attributes && file.attributes.type === 'file') ||
+    file._type === 'io.cozy.files'
   const isShortcut = file => file.class === 'shortcut'
   const isNote = file => file.name.endsWith('.cozy-note')
   let buildHref = ''
@@ -129,6 +131,7 @@ const FileOpener = ({
   } else {
     console.log('NOT FILE')
     console.log({ file })
+    console.log('file._type, ', file._type)
     buildHref = ''
   }
 

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -30,11 +30,11 @@ const enableTouchEvents = ev => {
     return false
   }
 
-  // // Check if the clicked element is a file path, in that case the FileOpener has nothing to handle
-  // if (ev.srcEvent.target.closest('[class^="fil-file-path"]')) {
-  //   console.log('case 3')
-  //   return false
-  // }
+  // Check if the clicked element is a file path, in that case the FileOpener has nothing to handle
+  if (ev.srcEvent.target.closest('[class^="fil-file-path"]')) {
+    console.log('case 3')
+    return false
+  }
 
   return true
 }
@@ -140,6 +140,8 @@ const FileOpener = ({
       id={file.id}
       href={buildHref}
       onClick={ev => {
+        console.log('on click file opener')
+
         ev.preventDefault()
       }}
     >

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -110,15 +110,46 @@ const FileOpener = ({
     )
   }
 
+  const isFolder = file =>
+    file.attributes && file.attributes.type === 'directory'
+  const isFile = file => file.attributes && file.attributes.type === 'file'
+  const isShortcut = file => file.class === 'shortcut'
+  const isNote = file => file.name.endsWith('.cozy-note')
+  let buildHref = ''
+  if (isFolder(file)) {
+    buildHref = `/#/folder/${file.id}`
+  } else if (isNote(file)) {
+    console.log('isNote')
+    console.log({ file })
+    // DO NOTHING
+    // http://drive.cozy.localhost:8080/#/folder/io.cozy.files.root-dir/file/682e64b839470826fda67a4abc022ff4
+    // notes.cozy.localhost:8080/#/n/682e64b839470826fda67a4abc022ff4
+  } else if (isShortcut(file)) {
+    console.log('isShortcut')
+    console.log({ file })
+    // generate external file <=
+    // DO NOTHING
+  } else if (isFile(file)) {
+    buildHref = `/#/folder/${file.dir_id}/file/${file.id}`
+  } else {
+    console.log('NOT FILE')
+    console.log({ file })
+    buildHref = ''
+  }
+
   return (
-    <span
+    <a // works only with folder broken
       data-testid="not-onlyoffice-span"
-      className={styles['file-opener']}
+      className={`${styles['file-opener']} ${styles['file-opener__a']}`}
       ref={rowRef}
       id={file.id}
+      href={buildHref}
+      onClick={ev => {
+        ev.preventDefault()
+      }}
     >
       {children}
-    </span>
+    </a>
   )
 }
 

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -30,8 +30,6 @@ export const getParentLink = element => {
 const enableTouchEvents = ev => {
   // remove event when you rename a file
   if (['INPUT', 'BUTTON'].indexOf(ev.target.nodeName) !== -1) {
-    console.log('case 1')
-
     return false
   }
 
@@ -41,15 +39,14 @@ const enableTouchEvents = ev => {
     parentDiv.className.indexOf(styles['fil-content-file-select']) !== -1 ||
     parentDiv.className.indexOf(styles['fil-content-file-action']) !== -1
   ) {
-    console.log('case 2')
     return false
   }
 
-  // Check if the clicked element is a file path, in that case the FileOpener has nothing to handle
-  if (ev.srcEvent.target.closest('[class^="fil-file-path"]')) {
-    console.log('case 3')
-    return false
-  }
+  // // Check if the clicked element is a file path, in that case the FileOpener has nothing to handle
+  // if (ev.srcEvent.target.closest('[class^="fil-file-path"]')) {
+  //   console.log('case 3')
+  //   return false
+  // }
 
   return true
 }
@@ -62,7 +59,9 @@ const FileOpener = ({
   open,
   selectionModeActive,
   isRenaming,
-  children
+  children,
+  folderUrlToNavigate,
+  fileUrlToNavigate
 }) => {
   const rowRef = useRef()
 
@@ -129,7 +128,7 @@ const FileOpener = ({
   const isNote = file => file.name.endsWith('.cozy-note')
   let buildHref = ''
   if (isFolder(file)) {
-    buildHref = `/#/folder/${file.id}`
+    buildHref = `/#${folderUrlToNavigate(file.id)}`
   } else if (isNote(file)) {
     // DO NOTHING
     // http://drive.cozy.localhost:8080/#/folder/io.cozy.files.root-dir/file/682e64b839470826fda67a4abc022ff4
@@ -138,7 +137,7 @@ const FileOpener = ({
     // generate external file <=
     // DO NOTHING
   } else if (isFile(file)) {
-    buildHref = `/#/folder/${file.dir_id}/file/${file.id}`
+    buildHref = `/#${fileUrlToNavigate(file.dir_id)(file)}`
   } else {
     console.log('NOT FILE')
     console.log({ file })

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -119,14 +119,10 @@ const FileOpener = ({
   if (isFolder(file)) {
     buildHref = `/#/folder/${file.id}`
   } else if (isNote(file)) {
-    console.log('isNote')
-    console.log({ file })
     // DO NOTHING
     // http://drive.cozy.localhost:8080/#/folder/io.cozy.files.root-dir/file/682e64b839470826fda67a4abc022ff4
     // notes.cozy.localhost:8080/#/n/682e64b839470826fda67a4abc022ff4
   } else if (isShortcut(file)) {
-    console.log('isShortcut')
-    console.log({ file })
     // generate external file <=
     // DO NOTHING
   } else if (isFile(file)) {
@@ -138,7 +134,7 @@ const FileOpener = ({
   }
 
   return (
-    <a // works only with folder broken
+    <a
       data-testid="not-onlyoffice-span"
       className={`${styles['file-opener']} ${styles['file-opener__a']}`}
       ref={rowRef}

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -30,6 +30,8 @@ export const getParentLink = element => {
 const enableTouchEvents = ev => {
   // remove event when you rename a file
   if (['INPUT', 'BUTTON'].indexOf(ev.target.nodeName) !== -1) {
+    console.log('case 1')
+
     return false
   }
 
@@ -39,11 +41,15 @@ const enableTouchEvents = ev => {
     parentDiv.className.indexOf(styles['fil-content-file-select']) !== -1 ||
     parentDiv.className.indexOf(styles['fil-content-file-action']) !== -1
   ) {
+    console.log('case 2')
     return false
   }
 
   // Check if the clicked element is a file path, in that case the FileOpener has nothing to handle
-  if (ev.srcEvent.target.closest('[class^="fil-file-path"]')) return false
+  if (ev.srcEvent.target.closest('[class^="fil-file-path"]')) {
+    console.log('case 3')
+    return false
+  }
 
   return true
 }
@@ -69,9 +75,12 @@ const FileOpener = ({
       console.log('tap press singletap')
 
       if (actionMenuVisible || disabled) return
+      console.log('RETURN PASSE')
       if (enableTouchEvents(ev)) {
+        console.log('TOUCH EVENT ENABLE')
         ev.preventDefault() // prevent a ghost click
         if (ev.type === 'press' || selectionModeActive) {
+          console.log('PRESS')
           ev.srcEvent.stopImmediatePropagation()
           toggle(ev.srcEvent)
         } else {

--- a/src/drive/web/modules/filelist/FileOpener.spec.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.spec.jsx
@@ -8,7 +8,7 @@ import { shouldBeOpenedByOnlyOffice } from 'cozy-client/dist/models/file'
 import AppLike from 'test/components/AppLike'
 import { generateFile } from 'test/generate'
 
-import FileOpener, { getParentLink } from './FileOpener'
+import FileOpener from './FileOpener'
 
 jest.mock('cozy-client/dist/models/file', () => ({
   ...jest.requireActual('cozy-client/dist/models/file'),
@@ -47,28 +47,5 @@ describe('FileOpener', () => {
 
     expect(queryByTestId('onlyoffice-link')).toBeFalsy()
     expect(queryByTestId('not-onlyoffice-span')).toBeTruthy()
-  })
-})
-
-describe('getParentLink function', () => {
-  it('should return the first link in the element ancestors', () => {
-    const div = document.createElement('div')
-    const link = document.createElement('a')
-    link.className = 'my-link'
-    const span = document.createElement('span')
-    const span2 = document.createElement('span')
-    div.appendChild(link)
-    link.appendChild(span)
-    span.appendChild(span2)
-    const result = getParentLink(span2)
-    expect(result).toEqual(link)
-  })
-
-  it('should return null if there is no link in the element ancestors', () => {
-    const div = document.createElement('div')
-    const span = document.createElement('span')
-    div.appendChild(span)
-    const result = getParentLink(span)
-    expect(result).toBeNull()
   })
 })

--- a/src/drive/web/modules/filelist/cells/FileName.jsx
+++ b/src/drive/web/modules/filelist/cells/FileName.jsx
@@ -81,7 +81,8 @@ const FileName = ({
   formattedUpdatedAt,
   refreshFolderContent,
   isInSyncFromSharing,
-  folderUrlToNavigate
+  folderUrlToNavigate,
+  open
 }) => {
   const classes = cx(
     styles['fil-content-cell'],
@@ -131,6 +132,11 @@ const FileName = ({
               <a
                 href={`/#${folderUrlToNavigate(attributes.dir_id)}`}
                 className={styles['fil-file-path']}
+                onClick={ev => {
+                  ev.preventDefault()
+                  console.log('on click')
+                  open(ev, { type: 'directory', id: attributes.dir_id })
+                }}
               >
                 <MidEllipsis text={attributes.displayedPath} />
               </a>

--- a/src/drive/web/modules/filelist/cells/FileName.jsx
+++ b/src/drive/web/modules/filelist/cells/FileName.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react'
 import cx from 'classnames'
-import { Link } from 'react-router'
 import get from 'lodash/get'
 
 import { useClient } from 'cozy-client'
@@ -81,7 +80,8 @@ const FileName = ({
   formattedSize,
   formattedUpdatedAt,
   refreshFolderContent,
-  isInSyncFromSharing
+  isInSyncFromSharing,
+  folderUrlToNavigate
 }) => {
   const classes = cx(
     styles['fil-content-cell'],
@@ -128,13 +128,12 @@ const FileName = ({
                 <CertificationsIcons attributes={attributes} />
               </div>
             ) : (
-              <Link
-                to={`/folder/${attributes.dir_id}`}
-                // Please do not modify the className as it is used in event handling, see FileOpener#46
+              <a
+                href={`/#${folderUrlToNavigate(attributes.dir_id)}`}
                 className={styles['fil-file-path']}
               >
                 <MidEllipsis text={attributes.displayedPath} />
-              </Link>
+              </a>
             ))}
           {!withFilePath &&
             (isDirectory(attributes) || (

--- a/src/drive/web/modules/filelist/cells/FileName.jsx
+++ b/src/drive/web/modules/filelist/cells/FileName.jsx
@@ -129,8 +129,7 @@ const FileName = ({
                 <CertificationsIcons attributes={attributes} />
               </div>
             ) : (
-              <a
-                href={`/#${folderUrlToNavigate(attributes.dir_id)}`}
+              <span
                 className={styles['fil-file-path']}
                 onClick={ev => {
                   ev.preventDefault()
@@ -139,7 +138,7 @@ const FileName = ({
                 }}
               >
                 <MidEllipsis text={attributes.displayedPath} />
-              </a>
+              </span>
             ))}
           {!withFilePath &&
             (isDirectory(attributes) || (

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -206,6 +206,8 @@ const DriveView = ({
         <FolderViewBody
           navigateToFolder={navigateToFolder}
           navigateToFile={navigateToFile}
+          fileUrlToNavigate={fileUrlToNavigate}
+          folderUrlToNavigate={folderUrlToNavigate}
           actions={actions}
           queryResults={[foldersResult, filesResult]}
           canSort

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -53,6 +53,10 @@ import AddMenuProvider from 'drive/web/modules/drive/AddMenu/AddMenuProvider'
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
+const folderUrlToNavigate = folderId => `/folder/${folderId}`
+const fileUrlToNavigate = currentFolderId => file =>
+  `/folder/${currentFolderId}/file/${file.id}`
+
 const DriveView = ({
   currentFolderId,
   router,
@@ -105,14 +109,14 @@ const DriveView = ({
 
   const navigateToFolder = useCallback(
     folderId => {
-      router.push(`/folder/${folderId}`)
+      router.push(folderUrlToNavigate(folderId))
     },
     [router]
   )
 
   const navigateToFile = useCallback(
     file => {
-      router.push(`/folder/${currentFolderId}/file/${file.id}`)
+      router.push(fileUrlToNavigate(currentFolderId)(file))
     },
     [router, currentFolderId]
   )

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -218,6 +218,7 @@ const FolderViewBody = ({
                           attributes={file}
                           withSelectionCheckbox
                           onFolderOpen={navigateToFolder}
+                          fileUrlToNavigate={fileUrlToNavigate}
                           folderUrlToNavigate={folderUrlToNavigate}
                           onFileOpen={handleFileOpen}
                           withFilePath={withFilePath}

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -44,7 +44,9 @@ const FolderViewBody = ({
   navigateToFolder,
   navigateToFile,
   refreshFolderContent = null,
-  extraColumns
+  extraColumns,
+  fileUrlToNavigate,
+  folderUrlToNavigate
 }) => {
   const { router } = useRouter()
   const { isDesktop } = useBreakpoints()
@@ -79,7 +81,8 @@ const FolderViewBody = ({
         replaceCurrentUrl: url => (window.location.href = url),
         openInNewTab: url => window.open(url, '_blank'),
         routeTo: url => router.push(url),
-        isOnlyOfficeEnabled: isOnlyOfficeEnabled()
+        isOnlyOfficeEnabled: isOnlyOfficeEnabled(),
+        fileUrlToNavigate
       })({
         event,
         file,
@@ -185,7 +188,7 @@ const FolderViewBody = ({
             {/* TODO FolderViewBody should not have the responsability to chose
           which empty component to display. It should be done by the "view" itself.
           But adding a new prop like <FolderViewBody emptyComponent={}
-          is not good enought too */}
+          is not good enough too */}
             {isEmpty && currentFolderId !== TRASH_DIR_ID && (
               <EmptyDrive isEncrypted={isEncFolder} canUpload={canUpload} />
             )}
@@ -214,6 +217,7 @@ const FolderViewBody = ({
                           attributes={file}
                           withSelectionCheckbox
                           onFolderOpen={navigateToFolder}
+                          folderUrlToNavigate={folderUrlToNavigate}
                           onFileOpen={handleFileOpen}
                           withFilePath={withFilePath}
                           thumbnailSizeBig={isBigThumbnail}

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -73,6 +73,7 @@ const FolderViewBody = ({
 
   const handleFileOpen = useCallback(
     ({ event, file, isAvailableOffline }) => {
+      console.log('handleFileOpen')
       return createFileOpeningHandler({
         client,
         isFlatDomain,

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -18,11 +18,12 @@ const createFileOpeningHandler = ({
   isOnlyOfficeEnabled,
   fileUrlToNavigate
 }) => async ({ event, file, isAvailableOffline }) => {
+  console.log('createFileOpeningHandler')
   const fileUrl =
     fileUrlToNavigate(file.dir_id)(file) ||
     `/folder/${file.dir_id}/file/${file.id}`
 
-  console.log('createFileOpeningHandler')
+  console.log('fireUrl')
 
   if (isAvailableOffline) {
     console.log('isAvailableOffline')
@@ -58,8 +59,10 @@ const createFileOpeningHandler = ({
       try {
         const routeToNote = await models.note.fetchURL(client, file)
         if (shouldOpenInNewTab) {
+          console.log('shouldOpenInNewTab')
           openInNewTab(routeToNote)
         } else {
+          console.log('should NOT OpenInNewTab')
           replaceCurrentUrl(routeToNote)
         }
       } catch (e) {

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -41,7 +41,12 @@ const createFileOpeningHandler = ({
     }
   } else if (isNote) {
     try {
-      replaceCurrentUrl(await models.note.fetchURL(client, file))
+      const routeToNote = await models.note.fetchURL(client, file)
+      if (event.ctrlKey || event.metaKey || event.shiftKey) {
+        openInNewTab(routeToNote)
+      } else {
+        replaceCurrentUrl(routeToNote)
+      }
     } catch (e) {
       Alerter.error('alert.offline')
     }
@@ -52,7 +57,11 @@ const createFileOpeningHandler = ({
       routeTo(makeOnlyOfficeFileRoute(file, true))
     }
   } else {
-    navigateToFile(file)
+    if (event.ctrlKey || event.metaKey || event.shiftKey) {
+      openInNewTab(`/#/folder/${file.dir_id}/file/${file.id}`)
+    } else {
+      navigateToFile(file)
+    }
   }
 }
 

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -214,6 +214,7 @@ const PublicFolderView = ({
             <FolderViewBody
               navigateToFolder={navigateToFolder}
               navigateToFile={navigateToFile}
+              folderUrlToNavigate={folderUrlToNavigate}
               actions={actions}
               queryResults={[filesResult]}
               canSort={false}

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -8,10 +8,8 @@ import uniqBy from 'lodash/uniqBy'
 
 import { useClient, models } from 'cozy-client'
 import { SharingContext } from 'cozy-sharing'
-import { isMobileApp } from 'cozy-device-helper'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Content, Overlay } from 'cozy-ui/transpiled/react'
-import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { SharingBannerPlugin, useSharingInfos } from 'cozy-sharing'
 
@@ -108,22 +106,8 @@ const PublicFolderView = ({
   )
 
   const navigateToFile = async file => {
-    const isNote = models.file.isNote(file)
-    if (isNote) {
-      try {
-        const noteUrl = await models.note.fetchURL(client, file)
-        const url = new URL(noteUrl)
-        if (!isMobileApp()) {
-          url.searchParams.set('returnUrl', window.location.href)
-        }
-        window.location.href = url.toString()
-      } catch (e) {
-        Alerter.error('alert.offline')
-      }
-    } else {
-      showInViewer(file)
-      setViewerOpened(true)
-    }
+    showInViewer(file)
+    setViewerOpened(true)
   }
 
   const showInViewer = useCallback(

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -62,6 +62,7 @@ const getBreadcrumbPath = (t, displayedFolder, parentFolder) =>
 
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
+const folderUrlToNavigate = folderId => `/folder/${folderId}`
 
 const PublicFolderView = ({
   currentFolderId,
@@ -101,7 +102,7 @@ const PublicFolderView = ({
 
   const navigateToFolder = useCallback(
     folderId => {
-      router.push(`/folder/${folderId}`)
+      router.push(folderUrlToNavigate(folderId))
     },
     [router]
   )

--- a/src/drive/web/modules/views/Recent/index.jsx
+++ b/src/drive/web/modules/views/Recent/index.jsx
@@ -35,6 +35,9 @@ import { makeExtraColumnsNamesFromMedia } from 'drive/web/modules/certifications
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
+const folderUrlToNavigate = folderId => `/folder/${folderId}`
+const fileUrlToNavigate = file => `/recent/file/${file.id}`
+
 export const RecentView = ({ router, location, children }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -55,14 +58,14 @@ export const RecentView = ({ router, location, children }) => {
 
   const navigateToFolder = useCallback(
     folderId => {
-      router.push(`/folder/${folderId}`)
+      router.push(folderUrlToNavigate(folderId))
     },
     [router]
   )
 
   const navigateToFile = useCallback(
     file => {
-      router.push(`/recent/file/${file.id}`)
+      router.push(fileUrlToNavigate(file))
     },
     [router]
   )

--- a/src/drive/web/modules/views/Recent/index.jsx
+++ b/src/drive/web/modules/views/Recent/index.jsx
@@ -36,7 +36,7 @@ const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
 const folderUrlToNavigate = folderId => `/folder/${folderId}`
-const fileUrlToNavigate = file => `/recent/file/${file.id}`
+const fileUrlToNavigate = () => file => `/recent/file/${file.id}`
 
 export const RecentView = ({ router, location, children }) => {
   const { t } = useI18n()

--- a/src/drive/web/modules/views/Recent/index.jsx
+++ b/src/drive/web/modules/views/Recent/index.jsx
@@ -113,6 +113,8 @@ export const RecentView = ({ router, location, children }) => {
       <FolderViewBody
         navigateToFolder={navigateToFolder}
         navigateToFile={navigateToFile}
+        fileUrlToNavigate={fileUrlToNavigate}
+        folderUrlToNavigate={folderUrlToNavigate}
         actions={actions}
         queryResults={[result]}
         canSort={false}

--- a/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
+++ b/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
@@ -34,6 +34,11 @@ import FolderViewBreadcrumb from '../Folder/FolderViewBreadcrumb'
 import { useExtraColumns } from 'drive/web/modules/certifications/useExtraColumns'
 import { makeExtraColumnsNamesFromMedia } from 'drive/web/modules/certifications'
 
+const folderUrlToNavigate = folderId =>
+  folderId ? `/sharings/${folderId}` : '/sharings'
+const fileUrlToNavigate = currentFolderId => file =>
+  `/sharings/${currentFolderId}/file/${file.id}`
+
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
@@ -77,15 +82,14 @@ const SharingsFolderView = ({
 
   const navigateToFolder = useCallback(
     folderId => {
-      if (folderId) router.push(`/sharings/${folderId}`)
-      else router.push('/sharings')
+      router.push(folderUrlToNavigate(folderId))
     },
     [router]
   )
 
   const navigateToFile = useCallback(
     file => {
-      router.push(`/sharings/${currentFolderId}/file/${file.id}`)
+      router.push(fileUrlToNavigate(currentFolderId)(file))
     },
     [router, currentFolderId]
   )
@@ -132,6 +136,8 @@ const SharingsFolderView = ({
       <FolderViewBody
         navigateToFolder={navigateToFolder}
         navigateToFile={navigateToFile}
+        fileUrlToNavigate={fileUrlToNavigate}
+        folderUrlToNavigate={folderUrlToNavigate}
         actions={actions}
         queryResults={[foldersResult, filesResult]}
         canSort

--- a/src/drive/web/modules/views/Sharings/index.jsx
+++ b/src/drive/web/modules/views/Sharings/index.jsx
@@ -116,6 +116,8 @@ export const SharingsView = ({
           <FolderViewBody
             navigateToFolder={navigateToFolder}
             navigateToFile={navigateToFile}
+            fileUrlToNavigate={fileUrlToNavigate}
+            folderUrlToNavigate={folderUrlToNavigate}
             actions={actions}
             queryResults={[result]}
             canSort={false}

--- a/src/drive/web/modules/views/Sharings/index.jsx
+++ b/src/drive/web/modules/views/Sharings/index.jsx
@@ -38,7 +38,7 @@ const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
 const folderUrlToNavigate = folderId => `/sharings/${folderId}`
-const fileUrlToNavigate = file => `/sharings/file/${file.id}`
+const fileUrlToNavigate = () => file => `/sharings/file/${file.id}`
 
 export const SharingsView = ({
   router,

--- a/src/drive/web/modules/views/Sharings/index.jsx
+++ b/src/drive/web/modules/views/Sharings/index.jsx
@@ -37,6 +37,9 @@ import FileListRowsPlaceholder from 'drive/web/modules/filelist/FileListRowsPlac
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
+const folderUrlToNavigate = folderId => `/sharings/${folderId}`
+const fileUrlToNavigate = file => `/sharings/file/${file.id}`
+
 export const SharingsView = ({
   router,
   location,
@@ -67,14 +70,14 @@ export const SharingsView = ({
 
   const navigateToFolder = useCallback(
     folderId => {
-      router.push(`/sharings/${folderId}`)
+      router.push(folderUrlToNavigate(folderId))
     },
     [router]
   )
 
   const navigateToFile = useCallback(
     file => {
-      router.push(`/sharings/file/${file.id}`)
+      router.push(fileUrlToNavigate(file))
     },
     [router]
   )

--- a/src/drive/web/modules/views/Trash/TrashFolderView.jsx
+++ b/src/drive/web/modules/views/Trash/TrashFolderView.jsx
@@ -122,6 +122,8 @@ const TrashFolderView = ({
         displayedFolder={displayedFolder}
         navigateToFolder={navigateToFolder}
         navigateToFile={navigateToFile}
+        fileUrlToNavigate={fileUrlToNavigate}
+        folderUrlToNavigate={folderUrlToNavigate}
         actions={actions}
         queryResults={[foldersResult, filesResult]}
         canSort

--- a/src/drive/web/modules/views/Trash/TrashFolderView.jsx
+++ b/src/drive/web/modules/views/Trash/TrashFolderView.jsx
@@ -31,6 +31,10 @@ import FolderViewBreadcrumb from '../Folder/FolderViewBreadcrumb'
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
+const folderUrlToNavigate = folderId => `/trash/${folderId}`
+const fileUrlToNavigate = currentFolderId => file =>
+  `/trash/${currentFolderId}/file/${file.id}`
+
 const TrashFolderView = ({
   currentFolderId,
   displayedFolder,
@@ -72,14 +76,14 @@ const TrashFolderView = ({
 
   const navigateToFolder = useCallback(
     folderId => {
-      router.push(`/trash/${folderId}`)
+      router.push(folderUrlToNavigate(folderId))
     },
     [router]
   )
 
   const navigateToFile = useCallback(
     file => {
-      router.push(`/trash/${currentFolderId}/file/${file.id}`)
+      router.push(fileUrlToNavigate(currentFolderId)(file))
     },
     [router, currentFolderId]
   )


### PR DESCRIPTION
This PR handles most of the case I found:
- Drive view
- Recent view
- Sharing view/index  (click on "/" path below a folder can have unexpected behaviour)
- Sharing view/ inside a folder
- Trash (not verified a last time)

Handle:
- img/mp3/txt file (so most common file)
- notes
- shortcut
- folder



But has not been cleant / tested at all.

⚠️ Won't fixed => to add in another story:
- in RecentView, right click on folder filepath MidEllipsis (because this span is located inside FileName inside FileOpener, that is an anchor opening the recent file - not the folder)

comment about this gif: 
- the link below the anchor is wrong (it's the same than the file of the table cell) => ❌ you can see on the below left corner on my browser
- when Cmd + Click, we have the expected feature (folder opened in a new tab) => ✅ I arrived inside the test folder
![2022-03-10 10 05 37](https://user-images.githubusercontent.com/8363334/157628286-9101c1c5-43b3-4f66-b3d9-873cee962b8e.gif)
- when right click, opening, we open the file instead of the folder => ❌ I arrived on the Recent gif, instead of the folder test


- on click on Notes / Shortcut, this needs the big refactor "Don't use on click, use only anchor - prefetch (query?)"