### PR TITLE
Fix home button click in Photos app

### DIFF
--- a/src/photos/targets/browser/index.jsx
+++ b/src/photos/targets/browser/index.jsx
@@ -81,7 +81,7 @@ const setupAppContext = memoize(() => {
 
 const App = props => {
   return (
-    <WebviewIntentProvider>
+    <WebviewIntentProvider setBarContext={cozyBar.setWebviewContext}>
       <Provider store={props.store}>
         <I18n
           lang={props.locale}

--- a/src/photos/targets/public/index.jsx
+++ b/src/photos/targets/public/index.jsx
@@ -74,7 +74,7 @@ async function init() {
   try {
     const { id } = await getSharedDocument(client)
     app = (
-      <WebviewIntentProvider>
+      <WebviewIntentProvider setBarContext={cozyBar.setWebviewContext}>
         <Provider store={store}>
           <CozyProvider client={client}>
             <BreakpointsProvider>


### PR DESCRIPTION
This PR fixes an issue with the Photos app where clicking on the Cozy icon (home button) would not navigate back to the home page. The issue was caused by the WebviewIntent not being injected into the Photos app, making the context unreachable. The same injection is present in the Drive app, and this PR brings the Photos app in line with the Drive app's behavior.

Changes:

Inject cozyBar.setWebviewContext into WebviewIntentProvider in src/photos/targets/browser/index.jsx
Inject cozyBar.setWebviewContext into WebviewIntentProvider in src/photos/targets/public/index.jsx