### PR TITLE
feat: Adapt OO header in responsive for iOS and Android

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Editor.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.jsx
@@ -9,7 +9,21 @@ import View from 'drive/web/modules/views/OnlyOffice/View'
 import Error from 'drive/web/modules/views/OnlyOffice/Error'
 import Loading from 'drive/web/modules/views/OnlyOffice/Loading'
 import Title from 'drive/web/modules/views/OnlyOffice/Title'
-import { DEFAULT_EDITOR_TOOLBAR_HEIGHT } from 'drive/web/modules/views/OnlyOffice/config'
+import {
+  DEFAULT_EDITOR_TOOLBAR_HEIGHT_IOS,
+  DEFAULT_EDITOR_TOOLBAR_HEIGHT
+} from 'drive/web/modules/views/OnlyOffice/config'
+import { isIOS } from 'cozy-device-helper'
+
+const getEditorToolbarHeight = editorToolbarHeightFlag => {
+  if (Number.isInteger(editorToolbarHeightFlag)) {
+    return editorToolbarHeightFlag
+  } else if (isIOS()) {
+    return DEFAULT_EDITOR_TOOLBAR_HEIGHT_IOS
+  } else {
+    return DEFAULT_EDITOR_TOOLBAR_HEIGHT
+  }
+}
 
 export const Editor = () => {
   const { config, status } = useConfig()
@@ -20,12 +34,9 @@ export const Editor = () => {
 
   const { serverUrl, apiUrl, docEditorConfig } = config
 
-  const editorToolbarHeight = Number.isInteger(
+  const editorToolbarHeight = getEditorToolbarHeight(
     flag('drive.onlyoffice.editorToolbarHeight')
   )
-    ? flag('drive.onlyoffice.editorToolbarHeight')
-    : DEFAULT_EDITOR_TOOLBAR_HEIGHT
-
   return (
     <>
       <Title />

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -13,7 +13,7 @@ import Toolbar from 'drive/web/modules/views/OnlyOffice/Toolbar'
 
 const useStyles = makeStyles(theme => ({
   root: {
-    width: 'calc(100% - 1rem)',
+    width: '100%',
     height: '3.5rem',
     backgroundColor: theme.palette.background.paper
   }

--- a/src/drive/web/modules/views/OnlyOffice/config.js
+++ b/src/drive/web/modules/views/OnlyOffice/config.js
@@ -1,3 +1,4 @@
 export const FRAME_EDITOR_NAME = 'frameEditor'
 
-export const DEFAULT_EDITOR_TOOLBAR_HEIGHT = 68
+export const DEFAULT_EDITOR_TOOLBAR_HEIGHT_IOS = 68
+export const DEFAULT_EDITOR_TOOLBAR_HEIGHT = 52


### PR DESCRIPTION
The size of the OO header change between iOS and Android, so we need to adapt the size of our header for iOS and Android.

```
### ✨ Features

*

### 🐛 Bug Fixes

* OnlyOffice header is correctly displayed on smartphone.

### 🔧 Tech

*
```
