### PR TITLE
fix: Reduce should always have an initial value

### DIFF
--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -107,7 +107,7 @@ const getProgress = (state, action) => {
     if (!timeout) {
       timeout = setTimeout(() => {
         averageRemainingTime =
-          remainingTimes.reduce((a, b) => a + b) / remainingTimes.length
+          remainingTimes.reduce((a, b) => a + b, 0) / remainingTimes.length
 
         clearTimeout(timeout)
         timeout = undefined


### PR DESCRIPTION
Fix error: Uncaught TypeError: reduce of empty
array with no initial value

when uploading a new file.


