### PR TITLE
feat: Refresh after outdated version of an OnlyOffice document

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
@@ -86,6 +86,10 @@ const useConfig = () => {
           }
         }
 
+        const onOutdatedVersion = () => {
+          window.location.reload()
+        }
+
         const serverUrl = onlyoffice.url
         const apiUrl = `${serverUrl}/web-apps/apps/api/documents/api.js`
         const docEditorConfig = {
@@ -100,7 +104,8 @@ const useConfig = () => {
           documentType: onlyoffice.documentType,
           events: {
             onAppReady: () => setIsEditorReady(true),
-            onWarning
+            onWarning,
+            onOutdatedVersion
           }
         }
 


### PR DESCRIPTION
When OnlyOffice detects an outdated version, it displays a modal to inform the user. When the user confirms, OnlyOffice sends back the `onOutdatedVersion` event and we take the opportunity to refresh the page

```
### ✨ Features

*  Refresh after outdated version of an OnlyOffice document
```