### PR TITLE
fix(useUpdateDocumentFavicon): Show the correct favicon for Only Office spreadsheet

### DIFF
--- a/src/drive/web/modules/views/useUpdateDocumentFavicon.jsx
+++ b/src/drive/web/modules/views/useUpdateDocumentFavicon.jsx
@@ -19,7 +19,15 @@ const acceptedTypes = [
 
 const defaultFaviconHref = '/public/app-icon.svg'
 
-const makeFaviconHref = type => {
+const normalizeClass = docClass => {
+  if (docClass === 'spreadsheet') {
+    return 'sheet'
+  }
+  return docClass
+}
+
+const makeFaviconHref = docClass => {
+  const type = normalizeClass(docClass)
   return `/public/icons/icon-type-${
     acceptedTypes.includes(type) ? type : 'files'
   }.svg`


### PR DESCRIPTION
The class attribute of Only Office spreadsheet document is a spreadsheet. The icon type is only named «sheet». To match the two, I had a normalisation function to spread with future exception.

```
### 🐛 Bug Fixes

* Show the correct favicon for Only Office spreadsheet
```
