### PR TITLE
fix(OnlyOffice): Regression from migration react-route to v6

### DIFF
--- a/src/drive/web/modules/views/OnlyOffice/index.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/index.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useMemo, useEffect } from 'react'
-import { useParams, useSearchParams } from 'react-router-dom'
+import { Outlet, useParams, useSearchParams } from 'react-router-dom'
 
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -60,8 +60,7 @@ const OnlyOffice = ({
   isReadOnly = false,
   isFromSharing,
   username,
-  isInSharedFolder,
-  children
+  isInSharedFolder
 }) => {
   const { fileId } = useParams()
   useHead()
@@ -77,7 +76,7 @@ const OnlyOffice = ({
         isInSharedFolder={isInSharedFolder}
       >
         <Editor />
-        {children}
+        <Outlet />
       </OnlyOfficeProvider>
     </Dialog>
   )


### PR DESCRIPTION
In react-router v6, we need an `<outlet />` instead of a children otherwise the subroute like paywall would no longer be displayed

```
### 🐛 Bug Fixes

* Display the OnlyOffice paywall when there are no editing rights
```
