### PR TITLE
fix: Make Search backward compatible

### DIFF
--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -81,7 +81,7 @@ class SuggestionProvider extends React.Component {
     const { client } = this.props
     const resp = await cozy.client.fetchJSON(
       'GET',
-      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,metadata.title,metadata.version&DesignDocs=false'
+      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
     )
     const files = resp.rows.map(row => ({ id: row.id, ...row.doc }))
     const folders = files.filter(file => file.type === TYPE_DIRECTORY)

--- a/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
@@ -64,7 +64,7 @@ describe('SuggestionProvider', () => {
     // Then
     expect(mockClient.fetchJSON).toHaveBeenCalledWith(
       'GET',
-      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,metadata.title,metadata.version&DesignDocs=false'
+      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
     )
   })
 


### PR DESCRIPTION
Like that, we don't have a dep between the stack
deployed and the drive version.

If the stack handles the Fields attribute then
fetch is optimized, if not, then we still got
the docs.


