### PR TITLE
fix: Use cozy fonts again

### DIFF
--- a/src/drive/targets/browser/index.ejs
+++ b/src/drive/targets/browser/index.ejs
@@ -26,6 +26,7 @@
     />
     <% if (__STACK_ASSETS__) { %>
     {{.CozyClientJS}}
+    {{.CozyFonts}}
     <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>" />
     <% }); %>

--- a/src/drive/targets/public/index.ejs
+++ b/src/drive/targets/public/index.ejs
@@ -26,6 +26,7 @@
     <script src="cordova.js" defer></script>
     <% } else if (__STACK_ASSETS__) { %>
     {{.CozyClientJS}}
+    {{.CozyFonts}}
     <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>" />
     <% }); %>

--- a/src/photos/targets/browser/index.ejs
+++ b/src/photos/targets/browser/index.ejs
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="<%- file %>" />
     <% }); %> <% if (__STACK_ASSETS__) { %>
     {{.CozyClientJS}}
+    {{.CozyFonts}}
     <% } %>
   </head>
   <div

--- a/src/photos/targets/public/index.ejs
+++ b/src/photos/targets/public/index.ejs
@@ -12,6 +12,7 @@
   <% }); %>
   <% if (__STACK_ASSETS__) { %>
     {{.CozyClientJS}}
+    {{.CozyFonts}}
   <% } %>
 </head>
 <body>


### PR DESCRIPTION
Before cozy fonts were imported with `{{ .cozyBar }}`  served from the stack. We bundle `cozy-bar` as a vendor now so we have to import fonts into index.ejs

```
### 🐛 Bug Fixes

* Use cozy fonts again
```

**Related PRs :**
- https://github.com/cozy/cozy-stack/pull/3638
