### PR TITLE
fix: Use replace instead of push on init router

### DIFF
--- a/src/drive/web/modules/navigation/Index.jsx
+++ b/src/drive/web/modules/navigation/Index.jsx
@@ -46,7 +46,7 @@ export const fetchSharing = async ({
   sharingId
 }) => {
   if (!sharingId) {
-    return router.push('/folder')
+    return router.replace('/folder')
   }
 
   try {
@@ -77,15 +77,15 @@ export const fetchSharing = async ({
     }
 
     if (!hasReferencedFile) {
-      return router.push(`/folder/${SHAREDWITHME_DIR_ID}`)
+      return router.replace(`/folder/${SHAREDWITHME_DIR_ID}`)
     }
-    return router.push(`/folder/${referencedFile.dir_id}`)
+    return router.replace(`/folder/${referencedFile.dir_id}`)
   } catch (e) {
     // eslint-disable-next-line
     console.warn(
       `fetchSharing error : ${e}. Redirect to /folder/${SHAREDWITHME_DIR_ID}`
     )
-    return router.push(`/folder/${SHAREDWITHME_DIR_ID}`)
+    return router.replace(`/folder/${SHAREDWITHME_DIR_ID}`)
   }
 }
 

--- a/src/drive/web/modules/navigation/Index.spec.js
+++ b/src/drive/web/modules/navigation/Index.spec.js
@@ -10,7 +10,7 @@ jest.mock('cozy-keys-lib', () => ({
   useVaultClient: jest.fn()
 }))
 const client = createMockClient({})
-const router = { push: jest.fn() }
+const router = { replace: jest.fn() }
 const setSharingsValue = jest.fn()
 const setFileValue = jest.fn()
 const sharingRes = { data: { id: '123' } }
@@ -51,7 +51,7 @@ describe('fetchSharing', () => {
 
     expect(setSharingsValue).not.toHaveBeenCalled()
     expect(setFileValue).not.toHaveBeenCalled()
-    expect(router.push).toHaveBeenCalledWith('/folder')
+    expect(router.replace).toHaveBeenCalledWith('/folder')
   })
 
   it('should redirect to /shared-with-me-dir and store sharing in context, if sharing id but no referenced file', async () => {
@@ -61,7 +61,9 @@ describe('fetchSharing', () => {
 
     expect(setSharingsValue).toHaveBeenCalled()
     expect(setFileValue).not.toHaveBeenCalled()
-    expect(router.push).toHaveBeenCalledWith(`/folder/${SHAREDWITHME_DIR_ID}`)
+    expect(router.replace).toHaveBeenCalledWith(
+      `/folder/${SHAREDWITHME_DIR_ID}`
+    )
   })
 
   it('should redirect to /folder/dirId and store nothing in context, if sharing id and referenced file but no shortcut', async () => {
@@ -72,7 +74,7 @@ describe('fetchSharing', () => {
 
     expect(setSharingsValue).not.toHaveBeenCalled()
     expect(setFileValue).not.toHaveBeenCalled()
-    expect(router.push).toHaveBeenCalledWith('/folder/dirId')
+    expect(router.replace).toHaveBeenCalledWith('/folder/dirId')
   })
 
   it('should redirect to /folder/dirId and store sharing and file in context, if sharing id, referenced file and shortcut', async () => {
@@ -84,6 +86,6 @@ describe('fetchSharing', () => {
 
     expect(setSharingsValue).toHaveBeenCalled()
     expect(setFileValue).toHaveBeenCalled()
-    expect(router.push).toHaveBeenCalledWith('/folder/dirId')
+    expect(router.replace).toHaveBeenCalledWith('/folder/dirId')
   })
 })


### PR DESCRIPTION
Currently, when going to drive from cozy-homepage,
the user gets stuck in an endless loop if trying to navigate backward.
This is because the app router is instantiated on a single hash,
then push the pathname after it.
An easy way to fix that is to use a router.replace,
so that way the initial hash route is deleted from the stack.
Now the user can navigate backward without any issue.

- [x] Changelog updated if needed
