### PR TITLE
fix: Display Drive when moving to the root of the cozy

### DIFF
--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -107,7 +107,7 @@ export class MoveModal extends React.Component {
       const response = await this.registerCancelable(
         client.query(Q('io.cozy.files').getById(folderId))
       )
-      const targetName = response.data.name
+      const targetName = response.data.name || t('breadcrumb.title_drive')
       Alerter.info('Move.success', {
         subject: entries.length === 1 ? entries[0].name : '',
         target: targetName,


### PR DESCRIPTION
the directory io.cozy.root-dir doesn't have a name. So when we moved a file to that folder, %targetName was displayed to the user. Now, if there is no name to a directory, then we display "Drive".

```
fix: When a user moved a file to the root directory, we displayed "the file was moved to %targetName. Now we display the file was moved to Drive"
```
