### PR TITLE
Fixes on dacc service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 🐛 Bug Fixes
 
+ - Compute sizes in MB instead of MiB in dacc service.
+ - Query files based on their uploaded date in dacc service.
+
 ## 🔧 Tech
 
 # 1.40.0

--- a/src/drive/lib/dacc/dacc.js
+++ b/src/drive/lib/dacc/dacc.js
@@ -50,7 +50,7 @@ export const sendToRemoteDoctype = async (
 
 const convertFileSizeInMB = file => {
   // The size is converted in MB to avoid too large values
-  return parseInt(file.size) / (1024 * 1024) // Size in MB
+  return parseInt(file.size) / (1000 * 1000) // Size in million of Bytes (MB)
 }
 
 /**

--- a/src/drive/lib/dacc/dacc.spec.js
+++ b/src/drive/lib/dacc/dacc.spec.js
@@ -54,10 +54,10 @@ describe('dacc service', () => {
       'maif',
       'maif-vie'
     ])
-    expect(sizesBySlug['drive']).toEqual(4)
-    expect(sizesBySlug['edf']).toEqual(2)
-    expect(sizesBySlug['maif']).toEqual(8)
-    expect(sizesBySlug['maif-vie']).toEqual(6)
+    expect(sizesBySlug['drive']).toEqual(4.194304)
+    expect(sizesBySlug['edf']).toEqual(2.097152)
+    expect(sizesBySlug['maif']).toEqual(8.388608)
+    expect(sizesBySlug['maif-vie']).toEqual(6.291456)
   })
 
   it('should aggregate all sizes but excluded slug', async () => {

--- a/src/drive/lib/dacc/query.js
+++ b/src/drive/lib/dacc/query.js
@@ -13,7 +13,7 @@ export const queryFilesByDate = async (client, endDate, bookmark = '') => {
     'cozyMetadata.createdByApp': {
       $gt: null
     },
-    created_at: { $lte: endDate }
+    'cozyMetadata.uploadedAt': { $lte: endDate }
   }
   const options = {
     partialFilter: {
@@ -21,8 +21,11 @@ export const queryFilesByDate = async (client, endDate, bookmark = '') => {
       trashed: false
     },
     fields: ['cozyMetadata.createdByApp', 'size'],
-    indexedFields: ['cozyMetadata.createdByApp', 'created_at'],
-    sort: [{ 'cozyMetadata.createdByApp': 'asc' }, { created_at: 'asc' }],
+    indexedFields: ['cozyMetadata.createdByApp', 'cozyMetadata.uploadedAt'],
+    sort: [
+      { 'cozyMetadata.createdByApp': 'asc' },
+      { 'cozyMetadata.uploadedAt': 'asc' }
+    ],
     limit: 1000,
     bookmark
   }


### PR DESCRIPTION
* Use MB instead of MiB for size
* Use `cozyMetadata.uploadedAt` instead of `created_at` for file date