### PR TITLE
fix: Avoid to search suggestions when files not indexed

### DIFF
--- a/src/drive/web/modules/services/components/SuggestionProvider.jsx
+++ b/src/drive/web/modules/services/components/SuggestionProvider.jsx
@@ -9,7 +9,7 @@ import { ROOT_DIR_ID } from 'drive/constants/config'
 class SuggestionProvider extends React.Component {
   componentDidMount() {
     const { intent } = this.props
-    this.hasIndexFilesBeenLaunched = false
+    this.hasIndexedFiles = false
 
     // re-attach the message listener for the intent to receive the suggestion requests
     window.addEventListener('message', event => {
@@ -40,9 +40,9 @@ class SuggestionProvider extends React.Component {
    * @returns {Promise<void>} nothing
    */
   async provideSuggestions(query, id, intent) {
-    if (!this.hasIndexFilesBeenLaunched) {
-      this.hasIndexFilesBeenLaunched = true
+    if (!this.hasIndexedFiles) {
       await this.indexFiles()
+      this.hasIndexedFiles = true
     }
 
     const searchResults = this.fuzzyPathSearch.search(query)


### PR DESCRIPTION
When you run the provideSuggestions function, first it run indexFiles. However, if indexFiles is not finished and you run provideSuggestions again, you can try to make a search even if the fuzzyPathSearch variable is not ready leading to an error.

@Crash-- It is linked to this commit https://github.com/cozy/cozy-drive/commit/acc29f0a116482c4adc8ecd8c7433725486f1ff6 Do you have any ideas of what were the duplication issue solved in the previous commit? Because we tried to create duplicate with this PR fix without success.

However, it is still possible to create duplicate in production (so not linked to this PR) by : 
- taping something like "tre"
- selecting tre with the mouse
- taping "tre" again

Co-authored-by: cballevre <celestin.ballevre@protonmail.com>

```
### 🐛 Bug Fixes

* Avoid to search suggestions when files not indexed

```
