### PR TITLE
fix: Shared OO document displayed a blank page due to infinite loop

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -15,10 +15,12 @@ export const isOnlyOfficeReadOnly = ({ data }) =>
  * Returns true in case of the document is shared and should be opened on another instance.
  * See https://docs.cozy.io/en/cozy-stack/office/#get-officeidopen
  * @param {object} params - Result of `/office/fileId/open`
+ * @param {string} instanceUri - Current instanceUri
  * @returns {boolean}
  */
-export const shouldBeOpenedOnOtherInstance = ({ data }) =>
-  data.attributes.sharecode
+export const shouldBeOpenedOnOtherInstance = ({ data }, instanceUri) => {
+  return !!instanceUri && !instanceUri.includes(data.attributes.instance)
+}
 
 export const makeOnlyOfficeIconByClass = fileClass => {
   const iconByClass = {

--- a/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.spec.js
@@ -1,7 +1,40 @@
 import {
   showSharingBanner,
-  makeName
+  makeName,
+  shouldBeOpenedOnOtherInstance
 } from 'drive/web/modules/views/OnlyOffice/helpers'
+
+describe('shouldBeOpenedOnOtherInstance', () => {
+  it('should return true if current instance is different from document instance', () => {
+    expect(
+      shouldBeOpenedOnOtherInstance(
+        {
+          data: {
+            attributes: {
+              instance: 'alice.cozy.localhost:8080'
+            }
+          }
+        },
+        'http://bob.cozy.localhost:8080'
+      )
+    ).toBe(true)
+  })
+
+  it('should return false if current instance is equal to document instance', () => {
+    expect(
+      shouldBeOpenedOnOtherInstance(
+        {
+          data: {
+            attributes: {
+              instance: 'alice.cozy.localhost:8080'
+            }
+          }
+        },
+        'http://alice.cozy.localhost:8080'
+      )
+    ).toBe(false)
+  })
+})
 
 describe('makeName', () => {
   describe('for public route', () => {

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.js
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.js
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
 
-import { isQueryLoading, generateWebLink } from 'cozy-client'
+import { useClient, isQueryLoading, generateWebLink } from 'cozy-client'
 import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
 
 import {
@@ -22,6 +22,9 @@ const useConfig = () => {
     isEditorForcedReadOnly,
     isFromSharing
   } = useContext(OnlyOfficeContext)
+  const client = useClient()
+  const instanceUri = client.getStackClient().uri
+
   const [config, setConfig] = useState()
   const [status, setStatus] = useState('loading')
 
@@ -38,7 +41,7 @@ const useConfig = () => {
 
   useEffect(() => {
     if (!isQueryLoading(queryResult) && fetchStatus !== 'error' && !config) {
-      if (shouldBeOpenedOnOtherInstance(data)) {
+      if (shouldBeOpenedOnOtherInstance(data, instanceUri)) {
         const {
           protocol,
           instance,
@@ -110,7 +113,8 @@ const useConfig = () => {
     isPublic,
     isEditorForcedReadOnly,
     username,
-    isFromSharing
+    isFromSharing,
+    instanceUri
   ])
 
   return { config, status }


### PR DESCRIPTION
The presence of a sharecode was used to determine if the document should be opened on other instance, but it was not sufficient. It only occured now because I updated recently the condition.

```
### ✨ Features

*

### 🐛 Bug Fixes

* Shared OO document displayed a blank page due to infinite loop

### 🔧 Tech

*
```
