### PR TITLE
fix: Remove useless permission on contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Improve cozy-bar implementation to fix UI bugs in Amirale
 * Fix navigation through mobile Flagship on Note creation and opening
+* Remove unused contacts permissions on Photos 
 
 ## 🔧 Tech
 

--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -86,14 +86,6 @@
         "PUT"
       ]
     },
-    "contacts": {
-      "description": "Required to to share photos with your contacts",
-      "type": "io.cozy.contacts",
-      "verbs": [
-        "GET",
-        "POST"
-      ]
-    },
     "settings": {
       "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
       "type": "io.cozy.settings",


### PR DESCRIPTION
This was probably forgotten when the cozy-to-cozy sharing was removed
from Photos
