### PR TITLE
fix: Add permissions to Photos

### DIFF
--- a/src/photos/targets/manifest.webapp
+++ b/src/photos/targets/manifest.webapp
@@ -109,6 +109,16 @@
       "verbs": ["POST"],
       "selector": "worker",
       "values": ["service"]
+    },
+    "triggersviewer": {
+      "description": "Required to display the konnector block status",
+      "type": "io.cozy.triggers",
+      "verbs": ["GET"]
+    },
+    "konnectors": {
+      "description": "Required to display the information of the konnector that retrieved the photos",
+      "type": "io.cozy.konnectors",
+      "verbs": ["GET"]
     }
   }
 }


### PR DESCRIPTION
Cozy-ui's viewer needs to be able to query
konnectors and triggers in order to display
the konnector block with the status of the
konnector and the icone.

```
fix: Viewer on photo display correctly the information about the konnector if there is some to display. 
```
