### PR TITLE
feat: Remove backwards compatibility with OnlyOffice flag

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -4,18 +4,12 @@ import FileTypeSlideIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSlide'
 import FileTypeTextIcon from 'cozy-ui/transpiled/react/Icons/FileTypeText'
 
 export const isOfficeEnabled = () => {
-  const office = flag('drive.office')
-  if (flag('drive.onlyoffice.enabled') || (office && office.enabled)) {
-    return true
-  }
+  if (flag('drive.office.enabled')) return true
   return false
 }
 
 export function canWriteOfficeDocument() {
-  const office = flag('drive.office')
-  if (office) {
-    return office.write
-  }
+  if (flag('drive.office.write')) return true
   return false
 }
 


### PR DESCRIPTION
We decided to completely remove the  flag when we went live. In order to limit dead code, I decided to remove backwards compatibility with this flag now

```
### ✨ Features

* Remove backwards compatibility with OnlyOffice flag
```
