### PR TITLE
fix: Make working back button for a file at another Cozy

### DIFF
--- a/src/drive/targets/public/components/AppRouter.jsx
+++ b/src/drive/targets/public/components/AppRouter.jsx
@@ -47,16 +47,6 @@ const AppRouter = ({
               />
             </Route>
             <Route
-              path="onlyoffice/:fileId/fromCreate"
-              element={
-                <OnlyOfficeView
-                  isPublic={true}
-                  isReadOnly={isReadOnly}
-                  isInSharedFolder={!isFile}
-                />
-              }
-            />
-            <Route
               path="onlyoffice/create/:folderId/:fileClass"
               element={<OnlyOfficeCreateView />}
             />

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -100,7 +100,9 @@ const FileOpener = ({
         className={`${styles['file-opener']} ${styles['file-opener__a']}`}
         ref={rowRef}
         id={file.id}
-        href={makeOnlyOfficeFileRoute(file)}
+        href={makeOnlyOfficeFileRoute(file.id, {
+          withoutRouter: true
+        })}
         onClick={ev => {
           ev.preventDefault()
         }}

--- a/src/drive/web/modules/filelist/FileOpener.jsx
+++ b/src/drive/web/modules/filelist/FileOpener.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import Hammer from '@egjs/hammerjs'
 import propagating from 'propagating-hammerjs'
+import { useLocation } from 'react-router-dom'
 
 import { models } from 'cozy-client'
 
@@ -59,6 +60,7 @@ const FileOpener = ({
   children
 }) => {
   const rowRef = useRef()
+  const { pathname } = useLocation()
 
   useEffect(() => {
     if (!rowRef || !rowRef.current) return
@@ -101,7 +103,8 @@ const FileOpener = ({
         ref={rowRef}
         id={file.id}
         href={makeOnlyOfficeFileRoute(file.id, {
-          withoutRouter: true
+          withoutRouter: true,
+          fromPathname: pathname
         })}
         onClick={ev => {
           ev.preventDefault()

--- a/src/drive/web/modules/navigation/AppRoute.jsx
+++ b/src/drive/web/modules/navigation/AppRoute.jsx
@@ -105,10 +105,6 @@ const AppRoute = () => (
         <Route path="paywall" element={<OnlyOfficePaywallView />} />
       </Route>
       <Route
-        path="onlyoffice/:fileId/fromCreate"
-        element={<OnlyOfficeView />}
-      />
-      <Route
         path="onlyoffice/create/:folderId/:fileClass"
         element={<OnlyOfficeCreateView />}
       />

--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { SharingBannerPlugin, useSharingInfos } from 'cozy-sharing'
@@ -20,12 +20,17 @@ import styles from 'drive/web/modules/viewer/barviewer.styl'
 const LightFileViewer = ({ files }) => {
   const sharingInfos = useSharingInfos()
   const { isDesktop, isMobile } = useBreakpoints()
-
+  const { pathname } = useLocation()
   const navigate = useNavigate()
 
   const onlyOfficeOpener = useCallback(
-    file => navigate(makeOnlyOfficeFileRoute(file.id)),
-    [navigate]
+    file => {
+      const route = makeOnlyOfficeFileRoute(file.id, {
+        fromPathname: pathname
+      })
+      navigate(route)
+    },
+    [navigate, pathname]
   )
 
   return (

--- a/src/drive/web/modules/public/LightFileViewer.jsx
+++ b/src/drive/web/modules/public/LightFileViewer.jsx
@@ -24,7 +24,7 @@ const LightFileViewer = ({ files }) => {
   const navigate = useNavigate()
 
   const onlyOfficeOpener = useCallback(
-    file => navigate(makeOnlyOfficeFileRoute(file, true)),
+    file => navigate(makeOnlyOfficeFileRoute(file.id)),
     [navigate]
   )
 

--- a/src/drive/web/modules/search/components/helpers.js
+++ b/src/drive/web/modules/search/components/helpers.js
@@ -47,7 +47,7 @@ export const makeNormalizedFile = (client, folders, file) => {
       url = `/n/${file.id}`
       openOn = 'notes'
     } else if (models.file.shouldBeOpenedByOnlyOffice(file)) {
-      url = makeOnlyOfficeFileRoute(file.id)
+      url = makeOnlyOfficeFileRoute(file.id, { fromPathname: urlToFolder })
     } else {
       url = `${urlToFolder}/file/${file._id}`
     }

--- a/src/drive/web/modules/search/components/helpers.js
+++ b/src/drive/web/modules/search/components/helpers.js
@@ -47,7 +47,7 @@ export const makeNormalizedFile = (client, folders, file) => {
       url = `/n/${file.id}`
       openOn = 'notes'
     } else if (models.file.shouldBeOpenedByOnlyOffice(file)) {
-      url = makeOnlyOfficeFileRoute(file, true)
+      url = makeOnlyOfficeFileRoute(file.id)
     } else {
       url = `${urlToFolder}/file/${file._id}`
     }

--- a/src/drive/web/modules/viewer/FileOpenerExternal.jsx
+++ b/src/drive/web/modules/viewer/FileOpenerExternal.jsx
@@ -86,8 +86,7 @@ export class FileOpener extends Component {
                 componentsProps={{
                   OnlyOfficeViewer: {
                     isEnabled: isOfficeEnabled(isDesktop),
-                    opener: file =>
-                      navigate(makeOnlyOfficeFileRoute(file, true))
+                    opener: file => navigate(makeOnlyOfficeFileRoute(file.id))
                   }
                 }}
               >

--- a/src/drive/web/modules/viewer/FilesViewer.jsx
+++ b/src/drive/web/modules/viewer/FilesViewer.jsx
@@ -205,7 +205,7 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange }) => {
           componentsProps={{
             OnlyOfficeViewer: {
               isEnabled: isOfficeEnabled(isDesktop),
-              opener: file => navigate(makeOnlyOfficeFileRoute(file, true))
+              opener: file => navigate(makeOnlyOfficeFileRoute(file.id))
             },
             toolbarProps: {
               showFilePath: true

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useContext, useState, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import get from 'lodash/get'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useClient, useCapabilities } from 'cozy-client'
 import { useVaultClient, VaultUnlocker } from 'cozy-keys-lib'
@@ -50,6 +50,7 @@ const FolderViewBody = ({
   const { isDesktop } = useBreakpoints()
   const navigate = useNavigate()
   const client = useClient()
+  const { pathname } = useLocation()
   /**
    *  Since we are not able to restore the scroll correctly,
    * and force the scroll to top every time we change the
@@ -102,7 +103,8 @@ const FolderViewBody = ({
         openInNewTab: url => window.open(url, '_blank'),
         routeTo: url => navigate(url),
         isOfficeEnabled: isOfficeEnabled(isDesktop),
-        webviewIntent
+        webviewIntent,
+        pathname
       })({
         event,
         file,
@@ -116,7 +118,8 @@ const FolderViewBody = ({
       isFlatDomain,
       navigate,
       webviewIntent,
-      isDesktop
+      isDesktop,
+      pathname
     ]
   )
 

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -17,7 +17,8 @@ const createFileOpeningHandler =
     openInNewTab,
     routeTo,
     isOfficeEnabled,
-    webviewIntent
+    webviewIntent,
+    pathname
   }) =>
   async ({ event, file, isAvailableOffline }) => {
     if (isAvailableOffline) {
@@ -61,11 +62,16 @@ const createFileOpeningHandler =
       if (event.ctrlKey || event.metaKey || event.shiftKey) {
         openInNewTab(
           makeOnlyOfficeFileRoute(file.id, {
-            withoutRouter: true
+            withoutRouter: true,
+            fromPathname: pathname
           })
         )
       } else {
-        routeTo(makeOnlyOfficeFileRoute(file.id))
+        routeTo(
+          makeOnlyOfficeFileRoute(file.id, {
+            fromPathname: pathname
+          })
+        )
       }
     } else {
       navigateToFile(file)

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -59,9 +59,13 @@ const createFileOpeningHandler =
       }
     } else if (isOnlyOffice && isOfficeEnabled) {
       if (event.ctrlKey || event.metaKey || event.shiftKey) {
-        openInNewTab(makeOnlyOfficeFileRoute(file))
+        openInNewTab(
+          makeOnlyOfficeFileRoute(file.id, {
+            withoutRouter: true
+          })
+        )
       } else {
-        routeTo(makeOnlyOfficeFileRoute(file, true))
+        routeTo(makeOnlyOfficeFileRoute(file.id))
       }
     } else {
       navigateToFile(file)

--- a/src/drive/web/modules/views/OnlyOffice/Create.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Create.jsx
@@ -28,7 +28,8 @@ const Create = () => {
 
   if (status === 'loaded' && fileId) {
     const url = makeOnlyOfficeFileRoute(fileId, {
-      fromCreate: true
+      fromCreate: true,
+      fromPathname: folderPath
     })
     return navigate(url, {
       replace: true

--- a/src/drive/web/modules/views/OnlyOffice/Create.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Create.jsx
@@ -7,15 +7,19 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Oops from 'components/Error/Oops'
 
 import useCreateFile from 'drive/web/modules/views/OnlyOffice/useCreateFile'
-import { canWriteOfficeDocument } from 'drive/web/modules/views/OnlyOffice/helpers'
+import {
+  canWriteOfficeDocument,
+  makeOnlyOfficeFileRoute
+} from 'drive/web/modules/views/OnlyOffice/helpers'
 
 const Create = () => {
   const navigate = useNavigate()
   const { folderId, fileClass } = useParams()
   const { status, fileId } = useCreateFile(folderId, fileClass)
+  const folderPath = `/folder/${folderId}`
 
   if (!canWriteOfficeDocument()) {
-    return <Navigate to={`/folder/${folderId}/paywall`} />
+    return <Navigate to={`${folderPath}/paywall`} />
   }
 
   if (status === 'error') {
@@ -23,7 +27,12 @@ const Create = () => {
   }
 
   if (status === 'loaded' && fileId) {
-    return navigate(`/onlyoffice/${fileId}/fromCreate`)
+    const url = makeOnlyOfficeFileRoute(fileId, {
+      fromCreate: true
+    })
+    return navigate(url, {
+      replace: true
+    })
   }
 
   return (

--- a/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Editor.spec.jsx
@@ -37,12 +37,9 @@ jest.mock('cozy-ui/transpiled/react/providers/Breakpoints', () => ({
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 
 jest.mock('cozy-flags')
-jest.mock(
-  'drive/web/modules/views/OnlyOffice/Toolbar/HomeLinker',
-  () =>
-    ({ children }) =>
-      <div>{children}</div>
-)
+jest.mock('drive/web/modules/views/OnlyOffice/Toolbar', () => () => (
+  <div>Toolbar</div>
+))
 
 const client = createMockClient({})
 client.plugins = {

--- a/src/drive/web/modules/views/OnlyOffice/Toolbar/BackButton.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Toolbar/BackButton.jsx
@@ -3,15 +3,19 @@ import React from 'react'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 const BackButton = ({ onClick }) => {
   // TODO: remove u-ml-half-s when https://github.com/cozy/cozy-ui/issues/1808 is fixed
+  const { t } = useI18n()
+
   return (
     <IconButton
       data-testid="onlyoffice-backButton"
       className="u-ml-half-s"
       onClick={onClick}
       size="medium"
+      aria-label={t('button.back')}
     >
       <Icon icon={PreviousIcon} />
     </IconButton>

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -68,13 +68,21 @@ export const isOfficeEditingEnabled = isDesktop => {
  * @param {string} fileId Id of the OnlyOffice file
  * @param {object} options
  * @param {boolean} options.withoutRouter To return an path without the hash prefix
+ * @param {boolean} options.fromCreate The document will be opened in edit mode
  * @returns {string} Path to OnlyOffice
  */
 export const makeOnlyOfficeFileRoute = (
   fileId,
-  { withoutRouter = false } = {}
+  { withoutRouter = false, fromCreate = false } = {}
 ) => {
-  return withoutRouter ? `/#/onlyoffice/${fileId}` : `/onlyoffice/${fileId}`
+  const params = new URLSearchParams()
+  if (fromCreate) {
+    params.append('fromCreate', true)
+  }
+  const searchParam = params.size > 0 ? `?${params.toString()}` : ''
+  return withoutRouter
+    ? `/#/onlyoffice/${fileId}${searchParam}`
+    : `/onlyoffice/${fileId}${searchParam}`
 }
 
 /**

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -69,15 +69,19 @@ export const isOfficeEditingEnabled = isDesktop => {
  * @param {object} options
  * @param {boolean} options.withoutRouter To return an path without the hash prefix
  * @param {boolean} options.fromCreate The document will be opened in edit mode
+ * @param {boolean} options.fromPathname Hash to redirect the user when he back
  * @returns {string} Path to OnlyOffice
  */
 export const makeOnlyOfficeFileRoute = (
   fileId,
-  { withoutRouter = false, fromCreate = false } = {}
+  { withoutRouter = false, fromCreate = false, fromPathname } = {}
 ) => {
   const params = new URLSearchParams()
   if (fromCreate) {
     params.append('fromCreate', true)
+  }
+  if (fromPathname) {
+    params.append('redirectLink', `drive#${fromPathname}`)
   }
   const searchParam = params.size > 0 ? `?${params.toString()}` : ''
   return withoutRouter

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -63,8 +63,19 @@ export const isOfficeEditingEnabled = isDesktop => {
   return true
 }
 
-export const makeOnlyOfficeFileRoute = (file, isWithRouter) =>
-  isWithRouter ? `/onlyoffice/${file.id}` : `/#/onlyoffice/${file.id}`
+/**
+ * Make hash to redirect user to an OnlyOffice file
+ * @param {string} fileId Id of the OnlyOffice file
+ * @param {object} options
+ * @param {boolean} options.withoutRouter To return an path without the hash prefix
+ * @returns {string} Path to OnlyOffice
+ */
+export const makeOnlyOfficeFileRoute = (
+  fileId,
+  { withoutRouter = false } = {}
+) => {
+  return withoutRouter ? `/#/onlyoffice/${fileId}` : `/onlyoffice/${fileId}`
+}
 
 /**
  * Returns true in case of the document is shared and should be opened on another instance.

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useMemo, useEffect } from 'react'
-import { useLocation, useParams } from 'react-router-dom'
+import { useLocation, useParams, useSearchParams } from 'react-router-dom'
 
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -20,8 +20,7 @@ const OnlyOfficeProvider = ({
   children
 }) => {
   const { isDesktop, isMobile } = useBreakpoints()
-  const { pathname } = useLocation()
-
+  const [searchParam] = useSearchParams()
   const [isEditorReady, setIsEditorReady] = useState(false)
 
   const [editorMode, setEditorMode] = useState(
@@ -29,16 +28,11 @@ const OnlyOfficeProvider = ({
   )
   const isEditorModeView = useMemo(() => editorMode === 'view', [editorMode])
 
-  const isFromCreate = useMemo(
-    () => pathname.endsWith('/fromCreate'),
-    [pathname]
-  )
-
   useEffect(() => {
-    if (isFromCreate) {
+    if (searchParam.get('fromCreate') === 'true') {
       setEditorMode('edit')
     }
-  }, [isFromCreate])
+  }, [searchParam])
 
   return (
     <OnlyOfficeContext.Provider
@@ -53,8 +47,7 @@ const OnlyOfficeProvider = ({
         setIsEditorReady,
         editorMode,
         setEditorMode,
-        isEditorModeView,
-        isFromCreate
+        isEditorModeView
       }}
     >
       {children}

--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useMemo, useEffect } from 'react'
-import { useLocation, useParams, useSearchParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'

--- a/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/useConfig.jsx
@@ -10,6 +10,7 @@ import {
   makeName
 } from 'drive/web/modules/views/OnlyOffice/helpers'
 import { OnlyOfficeContext } from 'drive/web/modules/views/OnlyOffice'
+import { useSearchParams } from 'react-router-dom'
 
 const useConfig = () => {
   const {
@@ -23,6 +24,7 @@ const useConfig = () => {
   } = useContext(OnlyOfficeContext)
   const client = useClient()
   const instanceUri = client.getStackClient().uri
+  const [currentSearchParams] = useSearchParams()
 
   const [config, setConfig] = useState()
   const [status, setStatus] = useState('loading')
@@ -54,6 +56,12 @@ const useConfig = () => {
         const searchParams = [['sharecode', sharecode]]
         searchParams.push(['isOnlyOfficeDocShared', true])
         searchParams.push(['onlyOfficeDocId', document_id])
+        if (currentSearchParams.get('redirectLink')) {
+          searchParams.push([
+            'redirectLink',
+            currentSearchParams.get('redirectLink')
+          ])
+        }
         if (public_name) searchParams.push(['username', public_name])
 
         const link = generateWebLink({
@@ -112,7 +120,8 @@ const useConfig = () => {
     username,
     isFromSharing,
     instanceUri,
-    isDesktop
+    isDesktop,
+    currentSearchParams
   ])
 
   return { config, status }


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Make working back button for a file at another Cozy
```

**Context:**
Historically, we were going backwards in the browser's history for 3 reasons: 
- We cannot use the relative route because it is not a sub-route of where the user is coming from
- The OnlyOffice shared file opens in the owner's cozy, to return you must reopen the previous cozy 
- The creation process has redirect process that we need to avoid if we don't want to fall into an endless lopp

Why did we decide to use redirectLink instead of jumping to the browser history?
- It doesn't matter how many steps before if you have redirect link you can bring the user back to the starting point
- It's a lot more predictable where the user will end up 

To get around the problem of whether or not the url is shared in the search parameters, we use the `/permission/self` request in the stack as it is included with who the file is shared with. Each person in a share has a unique link, so there is only one person included.