### PR TITLE
feat: Do not look for encryption when flag is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  * Compute sizes in MB instead of MiB in dacc service.
  * Query files based on their uploaded date in dacc service.
  * Upload drop zone can correctly upload file with name containing ampersand "&" and hash "#"
+ * Do not query encryption files when flag is not set
 
 ## 🔧 Tech
 

--- a/src/drive/lib/encryption.js
+++ b/src/drive/lib/encryption.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import flag from 'cozy-flags'
 import { DOCTYPE_FILES, DOCTYPE_FILES_ENCRYPTION } from 'drive/lib/doctypes'
 import { ENCRYPTION_MIME_TYPE } from 'drive/constants/config'
 import { buildEncryptionByIdQuery } from 'drive/web/modules/queries'
@@ -17,6 +18,9 @@ export const isEncryptedFile = file => {
 }
 
 export const getEncryptionKeyFromDirId = async (client, dirId) => {
+  if (!flag('drive.enable-encryption')) {
+    return null
+  }
   const docId = `${DOCTYPE_FILES}/${dirId}`
   const query = buildEncryptionByIdQuery(docId)
   const res = await client.query(query.definition, { options: query.options })

--- a/src/drive/lib/encryption.spec.js
+++ b/src/drive/lib/encryption.spec.js
@@ -1,0 +1,27 @@
+import { getEncryptionKeyFromDirId } from './encryption'
+import CozyClient from 'cozy-client'
+import flag from 'cozy-flags'
+
+jest.mock('cozy-flags', () => jest.fn())
+
+describe('encryption', () => {
+  const client = new CozyClient({})
+  beforeEach(() => {
+    client.query = jest.fn().mockResolvedValue({
+      data: {
+        key: 'super-secret-key'
+      }
+    })
+  })
+  it('should return nothing when flag is not set', async () => {
+    const key = await getEncryptionKeyFromDirId(client, null)
+    expect(key).toBeNull()
+  })
+
+  it('should return encryption key when flag is set', async () => {
+    flag.mockReturnValue('drive.enable-encryption')
+
+    const key = await getEncryptionKeyFromDirId(client, null)
+    expect(key).toBe('super-secret-key')
+  })
+})

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -25,4 +25,5 @@ const flagsList = () => {
   flag('drive.onlyoffice.forceReadOnlyOnDesktop')
   flag('drive.onlyoffice.editorToolbarHeight')
   flag('drive.logger')
+  flag('drive.enable-encryption')
 }


### PR DESCRIPTION
The query is useless if the encryption flag is not set