### PR TITLE
fix: Wrong mock make service crash

### DIFF
--- a/src/photos/ducks/clustering/reclusterize.js
+++ b/src/photos/ducks/clustering/reclusterize.js
@@ -7,8 +7,6 @@ import { prepareDataset } from './utils'
 import flatten from 'lodash/flatten'
 import log from 'cozy-logger'
 
-jest.mock('cozy-logger')
-
 // Insert the new photo into the sorted photos set
 const insertNewPhoto = (photos, newPhoto) => {
   const photoAlreadyExists = photos.find(p => p.id === newPhoto.id)

--- a/src/photos/ducks/clustering/reclusterize.spec.js
+++ b/src/photos/ducks/clustering/reclusterize.spec.js
@@ -4,6 +4,7 @@ import { getFilesByAutoAlbum } from './files'
 import { albumsToClusterize } from './reclusterize'
 import { prepareDataset } from './utils'
 import CozyClient from 'cozy-client'
+jest.mock('cozy-logger')
 
 const client = new CozyClient({})
 


### PR DESCRIPTION
The service is not working anymore because of the mock placed in the source file rather than the test file.
The tests were ok, but not the actual service execution...



```
### ✨ Features

*

### 🐛 Bug Fixes

* onPhotoUpload service that was unable to run

### 🔧 Tech

*
```
