### PR TITLE
fix: Share the displayed folder even from path ending with /

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/share/ShareButton.jsx
+++ b/src/drive/web/modules/drive/Toolbar/share/ShareButton.jsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { ShareButton } from 'cozy-sharing'
 
 import { useDisplayedFolder } from 'drive/hooks'
+import { getPathToShareDisplayedFolder } from 'drive/web/modules/drive/Toolbar/share/helpers'
 import styles from './styles.styl'
 
 const ShareButtonWithProps = ({ isDisabled }) => {
@@ -13,7 +14,7 @@ const ShareButtonWithProps = ({ isDisabled }) => {
   const { pathname } = useLocation()
 
   const share = () => {
-    navigate(`${pathname}/share`)
+    navigate(getPathToShareDisplayedFolder(pathname))
   }
 
   return (

--- a/src/drive/web/modules/drive/Toolbar/share/ShareItem.jsx
+++ b/src/drive/web/modules/drive/Toolbar/share/ShareItem.jsx
@@ -7,13 +7,14 @@ import { ActionMenuItem } from 'cozy-ui/transpiled/react/deprecated/ActionMenu'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 
+import { getPathToShareDisplayedFolder } from 'drive/web/modules/drive/Toolbar/share/helpers'
 import styles from 'drive/styles/toolbar.styl'
 
 const ShareItem = ({ displayedFolder, navigate, pathname }) => {
   const { t } = useI18n()
 
   const share = () => {
-    navigate(`${pathname}/share`)
+    navigate(getPathToShareDisplayedFolder(pathname))
   }
 
   return (

--- a/src/drive/web/modules/drive/Toolbar/share/SharedRecipients.jsx
+++ b/src/drive/web/modules/drive/Toolbar/share/SharedRecipients.jsx
@@ -3,6 +3,7 @@ import { SharedRecipients } from 'cozy-sharing'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useDisplayedFolder } from 'drive/hooks'
+import { getPathToShareDisplayedFolder } from 'drive/web/modules/drive/Toolbar/share/helpers'
 
 const SharedRecipientsComponent = () => {
   const displayedFolder = useDisplayedFolder()
@@ -10,7 +11,7 @@ const SharedRecipientsComponent = () => {
   const { pathname } = useLocation()
 
   const share = () => {
-    navigate(`${pathname}/share`)
+    navigate(getPathToShareDisplayedFolder(pathname))
   }
 
   return (

--- a/src/drive/web/modules/drive/Toolbar/share/helpers.js
+++ b/src/drive/web/modules/drive/Toolbar/share/helpers.js
@@ -1,0 +1,8 @@
+/**
+ * Get the path to share the displayed folder
+ * @param {string} pathname Current path
+ * @returns Next path
+ */
+export function getPathToShareDisplayedFolder(pathname) {
+  return `${pathname}${pathname.endsWith('/') ? '' : '/'}share`
+}

--- a/src/drive/web/modules/drive/Toolbar/share/helpers.spec.js
+++ b/src/drive/web/modules/drive/Toolbar/share/helpers.spec.js
@@ -1,0 +1,15 @@
+import { getPathToShareDisplayedFolder } from 'drive/web/modules/drive/Toolbar/share/helpers'
+
+describe('getPathToShareDisplayedFolder', () => {
+  it('should return path to displayed folder share modal', () => {
+    expect(getPathToShareDisplayedFolder('/path/to/folder/123')).toBe(
+      '/path/to/folder/123/share'
+    )
+  })
+
+  it('should return correct path if pathname ends with /', () => {
+    expect(getPathToShareDisplayedFolder('/path/to/folder/123/')).toBe(
+      '/path/to/folder/123/share'
+    )
+  })
+})


### PR DESCRIPTION

```
### 🐛 Bug Fixes

* Share the displayed folder even from path ending with /
```
