### PR TITLE
fix: File name took not all width in mobile file list

### DIFF
--- a/src/drive/styles/filelist.styl
+++ b/src/drive/styles/filelist.styl
@@ -379,6 +379,12 @@ column-width-thumbnail-bigger = 7rem
         padding-right .2rem
         margin-right 1em
 
+    .fil-content-header-action
+    .fil-content-file-action
+        flex 0
+        box-sizing content-box
+        width 100%
+
     .fil-content-cell.fil-content-file
     .fil-content-row-bigger .fil-content-cell.fil-content-file
         flex 1 1 auto


### PR DESCRIPTION
It was due to action button taking too much width in mobile file list.



```
### 🐛 Bug Fixes

* File name took not all width in mobile file list
```
