### PR TITLE
chore: Bump to 1.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
+# 1.45.0
+
+## ✨ Features
+## 🐛 Bug Fixes
+## 🔧 Tech
+
+
 # 1.44.0
 
 ## ✨ Features
 
+* Improvements to DACC service
+
 ## 🐛 Bug Fixes
 
+* Remove double elevator on file list on public pages
+* Fix issue on file upload
+* Fix display when moving element to the root
+
 ## 🔧 Tech
+
+* Use new DACC API
+* Remove verbose mode
+* Add all files for bundlemon and make it drastically sensitive 
+
 
 # 1.43.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-drive",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "main": "src/main.jsx",
   "scripts": {
     "build": "yarn build:drive && yarn build:photos",

--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -2,7 +2,7 @@
   "name": "Drive",
   "name_prefix": "Cozy",
   "slug": "drive",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "webapp",
   "licence": "AGPL-3.0",
   "icon": "public/app-icon.svg",

--- a/src/drive/targets/mobile/config.xml
+++ b/src/drive/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="14400000" id="io.cozy.drive.mobile" ios-CFBundleVersion="1.44.0.0" version="1.44.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="14500000" id="io.cozy.drive.mobile" ios-CFBundleVersion="1.45.0.0" version="1.45.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Drive</name>
     <description>Sync files from your Cozy.</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>
@@ -11,7 +11,7 @@
     <allow-intent href="sms:*" />
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
-    <preference name="AppendUserAgent" value="io.cozy.drive.mobile-1.44.0" />
+    <preference name="AppendUserAgent" value="io.cozy.drive.mobile-1.45.0" />
     <preference name="android-targetSdkVersion" value="29" />
     <platform name="android">
         <preference name="android-minSdkVersion" value="21" />

--- a/src/drive/targets/mobile/package.json
+++ b/src/drive/targets/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.cozy.drive.mobile",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "displayName": "Cozy Drive",
   "cordova": {
     "platforms": [

--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -2,7 +2,7 @@
   "name": "Photos",
   "name_prefix": "Cozy",
   "slug": "photos",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "webapp",
   "licence": "AGPL-3.0",
   "icon": "public/app-icon.svg",


### PR DESCRIPTION
### ✨ Features

* Improvements to DACC service

### 🐛 Bug Fixes

* Remove double elevator on file list on public pages
* Fix issue on file upload
* Fix display when moving element to the root

### 🔧 Tech

* Use new DACC API
* Remove verbose mode
* Add all files for bundlemon and make it drastically sensitive 
