### PR TITLE
fix(MoveModal): Wait for shares to load before authorising moves

### DIFF
--- a/src/drive/web/modules/move/Footer.jsx
+++ b/src/drive/web/modules/move/Footer.jsx
@@ -16,7 +16,8 @@ const Footer = ({
   currentDirId,
   isMoving,
   primaryTextAction,
-  secondaryTextAction
+  secondaryTextAction,
+  isLoading
 }) => {
   const { t } = useI18n()
   const primaryText = primaryTextAction ? primaryTextAction : t('Move.action')
@@ -30,8 +31,10 @@ const Footer = ({
       <Buttons
         label={primaryText}
         onClick={onConfirm}
-        disabled={areTargetsInCurrentDir(targets, currentDirId) || isMoving}
-        busy={isMoving}
+        disabled={
+          areTargetsInCurrentDir(targets, currentDirId) || isMoving || isLoading
+        }
+        busy={isMoving || isLoading}
       />
     </>
   )
@@ -44,11 +47,13 @@ Footer.propTypes = {
   currentDirId: PropTypes.string.isRequired,
   isMoving: PropTypes.bool,
   primaryTextAction: PropTypes.string,
-  secondaryTextAction: PropTypes.string
+  secondaryTextAction: PropTypes.string,
+  isLoading: PropTypes.bool
 }
 
 Footer.defaultProps = {
-  isMoving: false
+  isMoving: false,
+  isLoading: false
 }
 
 export default Footer

--- a/src/drive/web/modules/move/MoveModal.jsx
+++ b/src/drive/web/modules/move/MoveModal.jsx
@@ -64,7 +64,8 @@ const MoveModal = ({ onClose, entries, classes }) => {
     isOwner,
     revokeSelf,
     revokeAllRecipients,
-    byDocId
+    byDocId,
+    allLoaded
   } = useSharingContext()
 
   const [folderId, setFolderId] = useState(
@@ -257,6 +258,7 @@ const MoveModal = ({ onClose, entries, classes }) => {
             targets={entries}
             currentDirId={folderId}
             isMoving={isMoveInProgress}
+            isLoading={!allLoaded}
           />
         }
       />

--- a/src/drive/web/modules/move/MoveModal.spec.jsx
+++ b/src/drive/web/modules/move/MoveModal.spec.jsx
@@ -59,6 +59,7 @@ describe('MoveModal component', () => {
     sharedPaths = ['/sharedFolder'],
     byDocId = {},
     getSharedParentPath = () => null,
+    allLoaded = true,
     sharingContext = {}
   } = {}) => {
     const props = {
@@ -76,6 +77,7 @@ describe('MoveModal component', () => {
       hasSharedParent: path =>
         sharedPaths.filter(sharedPath => path.includes(sharedPath)).length > 0,
       byDocId,
+      allLoaded,
       ...sharingContext
     })
 
@@ -117,7 +119,17 @@ describe('MoveModal component', () => {
     )
   }
 
-  describe('moveEntries', () => {
+  describe('MoveModal', () => {
+    it('should wait for shares to load before authorising moves', async () => {
+      setup({ allLoaded: false })
+
+      const moveButton = await screen.findByRole('button', {
+        name: 'Move',
+        busy: true
+      })
+      expect(moveButton).toBeDisabled()
+    })
+
     it('should move entries to destination', async () => {
       CozyFile.getFullpath.mockImplementation((destinationFolder, name) =>
         Promise.resolve(


### PR DESCRIPTION
When users had a lot of shares, they could move one shared folder to another without being blocked because the shares were not fully loaded. Now, we wait before allowing the user to perform the move action

```
### 🐛 Bug Fixes

* Wait for shares to load before authorising moves
```
