### PR TITLE
feat: Update cozy-ui from 88.5.0 to 88.6.0

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -117,7 +117,7 @@
     },
     {
       "path": "drive/intents/**",
-      "maxPercentIncrease": 2
+      "maxPercentIncrease": 6
     },
     {
       "path": "drive/onlyOffice/**",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "cozy-scripts": "^8.1.0",
     "cozy-sharing": "8.0.0",
     "cozy-stack-client": "^34.1.5",
-    "cozy-ui": "^88.5.0",
+    "cozy-ui": "^88.6.0",
     "date-fns": "1.30.1",
     "diacritics": "1.3.0",
     "fastclick": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6170,10 +6170,10 @@ cozy-stack-client@^38.9.2:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^88.5.0:
-  version "88.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-88.5.0.tgz#db29399df5a6fc8f105f54203968ddd2c6445ac2"
-  integrity sha512-FGFl5zCDHOqnbQwhnrokToAYmeObKrq8M+uTE99cPPpx3QMWI3+PF746jRt4RtAUcbpK7RQRFb+HIyUoB4uk0A==
+cozy-ui@^88.6.0:
+  version "88.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-88.6.0.tgz#bbbd11a38a63f138bde1b406ad474493d62a1add"
+  integrity sha512-1tw6XJxXsF3jKPtMT9q4qloOyFOGAdJ0BbqHqzOCFqdK8wQNAAiw2ULbpNeP20eh5I527mcxhpiEeOllRC4/Fg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
This update gets back the new design of the QuotaAlert modal

```
### 🔧 Tech

* Update cozy-ui from 88.5.0 to 88.6.0
```
