### PR TITLE
[WIP] Refactor the web drive actions

### DIFF
--- a/src/drive/web/modules/actionmenu/ActionsItems.jsx
+++ b/src/drive/web/modules/actionmenu/ActionsItems.jsx
@@ -59,6 +59,7 @@ export const ActionsItems = ({ actions, file, onClose }) => {
     const Component = actionDefinition.Component
     const action = actionDefinition.action
     const label = actionDefinition.label
+    const icon = actionDefinition.icon
 
     const onClick = action
       ? () => {
@@ -75,7 +76,7 @@ export const ActionsItems = ({ actions, file, onClose }) => {
         )}
         key={actionName + i}
       >
-        <Component label={label} onClick={onClick} files={[file]} />
+        <Component icon={icon} label={label} onClick={onClick} files={[file]} />
       </div>
     )
   })

--- a/src/drive/web/modules/actionmenu/ActionsItems.jsx
+++ b/src/drive/web/modules/actionmenu/ActionsItems.jsx
@@ -58,6 +58,7 @@ export const ActionsItems = ({ actions, file, onClose }) => {
 
     const Component = actionDefinition.Component
     const action = actionDefinition.action
+    const label = actionDefinition.label
 
     const onClick = action
       ? () => {
@@ -74,7 +75,7 @@ export const ActionsItems = ({ actions, file, onClose }) => {
         )}
         key={actionName + i}
       >
-        <Component onClick={onClick} files={[file]} />
+        <Component label={label} onClick={onClick} files={[file]} />
       </div>
     )
   })

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -45,6 +45,7 @@ import { useI18n } from 'cozy-ui/transpiled/react'
 
 export const share = ({ hasWriteAccess, pushModal, popModal }) => {
   return {
+    name: 'share',
     icon: ShareIcon,
     displayCondition: selection =>
       hasWriteAccess &&
@@ -68,6 +69,7 @@ export const share = ({ hasWriteAccess, pushModal, popModal }) => {
 export const download = ({ client, vaultClient }) => {
   return isMobileApp()
     ? {
+        name: 'download',
         icon: isIOSApp() ? ShareIosIcon : ReplyIcon,
         label: 'forwardTo',
         displayCondition: files => {
@@ -91,6 +93,7 @@ export const download = ({ client, vaultClient }) => {
         }
       }
     : {
+        name: 'download',
         icon: DownloadIcon,
         label: 'download',
         displayCondition: files => {
@@ -128,6 +131,7 @@ export const hr = () => {
 
 export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
   return {
+    name: 'trash',
     icon: TrashIcon,
     label: 'trash',
     displayCondition: () => hasWriteAccess,
@@ -157,6 +161,7 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
 }
 export const open = ({ client, vaultClient }) => {
   return {
+    name: 'openWith',
     icon: isIOSApp() ? EyeIcon : LinkOutIcon,
     label: isIOSApp() ? 'applePreview' : 'openWith',
     displayCondition: selection =>
@@ -178,6 +183,7 @@ export const open = ({ client, vaultClient }) => {
 
 export const rename = ({ hasWriteAccess, dispatch }) => {
   return {
+    name: 'rename',
     icon: RenameIcon,
     label: 'rename',
     displayCondition: selection => hasWriteAccess && selection.length === 1,
@@ -198,6 +204,7 @@ export const rename = ({ hasWriteAccess, dispatch }) => {
 
 export const move = ({ canMove, pushModal, popModal }) => {
   return {
+    name: 'moveto',
     icon: MovetoIcon,
     label: 'moveto',
     displayCondition: () => canMove,
@@ -219,6 +226,7 @@ export const move = ({ canMove, pushModal, popModal }) => {
 
 export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
   return {
+    name: 'copy',
     icon: CopyIcon,
     label: 'copy',
     displayCondition: selection =>
@@ -230,7 +238,10 @@ export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
     Component: function Copy(props) {
       const { t } = useI18n()
       return (
-        <ActionMenuItem onClick={props.onClick} left={<Icon icon={props.icon} />}>
+        <ActionMenuItem
+          onClick={props.onClick}
+          left={<Icon icon={props.icon} />}
+        >
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
@@ -240,6 +251,7 @@ export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
 
 export const qualify = ({ pushModal, popModal }) => {
   return {
+    name: 'qualify',
     icon: QualifyIcon,
     label: 'qualify',
     displayCondition: selection =>
@@ -264,6 +276,7 @@ export const qualify = ({ pushModal, popModal }) => {
 
 export const versions = ({ router, location }) => {
   return {
+    name: 'history',
     icon: HistoryIcon,
     label: 'history',
     displayCondition: selection =>
@@ -287,10 +300,11 @@ export const versions = ({ router, location }) => {
       )
     }
   }
-
+}
 
 export const offline = () => {
   return {
+    name: 'phone-download',
     icon: PhoneDownloadIcon,
     displayCondition: selections =>
       isMobileApp() && selections.length === 1 && isFile(selections[0]),
@@ -302,6 +316,7 @@ export const offline = () => {
 
 export const restore = ({ refresh, client }) => {
   return {
+    name: 'restore',
     icon: RestoreIcon,
     label: 'restore',
     action: async files => {
@@ -324,6 +339,7 @@ export const restore = ({ refresh, client }) => {
 
 export const destroy = ({ pushModal, popModal }) => {
   return {
+    name: 'destroy',
     icon: TrashIcon,
     label: 'destroy',
     action: files =>

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -12,6 +12,8 @@ import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
 import MovetoIcon from 'cozy-ui/transpiled/react/Icons/Moveto'
 import CopyIcon from 'cozy-ui/transpiled/react/Icons/Copy'
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
+import PhoneDownloadIcon from 'cozy-ui/transpiled/react/Icons/PhoneDownload'
 import QualifyIcon from 'cozy-ui/transpiled/react/Icons/Qualify'
 import HistoryIcon from 'cozy-ui/transpiled/react/Icons/History'
 import RestoreIcon from 'cozy-ui/transpiled/react/Icons/Restore'
@@ -43,7 +45,7 @@ import { useI18n } from 'cozy-ui/transpiled/react'
 
 export const share = ({ hasWriteAccess, pushModal, popModal }) => {
   return {
-    icon: 'share',
+    icon: ShareIcon,
     displayCondition: selection =>
       hasWriteAccess &&
       selection.length === 1 &&
@@ -66,7 +68,7 @@ export const share = ({ hasWriteAccess, pushModal, popModal }) => {
 export const download = ({ client, vaultClient }) => {
   return isMobileApp()
     ? {
-        icon: 'download',
+        icon: isIOSApp() ? ShareIosIcon : ReplyIcon,
         label: 'forwardTo',
         displayCondition: files => {
           if (isIOSApp()) return files.length === 1 && isFile(files[0])
@@ -81,7 +83,7 @@ export const download = ({ client, vaultClient }) => {
           return (
             <ActionMenuItem
               onClick={props.onClick}
-              left={<Icon icon={isIOSApp() ? ShareIosIcon : ReplyIcon} />}
+              left={<Icon icon={props.icon} />}
             >
               {t('SelectionBar.' + props.label)}
             </ActionMenuItem>
@@ -89,7 +91,7 @@ export const download = ({ client, vaultClient }) => {
         }
       }
     : {
-        icon: 'download',
+        icon: DownloadIcon,
         label: 'download',
         displayCondition: files => {
           // We cannot generate archive for encrypted files, for now.
@@ -106,7 +108,7 @@ export const download = ({ client, vaultClient }) => {
           return (
             <ActionMenuItem
               onClick={props.onClick}
-              left={<Icon icon={DownloadIcon} />}
+              left={<Icon icon={props.icon} />}
             >
               {t('SelectionBar.' + props.label)}
             </ActionMenuItem>
@@ -117,7 +119,6 @@ export const download = ({ client, vaultClient }) => {
 
 export const hr = () => {
   return {
-    icon: 'hr',
     displayInSelectionBar: false,
     Component: function hr() {
       return <hr />
@@ -127,7 +128,7 @@ export const hr = () => {
 
 export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
   return {
-    icon: 'trash',
+    icon: TrashIcon,
     label: 'trash',
     displayCondition: () => hasWriteAccess,
     action: files =>
@@ -146,7 +147,7 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
+          left={<Icon icon={props.icon} color="var(--errorColor)" />}
         >
           <span className="u-error">{t('SelectionBar.' + props.label)}</span>
         </ActionMenuItem>
@@ -156,7 +157,7 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
 }
 export const open = ({ client, vaultClient }) => {
   return {
-    icon: 'openWith',
+    icon: isIOSApp() ? EyeIcon : LinkOutIcon,
     label: isIOSApp() ? 'applePreview' : 'openWith',
     displayCondition: selection =>
       isMobileApp() && selection.length === 1 && isFile(selection[0]),
@@ -166,7 +167,7 @@ export const open = ({ client, vaultClient }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={isIOSApp() ? EyeIcon : LinkOutIcon} />}
+          left={<Icon icon={props.icon} />}
         >
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
@@ -177,7 +178,7 @@ export const open = ({ client, vaultClient }) => {
 
 export const rename = ({ hasWriteAccess, dispatch }) => {
   return {
-    icon: 'rename',
+    icon: RenameIcon,
     label: 'rename',
     displayCondition: selection => hasWriteAccess && selection.length === 1,
     action: files => dispatch(startRenamingAsync(files[0])),
@@ -186,7 +187,7 @@ export const rename = ({ hasWriteAccess, dispatch }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={RenameIcon} />}
+          left={<Icon icon={props.icon} />}
         >
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
@@ -197,7 +198,7 @@ export const rename = ({ hasWriteAccess, dispatch }) => {
 
 export const move = ({ canMove, pushModal, popModal }) => {
   return {
-    icon: 'moveto',
+    icon: MovetoIcon,
     label: 'moveto',
     displayCondition: () => canMove,
     action: files =>
@@ -207,7 +208,7 @@ export const move = ({ canMove, pushModal, popModal }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={MovetoIcon} />}
+          left={<Icon icon={props.icon} />}
         >
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
@@ -218,7 +219,7 @@ export const move = ({ canMove, pushModal, popModal }) => {
 
 export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
   return {
-    icon: 'copy',
+    icon: CopyIcon,
     label: 'copy',
     displayCondition: selection =>
       selection.length === 1 && isFile(selection[0]) && hasWriteAccess,
@@ -229,7 +230,7 @@ export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
     Component: function Copy(props) {
       const { t } = useI18n()
       return (
-        <ActionMenuItem onClick={props.onClick} left={<Icon icon={CopyIcon} />}>
+        <ActionMenuItem onClick={props.onClick} left={<Icon icon={props.icon} />}>
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
@@ -239,7 +240,7 @@ export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
 
 export const qualify = ({ pushModal, popModal }) => {
   return {
-    icon: 'qualify',
+    icon: QualifyIcon,
     label: 'qualify',
     displayCondition: selection =>
       selection.length === 1 && isFile(selection[0]),
@@ -252,7 +253,7 @@ export const qualify = ({ pushModal, popModal }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={QualifyIcon} />}
+          left={<Icon icon={props.icon} />}
         >
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
@@ -263,7 +264,7 @@ export const qualify = ({ pushModal, popModal }) => {
 
 export const versions = ({ router, location }) => {
   return {
-    icon: 'history',
+    icon: HistoryIcon,
     label: 'history',
     displayCondition: selection =>
       selection.length === 1 && isFile(selection[0]),
@@ -279,18 +280,18 @@ export const versions = ({ router, location }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={HistoryIcon} />}
+          left={<Icon icon={props.icon} />}
         >
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
   }
-}
+
 
 export const offline = () => {
   return {
-    icon: 'phone-download',
+    icon: PhoneDownloadIcon,
     displayCondition: selections =>
       isMobileApp() && selections.length === 1 && isFile(selections[0]),
     Component: function MakeAvailableOfflineMenuItemInMenu({ files, ...rest }) {
@@ -301,7 +302,7 @@ export const offline = () => {
 
 export const restore = ({ refresh, client }) => {
   return {
-    icon: 'restore',
+    icon: RestoreIcon,
     label: 'restore',
     action: async files => {
       await restoreFiles(client, files)
@@ -312,7 +313,7 @@ export const restore = ({ refresh, client }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={RestoreIcon} />}
+          left={<Icon icon={props.icon} />}
         >
           {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
@@ -323,7 +324,7 @@ export const restore = ({ refresh, client }) => {
 
 export const destroy = ({ pushModal, popModal }) => {
   return {
-    icon: 'trash',
+    icon: TrashIcon,
     label: 'destroy',
     action: files =>
       pushModal(<DestroyConfirm files={files} onClose={popModal} />),
@@ -332,7 +333,7 @@ export const destroy = ({ pushModal, popModal }) => {
       return (
         <ActionMenuItem
           onClick={props.onClick}
-          left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
+          left={<Icon icon={props.icon} color="var(--errorColor)" />}
         >
           <span className="u-error">{t('SelectionBar.' + props.label)}</span>
         </ActionMenuItem>

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -80,9 +80,7 @@ export const download = ({ client, vaultClient }) => {
           const { t } = useI18n()
           return (
             <ActionMenuItem
-              onClick={() => {
-                return exportFilesNative(client, props.files, { vaultClient })
-              }}
+              onClick={props.onClick}
               left={<Icon icon={isIOSApp() ? ShareIosIcon : ReplyIcon} />}
             >
               {t('SelectionBar.forwardTo')}
@@ -106,9 +104,7 @@ export const download = ({ client, vaultClient }) => {
           const { t } = useI18n()
           return (
             <ActionMenuItem
-              onClick={() => {
-                return downloadFiles(client, props.files, { vaultClient })
-              }}
+              onClick={props.onClick}
               left={<Icon icon={DownloadIcon} />}
             >
               {t('SelectionBar.download')}
@@ -147,18 +143,7 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={() =>
-            pushModal(
-              <DeleteConfirm
-                files={props.files}
-                referenced={isAnyFileReferencedByAlbum(props.files)}
-                afterConfirmation={() => {
-                  refresh()
-                }}
-                onClose={popModal}
-              />
-            )
-          }
+          onClick={props.onClick}
           left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
         >
           <span className="u-error">{t('SelectionBar.trash')}</span>
@@ -177,7 +162,7 @@ export const open = ({ client, vaultClient }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={() => openFileWith(client, props.files[0], { vaultClient })}
+          onClick={props.onClick}
           left={<Icon icon={isIOSApp() ? EyeIcon : LinkOutIcon} />}
         >
           {isIOSApp()
@@ -198,7 +183,7 @@ export const rename = ({ hasWriteAccess, dispatch }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={() => dispatch(startRenamingAsync(props.files[0]))}
+          onClick={props.onClick}
           left={<Icon icon={RenameIcon} />}
         >
           {t('SelectionBar.rename')}
@@ -218,9 +203,7 @@ export const move = ({ canMove, pushModal, popModal }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={() =>
-            pushModal(<MoveModal entries={props.files} onClose={popModal} />)
-          }
+          onClick={props.onClick}
           left={<Icon icon={MovetoIcon} />}
         >
           {t('SelectionBar.moveto')}
@@ -242,13 +225,7 @@ export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
     Component: function Copy(props) {
       const { t } = useI18n()
       return (
-        <ActionMenuItem
-          onClick={async () => {
-            await client.collection('io.cozy.files').copy(props.files[0].id)
-            if (isPublic) refresh()
-          }}
-          left={<Icon icon={CopyIcon} />}
-        >
+        <ActionMenuItem onClick={props.onClick} left={<Icon icon={CopyIcon} />}>
           {t('SelectionBar.copy')}
         </ActionMenuItem>
       )
@@ -269,14 +246,7 @@ export const qualify = ({ pushModal, popModal }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={() =>
-            pushModal(
-              <EditDocumentQualification
-                document={props.files[0]}
-                onClose={popModal}
-              />
-            )
-          }
+          onClick={props.onClick}
           left={<Icon icon={QualifyIcon} />}
         >
           {t('SelectionBar.qualify')}
@@ -302,20 +272,7 @@ export const versions = ({ router, location }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={() => {
-            const tracker = getTracker()
-            if (tracker) {
-              tracker.push([
-                'trackEvent',
-                'Drive',
-                'Versioning',
-                'ClickFromMenuFile'
-              ])
-            }
-            return router.push(
-              `${location.pathname}/file/${props.files[0].id}/revision`
-            )
-          }}
+          onClick={props.onClick}
           left={<Icon icon={HistoryIcon} />}
         >
           {t('SelectionBar.history')}
@@ -347,10 +304,7 @@ export const restore = ({ refresh, client }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={async () => {
-            await restoreFiles(client, props.files)
-            refresh()
-          }}
+          onClick={props.onClick}
           left={<Icon icon={RestoreIcon} />}
         >
           {t('SelectionBar.restore')}
@@ -370,9 +324,7 @@ export const destroy = ({ pushModal, popModal }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem
-          onClick={() =>
-            pushModal(<DestroyConfirm files={props.files} onClose={popModal} />)
-          }
+          onClick={props.onClick}
           left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
         >
           <span className="u-error">{t('SelectionBar.destroy')}</span>

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -67,6 +67,7 @@ export const download = ({ client, vaultClient }) => {
   return isMobileApp()
     ? {
         icon: 'download',
+        label: 'forwardTo',
         displayCondition: files => {
           if (isIOSApp()) return files.length === 1 && isFile(files[0])
           return files.reduce(
@@ -75,7 +76,6 @@ export const download = ({ client, vaultClient }) => {
           )
         },
         action: files => exportFilesNative(client, files, { vaultClient }),
-        label: 'forwardTo',
         Component: function Download(props) {
           const { t } = useI18n()
           return (
@@ -83,13 +83,14 @@ export const download = ({ client, vaultClient }) => {
               onClick={props.onClick}
               left={<Icon icon={isIOSApp() ? ShareIosIcon : ReplyIcon} />}
             >
-              {t('SelectionBar.forwardTo')}
+              {t('SelectionBar.' + props.label)}
             </ActionMenuItem>
           )
         }
       }
     : {
         icon: 'download',
+        label: 'download',
         displayCondition: files => {
           // We cannot generate archive for encrypted files, for now.
           // Then, we do not display the download button when the selection
@@ -107,7 +108,7 @@ export const download = ({ client, vaultClient }) => {
               onClick={props.onClick}
               left={<Icon icon={DownloadIcon} />}
             >
-              {t('SelectionBar.download')}
+              {t('SelectionBar.' + props.label)}
             </ActionMenuItem>
           )
         }
@@ -127,6 +128,7 @@ export const hr = () => {
 export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
   return {
     icon: 'trash',
+    label: 'trash',
     displayCondition: () => hasWriteAccess,
     action: files =>
       pushModal(
@@ -146,7 +148,7 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
           onClick={props.onClick}
           left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
         >
-          <span className="u-error">{t('SelectionBar.trash')}</span>
+          <span className="u-error">{t('SelectionBar.' + props.label)}</span>
         </ActionMenuItem>
       )
     }
@@ -155,6 +157,7 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
 export const open = ({ client, vaultClient }) => {
   return {
     icon: 'openWith',
+    label: isIOSApp() ? 'applePreview' : 'openWith',
     displayCondition: selection =>
       isMobileApp() && selection.length === 1 && isFile(selection[0]),
     action: files => openFileWith(client, files[0], { vaultClient }),
@@ -165,9 +168,7 @@ export const open = ({ client, vaultClient }) => {
           onClick={props.onClick}
           left={<Icon icon={isIOSApp() ? EyeIcon : LinkOutIcon} />}
         >
-          {isIOSApp()
-            ? t('SelectionBar.applePreview')
-            : t('SelectionBar.openWith')}
+          {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
@@ -177,6 +178,7 @@ export const open = ({ client, vaultClient }) => {
 export const rename = ({ hasWriteAccess, dispatch }) => {
   return {
     icon: 'rename',
+    label: 'rename',
     displayCondition: selection => hasWriteAccess && selection.length === 1,
     action: files => dispatch(startRenamingAsync(files[0])),
     Component: function Rename(props) {
@@ -186,7 +188,7 @@ export const rename = ({ hasWriteAccess, dispatch }) => {
           onClick={props.onClick}
           left={<Icon icon={RenameIcon} />}
         >
-          {t('SelectionBar.rename')}
+          {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
@@ -196,6 +198,7 @@ export const rename = ({ hasWriteAccess, dispatch }) => {
 export const move = ({ canMove, pushModal, popModal }) => {
   return {
     icon: 'moveto',
+    label: 'moveto',
     displayCondition: () => canMove,
     action: files =>
       pushModal(<MoveModal entries={files} onClose={popModal} />),
@@ -206,7 +209,7 @@ export const move = ({ canMove, pushModal, popModal }) => {
           onClick={props.onClick}
           left={<Icon icon={MovetoIcon} />}
         >
-          {t('SelectionBar.moveto')}
+          {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
@@ -216,6 +219,7 @@ export const move = ({ canMove, pushModal, popModal }) => {
 export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
   return {
     icon: 'copy',
+    label: 'copy',
     displayCondition: selection =>
       selection.length === 1 && isFile(selection[0]) && hasWriteAccess,
     action: async files => {
@@ -226,7 +230,7 @@ export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
       const { t } = useI18n()
       return (
         <ActionMenuItem onClick={props.onClick} left={<Icon icon={CopyIcon} />}>
-          {t('SelectionBar.copy')}
+          {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
@@ -236,6 +240,7 @@ export const copy = ({ client, hasWriteAccess, refresh, isPublic }) => {
 export const qualify = ({ pushModal, popModal }) => {
   return {
     icon: 'qualify',
+    label: 'qualify',
     displayCondition: selection =>
       selection.length === 1 && isFile(selection[0]),
     action: files =>
@@ -249,7 +254,7 @@ export const qualify = ({ pushModal, popModal }) => {
           onClick={props.onClick}
           left={<Icon icon={QualifyIcon} />}
         >
-          {t('SelectionBar.qualify')}
+          {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
@@ -259,6 +264,7 @@ export const qualify = ({ pushModal, popModal }) => {
 export const versions = ({ router, location }) => {
   return {
     icon: 'history',
+    label: 'history',
     displayCondition: selection =>
       selection.length === 1 && isFile(selection[0]),
     action: files => {
@@ -275,7 +281,7 @@ export const versions = ({ router, location }) => {
           onClick={props.onClick}
           left={<Icon icon={HistoryIcon} />}
         >
-          {t('SelectionBar.history')}
+          {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
@@ -296,6 +302,7 @@ export const offline = () => {
 export const restore = ({ refresh, client }) => {
   return {
     icon: 'restore',
+    label: 'restore',
     action: async files => {
       await restoreFiles(client, files)
       refresh()
@@ -307,7 +314,7 @@ export const restore = ({ refresh, client }) => {
           onClick={props.onClick}
           left={<Icon icon={RestoreIcon} />}
         >
-          {t('SelectionBar.restore')}
+          {t('SelectionBar.' + props.label)}
         </ActionMenuItem>
       )
     }
@@ -327,7 +334,7 @@ export const destroy = ({ pushModal, popModal }) => {
           onClick={props.onClick}
           left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
         >
-          <span className="u-error">{t('SelectionBar.destroy')}</span>
+          <span className="u-error">{t('SelectionBar.' + props.label)}</span>
         </ActionMenuItem>
       )
     }

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -263,14 +263,7 @@ export const qualify = ({ pushModal, popModal }) => {
       selection.length === 1 && isFile(selection[0]),
     action: files =>
       pushModal(
-        <EditDocumentQualification
-          document={files[0]}
-          onQualified={() => {
-            popModal()
-            // changes should be retrieved through cozy-client
-          }}
-          onClose={popModal}
-        />
+        <EditDocumentQualification document={files[0]} onClose={popModal} />
       ),
     Component: function Qualify(props) {
       const { t } = useI18n()
@@ -280,10 +273,6 @@ export const qualify = ({ pushModal, popModal }) => {
             pushModal(
               <EditDocumentQualification
                 document={props.files[0]}
-                onQualified={() => {
-                  popModal()
-                  // changes should be retrieved through cozy-client
-                }}
                 onClose={popModal}
               />
             )

--- a/src/drive/web/modules/actions/useActions.jsx
+++ b/src/drive/web/modules/actions/useActions.jsx
@@ -24,7 +24,7 @@ const useActions = (actionCreators, actionOptions = {}) => {
       createAction(actionOptions),
       dispatch
     )
-    const name = enhancedAction.label || enhancedAction.icon
+    const name = enhancedAction.name
 
     actions.push({ [name]: enhancedAction })
   })

--- a/src/drive/web/modules/actions/useActions.spec.jsx
+++ b/src/drive/web/modules/actions/useActions.spec.jsx
@@ -73,6 +73,7 @@ describe('useActions', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     global.__TARGET__ = 'browser'
+    global.window.cordova = { platformId: 'web' }
   })
 
   const renderActionsHook = hookArgs => {

--- a/src/drive/web/modules/actions/useActions.spec.jsx
+++ b/src/drive/web/modules/actions/useActions.spec.jsx
@@ -18,6 +18,7 @@ import {
 } from './utils'
 import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
 import * as renameModule from 'drive/web/modules/drive/rename'
+import { getActionName } from 'drive/web/modules/actionmenu/ActionsItems'
 import * as selectionModule from 'drive/web/modules/selection/duck'
 
 import useActions from './useActions'
@@ -136,10 +137,10 @@ describe('useActions', () => {
     return action
   }
 
-  it('returns actions keyed by icon', () => {
+  it('returns actions keyed by name', () => {
     const { result } = renderActionsHook(defaultHookArgs)
     const keys = result.current.map(actionObject => {
-      return Object.keys(actionObject)[0]
+      return getActionName(actionObject)
     })
     expect(keys).toEqual([
       'share',
@@ -228,7 +229,7 @@ describe('useActions', () => {
 
       it('is visible for a single file on iOS', () => {
         global.window.cordova = { platformId: 'ios' }
-        const downloadAction = getAction('forwardTo')
+        const downloadAction = getAction('download')
         expect(
           downloadAction.displayCondition([{ id: 'abc', type: 'file' }])
         ).toBe(true)
@@ -251,7 +252,7 @@ describe('useActions', () => {
 
       it('is visible if only files are selected on android', () => {
         global.window.cordova = { platformId: 'android' }
-        const downloadAction = getAction('forwardTo')
+        const downloadAction = getAction('download')
         expect(
           downloadAction.displayCondition([
             { id: 'abc', type: 'file' },
@@ -267,7 +268,7 @@ describe('useActions', () => {
       })
 
       it('export files to the device when activated', () => {
-        const downloadAction = getAction('forwardTo')
+        const downloadAction = getAction('download')
         const mockDocuments = [
           { id: 'abc', name: 'my-file.md' },
           { id: 'def', name: 'my-file-2.md' }


### PR DESCRIPTION
The drive actions are used in two place: 
- in the selection bar
- in the action menu on the right side of a file line

Those two component are described by the same action object, contains the same informations but have two completely different API. The goal of this PR is to try to bring those two together in order to reduce code duplication and to ensure the same content for the components.