### PR TITLE
fix: Call `openApp()` on note creation when in a mobile Flagship app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## 🐛 Bug Fixes
 
 * Improve cozy-bar implementation to fix UI bugs in Amirale
+* Fix navigation through mobile Flagship on Note creation and opening
 
 ## 🔧 Tech
 


### PR DESCRIPTION
When in a mobile Flagship app we shouldn't rely on editing
`window.location.href` in order to trigger navigation

Instead we should call `openApp` from `cozy-intent` so the navigation
is handled on mobile app's native side

Based on 24af91284645c2eab42355ab402c868385f58326 implementation