### PR TITLE
chore: Make version:drive:androidbuild POSIX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "version:drive:mobilePackage": "replace '\"version\": \"\\d+\\.\\d+\\.\\d+\"' '\"version\": \"'$npm_package_version'\"' ./src/drive/targets/mobile/package.json",
     "version:drive:config": "replace 'version=\"\\d+\\.\\d+\\.\\d+\"' 'version=\"'$npm_package_version'\"' ./src/drive/targets/mobile/config.xml",
     "version:drive:iosbuild": "replace 'CFBundleVersion=\"\\d+\\.\\d+\\.\\d+.\\d+\"' 'CFBundleVersion=\"'$npm_package_version'.0\"' ./src/drive/targets/mobile/config.xml",
-    "version:drive:androidbuild": "replace 'android-versionCode=\"\\d+\"' 'android-versionCode=\"'${npm_package_version//\\./}'0000\"' ./src/drive/targets/mobile/config.xml",
+    "version:drive:androidbuild": "sed -i -E 's,android-versionCode=\"[0-9]+\",android-versionCode=\"'`echo ${npm_package_version} | tr -d .`'0000\",g' ./src/drive/targets/mobile/config.xml",
     "version:drive:useragent": "replace 'value=\"(.+)\\d+\\.\\d+\\.\\d+\"' 'value=\"$1'$npm_package_version'\"' ./src/drive/targets/mobile/config.xml",
     "version:drive": "npm-run-all --parallel 'version:drive:*'",
     "version:photos": "replace '\\d+\\.\\d+\\.\\d+' $npm_package_version ./src/photos/targets/manifest.webapp"


### PR DESCRIPTION
Make android build (i.e. `yarn version:drive:androidbuild`) POSIX compliant so it doesn't requires explicitely instructing node to use bash or wrongly assume `sh` shell is `bash`.