### PR TITLE
fix: Cc.cozycloud.errors

### DIFF
--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -148,7 +148,7 @@
       "type": "io.cozy.oauth.clients",
       "verbs": ["GET"]
     },
-    "reporting": {
+    "errorsreporting": {
       "description": "Allow to report unexpected errors to the support team",
       "type": "cc.cozycloud.errors",
       "verbs": ["POST"]

--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -106,7 +106,7 @@
       "type": "io.cozy.oauth.clients",
       "verbs": ["GET"]
     },
-     "reporting": {
+     "errorsreporting": {
       "description": "Allow to report unexpected errors to the support team",
       "type": "cc.cozycloud.errors",
       "verbs": ["POST"]


### PR DESCRIPTION
We recently updated the remote doctype to
use in order to send errors to our new Sentry.

But when updating the permission, we just
changed the type, without changing the name.

Cozy-Stack doesn't like that ATM. So let's
use a different name.
