### PR TITLE
fix: Handle undefined cases

### DIFF
--- a/src/photos/ducks/clustering/albums.js
+++ b/src/photos/ducks/clustering/albums.js
@@ -52,6 +52,10 @@ const removeRefs = async (client, ids, album) => {
 const addAutoAlbumReferences = async (client, photos, album) => {
   let refCount = 0
   const refsIds = []
+  if (!album.photos) {
+    log('warn', `No photos relationship for album ${album._id}`)
+    return
+  }
   for (const photo of photos) {
     if (photo.clusterId === album._id) {
       continue

--- a/src/photos/ducks/clustering/files.js
+++ b/src/photos/ducks/clustering/files.js
@@ -38,6 +38,10 @@ export const getFilesByAutoAlbum = async (client, album) => {
   let data = client.hydrateDocument(resp.data)
   const photos = await data.photos.data
   allPhotos = allPhotos.concat(photos)
+  if (!data.photos) {
+    log('warn', `No photo in auto album ${album._id}`)
+    return []
+  }
   while (data.photos.hasMore) {
     await data.photos.fetchMore()
     const fromState = client.getDocumentFromState(DOCTYPE_ALBUMS, album._id)

--- a/src/photos/lib/onPhotoUpload.js
+++ b/src/photos/lib/onPhotoUpload.js
@@ -140,6 +140,13 @@ const runClustering = async (client, setting) => {
   }
   const albums = await findAutoAlbums(client)
   const dataset = prepareDataset(photos, albums)
+  if (!dataset[0]) {
+    log(
+      'error',
+      `The oldest photo in dataset containing ${photos.length} photos is undefined`
+    )
+    return { photos: [], newSetting: setting }
+  }
   const result = await clusterizePhotos(client, setting, dataset, albums)
   if (!result) {
     return { photos: [], newSetting: setting }


### PR DESCRIPTION
It appears the datetime or photos object might be undefined, leading to
unexpected errors during the service execution.
We add checks and logs to cope with this.