### PR TITLE
fix: Improve wording of moving shared element inside another one

### DIFF
--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -585,7 +585,8 @@
     },
     "sharedFolderInsideAnother": {
       "title": "Cannot be moved",
-      "content": "You want to move a shared item to a shared folder. This type of move is not authorised. If you still wish to move %{source} to %{destination}, please stop sharing %{source}.",
+      "content_1": "You want to move a shared element into a shared folder. This type of move is not allowed.",
+      "content_2": "If you still wish to move %{source} to %{destination}, please stop sharing it. |||| If you still wish to move %{source} to %{destination}, please stop sharing :",
       "cancel": "Cancel move",
       "confirm": "Stop sharing"
     }

--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -63,7 +63,8 @@ const MoveModal = ({ onClose, entries, classes }) => {
     hasSharedParent,
     isOwner,
     revokeSelf,
-    revokeAllRecipients
+    revokeAllRecipients,
+    byDocId
   } = useSharingContext()
 
   const [folderId, setFolderId] = useState(
@@ -109,7 +110,7 @@ const MoveModal = ({ onClose, entries, classes }) => {
       }
     } else {
       const hasOneOrMoreEntriesShared =
-        entries.filter(({ path }) => sharedPaths.includes(path)).length > 0
+        entries.filter(({ _id }) => byDocId[_id] !== undefined).length > 0
       if (hasOneOrMoreEntriesShared && hasSharedParent(targetPath)) {
         setMovingSharedFolderInsideAnother(true)
       } else {
@@ -182,8 +183,8 @@ const MoveModal = ({ onClose, entries, classes }) => {
   const handleMovingSharedFolderInsideAnother = async () => {
     setMoveInProgress(true)
     entries.forEach(async entry => {
-      if (sharedPaths.includes(entry.path)) {
-        if (isOwner(entry.id)) {
+      if (byDocId[entry._id] !== undefined) {
+        if (isOwner(entry._id)) {
           await revokeAllRecipients(entry)
         } else {
           await revokeSelf(entry)

--- a/src/drive/web/modules/move/MoveModal.spec.jsx
+++ b/src/drive/web/modules/move/MoveModal.spec.jsx
@@ -57,6 +57,7 @@ describe('MoveModal component', () => {
     entries = defaultEntries,
     displayedFolderId = 'destinationFolder',
     sharedPaths = ['/sharedFolder'],
+    byDocId = {},
     getSharedParentPath = () => null,
     sharingContext = {}
   } = {}) => {
@@ -74,6 +75,7 @@ describe('MoveModal component', () => {
       getSharedParentPath,
       hasSharedParent: path =>
         sharedPaths.filter(sharedPath => path.includes(sharedPath)).length > 0,
+      byDocId,
       ...sharingContext
     })
 
@@ -222,6 +224,9 @@ describe('MoveModal component', () => {
 
       setup({
         sharedPaths: ['/bills/bill_201903.pdf', '/destinationFolder'],
+        byDocId: {
+          bill_201903: {}
+        },
         getSharedParentPath: () => null
       })
 
@@ -242,6 +247,9 @@ describe('MoveModal component', () => {
 
       setup({
         sharedPaths: ['/bills/bill_201903.pdf', '/destinationFolder'],
+        byDocId: {
+          bill_201903: {}
+        },
         getSharedParentPath: () => null,
         sharingContext: {
           isOwner: () => true,
@@ -276,6 +284,9 @@ describe('MoveModal component', () => {
 
       setup({
         sharedPaths: ['/bills/bill_201903.pdf', '/destinationFolder'],
+        byDocId: {
+          bill_201903: {}
+        },
         getSharedParentPath: () => null,
         sharingContext: {
           isOwner: () => false,

--- a/src/drive/web/modules/move/MoveSharedFolderInsideAnotherModal.jsx
+++ b/src/drive/web/modules/move/MoveSharedFolderInsideAnotherModal.jsx
@@ -5,6 +5,8 @@ import { useQuery } from 'cozy-client'
 import { ConfirmDialog } from 'cozy-ui/react/CozyDialogs'
 import Buttons from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'cozy-ui/transpiled/react'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useSharingContext } from 'cozy-sharing'
 
 import { buildOnlyFolderQuery } from 'drive/web/modules/queries'
 import { getEntriesName } from 'drive/web/modules/move/helpers'
@@ -20,7 +22,7 @@ const MoveSharedFolderInsideAnotherModal = ({
   onConfirm
 }) => {
   const { t } = useI18n()
-
+  const { byDocId } = useSharingContext()
   const folderQuery = buildOnlyFolderQuery(folderId)
   const { fetchStatus, data } = useQuery(
     folderQuery.definition,
@@ -28,14 +30,35 @@ const MoveSharedFolderInsideAnotherModal = ({
   )
 
   if (fetchStatus === 'loaded') {
+    const sharedEntries = entries.filter(
+      ({ _id }) => byDocId[_id] !== undefined
+    )
+
     return (
       <ConfirmDialog
         open
         title={t('Move.sharedFolderInsideAnother.title')}
-        content={t('Move.sharedFolderInsideAnother.content', {
-          source: getEntriesName(entries, t),
-          destination: data.name
-        })}
+        content={
+          <>
+            <Typography variant="body1" className="u-mb-half">
+              {t('Move.sharedFolderInsideAnother.content_1')}
+            </Typography>
+            <Typography variant="body1" className="u-mb-half">
+              {t('Move.sharedFolderInsideAnother.content_2', {
+                source: getEntriesName(entries, t),
+                destination: data.name,
+                smart_count: entries.length
+              })}
+            </Typography>
+            {entries.length > 1 ? (
+              <ul>
+                {sharedEntries.map(({ _id, name }) => (
+                  <li key={_id}>{name} </li>
+                ))}
+              </ul>
+            ) : null}
+          </>
+        }
         actions={
           <>
             <Buttons


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Check if file are shared also when moving a shared element inside another one
* Display the list of shared entries when moving a shared element within another one
```
