### PR TITLE
fix: Spacing on empty share page

### DIFF
--- a/src/drive/styles/main.styl
+++ b/src/drive/styles/main.styl
@@ -10,3 +10,10 @@ div:focus
     +small-screen()
         padding 0
 
+.center-layout
+    display flex
+    width 100%
+
+    +medium-screen()
+        min-height 100vh
+        padding 0 2rem

--- a/src/drive/targets/public/index.jsx
+++ b/src/drive/targets/public/index.jsx
@@ -25,6 +25,7 @@ import App from 'components/App/App'
 import StyledApp from 'drive/web/modules/drive/StyledApp'
 import cozyBar from 'lib/cozyBar'
 import AppRouter from 'drive/targets/public/components/AppRouter'
+import styles from 'drive/styles/main.styl'
 
 const initCozyBar = (data, client) => {
   if (data.app.name && data.app.editor && data.app.icon && data.locale) {
@@ -46,7 +47,9 @@ const renderError = (lang, root) =>
   render(
     <I18n lang={lang} dictRequire={lang => require(`drive/locales/${lang}`)}>
       <StyledApp>
-        <ErrorShare errorType={`public_unshared`} />
+        <main className={styles['center-layout']}>
+          <ErrorShare errorType={`public_unshared`} />
+        </main>
       </StyledApp>
     </I18n>,
     root


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Spacing on empty share page
```

Before : 
<img width="375" src="https://user-images.githubusercontent.com/7434420/230576849-7289714c-8369-43f3-b36e-5963398ce54a.png" />

After : 
<img width="375" src="https://user-images.githubusercontent.com/7434420/230576842-9782ea37-52ba-44d2-a916-a68ea52f0f5c.png" />
