### PR TITLE
fix: Upgrade cozy-ui to 73.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Improve cozy-bar implementation to fix UI bugs in Amirale
 * Fix navigation through mobile Flagship on Note creation and opening
 * Remove unused contacts permissions on Photos 
+* Do not display Download actions on iOS Flagship app until we fix the navigation bug
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "cozy-scripts": "^6.3.8",
     "cozy-sharing": "4.1.5",
     "cozy-stack-client": "^33.0.0",
-    "cozy-ui": "^70.6.2",
+    "cozy-ui": "^73.0.1",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/src/drive/web/modules/drive/AddMenu/AddMenu.spec.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenu.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
-import { act } from '@testing-library/react'
+import { render, fireEvent, act } from '@testing-library/react'
 
 import { isMobileApp } from 'cozy-device-helper'
 

--- a/src/drive/web/modules/drive/Fab.jsx
+++ b/src/drive/web/modules/drive/Fab.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import UiFab from 'cozy-ui/transpiled/react/Fab'
 import Icon from 'cozy-ui/transpiled/react/Icon'

--- a/src/drive/web/modules/drive/MakeAvailableOfflineMenuItem.jsx
+++ b/src/drive/web/modules/drive/MakeAvailableOfflineMenuItem.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { connect } from 'react-redux'
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import { useClient } from 'cozy-client'
 import { useVaultClient } from 'cozy-keys-lib'

--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { compose } from 'redux'
 import { connect } from 'react-redux'
-import { withStyles } from '@material-ui/core/styles'
+import { withStyles } from 'cozy-ui/transpiled/react/styles'
 
 import { Query, cancelable, withClient, Q } from 'cozy-client'
 import { CozyFile } from 'models'

--- a/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback } from 'react'
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
 import CheckIcon from 'cozy-ui/transpiled/react/Icons/Check'

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo } from 'react'
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import flag from 'cozy-flags'
 import { SharingBannerPlugin } from 'cozy-sharing'

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router'
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 import cx from 'classnames'
 
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -1,8 +1,7 @@
 import { useContext, useEffect, useState } from 'react'
 
-import { isQueryLoading } from 'cozy-client'
+import { isQueryLoading, generateWebLink } from 'cozy-client'
 import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
-import { generateWebLink } from 'cozy-client'
 
 import {
   isOnlyOfficeReadOnly,

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -7,7 +7,11 @@ import get from 'lodash/get'
 import uniqBy from 'lodash/uniqBy'
 
 import { useClient, models } from 'cozy-client'
-import { SharingContext } from 'cozy-sharing'
+import {
+  SharingContext,
+  SharingBannerPlugin,
+  useSharingInfos
+} from 'cozy-sharing'
 import { isMobileApp } from 'cozy-device-helper'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Content, Overlay } from 'cozy-ui/transpiled/react'
@@ -15,7 +19,6 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import FooterActionButtons from 'cozy-ui/transpiled/react/Viewer/Footer/FooterActionButtons'
 import ForwardOrDownloadButton from 'cozy-ui/transpiled/react/Viewer/Footer/ForwardOrDownloadButton'
-import { SharingBannerPlugin, useSharingInfos } from 'cozy-sharing'
 
 import { ModalStack, ModalContext } from 'drive/lib/ModalContext'
 import useActions from 'drive/web/modules/actions/useActions'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6307,10 +6307,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^70.6.2:
-  version "70.6.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-70.6.2.tgz#e13182d28d97f7e762fa3f761eec213565c2c833"
-  integrity sha512-NbPIicACol5LF9dcNsmEiu15pTGIev1jE5StaiosUwYp5yG/fZfMDoOm07TmNtv8PnL+Xak2/d8dPox6tipj7g==
+cozy-ui@^73.0.1:
+  version "73.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-73.1.0.tgz#3d307469c702bcfd5d8f0b4be2098917293b01af"
+  integrity sha512-ITTByIZKXwa0k12Jj4whz/DrEgBL/9aee4zRbnFPcFAyygdHkYZlIW8AmGqTx7FRyr3CVn1xtUZUBlduXW14wQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
I forgot the TODO from cozy/cozy-drive#2672 🤦 

I also added the changelog entry that I should have done in the initial PR

---

`cozy-ui` as been upgraded to to `73.0.1` to retrieve a fix that
disable Viewer's download button from cozy/cozy-ui#2215

This commit fixes the previous commit that wrongly set the version
7c6d187c10b758015b1cbeaeeb6a958159e280c6

Related PR: cozy/cozy-drive#2672
