### PR TITLE
fix(photos): timeline query needs select fields to be completed

### DIFF
--- a/src/photos/ducks/timeline/index.jsx
+++ b/src/photos/ducks/timeline/index.jsx
@@ -31,7 +31,16 @@ const TIMELINE_QUERY = client =>
       trashed: false
     })
     .indexFields(['class', 'metadata.datetime'])
-    .select(['dir_id', 'name', 'size', 'updated_at', 'metadata'])
+    .select([
+      'dir_id',
+      'name',
+      'size',
+      'updated_at',
+      'metadata',
+      'metadata.datetime',
+      'trashed',
+      'class'
+    ])
     .sortBy([
       {
         class: 'desc'


### PR DESCRIPTION
After v30.0.0 of cozy-client, select MUST include all the fields expressed in the selector and partialIndex

- [ ] Changelog updated if needed
