### PR TITLE
feat: Update cozy-sharing from 8.2.0 to 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "cozy-realtime": "4.4.1",
     "cozy-scanner": "^5.1.1",
     "cozy-scripts": "^8.1.0",
-    "cozy-sharing": "8.2.0",
+    "cozy-sharing": "8.3.0",
     "cozy-stack-client": "^40.0.1",
     "cozy-ui": "^90.0.0",
     "date-fns": "1.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6113,10 +6113,10 @@ cozy-scripts@^8.1.0:
     webpack-dev-server "3.10.3"
     webpack-merge "4.2.2"
 
-cozy-sharing@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-8.2.0.tgz#45941a79192941a3302137264a2c9e7d3c384b84"
-  integrity sha512-rluiUtgunDJ2NCHc/OqJ7Adk3bqlSsr8zRc8PP3/EuAHjCYOluP632MfNkWnD7dQCk0UUi9q7518gFoHE+Z3Hw==
+cozy-sharing@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-8.3.0.tgz#0d8b84702f302c4ee6cc49a68d58874acd1cf5ca"
+  integrity sha512-WjSaDj49yjIbpOz7vKp8PRpkvvMDJwHUjYQCECwrtMtQw8j1XFnqZbXgvcsYOQ7HGKTy+lJJRB807DQwicDb1A==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.2.6"


### PR DESCRIPTION
This update allows to limit the number of recipients per document (default: 100)

```
### 🔧 Tech

* Update cozy-sharing from 8.2.0 to 8.3.0
```
