### PR TITLE
Fix/oo header toolbar height

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/config.js
+++ b/src/drive/web/modules/views/OnlyOffice/config.js
@@ -1,4 +1,4 @@
 export const FRAME_EDITOR_NAME = 'frameEditor'
 
 export const DEFAULT_EDITOR_TOOLBAR_HEIGHT_IOS = 68
-export const DEFAULT_EDITOR_TOOLBAR_HEIGHT = 52
+export const DEFAULT_EDITOR_TOOLBAR_HEIGHT = 32


### PR DESCRIPTION
The red area was hidden on Android/web, so a part of the "Enter your name" message was also hidden.

<img width="469" alt="Screenshot 2022-11-04 at 10 50 23" src="https://user-images.githubusercontent.com/10849491/199944940-8e774b0a-5612-4179-ba33-a130b4d85b4c.png">

```
### ✨ Features

*

### 🐛 Bug Fixes

* Adapt OnlyOffice header in responsive for Android to show function bar

### 🔧 Tech

*
```
