### PR TITLE
feat: Use partial index for album query

### DIFF
--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -17,7 +17,7 @@ import { buildAlbumsQuery } from '../../queries/queries'
 const ALBUMS_QUERY = client =>
   client
     .find(DOCTYPE_ALBUMS, { created_at: { $gt: null } })
-    .where({
+    .partialIndex({
       auto: { $exists: false }
     })
     .indexFields(['created_at'])


### PR DESCRIPTION
Using a `$exists: false` in the selector is not efficient as it will full scan the index.
Rather, we use a partial index, which is way more efficient in this case: only the non-auto albums will be indexed



```
### ✨ Features

* More efficient album querying

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
