### PR TITLE
feat: Add OnlyOffice paywall

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -75,7 +75,7 @@
     },
     {
       "path": "drive/vendors/drive.<hash>.js",
-      "maxSize": "1.54 MB"
+      "maxSize": "1.6 MB"
     },
     {
       "path": "drive/<hash>.worker.js",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "cozy-scripts": "^7.0.0",
     "cozy-sharing": "6.0.4",
     "cozy-stack-client": "^34.1.5",
-    "cozy-ui": "^81.2.1",
+    "cozy-ui": "^81.4.0",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cozy-realtime": "4.3.0",
     "cozy-scanner": "2.4.6",
     "cozy-scripts": "^7.0.0",
-    "cozy-sharing": "6.0.4",
+    "cozy-sharing": "7.0.1",
     "cozy-stack-client": "^34.1.5",
     "cozy-ui": "^81.4.0",
     "date-fns": "1.30.1",

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -25,7 +25,7 @@ import FileHistory from 'components/FileHistory'
 import ErrorShare from 'components/Error/ErrorShare'
 import OnlyOfficeView from 'drive/web/modules/views/OnlyOffice'
 import OnlyOfficeCreateView from 'drive/web/modules/views/OnlyOffice/Create'
-import { isOnlyOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
+import { isOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
 import appMetadata from 'drive/appMetadata'
 import logger from 'lib/logger'
 import App from 'components/App/App'
@@ -122,7 +122,7 @@ const init = async () => {
         <App lang={lang} polyglot={polyglot} client={client} store={store}>
           <Router history={hashHistory}>
             <Route component={PublicLayout}>
-              {isOnlyOfficeEnabled() && (
+              {isOfficeEnabled() && (
                 <>
                   <Route
                     path="onlyoffice/:fileId"

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -32,6 +32,7 @@ import App from 'components/App/App'
 import ExternalRedirect from 'drive/web/modules/navigation/ExternalRedirect'
 import StyledApp from 'drive/web/modules/drive/StyledApp'
 import cozyBar from 'lib/cozyBar'
+import OnlyOfficePaywallView from 'drive/web/modules/views/OnlyOffice/OnlyOfficePaywallView'
 
 const initCozyBar = (data, client) => {
   if (data.app.name && data.app.editor && data.app.icon && data.locale) {
@@ -136,7 +137,14 @@ const init = async () => {
                         isInSharedFolder={!isFile}
                       />
                     )}
-                  />
+                  >
+                    <Route
+                      path="paywall"
+                      component={props => (
+                        <OnlyOfficePaywallView {...props} isPublic={true} />
+                      )}
+                    />
+                  </Route>
                   <Route
                     path="onlyoffice/:fileId/fromCreate"
                     component={props => (
@@ -172,6 +180,12 @@ const init = async () => {
                     <Route
                       path="file/:fileId/revision"
                       component={FileHistory}
+                    />
+                    <Route
+                      path="paywall"
+                      component={props => (
+                        <OnlyOfficePaywallView {...props} isPublic={true} />
+                      )}
                     />
                   </Route>
 

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -99,7 +99,7 @@ const init = async () => {
   })
 
   try {
-    const sharedDocumentId = await getSharedDocument(client)
+    const { id: sharedDocumentId, isReadOnly } = await getSharedDocument(client)
 
     // In the case of a shared folder, we want to get the id of the only office file,
     // not the id of the shared document (that is the folder)
@@ -130,6 +130,7 @@ const init = async () => {
                       <OnlyOfficeView
                         {...props}
                         isPublic={true}
+                        isReadOnly={isReadOnly}
                         username={username}
                         isFromSharing={isOnlyOfficeDocShared}
                         isInSharedFolder={!isFile}
@@ -142,6 +143,7 @@ const init = async () => {
                       <OnlyOfficeView
                         {...props}
                         isPublic={true}
+                        isReadOnly={isReadOnly}
                         isInSharedFolder={!isFile}
                       />
                     )}

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -33,6 +33,7 @@ import ExternalRedirect from 'drive/web/modules/navigation/ExternalRedirect'
 import StyledApp from 'drive/web/modules/drive/StyledApp'
 import cozyBar from 'lib/cozyBar'
 import OnlyOfficePaywallView from 'drive/web/modules/views/OnlyOffice/OnlyOfficePaywallView'
+import { redirectToOnlyOfficePaywall } from 'drive/web/modules/views/OnlyOffice/helpers'
 
 const initCozyBar = (data, client) => {
   if (data.app.name && data.app.editor && data.app.icon && data.locale) {
@@ -157,6 +158,7 @@ const init = async () => {
                     )}
                   />
                   <Route
+                    onEnter={redirectToOnlyOfficePaywall}
                     path="onlyoffice/create/:folderId/:fileClass"
                     component={OnlyOfficeCreateView}
                   />

--- a/src/drive/web/modules/drive/AddMenu/AddMenu.jsx
+++ b/src/drive/web/modules/drive/AddMenu/AddMenu.jsx
@@ -13,7 +13,7 @@ import CreateShortcut from 'drive/web/modules/drive/Toolbar/components/CreateSho
 import UploadItem from 'drive/web/modules/drive/Toolbar/components/UploadItem'
 import StartScanner from 'drive/web/modules/drive/Toolbar/components/StartScanner'
 import CreateOnlyOfficeItem from 'drive/web/modules/drive/Toolbar/components/CreateOnlyOfficeItem'
-import { isOnlyOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
+import { isOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
 import flag from 'cozy-flags'
 
 export const ActionMenuContent = ({
@@ -42,7 +42,7 @@ export const ActionMenuContent = ({
         <AddEncryptedFolderItem />
       )}
       {!isPublic && !isEncryptedFolder && <CreateNoteItem />}
-      {canUpload && isOnlyOfficeEnabled() && !isEncryptedFolder && (
+      {canUpload && isOfficeEnabled() && !isEncryptedFolder && (
         <>
           <CreateOnlyOfficeItem fileClass="text" />
           <CreateOnlyOfficeItem fileClass="spreadsheet" />

--- a/src/drive/web/modules/drive/Toolbar/components/CreateOnlyOfficeItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/components/CreateOnlyOfficeItem.jsx
@@ -7,7 +7,10 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 
 import { ROOT_DIR_ID } from 'drive/constants/config'
 import { useRouter } from 'drive/lib/RouterContext'
-import { makeOnlyOfficeIconByClass } from 'drive/web/modules/views/OnlyOffice/helpers'
+import {
+  makeOnlyOfficeIconByClass,
+  canWriteOfficeDocument
+} from 'drive/web/modules/views/OnlyOffice/helpers'
 
 const CreateOnlyOfficeItem = ({ fileClass }) => {
   const { t } = useI18n()
@@ -18,10 +21,13 @@ const CreateOnlyOfficeItem = ({ fileClass }) => {
     [router]
   )
 
-  const handleClick = useCallback(
-    () => router.push(`/onlyoffice/create/${folderId}/${fileClass}`),
-    [router, fileClass, folderId]
-  )
+  const handleClick = useCallback(() => {
+    if (canWriteOfficeDocument()) {
+      router.push(`/onlyoffice/create/${folderId}/${fileClass}`)
+    } else {
+      router.push(`/folder/${folderId}/paywall`)
+    }
+  }, [router, fileClass, folderId])
 
   const ClassIcon = useMemo(
     () => makeOnlyOfficeIconByClass(fileClass),

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -24,6 +24,7 @@ import SharingsFolderView from '../views/Sharings/SharingsFolderView'
 import OnlyOfficeView from '../views/OnlyOffice'
 import OnlyOfficeCreateView from '../views/OnlyOffice/Create'
 import SearchView from '../views/Search/SearchView'
+import OnlyOfficePaywallView from '../views/OnlyOffice/OnlyOfficePaywallView'
 
 import FilesViewerRecent from '../views/Recent/FilesViewerRecent'
 
@@ -32,6 +33,7 @@ import FilesViewerRecent from '../views/Recent/FilesViewerRecent'
 // first
 export const routes = [
   '/folder/:folderId',
+  '/folder/:folderId/paywall',
   '/folder/:folderId/file/:fileId',
   '/folder/:folderId/file/:fileId/revision',
   '/recent/file/:fileId',
@@ -69,6 +71,7 @@ const AppRoute = (
         <Route path=":folderId">
           <Route path="file/:fileId" component={FilesViewerDrive} />
           <Route path="file/:fileId/revision" component={FileHistory} />
+          <Route path="paywall" component={OnlyOfficePaywallView} />
         </Route>
         <Route path="file/:fileId" component={FilesViewerDrive} />
         <Route path="file/:fileId/revision" component={FileHistory} />
@@ -102,7 +105,10 @@ const AppRoute = (
         </Route>
       </Route>
 
-      <Route path="onlyoffice/:fileId" component={OnlyOfficeView} />
+      <Route path="onlyoffice/:fileId" component={OnlyOfficeView}>
+        <Route path="paywall" component={OnlyOfficePaywallView} />
+      </Route>
+
       <Route path="onlyoffice/:fileId/fromCreate" component={OnlyOfficeView} />
       <Route
         path="onlyoffice/create/:folderId/:fileClass"

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -10,6 +10,7 @@ import Layout from 'drive/web/modules/layout/Layout'
 import FileOpenerExternal from 'drive/web/modules/viewer/FileOpenerExternal'
 import FileHistory from 'components/FileHistory'
 import UploadFromMobile from 'drive/mobile/modules/upload'
+import { redirectToOnlyOfficePaywall } from 'drive/web/modules/views/OnlyOffice/helpers'
 
 import ExternalRedirect from './ExternalRedirect'
 import Index from './Index'
@@ -111,6 +112,7 @@ const AppRoute = (
 
       <Route path="onlyoffice/:fileId/fromCreate" component={OnlyOfficeView} />
       <Route
+        onEnter={redirectToOnlyOfficePaywall}
         path="onlyoffice/create/:folderId/:fileClass"
         component={OnlyOfficeCreateView}
       />

--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -11,7 +11,7 @@ import { useRouter } from 'drive/lib/RouterContext'
 import PublicViewer from 'drive/web/modules/viewer/PublicViewer'
 import PublicToolbar from 'drive/web/modules/public/PublicToolbar'
 import {
-  isOnlyOfficeEnabled,
+  isOfficeEnabled,
   makeOnlyOfficeFileRoute
 } from 'drive/web/modules/views/OnlyOffice/helpers'
 
@@ -43,7 +43,7 @@ const LightFileViewer = ({ files }) => {
           currentIndex={0}
           componentsProps={{
             OnlyOfficeViewer: {
-              isEnabled: isOnlyOfficeEnabled(),
+              isEnabled: isOfficeEnabled(),
               opener: onlyOfficeOpener
             }
           }}

--- a/src/drive/web/modules/services/components/Embeder.jsx
+++ b/src/drive/web/modules/services/components/Embeder.jsx
@@ -5,7 +5,7 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 
 import FileOpenerExternal from 'drive/web/modules/viewer/FileOpenerExternal'
-import { isOnlyOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
+import { isOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
 import OnlyOfficeView from 'drive/web/modules/views/OnlyOffice'
 
 class Embeder extends React.Component {
@@ -53,7 +53,7 @@ class Embeder extends React.Component {
                 />
               )}
             />
-            {isOnlyOfficeEnabled() && (
+            {isOfficeEnabled() && (
               <Route path="onlyoffice/:fileId" component={OnlyOfficeView} />
             )}
           </Router>

--- a/src/drive/web/modules/viewer/FileOpenerExternal.jsx
+++ b/src/drive/web/modules/viewer/FileOpenerExternal.jsx
@@ -23,7 +23,7 @@ import SharingButton from 'cozy-ui/transpiled/react/Viewer/Footer/Sharing'
 
 import Fallback from 'drive/web/modules/viewer/Fallback'
 import {
-  isOnlyOfficeEnabled,
+  isOfficeEnabled,
   makeOnlyOfficeFileRoute
 } from 'drive/web/modules/views/OnlyOffice/helpers'
 
@@ -88,7 +88,7 @@ export class FileOpener extends Component {
                 )}
                 componentsProps={{
                   OnlyOfficeViewer: {
-                    isEnabled: isOnlyOfficeEnabled(),
+                    isEnabled: isOfficeEnabled(),
                     opener: file =>
                       router.push(makeOnlyOfficeFileRoute(file, true))
                   }

--- a/src/drive/web/modules/viewer/FilesViewer.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.jsx
@@ -17,7 +17,7 @@ import SharingButton from 'cozy-ui/transpiled/react/Viewer/Footer/Sharing'
 import { useRouter } from 'drive/lib/RouterContext'
 import Fallback from 'drive/web/modules/viewer/Fallback'
 import {
-  isOnlyOfficeEnabled,
+  isOfficeEnabled,
   makeOnlyOfficeFileRoute
 } from 'drive/web/modules/views/OnlyOffice/helpers'
 
@@ -204,7 +204,7 @@ const FilesViewer = ({ filesQuery, files, fileId, onClose, onChange }) => {
           renderFallbackExtraContent={file => <Fallback file={file} t={t} />}
           componentsProps={{
             OnlyOfficeViewer: {
-              isEnabled: isOnlyOfficeEnabled(),
+              isEnabled: isOfficeEnabled(),
               opener: file => router.push(makeOnlyOfficeFileRoute(file, true))
             }
           }}

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -26,7 +26,7 @@ import { TRASH_DIR_ID } from 'drive/constants/config'
 import createFileOpeningHandler from 'drive/web/modules/views/Folder/createFileOpeningHandler'
 import { useSyncingFakeFile } from './useSyncingFakeFile'
 import { isReferencedByShareInSharingContext } from 'drive/web/modules/views/Folder/syncHelpers'
-import { isOnlyOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
+import { isOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
 import { isEncryptedFolder } from 'drive/lib/encryption'
 import { useWebviewIntent } from 'cozy-intent'
 
@@ -77,7 +77,7 @@ const FolderViewBody = ({
         replaceCurrentUrl: url => (window.location.href = url),
         openInNewTab: url => window.open(url, '_blank'),
         routeTo: url => router.push(url),
-        isOnlyOfficeEnabled: isOnlyOfficeEnabled(),
+        isOfficeEnabled: isOfficeEnabled(),
         webviewIntent
       })({
         event,

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -16,7 +16,7 @@ const createFileOpeningHandler =
     replaceCurrentUrl,
     openInNewTab,
     routeTo,
-    isOnlyOfficeEnabled,
+    isOfficeEnabled,
     webviewIntent
   }) =>
   async ({ event, file, isAvailableOffline }) => {
@@ -57,7 +57,7 @@ const createFileOpeningHandler =
       } catch (e) {
         Alerter.error('alert.offline')
       }
-    } else if (isOnlyOffice && isOnlyOfficeEnabled) {
+    } else if (isOnlyOffice && isOfficeEnabled) {
       if (event.ctrlKey || event.metaKey || event.shiftKey) {
         openInNewTab(makeOnlyOfficeFileRoute(file))
       } else {

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.spec.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.spec.js
@@ -78,8 +78,8 @@ describe('createFileOpeningHandler', () => {
     onlyofficeFile.class = 'slide'
 
     setup = (
-      { isOnlyOfficeEnabled, webviewIntent } = {
-        isOnlyOfficeEnabled: true,
+      { isOfficeEnabled, webviewIntent } = {
+        isOfficeEnabled: true,
         webviewIntent: { call: mockUseWebviewIntent }
       }
     ) =>
@@ -91,7 +91,7 @@ describe('createFileOpeningHandler', () => {
         replaceCurrentUrl,
         openInNewTab,
         routeTo,
-        isOnlyOfficeEnabled,
+        isOfficeEnabled,
         webviewIntent
       })
   })
@@ -200,7 +200,7 @@ describe('createFileOpeningHandler', () => {
 
   it('should redirect to the file for an onlyoffice document with onlyoffice deactivated', async () => {
     shouldBeOpenedByOnlyOffice.mockReturnValue(true)
-    const handler = setup({ isOnlyOfficeEnabled: false })
+    const handler = setup({ isOfficeEnabled: false })
     await handler({ file: onlyofficeFile, isAvailableOffline: false })
     expect(navigateToFile).toHaveBeenCalledWith(onlyofficeFile)
   })

--- a/src/drive/web/modules/views/OnlyOffice/Editor.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.jsx
@@ -27,7 +27,7 @@ const getEditorToolbarHeight = editorToolbarHeightFlag => {
 
 export const Editor = () => {
   const { config, status } = useConfig()
-  const { isEditorForcedReadOnly } = useContext(OnlyOfficeContext)
+  const { isEditorModeView } = useContext(OnlyOfficeContext)
 
   if (status === 'error') return <Error />
   if (status !== 'loaded' || !config) return <Loading />
@@ -42,7 +42,7 @@ export const Editor = () => {
       <Title />
       <DialogContent
         style={
-          isEditorForcedReadOnly
+          isEditorModeView
             ? {
                 marginTop: `-${editorToolbarHeight}px`
               }

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -8,7 +8,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import AppLike from 'test/components/AppLike'
 import { officeDocParam } from 'test/data'
 
-import { isOnlyOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
+import { isOfficeEnabled } from 'drive/web/modules/views/OnlyOffice/helpers'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 import Editor from 'drive/web/modules/views/OnlyOffice/Editor'
 
@@ -20,7 +20,7 @@ jest.mock('cozy-client/dist/hooks/useFetchJSON', () => ({
 
 jest.mock('drive/web/modules/views/OnlyOffice/helpers', () => ({
   ...jest.requireActual('drive/web/modules/views/OnlyOffice/helpers'),
-  isOnlyOfficeEnabled: jest.fn()
+  isOfficeEnabled: jest.fn()
 }))
 
 jest.mock('cozy-ui/transpiled/react/hooks/useBreakpoints', () => ({
@@ -109,7 +109,7 @@ describe('Editor', () => {
       data: officeDocParam
     })
     useQuery.mockReturnValue(officeDocParam)
-    isOnlyOfficeEnabled.mockReturnValue(true)
+    isOfficeEnabled.mockReturnValue(true)
 
     const { root } = setup()
     const { container, queryByTestId } = root
@@ -125,7 +125,7 @@ describe('Editor', () => {
       data: officeDocParam
     })
     useQuery.mockReturnValue(officeDocParam)
-    isOnlyOfficeEnabled.mockReturnValue(false)
+    isOfficeEnabled.mockReturnValue(false)
 
     const { root } = setup()
     const { container, queryByTestId, getAllByText } = root
@@ -146,7 +146,7 @@ describe('Editor', () => {
           data: officeDocParam
         })
         useQuery.mockReturnValue(officeDocParam)
-        isOnlyOfficeEnabled.mockReturnValue(true)
+        isOfficeEnabled.mockReturnValue(true)
 
         const { root } = setup({
           isMobile: true,
@@ -163,7 +163,7 @@ describe('Editor', () => {
           data: officeDocParam
         })
         useQuery.mockReturnValue(officeDocParam)
-        isOnlyOfficeEnabled.mockReturnValue(true)
+        isOfficeEnabled.mockReturnValue(true)
 
         const { root } = setup({ isMobile: true })
         const { queryByTestId } = root
@@ -179,7 +179,7 @@ describe('Editor', () => {
           data: officeDocParam
         })
         useQuery.mockReturnValue(officeDocParam)
-        isOnlyOfficeEnabled.mockReturnValue(true)
+        isOfficeEnabled.mockReturnValue(true)
 
         const { root } = setup({
           isMobile: false,
@@ -196,7 +196,7 @@ describe('Editor', () => {
           data: officeDocParam
         })
         useQuery.mockReturnValue(officeDocParam)
-        isOnlyOfficeEnabled.mockReturnValue(true)
+        isOfficeEnabled.mockReturnValue(true)
 
         const { root } = setup({ isMobile: false })
         const { queryByTestId } = root
@@ -213,7 +213,7 @@ describe('Editor', () => {
         data: officeDocParam
       })
       useQuery.mockReturnValue(officeDocParam)
-      isOnlyOfficeEnabled.mockReturnValue(true)
+      isOfficeEnabled.mockReturnValue(true)
 
       setup({ isMobile: true })
 
@@ -226,7 +226,7 @@ describe('Editor', () => {
         data: officeDocParam
       })
       useQuery.mockReturnValue(officeDocParam)
-      isOnlyOfficeEnabled.mockReturnValue(true)
+      isOfficeEnabled.mockReturnValue(true)
 
       setup({ isMobile: false })
 
@@ -239,7 +239,7 @@ describe('Editor', () => {
         data: officeDocParam
       })
       useQuery.mockReturnValue(officeDocParam)
-      isOnlyOfficeEnabled.mockReturnValue(true)
+      isOfficeEnabled.mockReturnValue(true)
 
       setup({ isMobile: false, isEditorForcedReadOnly: false })
 

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -44,7 +44,7 @@ client.plugins = {
 
 const setup = ({
   isMobile = false,
-  isEditorForcedReadOnly = true,
+  isEditorModeView = true,
   isReadOnly = false
 } = {}) => {
   useBreakpoints.mockReturnValue({ isMobile })
@@ -65,7 +65,7 @@ const setup = ({
           isPublic: 'false',
           isReadOnly,
           isEditorReady: true,
-          isEditorForcedReadOnly
+          isEditorModeView
         }}
       >
         <Editor />
@@ -143,7 +143,7 @@ describe('Editor', () => {
 
   describe('Title', () => {
     describe('on mobile', () => {
-      it('should hide title when isEditorForcedReadOnly false', () => {
+      it('should hide title when when the editor is in edit mode', () => {
         useFetchJSON.mockReturnValue({
           fetchStatus: 'loaded',
           data: officeDocParam
@@ -153,14 +153,14 @@ describe('Editor', () => {
 
         const { root } = setup({
           isMobile: true,
-          isEditorForcedReadOnly: false
+          isEditorModeView: false
         })
         const { queryByTestId } = root
 
         expect(queryByTestId('onlyoffice-title')).toBeFalsy()
       })
 
-      it('should show title when isEditorForcedReadOnly true', () => {
+      it('should show title when when the editor is in view mode', () => {
         useFetchJSON.mockReturnValue({
           fetchStatus: 'loaded',
           data: officeDocParam
@@ -176,7 +176,7 @@ describe('Editor', () => {
     })
 
     describe('on desktop', () => {
-      it('should show title when isEditorForcedReadOnly false', () => {
+      it('should show title when when the editor is in edit mode', () => {
         useFetchJSON.mockReturnValue({
           fetchStatus: 'loaded',
           data: officeDocParam
@@ -186,14 +186,14 @@ describe('Editor', () => {
 
         const { root } = setup({
           isMobile: false,
-          isEditorForcedReadOnly: false
+          isEditorModeView: false
         })
         const { queryByTestId } = root
 
         expect(queryByTestId('onlyoffice-title')).toBeTruthy()
       })
 
-      it('should show title when isEditorForcedReadOnly true', () => {
+      it('should show title when when the editor is in view mode', () => {
         useFetchJSON.mockReturnValue({
           fetchStatus: 'loaded',
           data: officeDocParam
@@ -210,59 +210,63 @@ describe('Editor', () => {
   })
 
   describe('ReadOnlyFab', () => {
-    it('should show the readOnlyFab on mobile', () => {
-      useFetchJSON.mockReturnValue({
-        fetchStatus: 'loaded',
-        data: officeDocParam
+    describe('on mobile', () => {
+      it('should show the readOnlyFab', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOfficeEnabled.mockReturnValue(true)
+
+        setup({ isMobile: true })
+
+        expect(screen.queryByLabelText('Edit')).toBeTruthy()
       })
-      useQuery.mockReturnValue(officeDocParam)
-      isOfficeEnabled.mockReturnValue(true)
-
-      setup({ isMobile: true })
-
-      expect(screen.queryByLabelText('Edit')).toBeTruthy()
     })
 
-    it('should show the readOnlyFab on desktop when isEditorForcedReadOnly is true', () => {
-      useFetchJSON.mockReturnValue({
-        fetchStatus: 'loaded',
-        data: officeDocParam
-      })
-      useQuery.mockReturnValue(officeDocParam)
-      isOfficeEnabled.mockReturnValue(true)
+    describe('on desktop', () => {
+      it('should show the readOnlyFab when the editor is in view mode', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOfficeEnabled.mockReturnValue(true)
 
-      setup({ isMobile: false })
+        setup({ isMobile: false })
 
-      expect(screen.queryByText('Edit')).toBeTruthy()
-    })
-
-    it('should hide the readOnlyFab on desktop when isEditorForcedReadOnly is false', () => {
-      useFetchJSON.mockReturnValue({
-        fetchStatus: 'loaded',
-        data: officeDocParam
-      })
-      useQuery.mockReturnValue(officeDocParam)
-      isOfficeEnabled.mockReturnValue(true)
-
-      setup({ isMobile: false, isEditorForcedReadOnly: false })
-
-      expect(screen.queryByText('Edit')).toBeFalsy()
-    })
-
-    it('should hide the readOnlyFab on desktop when the document is in read only', () => {
-      useFetchJSON.mockReturnValue({
-        fetchStatus: 'loaded',
-        data: officeDocParam
-      })
-      useQuery.mockReturnValue(officeDocParam)
-      isOfficeEnabled.mockReturnValue(true)
-
-      setup({
-        isMobile: true,
-        isReadOnly: true
+        expect(screen.queryByText('Edit')).toBeTruthy()
       })
 
-      expect(screen.queryByLabelText('Edit')).toBeFalsy()
+      it('should hide the readOnlyFab when the editor is in edit mode', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOfficeEnabled.mockReturnValue(true)
+
+        setup({ isMobile: false, isEditorModeView: false })
+
+        expect(screen.queryByText('Edit')).toBeFalsy()
+      })
+
+      it('should hide the readOnlyFab when the document is in read only', () => {
+        useFetchJSON.mockReturnValue({
+          fetchStatus: 'loaded',
+          data: officeDocParam
+        })
+        useQuery.mockReturnValue(officeDocParam)
+        isOfficeEnabled.mockReturnValue(true)
+
+        setup({
+          isMobile: true,
+          isReadOnly: true
+        })
+
+        expect(screen.queryByLabelText('Edit')).toBeFalsy()
+      })
     })
   })
 })

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -42,7 +42,11 @@ client.plugins = {
   }
 }
 
-const setup = ({ isMobile = false, isEditorForcedReadOnly = true } = {}) => {
+const setup = ({
+  isMobile = false,
+  isEditorForcedReadOnly = true,
+  isReadOnly = false
+} = {}) => {
   useBreakpoints.mockReturnValue({ isMobile })
   const root = render(
     <AppLike
@@ -59,8 +63,7 @@ const setup = ({ isMobile = false, isEditorForcedReadOnly = true } = {}) => {
         value={{
           fileId: '123',
           isPublic: 'false',
-          isEditorReadOnly: false,
-          setIsEditorReadOnly: jest.fn(),
+          isReadOnly,
           isEditorReady: true,
           isEditorForcedReadOnly
         }}
@@ -244,6 +247,22 @@ describe('Editor', () => {
       setup({ isMobile: false, isEditorForcedReadOnly: false })
 
       expect(screen.queryByText('Edit')).toBeFalsy()
+    })
+
+    it('should hide the readOnlyFab on desktop when the document is in read only', () => {
+      useFetchJSON.mockReturnValue({
+        fetchStatus: 'loaded',
+        data: officeDocParam
+      })
+      useQuery.mockReturnValue(officeDocParam)
+      isOfficeEnabled.mockReturnValue(true)
+
+      setup({
+        isMobile: true,
+        isReadOnly: true
+      })
+
+      expect(screen.queryByLabelText('Edit')).toBeFalsy()
     })
   })
 })

--- a/src/drive/web/modules/views/OnlyOffice/OnlyOfficePaywallView.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/OnlyOfficePaywallView.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { OnlyOfficePaywall } from 'cozy-ui/transpiled/react/Paywall'
+
+import { useRouter } from 'drive/lib/RouterContext'
+
+const OnlyOfficePaywallView = ({ isPublic = false }) => {
+  const { router } = useRouter()
+
+  const onClose = () => {
+    router.replace(`${router.location.pathname.replace('/paywall', '')}`)
+  }
+
+  return <OnlyOfficePaywall isPublic={isPublic} onClose={onClose} />
+}
+
+export default OnlyOfficePaywallView

--- a/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
@@ -7,9 +7,12 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import Fab from 'drive/web/modules/drive/Fab'
+import { useRouter } from 'drive/lib/RouterContext'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
+import { canWriteOfficeDocument } from 'drive/web/modules/views/OnlyOffice/helpers'
 
 const ReadOnlyFab = () => {
+  const { router } = useRouter()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
 
@@ -17,8 +20,12 @@ const ReadOnlyFab = () => {
     useContext(OnlyOfficeContext)
 
   const handleClick = useCallback(() => {
-    setEditorMode(editorMode === 'view' ? 'edit' : 'view')
-  }, [editorMode, setEditorMode])
+    if (canWriteOfficeDocument()) {
+      setEditorMode(editorMode === 'view' ? 'edit' : 'view')
+    } else {
+      router.push(`${router.location.pathname}/paywall`)
+    }
+  }, [editorMode, setEditorMode, router])
 
   const label = isEditorModeView
     ? t('OnlyOffice.actions.edit')

--- a/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/ReadOnlyFab.jsx
@@ -13,14 +13,14 @@ const ReadOnlyFab = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
 
-  const { isEditorForcedReadOnly, setIsEditorForcedReadOnly } =
+  const { isEditorModeView, editorMode, setEditorMode } =
     useContext(OnlyOfficeContext)
 
   const handleClick = useCallback(() => {
-    setIsEditorForcedReadOnly(v => !v)
-  }, [setIsEditorForcedReadOnly])
+    setEditorMode(editorMode === 'view' ? 'edit' : 'view')
+  }, [editorMode, setEditorMode])
 
-  const label = isEditorForcedReadOnly
+  const label = isEditorModeView
     ? t('OnlyOffice.actions.edit')
     : t('OnlyOffice.actions.validate')
 
@@ -31,7 +31,7 @@ const ReadOnlyFab = () => {
   return (
     <Fab color="primary" onClick={handleClick} {...fabProps}>
       <Icon
-        icon={isEditorForcedReadOnly ? RenameIcon : CheckIcon}
+        icon={isEditorModeView ? RenameIcon : CheckIcon}
         className={!isMobile ? 'u-mr-half' : ''}
         aria-hidden="true"
       />

--- a/src/drive/web/modules/views/OnlyOffice/Title.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Title.jsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
 
 const Title = () => {
   const { isMobile } = useBreakpoints()
-  const { isPublic, isFromSharing, isInSharedFolder, isEditorForcedReadOnly } =
+  const { isPublic, isFromSharing, isInSharedFolder, isEditorModeView } =
     useContext(OnlyOfficeContext)
   const styles = useStyles()
 
@@ -34,7 +34,7 @@ const Title = () => {
     [isPublic, isFromSharing, isInSharedFolder]
   )
 
-  const showDialogToolbar = isEditorForcedReadOnly || !isMobile
+  const showDialogToolbar = isEditorModeView || !isMobile
 
   return (
     <div style={{ zIndex: 'var(--zIndex-nav)' }}>

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles(theme => ({
 const FileName = ({ fileWithPath }) => {
   const muiStyles = useStyles()
   const { isMobile } = useBreakpoints()
-  const { isEditorReadOnly } = useContext(OnlyOfficeContext)
+  const { isReadOnly } = useContext(OnlyOfficeContext)
   const [isRenaming, setIsRenaming] = useState(false)
 
   const onRename = useCallback(() => setIsRenaming(true), [setIsRenaming])
@@ -57,11 +57,11 @@ const FileName = ({ fileWithPath }) => {
       ) : (
         <Typography
           className={cx(muiStyles.name, {
-            [`${muiStyles.renamable}`]: !isEditorReadOnly
+            [`${muiStyles.renamable}`]: !isReadOnly
           })}
           variant="h6"
           noWrap
-          onClick={!isEditorReadOnly ? onRename : undefined}
+          onClick={!isReadOnly ? onRename : undefined}
         >
           {fileWithPath.name}
         </Typography>

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -22,7 +22,7 @@ const Toolbar = () => {
     fileId,
     isPublic,
     isFromSharing,
-    isEditorReadOnly,
+    isReadOnly,
     isEditorReady,
     isFromCreate
   } = useContext(OnlyOfficeContext)
@@ -73,7 +73,7 @@ const Toolbar = () => {
         )}
         <FileName fileWithPath={fileWithPath} />
       </div>
-      {isEditorReadOnly && <ReadOnly />}
+      {isReadOnly && <ReadOnly />}
       {!isPublic && isEditorReady && <Sharing fileWithPath={fileWithPath} />}
     </>
   )

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.spec.jsx
@@ -32,7 +32,7 @@ client.plugins = {
 }
 
 const setup = ({
-  isEditorReadOnly = false,
+  isReadOnly = false,
   isPublic = false,
   isFromSharing = false,
   isMobile = false
@@ -56,8 +56,7 @@ const setup = ({
           fileId: officeDocParam.id,
           isPublic,
           isFromSharing,
-          isEditorReadOnly,
-          setIsEditorReadOnly: jest.fn(),
+          isReadOnly,
           isEditorReady: true
         }}
       >
@@ -105,7 +104,7 @@ describe('Toolbar', () => {
     it('should be able to rename the file if not in readOnly mode', () => {
       useQuery.mockReturnValue(officeDocParam)
 
-      const { root } = setup({ isEditorReadOnly: false })
+      const { root } = setup({ isReadOnly: false })
       const { getByText, getByRole } = root
 
       fireEvent.click(getByText(officeDocParam.data.name))
@@ -115,7 +114,7 @@ describe('Toolbar', () => {
     it('should not be able to rename the file in readOnly mode', () => {
       useQuery.mockReturnValue(officeDocParam)
 
-      const { root } = setup({ isEditorReadOnly: true })
+      const { root } = setup({ isReadOnly: true })
       const { getByText, queryByRole } = root
 
       fireEvent.click(getByText(officeDocParam.data.name))
@@ -126,7 +125,7 @@ describe('Toolbar', () => {
       it('should be able to rename the file if not in readOnly mode', () => {
         useQuery.mockReturnValue(officeDocParam)
 
-        const { root } = setup({ isEditorReadOnly: false, isMobile: true })
+        const { root } = setup({ isReadOnly: false, isMobile: true })
         const { getByText, getByRole } = root
 
         fireEvent.click(getByText(officeDocParam.data.name))
@@ -171,7 +170,7 @@ describe('Toolbar', () => {
     it('should show text and icon if editor is read only', () => {
       useQuery.mockReturnValue(officeDocParam)
 
-      const { root } = setup({ isEditorReadOnly: true, isMobile: false })
+      const { root } = setup({ isReadOnly: true, isMobile: false })
       const { queryByTestId } = root
 
       expect(queryByTestId('onlyoffice-readonly-icon')).toBeTruthy()
@@ -181,7 +180,7 @@ describe('Toolbar', () => {
     it('should not show text and icon if editor is not read only', () => {
       useQuery.mockReturnValue(officeDocParam)
 
-      const { root } = setup({ isEditorReadOnly: false, isMobile: false })
+      const { root } = setup({ isReadOnly: false, isMobile: false })
       const { queryByTestId } = root
 
       expect(queryByTestId('onlyoffice-readonly-icon')).toBeFalsy()
@@ -192,7 +191,7 @@ describe('Toolbar', () => {
       it('should show only icon if editor is read only', () => {
         useQuery.mockReturnValue(officeDocParam)
 
-        const { root } = setup({ isEditorReadOnly: true, isMobile: true })
+        const { root } = setup({ isReadOnly: true, isMobile: true })
         const { queryByTestId } = root
 
         expect(queryByTestId('onlyoffice-readonly-icon-only')).toBeTruthy()
@@ -202,7 +201,7 @@ describe('Toolbar', () => {
       it('should not show text and icon if editor is not read only', () => {
         useQuery.mockReturnValue(officeDocParam)
 
-        const { root } = setup({ isEditorReadOnly: false, isMobile: true })
+        const { root } = setup({ isReadOnly: false, isMobile: true })
         const { queryByTestId } = root
 
         expect(queryByTestId('onlyoffice-readonly-icon')).toBeFalsy()

--- a/src/drive/web/modules/views/OnlyOffice/View.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/View.jsx
@@ -16,7 +16,8 @@ const forceIframeHeight = value => {
 
 const View = ({ id, apiUrl, docEditorConfig }) => {
   const [isError, setIsError] = useState(false)
-  const { isEditorReady, isReadOnly, isEditorForcedReadOnly } =
+
+  const { isEditorReady, isReadOnly, isEditorModeView } =
     useContext(OnlyOfficeContext)
   const { isMobile } = useBreakpoints()
 
@@ -52,7 +53,7 @@ const View = ({ id, apiUrl, docEditorConfig }) => {
   }, [isEditorReady])
 
   const showReadOnlyFab =
-    isEditorReady && !isReadOnly && (isMobile || isEditorForcedReadOnly)
+    isEditorReady && !isReadOnly && (isMobile || isEditorModeView)
 
   if (isError) return <Error />
 

--- a/src/drive/web/modules/views/OnlyOffice/View.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/View.jsx
@@ -16,7 +16,7 @@ const forceIframeHeight = value => {
 
 const View = ({ id, apiUrl, docEditorConfig }) => {
   const [isError, setIsError] = useState(false)
-  const { isEditorReady, isEditorReadOnly, isEditorForcedReadOnly } =
+  const { isEditorReady, isReadOnly, isEditorForcedReadOnly } =
     useContext(OnlyOfficeContext)
   const { isMobile } = useBreakpoints()
 
@@ -52,7 +52,7 @@ const View = ({ id, apiUrl, docEditorConfig }) => {
   }, [isEditorReady])
 
   const showReadOnlyFab =
-    isEditorReady && !isEditorReadOnly && (isMobile || isEditorForcedReadOnly)
+    isEditorReady && !isReadOnly && (isMobile || isEditorForcedReadOnly)
 
   if (isError) return <Error />
 

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -3,7 +3,13 @@ import FileTypeSheetIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSheet'
 import FileTypeSlideIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSlide'
 import FileTypeTextIcon from 'cozy-ui/transpiled/react/Icons/FileTypeText'
 
-export const isOnlyOfficeEnabled = () => flag('drive.onlyoffice.enabled')
+export const isOfficeEnabled = () => {
+  const office = flag('drive.office')
+  if (flag('drive.onlyoffice.enabled') || (office && office.enabled)) {
+    return true
+  }
+  return false
+}
 
 export const makeOnlyOfficeFileRoute = (file, isWithRouter) =>
   isWithRouter ? `/onlyoffice/${file.id}` : `/#/onlyoffice/${file.id}`

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -11,6 +11,22 @@ export const isOfficeEnabled = () => {
   return false
 }
 
+export function canWriteOfficeDocument() {
+  const office = flag('drive.office')
+  if (office) {
+    return office.write
+  }
+  return false
+}
+
+export function redirectToOnlyOfficePaywall(nextState, replace) {
+  if (!canWriteOfficeDocument()) {
+    replace({
+      pathname: `/folder/${nextState.params.folderId}/paywall`
+    })
+  }
+}
+
 export const makeOnlyOfficeFileRoute = (file, isWithRouter) =>
   isWithRouter ? `/onlyoffice/${file.id}` : `/#/onlyoffice/${file.id}`
 

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -27,6 +27,14 @@ export function redirectToOnlyOfficePaywall(nextState, replace) {
   }
 }
 
+export function onlyOfficeDefaultMode() {
+  const office = flag('drive.office')
+  if (office && office.write && office.onlyOffice) {
+    return office.onlyOffice.defaultMode
+  }
+  return 'view'
+}
+
 export const makeOnlyOfficeFileRoute = (file, isWithRouter) =>
   isWithRouter ? `/onlyoffice/${file.id}` : `/#/onlyoffice/${file.id}`
 

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -14,9 +14,6 @@ export const isOfficeEnabled = () => {
 export const makeOnlyOfficeFileRoute = (file, isWithRouter) =>
   isWithRouter ? `/onlyoffice/${file.id}` : `/#/onlyoffice/${file.id}`
 
-export const isOnlyOfficeReadOnly = ({ data }) =>
-  data.attributes.onlyoffice.editor.mode === 'view'
-
 /**
  * Returns true in case of the document is shared and should be opened on another instance.
  * See https://docs.cozy.io/en/cozy-stack/office/#get-officeidopen

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -11,6 +11,7 @@ export const OnlyOfficeContext = createContext()
 const OnlyOfficeProvider = ({
   fileId,
   isPublic,
+  isReadOnly,
   isFromSharing,
   username,
   isInSharedFolder,
@@ -18,7 +19,6 @@ const OnlyOfficeProvider = ({
 }) => {
   const { router } = useRouter()
 
-  const [isEditorReadOnly, setIsEditorReadOnly] = useState()
   const [isEditorReady, setIsEditorReady] = useState(false)
   const [isEditorForcedReadOnly, setIsEditorForcedReadOnly] = useState(true)
 
@@ -38,11 +38,10 @@ const OnlyOfficeProvider = ({
       value={{
         fileId,
         isPublic,
+        isReadOnly,
         isFromSharing,
         username,
         isInSharedFolder,
-        isEditorReadOnly,
-        setIsEditorReadOnly,
         isEditorReady,
         setIsEditorReady,
         isEditorForcedReadOnly,
@@ -58,6 +57,7 @@ const OnlyOfficeProvider = ({
 const OnlyOffice = ({
   params: { fileId },
   isPublic,
+  isReadOnly = false,
   isFromSharing,
   username,
   isInSharedFolder
@@ -69,6 +69,7 @@ const OnlyOffice = ({
       <OnlyOfficeProvider
         fileId={fileId}
         isPublic={isPublic}
+        isReadOnly={isReadOnly}
         isFromSharing={isFromSharing}
         username={username}
         isInSharedFolder={isInSharedFolder}

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -20,7 +20,11 @@ const OnlyOfficeProvider = ({
   const { router } = useRouter()
 
   const [isEditorReady, setIsEditorReady] = useState(false)
-  const [isEditorForcedReadOnly, setIsEditorForcedReadOnly] = useState(true)
+
+  const [editorMode, setEditorMode] = useState('view')
+  const isEditorModeView = useMemo(() => {
+    return editorMode === 'view'
+  }, [editorMode])
 
   const isFromCreate = useMemo(
     () => router.location.pathname.endsWith('/fromCreate'),
@@ -29,7 +33,7 @@ const OnlyOfficeProvider = ({
 
   useEffect(() => {
     if (isFromCreate) {
-      setIsEditorForcedReadOnly(false)
+      setEditorMode('edit')
     }
   }, [isFromCreate])
 
@@ -44,8 +48,9 @@ const OnlyOfficeProvider = ({
         isInSharedFolder,
         isEditorReady,
         setIsEditorReady,
-        isEditorForcedReadOnly,
-        setIsEditorForcedReadOnly,
+        editorMode,
+        setEditorMode,
+        isEditorModeView,
         isFromCreate
       }}
     >

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -65,7 +65,8 @@ const OnlyOffice = ({
   isReadOnly = false,
   isFromSharing,
   username,
-  isInSharedFolder
+  isInSharedFolder,
+  children
 }) => {
   useHead({ fileId })
 
@@ -80,6 +81,7 @@ const OnlyOffice = ({
         isInSharedFolder={isInSharedFolder}
       >
         <Editor />
+        {children}
       </OnlyOfficeProvider>
     </Dialog>
   )

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -5,6 +5,7 @@ import Dialog from 'cozy-ui/transpiled/react/Dialog'
 import { useRouter } from 'drive/lib/RouterContext'
 import Editor from 'drive/web/modules/views/OnlyOffice/Editor'
 import useHead from 'components/useHead'
+import { onlyOfficeDefaultMode } from 'drive/web/modules/views/OnlyOffice/helpers'
 
 export const OnlyOfficeContext = createContext()
 
@@ -21,7 +22,7 @@ const OnlyOfficeProvider = ({
 
   const [isEditorReady, setIsEditorReady] = useState(false)
 
-  const [editorMode, setEditorMode] = useState('view')
+  const [editorMode, setEditorMode] = useState(onlyOfficeDefaultMode())
   const isEditorModeView = useMemo(() => {
     return editorMode === 'view'
   }, [editorMode])

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
@@ -16,8 +16,9 @@ const useConfig = () => {
     setIsEditorReady,
     isPublic,
     username,
-    isEditorForcedReadOnly,
-    isFromSharing
+    isFromSharing,
+    editorMode,
+    isEditorModeView
   } = useContext(OnlyOfficeContext)
   const client = useClient()
   const instanceUri = client.getStackClient().uri
@@ -34,7 +35,7 @@ const useConfig = () => {
 
   useEffect(() => {
     setConfig()
-  }, [isEditorForcedReadOnly])
+  }, [isEditorModeView])
 
   useEffect(() => {
     if (!isQueryLoading(queryResult) && fetchStatus !== 'error' && !config) {
@@ -86,7 +87,7 @@ const useConfig = () => {
           document: onlyoffice.document,
           editorConfig: {
             ...onlyoffice.editor,
-            mode: isEditorForcedReadOnly ? 'view' : onlyoffice.editor.mode,
+            mode: onlyoffice.editor.mode === 'edit' ? editorMode : 'view',
             user: { name }
           },
           token: onlyoffice.token,
@@ -103,6 +104,7 @@ const useConfig = () => {
       }
     }
   }, [
+    editorMode,
     queryResult,
     fetchStatus,
     data,
@@ -110,7 +112,6 @@ const useConfig = () => {
     setConfig,
     setIsEditorReady,
     isPublic,
-    isEditorForcedReadOnly,
     username,
     isFromSharing,
     instanceUri

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
@@ -4,7 +4,6 @@ import { useClient, isQueryLoading, generateWebLink } from 'cozy-client'
 import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
 
 import {
-  isOnlyOfficeReadOnly,
   shouldBeOpenedOnOtherInstance,
   isOfficeEnabled,
   makeName
@@ -14,8 +13,6 @@ import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
 const useConfig = () => {
   const {
     fileId,
-    isEditorReadOnly,
-    setIsEditorReadOnly,
     setIsEditorReady,
     isPublic,
     username,
@@ -66,10 +63,6 @@ const useConfig = () => {
 
         window.location = link
       } else if (isOfficeEnabled()) {
-        if (isEditorReadOnly !== isOnlyOfficeReadOnly(data)) {
-          setIsEditorReadOnly(isOnlyOfficeReadOnly(data))
-        }
-
         const { attributes } = data.data
         const { onlyoffice, public_name } = attributes
         const name = makeName({
@@ -113,8 +106,6 @@ const useConfig = () => {
     queryResult,
     fetchStatus,
     data,
-    isEditorReadOnly,
-    setIsEditorReadOnly,
     config,
     setConfig,
     setIsEditorReady,

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
@@ -6,7 +6,7 @@ import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
 import {
   isOnlyOfficeReadOnly,
   shouldBeOpenedOnOtherInstance,
-  isOnlyOfficeEnabled,
+  isOfficeEnabled,
   makeName
 } from 'drive/web/modules/views/OnlyOffice/helpers'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
@@ -65,7 +65,7 @@ const useConfig = () => {
         })
 
         window.location = link
-      } else if (isOnlyOfficeEnabled()) {
+      } else if (isOfficeEnabled()) {
         if (isEditorReadOnly !== isOnlyOfficeReadOnly(data)) {
           setIsEditorReadOnly(isOnlyOfficeReadOnly(data))
         }

--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -72,7 +72,7 @@ async function init() {
     })
   }
   try {
-    const id = await getSharedDocument(client)
+    const { id } = await getSharedDocument(client)
     app = (
       <WebviewIntentProvider>
         <Provider store={store}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6041,10 +6041,10 @@ cozy-stack-client@^35.3.1:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^81.2.1:
-  version "81.2.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-81.2.1.tgz#7ea31a4ff3e7610c22c3656bf66f5665a35c8cb4"
-  integrity sha512-IOLUn1+rXli5hn3J6c97uzWk3/lWffigQ7bJOIW/oC8h8egY4bCDfUXfOOURCIpbdS3vOzO6Bub3WDQM5cBPBw==
+cozy-ui@^81.4.0:
+  version "81.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-81.4.0.tgz#73c570eef5807c361f96138077269a006d8b7b05"
+  integrity sha512-kgoXdGpT374GfgCIyBZ4bBSTvk5wErH4BZvNLvXhcnRyDf05mLmO89Tr6AUxggerLEsDpDJY8RLu7sHPmbrUNw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -12714,9 +12714,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
-  version "1.0.6"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+  version "1.0.8"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -12724,9 +12724,9 @@ msgpack5@^4.0.2:
     react-use-gesture "^7.0.8"
     react-use-measure "^2.0.0"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
-  version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+  version "1.0.6"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5815,10 +5815,10 @@ cozy-doctypes@^1.82.1:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.88.0:
-  version "1.88.0"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.88.0.tgz#f5690c4487f98132e05486ca7011751f976c3e51"
-  integrity sha512-Em1sRQepA2WSZ4zzWXPKewTpl7FV21CPSSivPQZedSzDSNxe1JA6JanvaF25w7kq5nc+SIRRZH02hv4F0xNbGQ==
+cozy-doctypes@^1.88.1:
+  version "1.88.1"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.88.1.tgz#cdb032296e4f18aa1ed713b84085dcb20759c60b"
+  integrity sha512-WcMxxLSC9NN5BlPtzcaEOwSIBsD0cHP+x49NW8TdQ7jw6ouNhbZcaKjUJmMet+IGxD7+EL7RXqgv5oc0tqddHQ==
   dependencies:
     cozy-logger "^1.10.0"
     date-fns "^1.30.1"
@@ -6008,16 +6008,16 @@ cozy-scripts@^7.0.0:
     webpack-dev-server "3.10.3"
     webpack-merge "4.2.2"
 
-cozy-sharing@6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-6.0.4.tgz#4065d6eadad5f57ba114ca37daac185524996861"
-  integrity sha512-CMMtPG9y7qafBdIsSUWB2at2Jxuk43tkvGLnAhiOkx+uCW/nbIPQJ3o/Q3/nxzn3dSwY8/pXmaTa1KiuSlWAHg==
+cozy-sharing@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-7.0.1.tgz#92539684423d4a7bb51648efa384fc5a647a62a4"
+  integrity sha512-hdZiNMPc+dpcMyVOGtHyj6cYMO7TxHS0EmZVajNTWtoo00PUTYg2u1MVlQWUm+0KwWBmve9mBKTmK5/fWcYv1A==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.2.6"
     copy-text-to-clipboard "^2.1.1"
     cozy-device-helper "^2.7.0"
-    cozy-doctypes "^1.88.0"
+    cozy-doctypes "^1.88.1"
     lodash "^4.17.19"
     react-autosuggest "^10.1.0"
     react-tooltip "^3.11.1"
@@ -12714,9 +12714,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
-  version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+  version "1.0.6"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -12724,9 +12724,9 @@ msgpack5@^4.0.2:
     react-use-gesture "^7.0.8"
     react-use-measure "^2.0.0"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
-  version "1.0.6"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+  version "1.0.8"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
```
### ✨ Features

* Add OnlyOffice paywall
```

**Notes :** This PR comes with a new flag calls `drive.office` which replace `drive.onlyoffice.enabled` and extends it's features. You can set a default mode for the onlyoffice editor and give write permission. For example: 
```
{
  "enabled": true,
  "engine": "onlyOffice",
  "write": true,
  "onlyOffice": {
    "defaultMode": "edit"
  }
}
```

**Related PRs:**
* https://github.com/cozy/cozy-ui/pull/2366
* https://github.com/cozy/cozy-libs/pull/2058