### PR TITLE
feat: Add UploadQueue to the public view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Modify Viewers to handle [68.0.0 BC](https://github.com/cozy/cozy-ui/releases/tag/v68.0.0)
   - Fix on progress bar when uploading files [[68.4.0]](https://github.com/cozy/cozy-ui/releases/tag/v68.4.0)
 * Update cozy-scripts for Amirale development
+* Add visual feedback when uploading on a public view
 
 ## 🐛 Bug Fixes
 

--- a/src/drive/web/modules/public/PublicLayout.jsx
+++ b/src/drive/web/modules/public/PublicLayout.jsx
@@ -5,6 +5,7 @@ import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { RouterContextProvider } from 'drive/lib/RouterContext'
 import FlagSwitcher from 'cozy-flags/dist/FlagSwitcher'
+import UploadQueue from 'drive/web/modules/upload/UploadQueue'
 
 const PublicLayout = ({ children, ...otherProps }) => {
   const { t } = useI18n()
@@ -13,6 +14,8 @@ const PublicLayout = ({ children, ...otherProps }) => {
       <Layout>
         <FlagSwitcher />
         <Alerter t={t} />
+        <UploadQueue />
+
         {children}
         <Sprite />
       </Layout>

--- a/src/drive/web/modules/public/PublicLayout.spec.jsx
+++ b/src/drive/web/modules/public/PublicLayout.spec.jsx
@@ -5,6 +5,9 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import AppLike from 'test/components/AppLike'
 import PublicLayout from './PublicLayout'
 
+jest.mock('drive/web/modules/upload/UploadQueue', () => () => {
+  return null
+})
 const client = new createMockClient({})
 
 describe('PublicLayout', () => {


### PR DESCRIPTION
Currently we don't have any feedback when
uploading files on a public view. Let's
add the UploadQueue in order to give the
feedback needed.


![Capture d’écran 2022-08-31 à 13 08 19](https://user-images.githubusercontent.com/1107936/187665534-0dc0c806-0d88-4d9a-860b-823373311075.png)

