### PR TITLE
fix: do not dispatch in resume hook catch block

### DIFF
--- a/src/drive/web/modules/views/Upload/useResumeFromFlagship.ts
+++ b/src/drive/web/modules/views/Upload/useResumeFromFlagship.ts
@@ -5,11 +5,7 @@ import { useClient } from 'cozy-client'
 import { useWebviewIntent } from 'cozy-intent'
 import logger from 'cozy-logger'
 
-import {
-  getUploadQueue,
-  ADD_TO_UPLOAD_QUEUE,
-  purgeUploadQueue
-} from 'drive/web/modules/upload'
+import { getUploadQueue, ADD_TO_UPLOAD_QUEUE } from 'drive/web/modules/upload'
 import { FileFromNative } from 'drive/web/modules/views/Upload/UploadTypes'
 import { getErrorMessage } from 'drive/web/modules/drive/helpers'
 
@@ -39,8 +35,12 @@ export const useResumeUploadFromFlagship = (): void => {
           files: filesToHandle
         })
       } catch (error) {
-        logger('info', `hasFilesToHandle error, ${getErrorMessage(error)}`)
-        dispatch(purgeUploadQueue())
+        const errorMessage = getErrorMessage(error)
+        logger('info', `hasFilesToHandle error, ${errorMessage}`)
+
+        // It means we're on a cozy-flagship version that doesn't handle file sharing
+        // In that case we don't want to do anything and just let the upload queue empty
+        if (errorMessage.includes('has not been implemented')) return
       }
     }
 


### PR DESCRIPTION
### 🐛 Bug Fixes

*  Removed the purgeUpload, as it's not clear if it would really be useful
in case of an unknown error
*  Explicitely handle post-me not implemented error
In this case doing nothing is what's needed