### PR TITLE
fix: Fix pagination on Photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * When displaying cozy-home from Cozy's native application, the Support Us is not displayed
 * Upgrade Cozy-Scripts to enable service-worker
+* Photos: Fix pagination issue
 
 ## 🐛 Bug Fixes
 

--- a/src/photos/components/PhotoBoard.jsx
+++ b/src/photos/components/PhotoBoard.jsx
@@ -28,11 +28,12 @@ export class PhotoBoard extends Component {
       measureRef,
       contentRect: {
         entry: { width }
-      }
+      },
+      lastFetch
     } = this.props
-
     const isError = fetchStatus === 'failed'
-    const isFetching = fetchStatus === 'pending' || fetchStatus === 'loading'
+    const isFetching =
+      (fetchStatus === 'pending' || fetchStatus === 'loading') && !lastFetch
 
     if (isError) {
       return <ErrorComponent errorType={`${photosContext}_photos`} />

--- a/src/photos/ducks/albums/components/AlbumPhotos.jsx
+++ b/src/photos/ducks/albums/components/AlbumPhotos.jsx
@@ -121,8 +121,16 @@ class AlbumPhotos extends Component {
       return null
     }
 
-    const { t, router, album, shareAlbum, photos, hasMore, fetchMore } =
-      this.props
+    const {
+      t,
+      router,
+      album,
+      shareAlbum,
+      photos,
+      hasMore,
+      fetchMore,
+      lastFetch
+    } = this.props
     const { editing } = this.state
     const shared = {}
 
@@ -182,6 +190,7 @@ class AlbumPhotos extends Component {
                 fetchStatus={photos.fetchStatus}
                 hasMore={hasMore}
                 fetchMore={fetchMore}
+                lastFetch={lastFetch}
               />
             )}
             {this.renderViewer(this.props.children)}
@@ -221,7 +230,8 @@ AlbumPhotos.propTypes = {
   shareAlbum: PropTypes.func,
   photos: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired,
-  router: PropTypes.object.isRequired
+  router: PropTypes.object.isRequired,
+  lastFetch: PropTypes.string
 }
 
 export default flow(

--- a/src/photos/ducks/albums/components/AlbumsView.jsx
+++ b/src/photos/ducks/albums/components/AlbumsView.jsx
@@ -10,16 +10,15 @@ import ErrorComponent from 'components/Error/ErrorComponent'
 import Topbar from '../../../components/Topbar'
 
 const Content = ({ list }) => {
-  const { fetchStatus } = list
-  switch (fetchStatus) {
-    case 'pending':
-    case 'loading':
-      return <Loading loadingType="albums_fetching" />
-    case 'failed':
-      return <ErrorComponent errorType="albums" />
-    default:
-      return <AlbumsList {...list} />
+  const { fetchStatus, lastFetch } = list
+  if (!lastFetch && (fetchStatus === 'pending' || fetchStatus === 'loading')) {
+    return <Loading loadingType="albums_fetching" />
   }
+  if (fetchStatus === 'failed') {
+    return <ErrorComponent errorType="albums" />
+  }
+
+  return <AlbumsList {...list} />
 }
 
 class AlbumsView extends Component {

--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -134,7 +134,7 @@ export const AlbumPhotosWithLoader =
   // TODO: fix me
   // eslint-disable-next-line react/display-name
   (
-    { data: album, fetchStatus },
+    { data: album, fetchStatus, lastFetch },
     { updateAlbum, deleteAlbum, removePhotos }
   ) => {
     if (album && fetchStatus === 'loaded') {
@@ -147,6 +147,7 @@ export const AlbumPhotosWithLoader =
           removePhotos={removePhotos}
           hasMore={album.photos.hasMore}
           fetchMore={album.photos.fetchMore.bind(album.photos)}
+          lastFetch={lastFetch}
         >
           {children}
         </AlbumPhotos>

--- a/src/photos/ducks/timeline/components/Timeline.jsx
+++ b/src/photos/ducks/timeline/components/Timeline.jsx
@@ -111,7 +111,7 @@ class Timeline extends Component {
   }
 
   render() {
-    const { t, lists, fetchStatus, hasMore, fetchMore } = this.props
+    const { t, lists, fetchStatus, hasMore, fetchMore, lastFetch } = this.props
     return (
       <Selection
         actions={selection => ({
@@ -153,6 +153,7 @@ class Timeline extends Component {
                 fetchStatus={fetchStatus}
                 hasMore={hasMore}
                 fetchMore={fetchMore}
+                lastFetch={lastFetch}
               />
             </Content>
             {this.renderViewer(this.props.children)}


### PR DESCRIPTION
We need to check if lastFetch is defined to know
if we're in a fetchMore context or in the first
render.
