### PR TITLE
fix: Display Download actions on iOS Flagship app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 * Improve cozy-bar implementation to fix UI bugs in Amirale
 * Fix navigation through mobile Flagship on Note creation and opening
 * Remove unused contacts permissions on Photos
-* Do not display Download actions on iOS Flagship app until we fix the navigation bug
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "cozy-scripts": "^6.3.8",
     "cozy-sharing": "4.1.5",
     "cozy-stack-client": "33.0.5",
-    "cozy-ui": "^73.2.0",
+    "cozy-ui": "^74.4.0",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { isFile } from 'cozy-client/dist/models/file'
 import { ShareModal } from 'cozy-sharing'
-import { isFlagshipApp, isIOS, isIOSApp, isMobileApp } from 'cozy-device-helper'
+import { isIOSApp, isMobileApp } from 'cozy-device-helper'
 import { EditDocumentQualification } from 'cozy-scanner'
 import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
 import { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
@@ -92,11 +92,6 @@ export const download = ({ client, vaultClient }) => {
     : {
         icon: 'download',
         displayCondition: files => {
-          // Temporarily disable Download button on iOS Flagship app until
-          // the download feature is fixed on this platform
-          // When fixed on this platform, revert this commit from PR #2672
-          if (isFlagshipApp() && isIOS()) return null
-
           // We cannot generate archive for encrypted files, for now.
           // Then, we do not display the download button when the selection
           // includes an encrypted folder or several encrypted files

--- a/yarn.lock
+++ b/yarn.lock
@@ -6307,10 +6307,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^73.2.0:
-  version "73.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-73.2.0.tgz#2078612feed829e28e382648b9a92bbddf5b515f"
-  integrity sha512-19OlALIzXsegvIBU1gI32NVm6jrOGOy7mWAvZrcWwadb3iGsohtuYyZ+Ugpp6wkzVjEyK3w61yALIKJBgMI8uA==
+cozy-ui@^74.4.0:
+  version "74.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-74.4.0.tgz#f2309fa004ec16bb033e20bd37f2d76c16507da6"
+  integrity sha512-0AiB7nl0eJ7/K8XSh6ClOePNUb6XAiIapQnsIWjUznKcpC6mf4vc0Kr/mnJg3ALivanOHqxXRWJjyB9ihELW7A==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -6325,7 +6325,7 @@ cozy-ui@^73.2.0:
     hammerjs "^2.0.8"
     intersection-observer "0.11.0"
     mime-types "2.1.35"
-    mui-bottom-sheet "https://github.com/cozy/mui-bottom-sheet.git#v1.0.8"
+    mui-bottom-sheet "https://github.com/cozy/mui-bottom-sheet.git#v1.0.9"
     node-polyglot "^2.2.2"
     normalize.css "^8.0.0"
     piwik-react-router "0.12.1"
@@ -13038,9 +13038,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
-  version "1.0.6"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+  version "1.0.8"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -13048,9 +13048,9 @@ msgpack5@^4.0.2:
     react-use-gesture "^7.0.8"
     react-use-measure "^2.0.0"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.8":
-  version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#8535a9da5c334890dcf95ae4e6aeb4f6ec2d56a0"
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+  version "1.0.6"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
This commit is a revert from 268b46e415f90289337aa58f91480331eecc087a
and from b4fb66b184f1ad7f435f9e2c04b2a5ea6844f9f5

In previous commit we removed the Download button on iOS Flagship app
as this platform was not able to handle downloads correctly

Now that we implemented a solution to handle downloads on this platform
we can add this feature back

Related PR: cozy/cozy-drive#2672
Related PR: cozy/cozy-drive#2676

___

TODO:

- [x] Upgrade cozy-ui after https://github.com/cozy/cozy-ui/pull/2234 is merged
