### PR TITLE
fix: Request encryption key only when encryption flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  * Compute sizes in MB instead of MiB in dacc service.
  * Query files based on their uploaded date in dacc service.
  * Do not query encryption files when flag is not set
+ * Fix upload on shared folders
 
 ## 🔧 Tech
 

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -10,6 +10,7 @@ import {
   getEncryptionKeyFromDirId
 } from 'drive/lib/encryption'
 import { DOCTYPE_FILES } from 'drive/lib/doctypes'
+import flag from 'cozy-flags'
 
 import { models } from 'cozy-client'
 const { doMobileUpload, readMobileFile, uploadFileWithConflictStrategy } =
@@ -186,7 +187,9 @@ export const processNextFile =
     }
 
     const { file, entry, isDirectory } = item
-    const encryptionKey = await getEncryptionKeyFromDirId(client, dirID)
+    const encryptionKey = flag('drive.enable-encryption')
+      ? await getEncryptionKeyFromDirId(client, dirID)
+      : null
     try {
       dispatch({ type: UPLOAD_FILE, file })
       if (entry && isDirectory) {


### PR DESCRIPTION
In a shared folder, the upload was broken because one does not have the
rights to GET on the `io.cozy.files.encryption` doctype.
This is a quick fix to solve the issue found in prod 