### PR TITLE
fix: Navigation from Trash to Recent was displaying a blank page

### DIFF
--- a/src/drive/web/modules/views/Trash/TrashFolderView.jsx
+++ b/src/drive/web/modules/views/Trash/TrashFolderView.jsx
@@ -35,11 +35,10 @@ const TrashFolderView = ({ currentFolderId, router, params, children }) => {
 
   useHead(params)
   const displayedFolderQuery = buildOnlyFolderQuery(currentFolderId)
-  const displayedFolder = useQuery(
-    displayedFolderQuery.definition,
-    displayedFolderQuery.options
-  ).data
-
+  const displayedFolder = useQuery(displayedFolderQuery.definition, {
+    ...displayedFolderQuery.options,
+    enabled: !!currentFolderId
+  }).data
   const extraColumnsNames = makeExtraColumnsNamesFromMedia({
     isMobile,
     desktopExtraColumnsNames,
@@ -129,6 +128,25 @@ const TrashFolderView = ({ currentFolderId, router, params, children }) => {
   )
 }
 
+const TrashFolderViewWrapper = ({
+  currentFolderId,
+  router,
+  params,
+  children
+}) => {
+  // Since playing with qDef.options.enabled is not enought
+  // at the moment. See https://github.com/cozy/cozy-client/pull/1273
+  if (!currentFolderId) return null
+  return (
+    <TrashFolderView
+      currentFolderId={currentFolderId}
+      router={router}
+      params={params}
+    >
+      {children}
+    </TrashFolderView>
+  )
+}
 export default connect(state => ({
   currentFolderId: getCurrentFolderId(state)
-}))(TrashFolderView)
+}))(TrashFolderViewWrapper)


### PR DESCRIPTION
Since we started to call useQuery() instead of reading the redux store 162aa9a8611165e094a82f447bddbcd707fdc500

We were able to call useQuery without a defined currentFolderId

Since we can't call getById() with an undefined ID ATM even with enabled to false, we need to handle that in Drive's code.

How currentFolderId can be undefined between the change of trash to recent view? Because we have a lot of re-render before moving from one view to an other. Not relying on redux is part of this effort to remove all this re-render it's a long work.

(no changelog since this is a bug introduced by a previous non released commit)