### PR TITLE
fix: Delete warning only when referenced by manual album

### DIFF
--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -128,7 +128,7 @@
     "albums": {
       "description": "Required to manage photos albums",
       "type": "io.cozy.photos.albums",
-      "verbs": ["PUT"]
+      "verbs": ["PUT", "GET"]
     },
     "contacts": {
       "type": "io.cozy.contacts",

--- a/src/drive/web/modules/actions/index.jsx
+++ b/src/drive/web/modules/actions/index.jsx
@@ -33,7 +33,6 @@ import DestroyConfirm from 'drive/web/modules/trash/components/DestroyConfirm'
 import { startRenamingAsync } from 'drive/web/modules/drive/rename'
 
 import {
-  isAnyFileReferencedByAlbum,
   exportFilesNative,
   downloadFiles,
   openFileWith,
@@ -136,7 +135,6 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
       pushModal(
         <DeleteConfirm
           files={files}
-          referenced={isAnyFileReferencedByAlbum(files)}
           afterConfirmation={() => {
             refresh()
           }}
@@ -151,7 +149,6 @@ export const trash = ({ pushModal, popModal, hasWriteAccess, refresh }) => {
             pushModal(
               <DeleteConfirm
                 files={props.files}
-                referenced={isAnyFileReferencedByAlbum(props.files)}
                 afterConfirmation={() => {
                   refresh()
                 }}

--- a/src/drive/web/modules/actions/useActions.spec.jsx
+++ b/src/drive/web/modules/actions/useActions.spec.jsx
@@ -36,7 +36,6 @@ import {
 } from './index'
 
 jest.mock('./utils', () => ({
-  isAnyFileReferencedByAlbum: jest.fn(),
   exportFilesNative: jest.fn(),
   downloadFiles: jest.fn(),
   trashFiles: jest.fn(),

--- a/src/drive/web/modules/actions/utils.js
+++ b/src/drive/web/modules/actions/utils.js
@@ -2,7 +2,7 @@ import {
   saveFileWithCordova,
   saveAndOpenWithCordova
 } from 'cozy-client/dist/models/fsnative'
-import { isDirectory, isReferencedByAlbum } from 'cozy-client/dist/models/file'
+import { isDirectory } from 'cozy-client/dist/models/file'
 import { receiveQueryResult } from 'cozy-client/dist/store'
 import { isMobileApp, isIOS } from 'cozy-device-helper'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -14,13 +14,6 @@ import {
   isEncryptedFile
 } from 'drive/lib/encryption'
 import { DOCTYPE_FILES } from 'drive/lib/doctypes'
-
-export const isAnyFileReferencedByAlbum = files => {
-  for (let i = 0, l = files.length; i < l; ++i) {
-    if (isReferencedByAlbum(files[i])) return true
-  }
-  return false
-}
 
 const isMissingFileError = error => error.status === 404
 

--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -1,6 +1,6 @@
 import CozyClient, { Q } from 'cozy-client'
 import { TRASH_DIR_ID } from 'drive/constants/config'
-import { DOCTYPE_FILES_ENCRYPTION } from 'drive/lib/doctypes'
+import { DOCTYPE_FILES_ENCRYPTION, DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
 
 // Needs to be less than 10 minutes, since "thumbnails" links
 // are only valid for 10 minutes.
@@ -321,6 +321,14 @@ export const buildEncryptionByIdQuery = id => ({
   definition: Q(DOCTYPE_FILES_ENCRYPTION).getById(id),
   options: {
     as: id,
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
+export const buildAlbumByIdQuery = id => ({
+  definition: Q(DOCTYPE_ALBUMS).getById(id),
+  options: {
+    as: `io.cozy.photos.albums/${id}`,
     fetchPolicy: defaultFetchPolicy
   }
 })

--- a/src/drive/web/modules/views/Folder/FolderView.jsx
+++ b/src/drive/web/modules/views/Folder/FolderView.jsx
@@ -16,6 +16,7 @@ const FolderView = ({ children }) => {
   return (
     <Main>
       <RealTimeQueries doctype="io.cozy.files" />
+      <RealTimeQueries doctype="io.cozy.photos.albums" />
       <ModalStack />
       <ModalManager />
       {children}


### PR DESCRIPTION
Previously, when you wanted to delete a photo, a delete warning was displayed every time the photo was referenced by an album. Even if the album was a cluster album which does not make sense.



```
### ✨ Features

*

### 🐛 Bug Fixes

* Show delete photo from album warning only when necessary

### 🔧 Tech

*
```
