### PR TITLE
chore: Fix `yarn build:photos`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:drive:browser": "COZY_APP_SLUG=drive cozy-scripts start --manifest src/drive/targets/manifest.webapp --build-dir build/drive --src-dir src/drive --barV7 false",
     "start:drive:mobile": "COZY_APP_SLUG=drive NODE_ENV=mobile:development  cozy-scripts start  --mobile --manifest src/drive/targets/manifest.webapp --src-dir src/drive --barV7 false",
     "start:drive:standalone": "COZY_APP_SLUG=drive NODE_ENV=mobile:development cozy-scripts start  --manifest src/drive/targets/manifest.webapp --src-dir src/drive --barV7 false",
-    "build:photos": "npm-run-all --parallel build:photos:browser --barV7 false",
+    "build:photos": "yarn build:photos:browser",
     "build:photos:browser": "COZY_APP_SLUG=photos cozy-scripts build --manifest src/photos/targets/manifest.webapp --build-dir build/photos --src-dir src/photos --barV7 false",
     "watch:photos": "yarn watch:photos:browser",
     "watch:photos:browser": "COZY_APP_SLUG=photos cozy-scripts watch --manifest src/photos/targets/manifest.webapp --build-dir build/photos --src-dir src/photos --barV7 false",


### PR DESCRIPTION
This command wasn't working anymore because of the `--barV7` option that is only accepted by cozy-scripts.
We also remove the unecessary `npm-run-all` as only one command is run.



```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Fix `yarn build:photos` command
```
