### PR TITLE
fix: Detect touch screen device to enable OnlyOffice

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -1,11 +1,13 @@
 import flag from 'cozy-flags'
+import { isMobile } from 'cozy-device-helper'
+
 import FileTypeSheetIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSheet'
 import FileTypeSlideIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSlide'
 import FileTypeTextIcon from 'cozy-ui/transpiled/react/Icons/FileTypeText'
 
 export const isOfficeEnabled = isDesktop => {
   const officeEnabled = flag(
-    `drive.office.${!isDesktop ? 'touchScreen.' : ''}enabled`
+    `drive.office.${!isDesktop || isMobile() ? 'touchScreen.' : ''}enabled`
   )
   if (officeEnabled !== null) {
     return officeEnabled
@@ -62,7 +64,7 @@ export const isOfficeEditingEnabled = isDesktop => {
     return false
   }
 
-  if (!isDesktop && flag('drive.office.touchScreen.readOnly')) {
+  if ((!isDesktop || isMobile()) && flag('drive.office.touchScreen.readOnly')) {
     return false
   }
 


### PR DESCRIPTION
New tablet has greater resolution than the tablet breakpoint which is 1023px. For example, the new iPad Pro has an resolution of 2560 X 1600px. That's why now we check also on which device we are with the cozy-device-helper

```
### 🐛 Bug Fixes

*  Detect touch screen device to enable OnlyOffice
```
