### PR TITLE
feat: Add cache to the clients query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
   - Fix on progress bar when uploading files [[68.4.0]](https://github.com/cozy/cozy-ui/releases/tag/v68.4.0)
 * Update cozy-scripts for Amirale development
 * Add visual feedback when uploading on a public view
-
+* Cache on clients request. Specially useful when the user didn't hide the "Install Cozy Drive for desktop" banner.
+  
 ## 🐛 Bug Fixes
 
 * Improve cozy-bar implementation to fix UI bugs in Amirale

--- a/src/components/pushClient/index.js
+++ b/src/components/pushClient/index.js
@@ -1,6 +1,6 @@
 import get from 'lodash/get'
 
-import { Q } from 'cozy-client'
+import CozyClient, { Q } from 'cozy-client'
 import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
 
 export const DESKTOP_SOFTWARE_ID = 'github.com/cozy-labs/cozy-desktop'
@@ -26,7 +26,13 @@ export const DESKTOP_BANNER = 'desktop_banner'
 export const NOVIEWER_DESKTOP_CTA = 'noviewer_desktop_cta'
 
 export const isClientAlreadyInstalled = async client => {
-  const { data } = await client.query(Q('io.cozy.settings').getById('clients'))
+  const { data } = await client.query(
+    Q('io.cozy.settings').getById('clients'),
+    {
+      as: 'io.cozy.settings/clients',
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+    }
+  )
   return Object.values(data).some(
     device => get(device, 'attributes.software_id') === DESKTOP_SOFTWARE_ID
   )


### PR DESCRIPTION
This component makes request at every
render. If the user doesn't hide the
banner, the request is done every time
he/she clicks on a new view.

By adding a name and a fetch policy
we don't always make the request.


