### PR TITLE
fix: Breadcrumb endless loop for not found folder

### DIFF
--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -1,6 +1,6 @@
 /* global __TARGET__ */
 
-import React, { useCallback, useContext, useEffect } from 'react'
+import React, { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
 import { useNavigate, Outlet, useLocation, useParams } from 'react-router-dom'
 
@@ -163,10 +163,13 @@ const DriveView = () => {
   )
 
   const { t } = useI18n()
-  const rootBreadcrumbPath = {
-    id: ROOT_DIR_ID,
-    name: t('breadcrumb.title_drive')
-  }
+  const rootBreadcrumbPath = useMemo(
+    () => ({
+      id: ROOT_DIR_ID,
+      name: t('breadcrumb.title_drive')
+    }),
+    [t]
+  )
   useEffect(() => {
     if (canWriteToCurrentFolder) {
       setIsFabDisplayed(isMobile)

--- a/src/drive/web/modules/views/Folder/hooks/useBreadcrumbPath.jsx
+++ b/src/drive/web/modules/views/Folder/hooks/useBreadcrumbPath.jsx
@@ -46,6 +46,9 @@ export const useBreadcrumbPath = ({
           setPaths(returnedPaths)
         }
       } else {
+        if (isSubscribed && rootBreadcrumbPath) {
+          setPaths([rootBreadcrumbPath])
+        }
         log(
           'error',
           `Error while fetching folder for breadcrumbs of folder id: ${currentFolderId}, here is the error: ${error}`

--- a/src/drive/web/modules/views/Folder/hooks/useBreadcrumbPath.spec.jsx
+++ b/src/drive/web/modules/views/Folder/hooks/useBreadcrumbPath.spec.jsx
@@ -80,13 +80,15 @@ describe('useBreadcrumbPath', () => {
     fetchFolder.mockRejectedValue('error')
 
     // When
+    let render
     await act(async () => {
-      await renderHook(() =>
+      render = await renderHook(() =>
         useBreadcrumbPath({ rootBreadcrumbPath, currentFolderId })
       )
     })
 
     // Then
+    expect(render.result.current).toEqual([rootBreadcrumbPath])
     expect(log).toHaveBeenCalledWith(
       'error',
       'Error while fetching folder for breadcrumbs of folder id: 1234, here is the error: error'

--- a/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
+++ b/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
 import { useNavigate, Outlet, useLocation } from 'react-router-dom'
 import { useDispatch } from 'react-redux'
 
@@ -113,9 +113,13 @@ const SharingsFolderView = ({ sharedDocumentIds }) => {
   )
 
   const { t } = useI18n()
-  const rootBreadcrumbPath = {
-    name: t('breadcrumb.title_sharings')
-  }
+
+  const rootBreadcrumbPath = useMemo(
+    () => ({
+      name: t('breadcrumb.title_sharings')
+    }),
+    [t]
+  )
 
   return (
     <FolderView>

--- a/src/drive/web/modules/views/Trash/TrashFolderView.jsx
+++ b/src/drive/web/modules/views/Trash/TrashFolderView.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
 import { useNavigate, Outlet } from 'react-router-dom'
 
 import { useQuery, useClient } from 'cozy-client'
@@ -97,10 +97,13 @@ export const TrashFolderView = ({ currentFolderId }) => {
   const actions = useActions([restore, destroy], actionsOptions)
 
   const { t } = useI18n()
-  const rootBreadcrumbPath = {
-    id: TRASH_DIR_ID,
-    name: t('breadcrumb.title_trash')
-  }
+  const rootBreadcrumbPath = useMemo(
+    () => ({
+      id: TRASH_DIR_ID,
+      name: t('breadcrumb.title_trash')
+    }),
+    [t]
+  )
 
   return (
     <FolderView>


### PR DESCRIPTION
In case of an error (eg. Not found), the breadcrumb displayed the root path (eg. Trash)

```
### 🐛 Bug Fixes

*  Remove the endless loop when accessing a folder not found
```
