### PR TITLE
fix: Return button with OnlyOffice

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -46,7 +46,7 @@ const Toolbar = () => {
   )
 
   const handleOnClick = useCallback(
-    () => (hasOnyMoreHistoryEntry ? navigate('../../') : navigate('../')),
+    () => (hasOnyMoreHistoryEntry ? navigate(-2) : navigate(-1)),
     [hasOnyMoreHistoryEntry, navigate]
   )
 


### PR DESCRIPTION
This decline is due to the migration to react-router v6. We went backwards in the routes and no longer in the url history.

```
### 🐛 Bug Fixes

* Back into the previous folder in OnlyOffice editor
```
