### PR TITLE
feat: Do not display unsupported menu items inside an encrypted folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Display tiny thumbnail instead of small
 * Display thumbnail for PDF (behind a flag)
 * Support client-side encrypted files visualization 
+* Disable unsuported items inside encrypted folder
 
 ## 🐛 Bug Fixes
 

--- a/src/drive/lib/encryption.js
+++ b/src/drive/lib/encryption.js
@@ -5,6 +5,10 @@ import { buildEncryptionByIdQuery } from 'drive/web/modules/queries'
 import { models } from 'cozy-client'
 const { isEncrypted } = models.file
 
+export const isEncryptedFileOrFolder = fileOrdir => {
+  return isEncryptedFolder(fileOrdir) || isEncryptedFile(fileOrdir)
+}
+
 export const isEncryptedFolder = dir => {
   return !!getEncryptiondRef(dir)
 }

--- a/src/drive/lib/encryption.js
+++ b/src/drive/lib/encryption.js
@@ -5,7 +5,7 @@ import { buildEncryptionByIdQuery } from 'drive/web/modules/queries'
 import { models } from 'cozy-client'
 const { isEncrypted } = models.file
 
-export const hasEncryptionRef = dir => {
+export const isEncryptedFolder = dir => {
   return !!getEncryptiondRef(dir)
 }
 

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -19,7 +19,7 @@ import ShareIosIcon from 'cozy-ui/transpiled/react/Icons/ShareIos'
 import LinkOutIcon from 'cozy-ui/transpiled/react/Icons/LinkOut'
 import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
 
-import { hasEncryptionRef } from 'drive/lib/encryption'
+import { isEncryptedFolder } from 'drive/lib/encryption'
 import DeleteConfirm from 'drive/web/modules/drive/DeleteConfirm'
 import MoveModal from 'drive/web/modules/move/MoveModal'
 import ShareMenuItem from 'drive/web/modules/drive/ShareMenuItem'
@@ -87,7 +87,7 @@ export const download = ({ client, vaultClient }) => {
         displayCondition: files => {
           // Do not display when an encrypted folder is selected, as we cannot
           // generate archive for encrypted files, for now.
-          return !files.find(file => hasEncryptionRef(file))
+          return !files.find(file => isEncryptedFolder(file))
         },
         action: files => downloadFiles(client, files, { vaultClient }),
         Component: function Download(props) {

--- a/src/drive/web/modules/actions/index.spec.js
+++ b/src/drive/web/modules/actions/index.spec.js
@@ -1,0 +1,59 @@
+import { download } from './index'
+import { DOCTYPE_FILES_ENCRYPTION } from 'drive/lib/doctypes'
+
+describe('download', () => {
+  it('should not display when an encrypted folder is selected', () => {
+    const files = [
+      {
+        type: 'directory',
+        referenced_by: [
+          {
+            type: DOCTYPE_FILES_ENCRYPTION,
+            id: '123'
+          }
+        ]
+      }
+    ]
+    const dl = download({ client: {}, vaultClient: {} })
+    expect(dl.displayCondition(files)).toBe(false)
+  })
+
+  it('should not display when several encrypted files are selected', () => {
+    const files = [
+      {
+        type: 'file',
+        encrypted: true
+      },
+      {
+        type: 'file',
+        encrypted: true
+      }
+    ]
+    const dl = download({ client: {}, vaultClient: {} })
+    expect(dl.displayCondition(files)).toBe(false)
+  })
+
+  it('should display when a single encrypted file is selected', () => {
+    const files = [
+      {
+        type: 'file',
+        encrypted: true
+      }
+    ]
+    const dl = download({ client: {}, vaultClient: {} })
+    expect(dl.displayCondition(files)).toBe(true)
+  })
+
+  it('should display when selection does not include encrypted folder nor file', () => {
+    const files = [
+      {
+        type: 'file'
+      },
+      {
+        type: 'directory'
+      }
+    ]
+    const dl = download({ client: {}, vaultClient: {} })
+    expect(dl.displayCondition(files)).toBe(true)
+  })
+})

--- a/src/drive/web/modules/actions/utils.js
+++ b/src/drive/web/modules/actions/utils.js
@@ -9,7 +9,7 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import {
   getEncryptionKeyFromDirId,
   downloadEncryptedFile,
-  hasEncryptionRef,
+  isEncryptedFolder,
   decryptFile,
   isEncryptedFile
 } from 'drive/lib/encryption'
@@ -71,7 +71,7 @@ export const downloadFiles = async (client, files, { vaultClient } = {}) => {
       return Alerter.error('error.download_file.encryption_many')
     }
     const hasEncryptedDirs = files.find(
-      file => isDirectory(file) && hasEncryptionRef(file)
+      file => isDirectory(file) && isEncryptedFolder(file)
     )
     if (hasEncryptedDirs) {
       // We cannot download encrypted folder because we cannot generate client archive for now.

--- a/src/drive/web/modules/drive/AddMenu/AddMenu.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenu.jsx
@@ -21,7 +21,8 @@ export const ActionMenuContent = ({
   canCreateFolder,
   canUpload,
   refreshFolderContent,
-  isPublic
+  isPublic,
+  isEncryptedFolder
 }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -36,19 +37,21 @@ export const ActionMenuContent = ({
           <hr />
         </>
       )}
-      {canCreateFolder && <AddFolderItem />}
-      {canCreateFolder && flag('drive.enable-encryption') && (
+      {canCreateFolder && !isEncryptedFolder && <AddFolderItem />}
+      {canCreateFolder && !isPublic && flag('drive.enable-encryption') && (
         <AddEncryptedFolderItem />
       )}
-      {!isPublic && <CreateNoteItem />}
-      {canUpload && isOnlyOfficeEnabled() && (
+      {!isPublic && !isEncryptedFolder && <CreateNoteItem />}
+      {canUpload && isOnlyOfficeEnabled() && !isEncryptedFolder && (
         <>
           <CreateOnlyOfficeItem fileClass="text" />
           <CreateOnlyOfficeItem fileClass="spreadsheet" />
           <CreateOnlyOfficeItem fileClass="slide" />
         </>
       )}
-      <CreateShortcut onCreated={refreshFolderContent} />
+      {!isEncryptedFolder && (
+        <CreateShortcut onCreated={refreshFolderContent} />
+      )}
       {canUpload && <hr />}
       {canUpload && (
         <UploadItem disabled={isDisabled} onUploaded={refreshFolderContent} />
@@ -65,7 +68,8 @@ const AddMenu = ({
   canCreateFolder,
   canUpload,
   refreshFolderContent,
-  isPublic
+  isPublic,
+  isEncryptedFolder
 }) => {
   return (
     <ActionMenu
@@ -82,6 +86,7 @@ const AddMenu = ({
         canUpload={canUpload}
         refreshFolderContent={refreshFolderContent}
         isPublic={isPublic}
+        isEncryptedFolder={isEncryptedFolder}
       />
     </ActionMenu>
   )

--- a/src/drive/web/modules/drive/AddMenu/AddMenu.spec.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenu.spec.jsx
@@ -26,7 +26,8 @@ const setup = async (
     canCreateFolder = false,
     canUpload = true,
     hasWriteAccess = true,
-    isPublic = false
+    isPublic = false,
+    isEncryptedFolder = false
   } = {}
 ) => {
   const { client, store } = await setupFolderContent({
@@ -44,6 +45,7 @@ const setup = async (
           canUpload={canUpload}
           hasWriteAccess={hasWriteAccess}
           isPublic={isPublic}
+          isEncryptedFolder={isEncryptedFolder}
         />
       </ScanWrapper>
     </AppLike>
@@ -148,6 +150,24 @@ describe('AddMenu', () => {
         )
         const { queryByText } = root
         expect(queryByText('Note')).toBeTruthy()
+      })
+    })
+
+    it('does not display non-supported items inside an encrypted directory', async () => {
+      isMobileApp.mockReturnValue(false)
+
+      await act(async () => {
+        const { root } = await setup(
+          { folderId: 'directory-foobar0' },
+          { isEncryptedFolder: true }
+        )
+        const { queryByText } = root
+        expect(queryByText('Note')).toBeNull()
+        expect(queryByText('Shortcut')).toBeNull()
+        expect(queryByText('Folder')).toBeNull()
+        expect(queryByText('Text document')).toBeNull()
+        expect(queryByText('Spreadsheet')).toBeNull()
+        expect(queryByText('Presentation')).toBeNull()
       })
     })
   })

--- a/src/drive/web/modules/drive/AddMenu/AddMenuProvider.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenuProvider.jsx
@@ -18,6 +18,8 @@ import {
 } from 'drive/web/modules/drive/Toolbar/components/MoreMenu'
 import AddMenu from 'drive/web/modules/drive/AddMenu/AddMenu'
 import ScanWrapper from 'drive/web/modules/drive/Toolbar/components/ScanWrapper'
+import toolbarContainer from 'drive/web/modules/drive/Toolbar/toolbar'
+import { isEncryptedFolder } from 'drive/lib/encryption'
 
 export const AddMenuContext = createContext()
 
@@ -27,7 +29,8 @@ const AddMenuProvider = ({
   canUpload,
   refreshFolderContent,
   children,
-  isPublic
+  isPublic,
+  displayedFolder
 }) => {
   const [menuIsVisible, setMenuVisible] = useState(false)
   const selectionModeActive = useSelector(isSelectionBarVisible)
@@ -47,6 +50,11 @@ const AddMenuProvider = ({
   const isDisabled = useMemo(
     () => disabled || selectionModeActive,
     [disabled, selectionModeActive]
+  )
+
+  const isEncryptedDir = useMemo(
+    () => isEncryptedFolder(displayedFolder),
+    [displayedFolder]
   )
 
   const handleOfflineClick = useCallback(e => {
@@ -78,6 +86,7 @@ const AddMenuProvider = ({
             canUpload={canUpload}
             refreshFolderContent={refreshFolderContent}
             isPublic={isPublic}
+            isEncryptedFolder={isEncryptedDir}
           />
         )}
       </ScanWrapper>
@@ -85,4 +94,4 @@ const AddMenuProvider = ({
   )
 }
 
-export default React.memo(AddMenuProvider)
+export default React.memo(toolbarContainer(AddMenuProvider))

--- a/src/drive/web/modules/drive/AddMenu/AddMenuProvider.spec.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenuProvider.spec.jsx
@@ -3,6 +3,8 @@ import { fireEvent, render } from '@testing-library/react'
 import AddMenuProvider, { AddMenuContext } from './AddMenuProvider'
 import { logException } from 'drive/lib/reporter'
 
+jest.mock('drive/web/modules/drive/Toolbar/toolbar', () => children => children)
+
 jest.mock(
   'drive/web/modules/drive/Toolbar/components/ScanWrapper',
   // eslint-disable-next-line react/display-name
@@ -28,7 +30,6 @@ describe('AddMenuContext', () => {
         <Component />
       </AddMenuProvider>
     )
-
     // When
     fireEvent.click(getByTestId('button'))
     fireEvent.click(container)

--- a/src/drive/web/modules/drive/Toolbar/toolbar.jsx
+++ b/src/drive/web/modules/drive/Toolbar/toolbar.jsx
@@ -6,13 +6,16 @@ import {
   getDisplayedFolder,
   getCurrentFolderId
 } from 'drive/web/modules/selectors'
+import { isEncryptedFolder } from 'drive/lib/encryption'
 
 const mapStateToProps = state => {
   const displayedFolder = getDisplayedFolder(state)
   const folderId = getCurrentFolderId(state)
-
   const insideRegularFolder =
-    folderId && displayedFolder && displayedFolder.id !== ROOT_DIR_ID
+    folderId &&
+    displayedFolder &&
+    displayedFolder.id !== ROOT_DIR_ID &&
+    !isEncryptedFolder(displayedFolder)
 
   return {
     displayedFolder,

--- a/src/drive/web/modules/filelist/FileIconMime.jsx
+++ b/src/drive/web/modules/filelist/FileIconMime.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types'
 
 import { isDirectory } from 'cozy-client/dist/models/file'
 import { Icon } from 'cozy-ui/transpiled/react'
-import { hasEncryptionRef } from 'drive/lib/encryption'
+import { isEncryptedFolder } from 'drive/lib/encryption'
 import getMimeTypeIcon from 'drive/lib/getMimeTypeIcon'
 
 const FileIcon = ({ file, size = 32, isEncrypted = false }) => {
   const isDir = isDirectory(file)
-  const isDirEncrypted = isEncrypted || (isDirectory && hasEncryptionRef(file))
+  const isDirEncrypted = isEncrypted || (isDirectory && isEncryptedFolder(file))
 
   return (
     <Icon

--- a/src/drive/web/modules/move/FileList.jsx
+++ b/src/drive/web/modules/move/FileList.jsx
@@ -3,11 +3,7 @@ import PropTypes from 'prop-types'
 import { DumbFile as File } from 'drive/web/modules/filelist/File'
 import { VaultUnlocker } from 'cozy-keys-lib'
 import { ROOT_DIR_ID } from 'drive/constants/config'
-import { hasEncryptionRef } from 'drive/lib/encryption'
-
-const isEncryptedFolder = folder => {
-  return hasEncryptionRef(folder)
-}
+import { isEncryptedFolder } from 'drive/lib/encryption'
 
 const isInvalidMoveTarget = (subjects, target) => {
   const isASubject = subjects.find(subject => subject._id === target._id)

--- a/src/drive/web/modules/selectors.js
+++ b/src/drive/web/modules/selectors.js
@@ -6,7 +6,6 @@ import { getDocumentFromState } from 'cozy-client/dist/store'
 import { DOCTYPE_FILES } from 'drive/lib/doctypes'
 import { ROOT_DIR_ID, TRASH_DIR_ID } from 'drive/constants/config'
 import { getMirrorQueryId, parseFolderQueryId } from './queries'
-import { hasEncryptionRef } from 'drive/lib/encryption'
 
 export const getCurrentFolderId = rootState => {
   if (get(rootState, 'router.params.folderId')) {
@@ -98,11 +97,4 @@ export const getFolderContent = (rootState, folderId) => {
   } else {
     return null
   }
-}
-
-export const isEncryptedFolder = (rootState, { folderId } = {}) => {
-  const folder = folderId
-    ? getDocumentFromState(rootState, DOCTYPE_FILES, folderId)
-    : getDisplayedFolder(rootState)
-  return hasEncryptionRef(folder)
 }

--- a/src/drive/web/modules/services/components/iconContext.js
+++ b/src/drive/web/modules/services/components/iconContext.js
@@ -1,6 +1,6 @@
 import { TYPE_DIRECTORY } from './helpers'
 import { models } from 'cozy-client'
-import { hasEncryptionRef } from 'drive/lib/encryption'
+import { isEncryptedFolder } from 'drive/lib/encryption'
 import { getFileMimetype } from 'drive/lib/getFileMimetype'
 
 const iconsContext = require.context(
@@ -17,7 +17,7 @@ const icons = iconsContext.keys().reduce((acc, item) => {
 export function getIconUrl(file) {
   let keyIcon
   if (file.type === TYPE_DIRECTORY) {
-    if (hasEncryptionRef(file)) {
+    if (isEncryptedFolder(file)) {
       keyIcon = 'encrypted-folder'
     } else {
       keyIcon = 'folder'

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -27,7 +27,7 @@ import createFileOpeningHandler from 'drive/web/modules/views/Folder/createFileO
 import { useSyncingFakeFile } from './useSyncingFakeFile'
 import { isReferencedByShareInSharingContext } from 'drive/web/modules/views/Folder/syncHelpers'
 import { isOnlyOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
-import { hasEncryptionRef } from 'drive/lib/encryption'
+import { isEncryptedFolder } from 'drive/lib/encryption'
 
 // TODO: extraColumns is then passed to 'FileListHeader', 'AddFolder',
 // and 'File' (this one from a 'syncingFakeFile' and a normal file).
@@ -101,7 +101,7 @@ const FolderViewBody = ({
   const isSharingContextEmpty = Object.keys(sharingsValue).length <= 0
 
   const { syncingFakeFile } = useSyncingFakeFile({ isEmpty, queryResults })
-  const isEncFolder = hasEncryptionRef(displayedFolder)
+  const isEncFolder = isEncryptedFolder(displayedFolder)
 
   /**
    * When we mount the component when we already have data in cache,


### PR DESCRIPTION
We do not support the following features with client-side encryption:
- Notes
- OnlyOffice
- Shortcuts
- Archive download
- Sharing

Those items are therefore disabled in the UI inside an encrypted folder.
Moreover, the regular folder creation is disabled as well, as we do not
want to allow non-encrypted files inside an encrypted folder.
