### PR TITLE
fix(Search): prevent duplicate API called when suggestions are fetched

### DIFF
--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -8,7 +8,7 @@ import { TYPE_DIRECTORY, makeNormalizedFile } from './helpers'
 class SuggestionProvider extends React.Component {
   componentDidMount() {
     const { intent } = this.props
-    this.hasIndexedFiles = false
+    this.hasIndexFilesBeenLaunched = false
 
     // re-attach the message listener for the intent to receive the suggestion requests
     window.addEventListener('message', event => {
@@ -39,7 +39,8 @@ class SuggestionProvider extends React.Component {
    * @returns {Promise<void>} nothing
    */
   async provideSuggestions(query, id, intent) {
-    if (!this.hasIndexedFiles) {
+    if (!this.hasIndexFilesBeenLaunched) {
+      this.hasIndexFilesBeenLaunched = true
       await this.indexFiles()
     }
 
@@ -96,7 +97,6 @@ class SuggestionProvider extends React.Component {
     )
 
     this.fuzzyPathSearch = new FuzzyPathSearch(normalizedFiles)
-    this.hasIndexedFiles = true
   }
 
   render() {


### PR DESCRIPTION
In production build, the number of Suggestions looks duplicated (or worst)
In order to prevent the duplicate called, we should set the fetching
indicator directly when we call indexFiles method

Before:
![Capture d’écran 2022-09-02 à 16 38 51](https://user-images.githubusercontent.com/8363334/188173324-84dd6cba-5a75-4ae3-b862-6e5c2a0e9178.png)



- [ ] Changelog updated if needed
