### PR TITLE
fix: Navigate to shortcuts instead of opening new tab on Flagship app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## 🔧 Tech
 
 * Move dacc-run file to a lib folder to prevent it occurring in build
+* Shortcut links are now opened directly in the webview when executed inside of the Flagship mobile app
 
 # 1.42.1
 

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -29,7 +29,7 @@ const createFileOpeningHandler =
     const isOnlyOffice = models.file.shouldBeOpenedByOnlyOffice(file)
 
     if (isShortcut) {
-      if (isMobileApp()) {
+      if (isMobileApp() || isFlagshipApp()) {
         try {
           const resp = await client.query(
             Q(DOCTYPE_FILES_SHORTCUT).getById(file.id)


### PR DESCRIPTION
When on flagship app we want to handle shortcuts as navigation instead
of opening them in new tab

By doing so we ease links interception on Flagship app, so it would be
able to decide to navigate between cozy-apps, or to open InAppBrowser
regarding the link content

Note that the previous implementation would trigger the new
`onOpenWindow` event from cozy/react-native-webview#2
But this is not enough as the provided url would be an `#/external/`
link which cannot be analysed easily. With the new implementation we
provide the final URL that can by analysed directly

___

Related PRs:

- cozy/cozy-react-native#391