### PR TITLE
chore: Add test in node 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node-preset: &node # Used internally to share configuration, ignored by travis.
   language: node_js
   node_js:
     - 16
-    - 18
+    - 20
   cache:
     yarn: true
     directories:
@@ -31,11 +31,11 @@ jobs:
       node_js:
         - 16
       script: yarn test
-    - name: "Unit tests node 18"
+    - name: "Unit tests node 20"
       stage: "prebuild"
       <<: *node
       node_js:
-        - 18
+        - 20
       script: yarn test
     - &build-web
       name: "Drive web"


### PR DESCRIPTION
The service execution production environment will be migrated to node 20 instead of node 16. To prepare for this change, we're running tests in node 20

```
### 🔧 Tech

* Add test in node 20
```
