### PR TITLE
fix(SharingsNavItem): Only count new sharing shortcut not trashed

### DIFF
--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -361,9 +361,10 @@ export const buildNewSharingShortcutQuery = () => ({
     Q('io.cozy.files')
       .where({
         'metadata.sharing.status': 'new',
-        class: 'shortcut'
+        class: 'shortcut',
+        trashed: false
       })
-      .indexFields(['metadata.sharing.status', 'class']),
+      .indexFields(['metadata.sharing.status', 'class', 'trashed']),
   options: {
     as: 'io.cozy.files/metadata.sharing.status/new/class/shortcut',
     fetchPolicy: defaultFetchPolicy


### PR DESCRIPTION
This ensures consistency between the number of shortcuts displayed in recent and their number in the sidebar

```
### 🐛 Bug Fixes

* Only count new sharing shortcut not trashed into sidebar
```
