### PR TITLE
fix: Hide path in OnlyOffice editor in public

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -37,6 +37,12 @@ jest.mock('cozy-ui/transpiled/react/hooks/useBreakpoints', () => ({
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 
 jest.mock('cozy-flags')
+jest.mock(
+  'drive/web/modules/views/OnlyOffice/Toolbar/HomeLinker',
+  () =>
+    ({ children }) =>
+      <div>{children}</div>
+)
 
 const client = createMockClient({})
 client.plugins = {
@@ -49,7 +55,8 @@ client.plugins = {
 const setup = ({
   isMobile = false,
   isEditorModeView = true,
-  isReadOnly = false
+  isReadOnly = false,
+  isPublic = false
 } = {}) => {
   useBreakpoints.mockReturnValue({ isMobile })
   const root = render(
@@ -66,7 +73,7 @@ const setup = ({
       <OnlyOfficeContext.Provider
         value={{
           fileId: '123',
-          isPublic: 'false',
+          isPublic,
           isReadOnly,
           isEditorReady: true,
           isEditorModeView

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/FileName.jsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-const FileName = ({ fileWithPath }) => {
+const FileName = ({ fileWithPath, isPublic }) => {
   const muiStyles = useStyles()
   const { isMobile } = useBreakpoints()
   const { isReadOnly } = useContext(OnlyOfficeContext)
@@ -66,7 +66,7 @@ const FileName = ({ fileWithPath }) => {
           {fileWithPath.name}
         </Typography>
       )}
-      {fileWithPath.displayedPath && !isMobile && (
+      {fileWithPath.displayedPath && !isMobile && !isPublic && (
         <Link
           data-testid="onlyoffice-filename-path"
           to={`/folder/${fileWithPath.dir_id}`}
@@ -82,7 +82,8 @@ const FileName = ({ fileWithPath }) => {
 }
 
 FileName.propTypes = {
-  fileWithPath: PropTypes.object.isRequired
+  fileWithPath: PropTypes.object.isRequired,
+  isPublic: PropTypes.bool
 }
 
 export default React.memo(FileName)

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -70,7 +70,7 @@ const Toolbar = () => {
         {!isMobile && fileWithPath.class && (
           <FileIcon fileClass={fileWithPath.class} />
         )}
-        <FileName fileWithPath={fileWithPath} />
+        <FileName fileWithPath={fileWithPath} isPublic={isPublic} />
       </div>
       {isReadOnly && <ReadOnly />}
       {!isPublic && isEditorReady && <Sharing fileWithPath={fileWithPath} />}


### PR DESCRIPTION

```
### 🐛 Bug Fixes

* Hide path in OnlyOffice editor in public
```
