### PR TITLE
fix: Always show shared entries in MoveSharedFolderInsideAnotherModal

### DIFF
--- a/src/drive/locales/en.json
+++ b/src/drive/locales/en.json
@@ -587,7 +587,7 @@
     "sharedFolderInsideAnother": {
       "title": "Cannot be moved",
       "content_1": "You want to move a shared element into a shared folder. This type of move is not allowed.",
-      "content_2": "If you still wish to move %{source} to %{destination}, please stop sharing it. |||| If you still wish to move %{source} to %{destination}, please stop sharing :",
+      "content_2": "If you still wish to move %{source} to %{destination}, please stop sharing :",
       "cancel": "Cancel move",
       "confirm": "Stop sharing"
     }

--- a/src/drive/web/modules/move/MoveSharedFolderInsideAnotherModal.jsx
+++ b/src/drive/web/modules/move/MoveSharedFolderInsideAnotherModal.jsx
@@ -46,17 +46,14 @@ const MoveSharedFolderInsideAnotherModal = ({
             <Typography variant="body1" className="u-mb-half">
               {t('Move.sharedFolderInsideAnother.content_2', {
                 source: getEntriesName(entries, t),
-                destination: data.name,
-                smart_count: entries.length
+                destination: data.name
               })}
             </Typography>
-            {entries.length > 1 ? (
-              <ul>
-                {sharedEntries.map(({ _id, name }) => (
-                  <li key={_id}>{name} </li>
-                ))}
-              </ul>
-            ) : null}
+            <ul>
+              {sharedEntries.map(({ _id, name }) => (
+                <li key={_id}>{name} </li>
+              ))}
+            </ul>
           </>
         }
         actions={


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Always show shared entries in MoveSharedFolderInsideAnotherModal
```
