### PR TITLE
feat: Update cozy-bar from 8.13.1 to 8.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "classnames": "2.3.1",
     "copy-text-to-clipboard": "1.0.4",
     "cozy-authentication": "2.10.10",
-    "cozy-bar": "8.13.1",
+    "cozy-bar": "8.14.0",
     "cozy-ci": "0.5.2",
     "cozy-client": "^34.11.0",
     "cozy-client-js": "0.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5683,10 +5683,10 @@ cozy-authentication@2.10.10:
     snarkdown "1.2.2"
     url-polyfill "1.1.7"
 
-cozy-bar@8.13.1:
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-8.13.1.tgz#0d9c10807908a5a228f05597e55cb4fa2a20812e"
-  integrity sha512-AIkbuQ6YjvOZ2FyDhfyx8Utu33XdmlTcXKKjQQ4fcQSKvoP7ocxgXdtZk5p42A8rMdYkTj1L2o5c3yYdOsdyuA==
+cozy-bar@8.14.0:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-8.14.0.tgz#3e70289f50997e89b50fb88d883548eeea05823e"
+  integrity sha512-PZSpOCL3KaZtyIuLp89jfsxGaxuXlFw6t+x2DZRzZPzD4e//Y626PWmsbQxlfBmqo5/RqCIZaAXBALM7nidrjw==
   dependencies:
     hammerjs "2.0.8"
     lodash.debounce "4.0.8"


### PR DESCRIPTION
The goal of the update is to have the contact page link on settings rather than open a modal

```
### 🔧 Tech

* Update cozy-bar from 8.13.1 to 8.14.0
```
