### PR TITLE
fix: Open directly an OO file from the searchbar

### DIFF
--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -81,7 +81,7 @@ class SuggestionProvider extends React.Component {
     const { client } = this.props
     const resp = await cozy.client.fetchJSON(
       'GET',
-      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
+      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,class,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
     )
     const files = resp.rows.map(row => ({ id: row.id, ...row.doc }))
     const folders = files.filter(file => file.type === TYPE_DIRECTORY)

--- a/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.spec.jsx
@@ -64,7 +64,7 @@ describe('SuggestionProvider', () => {
     // Then
     expect(mockClient.fetchJSON).toHaveBeenCalledWith(
       'GET',
-      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
+      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,class,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
     )
   })
 

--- a/src/drive/web/modules/services/components/helpers.js
+++ b/src/drive/web/modules/services/components/helpers.js
@@ -1,6 +1,8 @@
 import { models } from 'cozy-client'
 import { getIconUrl } from './iconContext'
 
+import { makeOnlyOfficeFileRoute } from 'drive/web/modules/views/OnlyOffice/helpers'
+
 export const TYPE_DIRECTORY = 'directory'
 
 /**
@@ -29,6 +31,8 @@ export const makeNormalizedFile = (client, folders, file) => {
     path = parentDir && parentDir.path ? parentDir.path : ''
     if (models.file.isNote(file)) {
       onSelect = `id_note:${file.id}`
+    } else if (models.file.shouldBeOpenedByOnlyOffice(file)) {
+      url = makeOnlyOfficeFileRoute(file)
     } else {
       url = `${urlToFolder}/file/${file._id}`
     }


### PR DESCRIPTION
URL sent to cozy-bar is now the direct OO editor URL and not the preview URL

```
### 🐛 Bug Fixes

* Open directly an OO file from the searchbar
```
