### PR TITLE
fix: Revert refresh after OnlyOffice idle session

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
@@ -79,13 +79,6 @@ const useConfig = () => {
           public_name
         })
 
-        const onWarning = event => {
-          // sessionIdle
-          if (event.data.warningCode === -121) {
-            window.location.reload()
-          }
-        }
-
         const serverUrl = onlyoffice.url
         const apiUrl = `${serverUrl}/web-apps/apps/api/documents/api.js`
         const docEditorConfig = {
@@ -99,8 +92,7 @@ const useConfig = () => {
           token: onlyoffice.token,
           documentType: onlyoffice.documentType,
           events: {
-            onAppReady: () => setIsEditorReady(true),
-            onWarning
+            onAppReady: () => setIsEditorReady(true)
           }
         }
 


### PR DESCRIPTION
This update changes the OnlyOffice key on the stack side without updating the front side. This side effect leads to an outdated version message on OnlyOffice, which is not desirable from a user experience point of view. We have chosen to go back until we get a better user experience

Refs: 8276fed5b96d1c655fac23d107deee0d755c147d

```
### 🐛 Bug Fixes

* Revert refresh after OnlyOffice idle session
```
