### PR TITLE
fix(search): Improve speed of search suggestions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,6 @@
     "no-console": 1,
     "no-param-reassign": "error",
     "react-hooks/exhaustive-deps": "error"
-
   },
   "globals": {
     "fixture": false
@@ -13,5 +12,13 @@
     "react": {
       "version": "detect"
     }
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.spec.js[x]"],
+      "rules": {
+        "react/display-name": "off"
+      }
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## ✨ Features
 
 * Upgrade cozy-bar@7.20.1 to be able to call onSelect function
+* Improve speed of search suggestion by preventing fetch notes url until click
 * Update cozy-stack-client and cozy-pouch-link to sync with cozy-client version
 * Update cozy-ui
   - Modify Viewers to handle [68.0.0 BC](https://github.com/cozy/cozy-ui/releases/tag/v68.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## ✨ Features
 
+* Upgrade cozy-bar@7.20.1 to be able to call onSelect function
 * Update cozy-stack-client and cozy-pouch-link to sync with cozy-client version
 * Update cozy-ui
   - Modify Viewers to handle [68.0.0 BC](https://github.com/cozy/cozy-ui/releases/tag/v68.0.0)
@@ -12,7 +13,7 @@
 
 * Improve cozy-bar implementation to fix UI bugs in Amirale
 * Fix navigation through mobile Flagship on Note creation and opening
-* Remove unused contacts permissions on Photos 
+* Remove unused contacts permissions on Photos
 * Do not display Download actions on iOS Flagship app until we fix the navigation bug
 
 ## 🔧 Tech

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "classnames": "2.3.1",
     "copy-text-to-clipboard": "1.0.4",
     "cozy-authentication": "2.8.3",
-    "cozy-bar": "7.19.1",
+    "cozy-bar": "7.20.1",
     "cozy-ci": "0.4.1",
     "cozy-client": "^33.0.0",
     "cozy-client-js": "0.19.0",

--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -4,7 +4,6 @@ import FuzzyPathSearch from '../FuzzyPathSearch'
 import { withClient } from 'cozy-client'
 
 import { TYPE_DIRECTORY, makeNormalizedFile } from './helpers'
-import { getIconUrl } from './iconContext'
 
 class SuggestionProvider extends React.Component {
   componentDidMount() {
@@ -38,7 +37,7 @@ class SuggestionProvider extends React.Component {
           title: result.name,
           subtitle: result.path,
           term: result.name,
-          onSelect: 'open:' + result.url,
+          onSelect: result.onSelect || 'open:' + result.url,
           icon: result.icon
         }))
       },
@@ -54,7 +53,7 @@ class SuggestionProvider extends React.Component {
     return new Promise(async resolve => {
       const resp = await cozy.client.fetchJSON(
         'GET',
-        `/data/io.cozy.files/_all_docs?include_docs=true`
+        '/data/io.cozy.files/_all_docs?include_docs=true'
       )
       const files = resp.rows
         // TODO: fix me
@@ -73,11 +72,8 @@ class SuggestionProvider extends React.Component {
         .filter(notInTrash)
         .filter(notOrphans)
 
-      const normalizedFiles = await Promise.all(
-        normalizedFilesPrevious.map(
-          async file =>
-            await makeNormalizedFile(client, folders, file, getIconUrl)
-        )
+      const normalizedFiles = normalizedFilesPrevious.map(file =>
+        makeNormalizedFile(client, folders, file)
       )
 
       this.fuzzyPathSearch = new FuzzyPathSearch(normalizedFiles)

--- a/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import SuggestionProvider from './SuggestionProvider'
+import { dummyFile, dummyNote } from 'test/dummies/dummyFile'
+
+const makeFileWithDoc = file => ({ ...file, doc: file })
+const parentFolder = makeFileWithDoc(dummyFile({ _id: 'id-file' }))
+const folder = makeFileWithDoc(dummyFile({ dir_id: 'id-file' }))
+const note = makeFileWithDoc(
+  dummyNote({
+    dir_id: 'id-file',
+    name: 'name.cozy-note'
+  })
+)
+const mockClient = {
+  fetchJSON: jest.fn().mockReturnValue({ rows: [parentFolder, folder, note] })
+}
+const mockIntentAttributesClient = 'intent-attributes-client'
+
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  withClient: Component => () => {
+    const intent = {
+      _id: 'id_intent',
+      attributes: { client: mockIntentAttributesClient }
+    }
+    return <Component client={mockClient} intent={intent}></Component>
+  }
+}))
+jest.mock('./iconContext', () => ({ getIconUrl: () => 'iconUrl' }))
+
+describe('SuggestionProvider', () => {
+  let events = {}
+  let event
+
+  beforeEach(() => {
+    window.cozy.client = mockClient
+    window.addEventListener = jest.fn((event, callback) => {
+      events[event] = callback
+    })
+    window.parent.postMessage = jest.fn()
+    event = {
+      origin: mockIntentAttributesClient,
+      data: { query: 'name', id: 'id' }
+    }
+  })
+
+  it('should query all files to display fuzzy suggestion', () => {
+    // Given
+    render(<SuggestionProvider />)
+
+    // When
+    events.message(event)
+
+    // Then
+    expect(mockClient.fetchJSON).toHaveBeenCalledWith(
+      'GET',
+      '/data/io.cozy.files/_all_docs?include_docs=true'
+    )
+  })
+
+  it('should provide onSelect with open url when file is not a note + and function when it is a note', async () => {
+    // Given
+    render(<SuggestionProvider />)
+
+    // When
+    events.message(event)
+
+    // Then
+    await waitFor(() => {
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          id: 'id',
+          suggestions: [
+            {
+              icon: 'iconUrl',
+              id: 'id-file',
+              onSelect: 'open:http://localhost/#/folder/id-file',
+              subtitle: '/path',
+              term: 'name',
+              title: 'name'
+            },
+            {
+              icon: 'iconUrl',
+              id: 'id-file',
+              onSelect: 'id_note:id-file',
+              subtitle: '/path',
+              term: 'name.cozy-note',
+              title: 'name.cozy-note'
+            }
+          ],
+          type: 'intent-id_intent:data'
+        },
+        'intent-attributes-client'
+      )
+    })
+  })
+})

--- a/src/drive/web/modules/services/components/helpers.spec.js
+++ b/src/drive/web/modules/services/components/helpers.spec.js
@@ -1,7 +1,6 @@
 import { createMockClient, models } from 'cozy-client'
 
 import { makeNormalizedFile, TYPE_DIRECTORY } from './helpers'
-import { getIconUrl } from './iconContext'
 
 jest.mock('./iconContext', () => ({ getIconUrl: () => 'iconUrl' }))
 models.note.fetchURL = jest.fn(() => 'noteUrl')
@@ -19,7 +18,7 @@ const noteFileProps = {
 }
 
 describe('makeNormalizedFile', () => {
-  it('should return correct values for a directory', async () => {
+  it('should return correct values for a directory', () => {
     const folders = []
     const file = {
       _id: 'fileId',
@@ -28,14 +27,10 @@ describe('makeNormalizedFile', () => {
       name: 'fileName'
     }
 
-    const normalizedFile = await makeNormalizedFile(
-      client,
-      folders,
-      file,
-      getIconUrl
-    )
+    const normalizedFile = makeNormalizedFile(client, folders, file)
 
-    expect(normalizedFile).toMatchObject({
+    expect(normalizedFile).toEqual({
+      icon: 'iconUrl',
       id: 'fileId',
       name: 'fileName',
       path: 'filePath',
@@ -43,7 +38,7 @@ describe('makeNormalizedFile', () => {
     })
   })
 
-  it('should return correct values for a file', async () => {
+  it('should return correct values for a file', () => {
     const folders = [{ _id: 'folderId', path: 'folderPath' }]
     const file = {
       _id: 'fileId',
@@ -52,14 +47,10 @@ describe('makeNormalizedFile', () => {
       name: 'fileName'
     }
 
-    const normalizedFile = await makeNormalizedFile(
-      client,
-      folders,
-      file,
-      getIconUrl
-    )
+    const normalizedFile = makeNormalizedFile(client, folders, file)
 
-    expect(normalizedFile).toMatchObject({
+    expect(normalizedFile).toEqual({
+      icon: 'iconUrl',
       id: 'fileId',
       name: 'fileName',
       path: 'folderPath',
@@ -67,28 +58,47 @@ describe('makeNormalizedFile', () => {
     })
   })
 
-  it('should return correct values for a note', async () => {
+  it('should return correct values for a note with on Select function - better for performance', () => {
     const folders = [{ _id: 'folderId', path: 'folderPath' }]
     const file = {
       _id: 'fileId',
+      id: 'noteId',
       dir_id: 'folderId',
       type: 'file',
       name: 'fileName',
       ...noteFileProps
     }
 
-    const normalizedFile = await makeNormalizedFile(
-      client,
-      folders,
-      file,
-      getIconUrl
-    )
+    const normalizedFile = makeNormalizedFile(client, folders, file)
 
-    expect(normalizedFile).toMatchObject({
+    expect(normalizedFile).toEqual({
+      icon: 'iconUrl',
       id: 'fileId',
       name: 'note.cozy-note',
       path: 'folderPath',
-      url: 'noteUrl'
+      onSelect: 'id_note:noteId'
+    })
+  })
+
+  it('should not return filled onSelect for a note without metadata', () => {
+    const folders = [{ _id: 'folderId', path: 'folderPath' }]
+    const file = {
+      _id: 'fileId',
+      id: 'noteId',
+      dir_id: 'folderId',
+      type: 'file',
+      name: 'note.cozy-note'
+    }
+
+    const normalizedFile = makeNormalizedFile(client, folders, file)
+
+    expect(normalizedFile).toEqual({
+      icon: 'iconUrl',
+      id: 'fileId',
+      name: 'note.cozy-note',
+      path: 'folderPath',
+      onSelect: undefined,
+      url: 'http://localhost/#/folder/folderId/file/fileId'
     })
   })
 })

--- a/test/dummies/dummyFile.js
+++ b/test/dummies/dummyFile.js
@@ -1,0 +1,37 @@
+// eslint-disable-next-line no-unused-vars
+const { IOCozyFile } = require('cozy-client/dist/types')
+
+/**
+ * Create a dummy file, with overridden value of given param
+ *
+ * @param {Partial<IOCozyFile>} [file={}] - optional file with value to keep
+ * @returns {IOCozyFile} a dummy file
+ */
+export const dummyFile = file => ({
+  _id: 'id-file',
+  _type: 'doctype-file',
+  name: 'name',
+  id: 'id-file',
+  icon: 'icon',
+  path: '/path',
+  type: 'directory',
+  ...file
+})
+
+/**
+ * Create a dummy note, with overridden value of given param
+ *
+ * @param {Partial<IOCozyFile>} [note={}]
+ * @returns {IOCozyFile} a dummy note
+ */
+export const dummyNote = note => ({
+  ...dummyFile(),
+  type: 'file',
+  metadata: {
+    content: '',
+    schema: '',
+    title: '',
+    version: ''
+  },
+  ...note
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5924,10 +5924,10 @@ cozy-authentication@2.8.3:
     snarkdown "1.2.2"
     url-polyfill "1.1.7"
 
-cozy-bar@7.19.1:
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-7.19.1.tgz#ed20e3909ed2452a07596c1afb214499165a61bb"
-  integrity sha512-0lgy5PayOUTtaoyrvdMzbNr5nEesK1n3B5VV+Za8BhZReJx5/GXp+5yTgNJcwLBLwR6/Dl6EhvNogLiCgtO1yg==
+cozy-bar@7.20.1:
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-7.20.1.tgz#9ae1f112c2e9f5a5c8369f1ceea686d9f63c77bb"
+  integrity sha512-Aa9R9G8lCjCscOLeX8MaG/PB1LXpvflaBUtG/LFpBOYW9gfNVP7YM2YNQKcN7hKKhhGjY5/52sU1K9HOb+ke1g==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     cozy-client "^27.14.4"


### PR DESCRIPTION
By preventing every notes fetching url, loading only once a note is clicked

Last question: should we update isNote in cozy-client? (I think yes, but I will confirm)

after https://github.com/cozy/cozy-drive/pull/2663#issuecomment-1224092333