### PR TITLE
Fix: Rename photo album desktop

### DIFF
--- a/src/photos/components/EditableAlbumName.jsx
+++ b/src/photos/components/EditableAlbumName.jsx
@@ -1,0 +1,59 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+const KEYCODE_ENTER = 13
+const KEYCODE_ESC = 27
+
+class EditableAlbumName extends Component {
+  constructor(props) {
+    super(props)
+    this.ignoreBlurEvent = false // we'll ignore blur events if they are triggered by pressing enter or escape, to prevent `onEdit` from firing twice
+    this.inputElement = null
+  }
+
+  componentDidMount() {
+    if (this.inputElement !== null) {
+      this.inputElement.focus()
+      this.inputElement.select()
+    }
+  }
+
+  handleBlur = e => {
+    if (!this.ignoreBlurEvent && this.props.onEdit)
+      this.props.onEdit(
+        e.target.value.trim() !== '' ? e.target.value : this.props.albumName
+      )
+  }
+
+  handleKeyDown = e => {
+    if (e.keyCode === KEYCODE_ENTER && this.props.onEdit) {
+      this.ignoreBlurEvent = true
+      this.props.onEdit(e.target.value)
+    } else if (e.keyCode === KEYCODE_ESC && this.props.onEdit) {
+      this.ignoreBlurEvent = true
+      this.props.onEdit(this.props.albumName)
+    }
+  }
+
+  render() {
+    const { albumName } = this.props
+    return (
+      <input
+        type="text"
+        defaultValue={albumName}
+        onKeyDown={this.handleKeyDown}
+        onBlur={this.handleBlur}
+        ref={elem => {
+          this.inputElement = elem
+        }}
+      />
+    )
+  }
+}
+
+EditableAlbumName.propTypes = {
+  albumName: PropTypes.string,
+  onEdit: PropTypes.func.isRequired
+}
+
+export default EditableAlbumName

--- a/src/photos/components/EditableAlbumName.jsx
+++ b/src/photos/components/EditableAlbumName.jsx
@@ -1,54 +1,44 @@
-import React, { Component } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
 const KEYCODE_ENTER = 13
 const KEYCODE_ESC = 27
 
-class EditableAlbumName extends Component {
-  constructor(props) {
-    super(props)
-    this.ignoreBlurEvent = false // we'll ignore blur events if they are triggered by pressing enter or escape, to prevent `onEdit` from firing twice
-    this.inputElement = null
-  }
+const EditableAlbumName = ({ onEdit, albumName }) => {
+  // we'll ignore blur events if they are triggered by pressing enter or escape, to prevent `onEdit` from firing twice
+  const [ignoreBlurEvent, setIgnoreBlurEvent] = useState(false)
+  const inputRef = useRef(null)
 
-  componentDidMount() {
-    if (this.inputElement !== null) {
-      this.inputElement.focus()
-      this.inputElement.select()
+  useEffect(() => {
+    inputRef.current.focus()
+    inputRef.current.select()
+  }, [])
+
+  const handleBlur = e => {
+    if (!ignoreBlurEvent && onEdit) {
+      onEdit(e.target.value.trim() !== '' ? e.target.value : albumName)
     }
   }
 
-  handleBlur = e => {
-    if (!this.ignoreBlurEvent && this.props.onEdit)
-      this.props.onEdit(
-        e.target.value.trim() !== '' ? e.target.value : this.props.albumName
-      )
-  }
-
-  handleKeyDown = e => {
-    if (e.keyCode === KEYCODE_ENTER && this.props.onEdit) {
-      this.ignoreBlurEvent = true
-      this.props.onEdit(e.target.value)
-    } else if (e.keyCode === KEYCODE_ESC && this.props.onEdit) {
-      this.ignoreBlurEvent = true
-      this.props.onEdit(this.props.albumName)
+  const handleKeyDown = e => {
+    if (e.keyCode === KEYCODE_ENTER && onEdit) {
+      setIgnoreBlurEvent(true)
+      onEdit(e.target.value)
+    } else if (e.keyCode === KEYCODE_ESC && onEdit) {
+      setIgnoreBlurEvent(true)
+      onEdit(albumName)
     }
   }
 
-  render() {
-    const { albumName } = this.props
-    return (
-      <input
-        type="text"
-        defaultValue={albumName}
-        onKeyDown={this.handleKeyDown}
-        onBlur={this.handleBlur}
-        ref={elem => {
-          this.inputElement = elem
-        }}
-      />
-    )
-  }
+  return (
+    <input
+      type="text"
+      defaultValue={albumName}
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+      ref={inputRef}
+    />
+  )
 }
 
 EditableAlbumName.propTypes = {

--- a/src/photos/components/MoreMenu.jsx
+++ b/src/photos/components/MoreMenu.jsx
@@ -26,6 +26,8 @@ const MoreMenu = ({ actions }) => {
         />
       </div>
       <ActionMenu
+        disableEnforceFocus
+        disableRestoreFocus
         id="more-menu"
         ref={anchorRef}
         open={isMenuOpen}

--- a/src/photos/components/Topbar.jsx
+++ b/src/photos/components/Topbar.jsx
@@ -11,61 +11,7 @@ import SharingProvider from 'cozy-sharing'
 import { DOCTYPE_ALBUMS } from 'drive/lib/doctypes'
 
 import { BarCenter, BarRight, BarLeft } from 'components/Bar'
-
-const KEYCODE_ENTER = 13
-const KEYCODE_ESC = 27
-
-class EditableAlbumName extends Component {
-  constructor(props) {
-    super(props)
-    this.ignoreBlurEvent = false // we'll ignore blur events if they are triggered by pressing enter or escape, to prevent `onEdit` from firing twice
-    this.inputElement = null
-  }
-
-  componentDidMount() {
-    if (this.inputElement !== null) {
-      this.inputElement.focus()
-      this.inputElement.select()
-    }
-  }
-
-  handleBlur = e => {
-    if (!this.ignoreBlurEvent && this.props.onEdit)
-      this.props.onEdit(
-        e.target.value.trim() !== '' ? e.target.value : this.props.albumName
-      )
-  }
-
-  handleKeyDown = e => {
-    if (e.keyCode === KEYCODE_ENTER && this.props.onEdit) {
-      this.ignoreBlurEvent = true
-      this.props.onEdit(e.target.value)
-    } else if (e.keyCode === KEYCODE_ESC && this.props.onEdit) {
-      this.ignoreBlurEvent = true
-      this.props.onEdit(this.props.albumName)
-    }
-  }
-
-  render() {
-    const { albumName } = this.props
-    return (
-      <input
-        type="text"
-        defaultValue={albumName}
-        onKeyDown={this.handleKeyDown}
-        onBlur={this.handleBlur}
-        ref={elem => {
-          this.inputElement = elem
-        }}
-      />
-    )
-  }
-}
-
-EditableAlbumName.propTypes = {
-  albumName: PropTypes.string,
-  onEdit: PropTypes.func.isRequired
-}
+import EditableAlbumName from 'photos/components/EditableAlbumName'
 
 const TopbarTitle = ({ children }) => (
   <h2 data-testid="pho-content-title" className={styles['pho-content-title']}>


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Fixed the ability to rename a photo album on desktop
```

The problem stems from a conflict with the MUI Menu. The menu goes into focus when it is opened for accessibility reasons. This causes the input to lose focus and disappear just afterwards because it blurs. I've disabled autoFocus for this specific case until I find a fix in cozy-ui. I find my dirty fix in MUI  issue: https://github.com/mui/material-ui/issues/4387.

During my tests, I converted EditableAlbumName into a functional component. It's not required for the fix but as the work had been done I incorporated it. 

I'll try to find a better solution tomorrow but I'll take it if you have any other ideas