### PR TITLE
feat: Backwards compatibility with onlyoffice flag

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -28,7 +28,7 @@ export function redirectToOnlyOfficePaywall(nextState, replace) {
 }
 
 export function onlyOfficeDefaultMode(isDesktop, isMobile) {
-  if (!isDesktop && flag('drive.office.disableMobileEditing')) {
+  if (!isDesktop && flag('drive.office.touchScreen.readOnly')) {
     return 'view'
   }
 
@@ -52,7 +52,7 @@ export const isOfficeEditingEnabled = isDesktop => {
     return false
   }
 
-  if (!isDesktop && flag('drive.office.disableMobileEditing')) {
+  if (!isDesktop && flag('drive.office.touchScreen.readOnly')) {
     return false
   }
 

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -27,19 +27,19 @@ export function redirectToOnlyOfficePaywall(nextState, replace) {
   }
 }
 
-export function onlyOfficeDefaultMode(isDesktop, isMobile) {
+export function officeDefaultMode(isDesktop, isMobile) {
   if (!isDesktop && flag('drive.office.touchScreen.readOnly')) {
     return 'view'
   }
 
   const canWrite = canWriteOfficeDocument()
 
-  const mobileDefaultMode = flag('drive.office.onlyOffice.mobileDefaultMode')
+  const mobileDefaultMode = flag('drive.office.mobile.defaultMode')
   if (isMobile && canWrite && mobileDefaultMode !== null) {
     return mobileDefaultMode
   }
 
-  const defaultMode = flag('drive.office.onlyOffice.defaultMode')
+  const defaultMode = flag('drive.office.defaultMode')
   if (canWrite && defaultMode !== null) {
     return defaultMode
   }

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -4,18 +4,26 @@ import FileTypeSlideIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSlide'
 import FileTypeTextIcon from 'cozy-ui/transpiled/react/Icons/FileTypeText'
 
 export const isOfficeEnabled = () => {
-  const office = flag('drive.office')
-  if (flag('drive.onlyoffice.enabled') || (office && office.enabled)) {
-    return true
+  const officeEnabled = flag('drive.office.enabled')
+  if (officeEnabled !== null) {
+    return officeEnabled
   }
+
+  // Keeping compatibility with the old flag but with a lower priority
+  if (flag('drive.onlyoffice.enabled')) return true
+
   return false
 }
 
 export function canWriteOfficeDocument() {
-  const office = flag('drive.office')
-  if (office) {
-    return office.write
+  const officeWrite = flag('drive.office.write')
+  if (officeWrite !== null) {
+    return officeWrite
   }
+
+  // Keeping compatibility with the old flag but with a lower priority
+  if (flag('drive.onlyoffice.enabled')) return true
+
   return false
 }
 

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -6,7 +6,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { useRouter } from 'drive/lib/RouterContext'
 import Editor from 'drive/web/modules/views/OnlyOffice/Editor'
 import useHead from 'components/useHead'
-import { onlyOfficeDefaultMode } from 'drive/web/modules/views/OnlyOffice/helpers'
+import { officeDefaultMode } from 'drive/web/modules/views/OnlyOffice/helpers'
 
 export const OnlyOfficeContext = createContext()
 
@@ -25,11 +25,9 @@ const OnlyOfficeProvider = ({
   const [isEditorReady, setIsEditorReady] = useState(false)
 
   const [editorMode, setEditorMode] = useState(
-    onlyOfficeDefaultMode(isDesktop, isMobile)
+    officeDefaultMode(isDesktop, isMobile)
   )
-  const isEditorModeView = useMemo(() => {
-    return editorMode === 'view'
-  }, [editorMode])
+  const isEditorModeView = useMemo(() => editorMode === 'view', [editorMode])
 
   const isFromCreate = useMemo(
     () => router.location.pathname.endsWith('/fromCreate'),


### PR DESCRIPTION
```
### ✨ Features

* Add backwards compatibility with `drive.onlyoffice.enabled` flag
```

Some bug fix are waiting the work on Only Office to deploy. To unlock the situation, we decide to make backwards compatibility with the flag `drive.onlyoffice.enabled`. 

It's override if the flag `drive.office` exists. Its default mode is view on mobile so in some context we can set its default mode to edit on desktop with `drive.office.defaultMode: edit`

This PR also modifies the `drive.office` flag by grouping all the mobile-specific settings in a single object. 

Old: 
```
drive.office : {
  "enabled": true,
  "write": false,
  "disableMobileEditing": true,
  "onlyOffice": {
    "defaultMode": "edit",
    "mobileDefaultMode": "view"
  }
}
```

New: 
```
drive.office : {
  "enabled":true,
  "write": true,
  "defaultMode":"edit", 
  "mobile": {
    "defaultMode": "view"
  }, 
  "touchScreen": {
    "disableEditing": true
  }
}
```
