### PR TITLE
fix: Shared OO document displayed a blank page

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -38,7 +38,7 @@ const useConfig = () => {
 
   useEffect(() => {
     if (!isQueryLoading(queryResult) && fetchStatus !== 'error' && !config) {
-      if (!isPublic && shouldBeOpenedOnOtherInstance(data)) {
+      if (shouldBeOpenedOnOtherInstance(data)) {
         const {
           protocol,
           instance,


### PR DESCRIPTION
When there was a cozy to cozy sharing from Alice to Bob with a OO file, and Bob share the OO file with a public link, the public link displayed a blank page. The code to open the file on an other instance was bypassed when the file was public.

I did not understand what was the purpose of the `!isPublic` I removed with @Crash-- help, so if you have any idea of the purpose, tell me.

### 🐛 Bug Fixes

* A public OnlyOffice document from a cozy to cozy share is now displayed correctly
