### PR TITLE
fix: Set correct returnUrl hash for note creation from Flagship app

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/components/CreateNoteItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/CreateNoteItem.jsx
@@ -43,7 +43,8 @@ const CreateNoteItem = ({ client, t, displayedFolder }) => {
         slug: 'drive',
         cozyUrl: client.getStackClient().uri,
         subDomainType: isFlatDomain ? 'flat' : 'nested',
-        pathname: `/files/${displayedFolder.id}`
+        pathname: '',
+        hash: `/files/${displayedFolder.id}`
       })
     } else {
       returnUrl = generateUniversalLink({


### PR DESCRIPTION
In 953e2c4e25e0c8461b9813f18599d9aa39d38bd2 we generated `returnUrl` using `generateWebLink` when a cozy-note from a Flagship app

We incorrectly inserted the origin folder's path as we used the pathname attribute instead of the hash, which would break the application on Android as the browser would try to interpret the pathname and try to load an non-existing asset. On iOS the app was loading correctly but did not navigate to the requested path



```
### 🐛 Bug Fixes

* Set correct returnUrl hash for note creation from Flagship app
```
