### PR TITLE
fix: Dedup of date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,5 +173,8 @@
     "snarkdown": "2.0.0",
     "webpack-node-externals": "3.0.0",
     "whatwg-fetch": "3.0.0"
+  },
+  "resolutions": {
+    "date-fns": "1.30.1"
   }
 }

--- a/src/drive/date-fns/add.js
+++ b/src/drive/date-fns/add.js
@@ -1,0 +1,6 @@
+/** This a mock of date-fns function add
+ TODO : Remove wildcard import into cozy-client
+*/
+const add = () => {}
+
+export default add

--- a/src/drive/date-fns/sub.js
+++ b/src/drive/date-fns/sub.js
@@ -1,0 +1,6 @@
+/** This a mock of date-fns function sub
+ TODO : Remove wildcard import into cozy-client
+*/
+const sub = () => {}
+
+export default sub

--- a/yarn.lock
+++ b/yarn.lock
@@ -6432,15 +6432,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@1.30.1, date-fns@^1.28.5, date-fns@^1.30.1:
+date-fns@1.30.1, date-fns@2.29.3, date-fns@^1.28.5, date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
-date-fns@2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 debounce@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
Since the cozy-client upgrade to 34.7.1 date-fns is a needed dep for a few of its models. But we don't need them in Drive for now and we have a few issues with the tree shaking of cozy-client.

(see https://github.com/cozy/cozy-client/pull/1274)

So the workaround is to force the resolution to date-fns 1 which is required by drive, in order to not duplicate the package.

We should not have issue with that. When we'll upgrade date-fns to v2 in drive & ui, then, we'll be able to remove this line.


