### PR TITLE
fix(File): Add the ability to disable file selection

### DIFF
--- a/src/drive/web/modules/filelist/File.jsx
+++ b/src/drive/web/modules/filelist/File.jsx
@@ -29,7 +29,26 @@ import { extraColumnsPropTypes } from 'drive/web/modules/certifications'
 import styles from 'drive/styles/filelist.styl'
 import { useSelectionContext } from 'drive/web/modules/selection/SelectionProvider'
 
-const File = props => {
+const File = ({
+  t,
+  f,
+  attributes,
+  actions,
+  isRenaming,
+  withSelectionCheckbox,
+  withFilePath,
+  isAvailableOffline,
+  disabled,
+  styleDisabled,
+  thumbnailSizeBig,
+  refreshFolderContent,
+  isInSyncFromSharing,
+  extraColumns,
+  breakpoints: { isExtraLarge, isMobile },
+  onFolderOpen,
+  onFileOpen,
+  disableSelection = false
+}) => {
   const [actionMenuVisible, setActionMenuVisible] = useState(false)
   const filerowMenuToggleRef = useRef()
   const { toggleSelectedItem, isItemSelected, isSelectionBarVisible } =
@@ -55,11 +74,10 @@ const File = props => {
 
   const toggle = e => {
     e.stopPropagation()
-    toggleSelectedItem(props.attributes)
+    toggleSelectedItem(attributes)
   }
 
   const open = (event, attributes) => {
-    const { onFolderOpen, onFileOpen, isAvailableOffline } = props
     event.stopPropagation()
     if (isDirectory(attributes)) {
       onFolderOpen(attributes.id)
@@ -71,24 +89,6 @@ const File = props => {
       })
     }
   }
-
-  const {
-    t,
-    f,
-    attributes,
-    actions,
-    isRenaming,
-    withSelectionCheckbox,
-    withFilePath,
-    isAvailableOffline,
-    disabled,
-    styleDisabled,
-    thumbnailSizeBig,
-    refreshFolderContent,
-    isInSyncFromSharing,
-    extraColumns,
-    breakpoints: { isExtraLarge, isMobile }
-  } = props
 
   const isImage = attributes.class === 'image'
   const isLargeRow = isImage && thumbnailSizeBig
@@ -120,7 +120,7 @@ const File = props => {
         withSelectionCheckbox={withSelectionCheckbox}
         selected={selected}
         onClick={e => toggle(e)}
-        disabled={isRowDisabledOrInSyncFromSharing}
+        disabled={isRowDisabledOrInSyncFromSharing || disableSelection}
       />
       <FileOpener
         file={attributes}
@@ -216,7 +216,9 @@ File.propTypes = {
   onFileOpen: PropTypes.func.isRequired,
   refreshFolderContent: PropTypes.func,
   isInSyncFromSharing: PropTypes.bool,
-  extraColumns: extraColumnsPropTypes
+  extraColumns: extraColumnsPropTypes,
+  /** Disables the ability to select a file */
+  disableSelection: PropTypes.bool
 }
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/drive/web/modules/filelist/File.spec.jsx
+++ b/src/drive/web/modules/filelist/File.spec.jsx
@@ -21,7 +21,8 @@ const setup = ({
   onFolderOpen = jest.fn(),
   onFileOpen = jest.fn(),
   onCheckboxToggle = jest.fn(),
-  isInSyncFromSharing = false
+  isInSyncFromSharing = false,
+  disableSelection = false
 } = {}) => {
   const root = render(
     <AppLike client={client}>
@@ -36,6 +37,7 @@ const setup = ({
         onFileOpen={onFileOpen}
         onCheckboxToggle={onCheckboxToggle}
         isInSyncFromSharing={isInSyncFromSharing}
+        disableSelection={disableSelection}
       />
     </AppLike>
   )
@@ -85,8 +87,15 @@ describe('File', () => {
       expect(queryByText('ActionsMenuItem')).toBeNull()
     })
 
-    it('should not show a select box', () => {
+    it('should not show a select box when syncing', () => {
       const { root } = setup({ isInSyncFromSharing: true })
+      const { queryByRole } = root
+
+      expect(queryByRole('checkbox')).toBeNull()
+    })
+
+    it('should not show a select box when selection disabled', () => {
+      const { root } = setup({ disableSelection: true })
       const { queryByRole } = root
 
       expect(queryByRole('checkbox')).toBeNull()

--- a/src/drive/web/modules/move/FileList.jsx
+++ b/src/drive/web/modules/move/FileList.jsx
@@ -43,6 +43,7 @@ const FileList = ({ targets, files, folder, navigateTo }) => {
             withSelectionCheckbox={false}
             withFilePath={false}
             withSharedBadge
+            disableSelection={true}
           />
         ))}
       </>

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -236,6 +236,7 @@ const FolderViewBody = ({
                       actions={[]}
                       isInSyncFromSharing={true}
                       extraColumns={extraColumns}
+                      disableSelection={true}
                     />
                   )}
                   {queryResults.map((query, queryIndex) => (


### PR DESCRIPTION
This commit aims to correct the regression introduced since migration of the selection to a Provider. It was possible to select a file in the dialog to move it even though no checkbox was displayed

```
### 🐛 Bug Fixes

* Disable file selection into move modal 
```
