### PR TITLE
fix: Upload photos on mobile with ActionsMenu

### DIFF
--- a/src/photos/components/actions/upload.jsx
+++ b/src/photos/components/actions/upload.jsx
@@ -8,10 +8,11 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import UploadButton from '../UploadButton'
 
-const download = (onUpload, disabled) => () => ({
-  name: 'download',
-  action: () => {},
-  Component: forwardRef(function Download(props, ref) {
+const upload = (onUpload, disabled) => () => ({
+  name: 'upload',
+  // FileInput needs to stay rendered until the onChange event, so we prevent the event from bubbling
+  action: e => e.stopPropagation(),
+  Component: forwardRef(function Upload(props, ref) {
     const { t } = useI18n()
     return (
       <ActionMenuItem {...props} ref={ref}>
@@ -29,4 +30,4 @@ const download = (onUpload, disabled) => () => ({
   })
 })
 
-export default download
+export default upload


### PR DESCRIPTION
This morning, I was investigating a bug with photo uploads to Drive. I realised that there must have been a bug on Photos following my migration to MenuActions because we weren't behaving the same way. So I'm correcting this error and a few naming errors. The solution isn't perfect at the moment, but I'm going to look at how we could improve this with cozy-ui as it's linked to ActionsMenu

```
### 🐛 Bug Fixes

* Upload photos on mobile with ActionsMenu
```
