### PR TITLE
fix: Missing qualification label on ActionMenuWithHeader component

### DIFF
--- a/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
+++ b/src/drive/web/modules/actionmenu/ActionMenuWithHeader.jsx
@@ -62,14 +62,14 @@ const MenuHeaderFile = ({ file, lang }) => {
               {extension}
             </span>
           </div>
-          {file.metadata && file.metadata.label && (
+          {file.metadata?.qualification?.label && (
             <div className="u-coolGrey u-fz-tiny u-fs-normal u-flex u-flex-items-center">
               <Icon icon={QualifyIcon} size="10" />
               <Typography
                 variant="caption"
                 className={classNames(styles['fil-mobileactionmenu-category'])}
               >
-                {scannerT(`Scan.items.${file.metadata.label}`)}
+                {scannerT(`Scan.items.${file.metadata.qualification.label}`)}
               </Typography>
             </div>
           )}


### PR DESCRIPTION
`file.metadata.label` does not exist (anymore?), therefore we had lost the display of the qualification label on the ActionMenu in Mobile mode. (see screenshot)

![Capture d’écran 2023-04-12 à 12 04 23](https://user-images.githubusercontent.com/14182143/231426310-e4e70224-0284-490e-8dde-fabc4acca9d6.png)


```
### 🐛 Bug Fixes

* Missing qualification label on ActionMenuWithHeader component
```
