### PR TITLE
fix: Index files only once in SearchView

### DIFF
--- a/src/drive/web/modules/views/Search/SearchView.jsx
+++ b/src/drive/web/modules/views/Search/SearchView.jsx
@@ -40,7 +40,8 @@ const SearchView = () => {
 
   useEffect(() => {
     makeIndexes()
-  }, [makeIndexes])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const onInputChanged = event => {
     setInput(event.target.value)


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Index files only once in SearchView
```
