### PR TITLE
feat: Support move for encrypted files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 # 1.42.0
 
+## ✨ Features
+
+* Support moving files from/to encrypted folder
+
 ## 🐛 Bug Fixes
 
 * Disable sharing on public file viewer

--- a/jestHelpers/setup.js
+++ b/jestHelpers/setup.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
@@ -8,6 +9,35 @@ import Adapter from 'enzyme-adapter-react-16'
 jest.mock('cozy-ui/transpiled/react/utils/color', () => ({
   ...jest.requireActual('cozy-ui/transpiled/react/utils/color'),
   getCssVariableValue: () => '#fff'
+}))
+
+jest.mock('cozy-keys-lib', () => ({
+  withVaultUnlockContext: BaseComponent => {
+    const Wrapper = props => {
+      return <BaseComponent {...props} />
+    }
+    Wrapper.displayName = `withVaultUnlockContext(${
+      BaseComponent.displayName || BaseComponent.name
+    })`
+    return Wrapper
+  },
+  withVaultClient: BaseComponent => {
+    const Component = props => (
+      <>
+        {({ vaultClient }) => (
+          <BaseComponent vaultClient={vaultClient} {...props} />
+        )}
+      </>
+    )
+
+    Component.displayName = `withVaultClient(${
+      BaseComponent.displayName || BaseComponent.name
+    })`
+
+    return Component
+  },
+  useVaultUnlockContext: jest.fn().mockReturnValue(jest.fn()),
+  useVaultClient: jest.fn()
 }))
 
 global.cozy = {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "cozy-scanner": "2.0.2",
     "cozy-scripts": "6.3.1",
     "cozy-sharing": "4.1.5",
-    "cozy-stack-client": "^29.0.0",
+    "cozy-stack-client": "^29.1.0",
     "cozy-ui": "^67.0.2",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",

--- a/src/drive/mobile/modules/offline/duck.js
+++ b/src/drive/mobile/modules/offline/duck.js
@@ -11,7 +11,7 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 
 import {
   getEncryptionKeyFromDirId,
-  decryptFile,
+  decryptFileToBlob,
   isEncryptedFile
 } from 'drive/lib/encryption'
 import { openFileWith } from 'drive/web/modules/actions/utils'
@@ -73,8 +73,11 @@ export const saveOfflineFileCopy = async (file, client, { vaultClient }) => {
   try {
     let blob
     if (isEncryptedFile(file)) {
-      const encryptionKey = await getEncryptionKeyFromDirId(client, file.dir_id)
-      blob = await decryptFile(client, vaultClient, { file, encryptionKey })
+      const decryptionKey = await getEncryptionKeyFromDirId(client, file.dir_id)
+      blob = await decryptFileToBlob(client, vaultClient, {
+        file,
+        decryptionKey
+      })
     } else {
       const response = await client
         .collection(DOCTYPE_FILES)

--- a/src/drive/mobile/modules/upload/index.jsx
+++ b/src/drive/mobile/modules/upload/index.jsx
@@ -135,9 +135,8 @@ export class DumbUpload extends Component {
                   >
                     <div>
                       <FileList
-                        folder={folder}
                         files={data}
-                        targets={items}
+                        entries={items}
                         navigateTo={this.navigateTo}
                       />
                       <LoadMore hasMore={hasMore} fetchMore={fetchMore} />

--- a/src/drive/mobile/modules/upload/index.spec.js
+++ b/src/drive/mobile/modules/upload/index.spec.js
@@ -4,7 +4,8 @@ import { shallow } from 'enzyme'
 import { DumbUpload, generateForQueue } from './'
 
 jest.mock('cozy-keys-lib', () => ({
-  withVaultClient: jest.fn().mockReturnValue({})
+  withVaultClient: jest.fn().mockReturnValue({}),
+  withVaultUnlockContext: jest.fn().mockReturnValue({})
 }))
 
 const tSpy = jest.fn()

--- a/src/drive/web/modules/actions/index.spec.js
+++ b/src/drive/web/modules/actions/index.spec.js
@@ -1,6 +1,10 @@
 import { download } from './index'
 import { DOCTYPE_FILES_ENCRYPTION } from 'drive/lib/doctypes'
 
+jest.mock('cozy-keys-lib', () => ({
+  withVaultUnlockContext: jest.fn().mockReturnValue({})
+}))
+
 describe('download', () => {
   it('should not display when an encrypted folder is selected', () => {
     const files = [

--- a/src/drive/web/modules/actions/utils.spec.js
+++ b/src/drive/web/modules/actions/utils.spec.js
@@ -10,7 +10,7 @@ import {
 import {
   getEncryptionKeyFromDirId,
   downloadEncryptedFile,
-  decryptFile
+  decryptFileToBlob
 } from 'drive/lib/encryption'
 import { DOCTYPE_FILES_ENCRYPTION } from 'drive/lib/doctypes'
 import { TRASH_DIR_ID } from 'drive/constants/config'
@@ -50,7 +50,7 @@ jest.mock('drive/lib/encryption', () => ({
   ...jest.requireActual('drive/lib/encryption'),
   getEncryptionKeyFromDirId: jest.fn(),
   downloadEncryptedFile: jest.fn(),
-  decryptFile: jest.fn()
+  decryptFileToBlob: jest.fn()
 }))
 
 describe('trashFiles', () => {
@@ -140,7 +140,7 @@ describe('downloadFiles', () => {
     expect(downloadEncryptedFile).toHaveBeenCalledWith(
       mockClient,
       {},
-      { file, encryptionKey: 'encryption-key' }
+      { file, decryptionKey: 'encryption-key' }
     )
   })
 
@@ -254,14 +254,14 @@ describe('openFileWith', () => {
 
   it('open an encrypted file', async () => {
     getEncryptionKeyFromDirId.mockResolvedValueOnce('encryption-key')
-    decryptFile.mockResolvedValueOnce('fake file blob')
+    decryptFileToBlob.mockResolvedValueOnce('fake file blob')
     await openFileWith(mockClient, encryptedFile, { vaultClient })
-    expect(decryptFile).toHaveBeenCalledWith(
+    expect(decryptFileToBlob).toHaveBeenCalledWith(
       mockClient,
       {},
       {
         file: encryptedFile,
-        encryptionKey: 'encryption-key'
+        decryptionKey: 'encryption-key'
       }
     )
     expect(saveAndOpenWithCordova).toHaveBeenCalledWith('fake file blob', {
@@ -344,12 +344,12 @@ describe('exportFilesNative', () => {
     await exportFilesNative(mockClient, encryptedFiles, { vaultClient })
 
     encryptedFiles.forEach(file =>
-      expect(decryptFile).toHaveBeenCalledWith(
+      expect(decryptFileToBlob).toHaveBeenCalledWith(
         mockClient,
         {},
         {
           file,
-          encryptionKey: 'encryption-key'
+          decryptionKey: 'encryption-key'
         }
       )
     )

--- a/src/drive/web/modules/filelist/AddFolder.spec.jsx
+++ b/src/drive/web/modules/filelist/AddFolder.spec.jsx
@@ -16,7 +16,8 @@ jest.mock('cozy-flags', () => jest.fn())
 jest.mock('cozy-keys-lib', () => ({
   withVaultClient: jest.fn().mockReturnValue({}),
   useVaultClient: jest.fn(),
-  WebVaultClient: jest.fn().mockReturnValue({})
+  WebVaultClient: jest.fn().mockReturnValue({}),
+  withVaultUnlockContext: jest.fn().mockReturnValue({})
 }))
 describe('AddFolder', () => {
   const setup = () => {

--- a/src/drive/web/modules/move/FileList.jsx
+++ b/src/drive/web/modules/move/FileList.jsx
@@ -1,57 +1,86 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { DumbFile as File } from 'drive/web/modules/filelist/File'
-import { VaultUnlocker } from 'cozy-keys-lib'
-import { ROOT_DIR_ID } from 'drive/constants/config'
+import { useVaultUnlockContext } from 'cozy-keys-lib'
 import { isEncryptedFolder } from 'drive/lib/encryption'
 
-const isInvalidMoveTarget = (subjects, target) => {
-  const isASubject = subjects.find(subject => subject._id === target._id)
-  const isAFile = target.type === 'file'
-
-  return isAFile || isASubject
+const getFoldersInEntries = entries => {
+  return entries.filter(entry => entry.type === 'directory')
 }
 
-const FileList = ({ targets, files, folder, navigateTo }) => {
-  const [shouldUnlock, setShouldUnlock] = useState(true)
-  const isEncFolder = isEncryptedFolder(folder)
+const getEncryptedFolders = entries => {
+  return entries.filter(entry => {
+    if (entry.type !== 'directory') {
+      return false
+    }
+    return isEncryptedFolder(entry)
+  })
+}
 
-  if (isEncFolder && shouldUnlock) {
-    return (
-      <VaultUnlocker
-        onDismiss={() => {
-          setShouldUnlock(false)
-          return navigateTo(ROOT_DIR_ID)
-        }}
-        onUnlock={() => setShouldUnlock(false)}
-      />
-    )
-  } else {
-    return (
-      <>
-        {files.map(file => (
-          <File
-            key={file.id}
-            disabled={isInvalidMoveTarget(targets, file)}
-            styleDisabled={isInvalidMoveTarget(targets, file)}
-            attributes={file}
-            displayedFolder={null}
-            actions={null}
-            isRenaming={false}
-            onFolderOpen={id => navigateTo(files.find(f => f.id === id))}
-            onFileOpen={null}
-            withSelectionCheckbox={false}
-            withFilePath={false}
-            withSharedBadge
-          />
-        ))}
-      </>
-    )
+export const isInvalidMoveTarget = (entries, target) => {
+  const isTargetAnEntry = entries.find(subject => subject._id === target._id)
+  const isTargetAFile = target.type === 'file'
+  if (isTargetAFile || isTargetAnEntry) {
+    return true
   }
+  const dirs = getFoldersInEntries(entries)
+  if (dirs.length > 0) {
+    const encryptedFoldersEntries = getEncryptedFolders(dirs)
+    const hasEncryptedFolderEntries = encryptedFoldersEntries.length > 0
+    const hasEncryptedAndNonEncryptedFolderEntries =
+      hasEncryptedFolderEntries &&
+      encryptedFoldersEntries.length !== dirs.length
+    const isTargetEncrypted = isEncryptedFolder(target)
+
+    if (isTargetEncrypted && !hasEncryptedFolderEntries) {
+      // Do not allow moving a non-encrypted folder to an encrypted one
+      return true
+    }
+    if (isTargetEncrypted && hasEncryptedAndNonEncryptedFolderEntries) {
+      // Do not allow moving encrypted + non encrypted folders
+      return true
+    }
+  }
+  return false
+}
+
+const FileList = ({ entries, files, folder, navigateTo }) => {
+  const { showUnlockForm } = useVaultUnlockContext()
+
+  const onFolderOpen = folderId => {
+    const dir = folder ? folder._id : files.find(f => f._id === folderId)
+    const shouldUnlock = isEncryptedFolder(dir)
+    if (shouldUnlock) {
+      return showUnlockForm({ onUnlock: () => navigateTo(dir) })
+    } else {
+      return navigateTo(dir)
+    }
+  }
+
+  return (
+    <>
+      {files.map(file => (
+        <File
+          key={file.id}
+          disabled={isInvalidMoveTarget(entries, file)}
+          styleDisabled={isInvalidMoveTarget(entries, file)}
+          attributes={file}
+          displayedFolder={null}
+          actions={null}
+          isRenaming={false}
+          onFolderOpen={id => onFolderOpen(id)}
+          onFileOpen={null}
+          withSelectionCheckbox={false}
+          withFilePath={false}
+          withSharedBadge
+        />
+      ))}
+    </>
+  )
 }
 
 FileList.propTypes = {
-  targets: PropTypes.array.isRequired,
+  entries: PropTypes.array.isRequired,
   files: PropTypes.array.isRequired,
   navigateTo: PropTypes.func.isRequired,
   folder: PropTypes.object

--- a/src/drive/web/modules/move/FileList.spec.jsx
+++ b/src/drive/web/modules/move/FileList.spec.jsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { createMockClient } from 'cozy-client'
+import { DOCTYPE_FILES_ENCRYPTION } from 'drive/lib/doctypes'
+import AppLike from 'test/components/AppLike'
+import { generateFile } from 'test/generate'
+import FileList, { isInvalidMoveTarget } from 'drive/web/modules/move/FileList'
+
+jest.mock('cozy-keys-lib', () => ({
+  useVaultUnlockContext: jest
+    .fn()
+    .mockReturnValue({ showUnlockForm: jest.fn() })
+}))
+const client = createMockClient({})
+
+const setup = ({ files, entries, navigateTo }) => {
+  const root = render(
+    <AppLike client={client}>
+      <FileList files={files} entries={entries} navigateTo={navigateTo} />
+    </AppLike>
+  )
+
+  return { root }
+}
+
+describe('FileList', () => {
+  it('should display files', () => {
+    const entries = [generateFile({ i: '1', type: 'file' })]
+    const files = [
+      generateFile({ i: '1', type: 'directory', prefix: '' }),
+      generateFile({ i: '2', type: 'file', prefix: '' })
+    ]
+
+    const { root } = setup({ files, entries, navigateTo: () => null })
+    const { queryAllByText } = root
+
+    expect(queryAllByText('directory-1')).toBeTruthy()
+    expect(queryAllByText('file-2')).toBeTruthy()
+  })
+})
+
+describe('isInvalidMoveTarget', () => {
+  it('should return true when target is a file', () => {
+    const target = { _id: '1', type: 'file' }
+    const entries = [{ _id: 'dir1', type: 'directory' }]
+    expect(isInvalidMoveTarget(entries, target)).toBe(true)
+  })
+
+  it('should return true when subject is the target', () => {
+    const target = { _id: '1', type: 'directory' }
+    const entries = [{ _id: '1', type: 'directory' }]
+    expect(isInvalidMoveTarget(entries, target)).toBe(true)
+  })
+
+  it('should return true when target is an encrypted directory and entries has non-encrypted folder', () => {
+    const target = {
+      _id: '1',
+      type: 'directory',
+      referenced_by: [{ type: DOCTYPE_FILES_ENCRYPTION, id: 'encrypted-key-1' }]
+    }
+    const entries = [{ _id: 'dir1', type: 'directory' }]
+    expect(isInvalidMoveTarget(entries, target)).toBe(true)
+  })
+
+  it('shold return true when target is an encrypted dir and entries include both encrytped and non-encrypted dir', () => {
+    const target = {
+      _id: '1',
+      type: 'directory',
+      referenced_by: [{ type: DOCTYPE_FILES_ENCRYPTION, id: 'encrypted-key-1' }]
+    }
+    const entries = [
+      {
+        _id: 'dir1',
+        type: 'directory',
+        referenced_by: [
+          { type: DOCTYPE_FILES_ENCRYPTION, id: 'encrypted-key-1' }
+        ]
+      },
+      {
+        _id: 'dir2',
+        type: 'directory'
+      }
+    ]
+    expect(isInvalidMoveTarget(entries, target)).toBe(true)
+  })
+
+  it('should return false when both target and entries are encrypted', () => {
+    const target = {
+      _id: '1',
+      type: 'directory',
+      referenced_by: [{ type: DOCTYPE_FILES_ENCRYPTION, id: 'encrypted-key-1' }]
+    }
+    const entries = [
+      {
+        _id: 'dir1',
+        type: 'directory',
+        referenced_by: [
+          { type: DOCTYPE_FILES_ENCRYPTION, id: 'encrypted-key-1' }
+        ]
+      }
+    ]
+    expect(isInvalidMoveTarget(entries, target)).toBe(false)
+  })
+
+  it('should return false when both target and entries are regular folders', () => {
+    const target = { _id: '1', type: 'directory' }
+    const entries = [{ _id: 'dir1', type: 'directory' }]
+    expect(isInvalidMoveTarget(entries, target)).toBe(false)
+  })
+
+  it('should return false when subject is a mix of regular file and folder and target a regular folder', () => {
+    const target = { _id: '1', type: 'directory' }
+    const entries = [
+      { _id: 'dir1', type: 'file' },
+      { _id: 'file1', type: 'file' }
+    ]
+    expect(isInvalidMoveTarget(entries, target)).toBe(false)
+  })
+})

--- a/src/drive/web/modules/navigation/duck/actions.spec.jsx
+++ b/src/drive/web/modules/navigation/duck/actions.spec.jsx
@@ -9,7 +9,8 @@ import { createFolder } from './actions'
 jest.mock('cozy-keys-lib', () => ({
   withVaultClient: jest.fn().mockReturnValue({}),
   useVaultClient: jest.fn(),
-  WebVaultClient: jest.fn().mockReturnValue({})
+  WebVaultClient: jest.fn().mockReturnValue({}),
+  withVaultUnlockContext: jest.fn().mockReturnValue({})
 }))
 const vaultClient = new WebVaultClient('http://alice.cozy.cloud')
 

--- a/src/drive/web/modules/public/LightFileViewer.spec.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.spec.jsx
@@ -16,6 +16,10 @@ jest.mock('cozy-ui/transpiled/react/hooks/useBreakpoints', () => ({
   default: jest.fn(),
   BreakpointsProvider: ({ children }) => children
 }))
+jest.mock('cozy-keys-lib', () => ({
+  withVaultUnlockContext: jest.fn().mockReturnValue(<></>),
+  withVaultClient: jest.fn().mockReturnValue(<></>)
+}))
 
 const client = new createMockClient({})
 

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -337,7 +337,7 @@ const uploadFile = async (client, file, dirID, options = {}) => {
     const fr = new FileReader()
     fr.onloadend = async () => {
       return encryptAndUploadNewFile(client, vaultClient, {
-        file: fr.result,
+        binary: fr.result,
         encryptionKey,
         fileOptions: {
           name: file.name,

--- a/src/drive/web/modules/viewer/FilesViewer.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.jsx
@@ -131,13 +131,13 @@ const FilesViewer = ({ filesQuery, files, fileId, onClose, onChange }) => {
     const getDecryptedURLIfNecessary = async () => {
       const file = files[currentIndex]
       if (file && isEncryptedFile(file)) {
-        const encryptionKey = await getEncryptionKeyFromDirId(
+        const decryptionKey = await getEncryptionKeyFromDirId(
           client,
           file.dir_id
         )
         const url = await getDecryptedFileURL(client, vaultClient, {
           file,
-          encryptionKey
+          decryptionKey
         })
         setCurrentDecryptedFileURL(url)
       }

--- a/src/drive/web/modules/viewer/FilesViewer.spec.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.spec.jsx
@@ -10,7 +10,8 @@ import { getEncryptionKeyFromDirId } from 'drive/lib/encryption'
 
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
+  useVaultClient: jest.fn(),
+  withVaultUnlockContext: jest.fn().mockReturnValue({})
 }))
 
 jest.mock('drive/lib/encryption', () => ({

--- a/src/drive/web/modules/viewer/helpers.js
+++ b/src/drive/web/modules/viewer/helpers.js
@@ -6,8 +6,8 @@ import {
 
 export const downloadFile = async (client, file, { vaultClient }) => {
   if (isEncryptedFile(file)) {
-    const encryptionKey = await getEncryptionKeyFromDirId(client, file.dir_id)
-    return downloadEncryptedFile(client, vaultClient, { file, encryptionKey })
+    const decryptionKey = await getEncryptionKeyFromDirId(client, file.dir_id)
+    return downloadEncryptedFile(client, vaultClient, { file, decryptionKey })
   } else {
     return client.collection('io.cozy.files').download(file)
   }

--- a/test/setup.jsx
+++ b/test/setup.jsx
@@ -13,25 +13,6 @@ import FolderContent from 'test/components/FolderContent'
 import { generateFile } from './generate'
 import { act } from 'react-dom/test-utils'
 
-jest.mock('cozy-keys-lib', () => ({
-  withVaultClient: BaseComponent => {
-    const Component = props => (
-      <>
-        {({ vaultClient }) => (
-          <BaseComponent vaultClient={vaultClient} {...props} />
-        )}
-      </>
-    )
-
-    Component.displayName = `withVaultClient(${
-      BaseComponent.displayName || BaseComponent.name
-    })`
-
-    return Component
-  },
-  useVaultClient: jest.fn()
-}))
-
 configure({ testIdAttribute: 'data-testid' })
 
 export const mockCozyClientRequestQuery = () => {


### PR DESCRIPTION
This adds the possiilbity to move files from/to an encrypted folder.

3 scenarios are supported:
- From a non-encrypted folder to an encrypted folder
- From an encrypted folder to a non-encrypted folder
- From an encrypted folder to another encrypted folder

Note we do not support the moving of non-encrypted folder to an
encrypted one, because of the potential cost if it has a deep hierarchy
and/or many files. However, the moving of an encrypted folder to is
supported for both non-encrypted and encrypted folder, as the files remain
encrypted with the same encryption key.