### PR TITLE
feat: Add sharing option to the Recent View

### DIFF
--- a/src/drive/web/modules/views/Recent/index.jsx
+++ b/src/drive/web/modules/views/Recent/index.jsx
@@ -22,7 +22,8 @@ import {
   qualify,
   versions,
   offline,
-  hr
+  hr,
+  share
 } from 'drive/web/modules/actions'
 import {
   buildRecentQuery,
@@ -86,6 +87,7 @@ export const RecentView = ({ router, location, children }) => {
 
   const actions = useActions(
     [
+      share,
       download,
       hr,
       qualify,


### PR DESCRIPTION
feat: Add sharing option to the Recent View. 

I just added this option as is since the sharing
modal already does the check to know if the file
is inside an already shared folder (we restrict 
the fact to share a subfolder of an already 
shared folder)

