### PR TITLE
fix(search): Group filter calculation should use && to be equivalent

### DIFF
--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -90,7 +90,7 @@ class SuggestionProvider extends React.Component {
     const notOrphans = file =>
       folders.find(folder => folder._id === file.dir_id) !== undefined
 
-    const normalizedFilesPrevious = files.filter(notInTrash || notOrphans)
+    const normalizedFilesPrevious = files.filter(notInTrash && notOrphans)
 
     const normalizedFiles = normalizedFilesPrevious.map(file =>
       makeNormalizedFile(client, folders, file)

--- a/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
@@ -83,14 +83,6 @@ describe('SuggestionProvider', () => {
             {
               icon: 'iconUrl',
               id: 'id-file',
-              onSelect: 'open:http://localhost/#/folder/id-file',
-              subtitle: '/path',
-              term: 'name',
-              title: 'name'
-            },
-            {
-              icon: 'iconUrl',
-              id: 'id-file',
               onSelect: 'id_note:id-file',
               subtitle: '/path',
               term: 'name.cozy-note',


### PR DESCRIPTION
that commit  24c2d46d was not equivalent to previous version, now it is.

proof:
![Capture d’écran 2022-09-05 à 11 38 48](https://user-images.githubusercontent.com/8363334/188419576-1b52c830-76e0-4627-963c-ffa29e303bb8.png)
