### PR TITLE
feat: Update cozy-scanner from 5.1.1 to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "cozy-logger": "1.9.1",
     "cozy-pouch-link": "^40.0.1",
     "cozy-realtime": "4.4.1",
-    "cozy-scanner": "^5.1.1",
+    "cozy-scanner": "^5.2.0",
     "cozy-scripts": "^8.1.0",
     "cozy-sharing": "8.3.0",
     "cozy-stack-client": "^40.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6046,10 +6046,10 @@ cozy-release@1.10.0:
   dependencies:
     exec-sh "0.3.2"
 
-cozy-scanner@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-scanner/-/cozy-scanner-5.1.1.tgz#3af3f14371383bf104e727ef2a29dee8807964be"
-  integrity sha512-80dANgWHmZ0whuayn4p8qWPkuPXsJkwfQcpVggfuQ1AQHLn4ojYNG8phiLYIkLiUJxCznTnXb94pdyFpJOU9Sw==
+cozy-scanner@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-scanner/-/cozy-scanner-5.2.0.tgz#9ef750333741585e97aeedd948139eb7e7aebc3e"
+  integrity sha512-3MnxUNcTZZfCNogDraCtQEG00mCkv41AUVPVRsmbo68evi8avwlXTuyZMjq6S5FDsKaB4kqCyPHvULHB/8YShw==
   dependencies:
     cozy-device-helper "^2.7.0"
 


### PR DESCRIPTION
To benefit from the renamed Notes qualifications

```
### 🔧 Tech

* Update cozy-scanner from 5.1.1 to 5.2.0
```
