### PR TITLE
fix: Wrong mock make service crash

### DIFF
--- a/src/photos/ducks/clustering/reclusterize.js
+++ b/src/photos/ducks/clustering/reclusterize.js
@@ -7,8 +7,6 @@ import { prepareDataset } from './utils'
 import flatten from 'lodash/flatten'
 import log from 'cozy-logger'
 
-jest.mock('cozy-logger')
-
 // Insert the new photo into the sorted photos set
 const insertNewPhoto = (photos, newPhoto) => {
   const photoAlreadyExists = photos.find(p => p.id === newPhoto.id)

--- a/src/photos/ducks/clustering/reclusterize.spec.js
+++ b/src/photos/ducks/clustering/reclusterize.spec.js
@@ -4,6 +4,7 @@ import { getFilesByAutoAlbum } from './files'
 import { albumsToClusterize } from './reclusterize'
 import { prepareDataset } from './utils'
 import CozyClient from 'cozy-client'
+jest.mock('cozy-logger')
 
 const client = new CozyClient({})
 


### PR DESCRIPTION
This is a backport of https://github.com/cozy/cozy-drive/pull/2838 that was a patch for the 1.48.0 stable
