### PR TITLE
fix: OnlyOffice back button redirect when coming from public folder

### DIFF
--- a/src/drive/targets/public/components/AppRouter.jsx
+++ b/src/drive/targets/public/components/AppRouter.jsx
@@ -48,7 +48,7 @@ const AppRouter = ({
             </Route>
             <Route
               path="onlyoffice/create/:folderId/:fileClass"
-              element={<OnlyOfficeCreateView />}
+              element={<OnlyOfficeCreateView isPublic={true} />}
             />
             {models.file.shouldBeOpenedByOnlyOffice(data) && (
               <Route

--- a/src/drive/web/modules/views/Folder/FolderViewBody.jsx
+++ b/src/drive/web/modules/views/Folder/FolderViewBody.jsx
@@ -45,7 +45,8 @@ const FolderViewBody = ({
   navigateToFolder,
   navigateToFile,
   refreshFolderContent = null,
-  extraColumns
+  extraColumns,
+  isPublic = false
 }) => {
   const { isDesktop } = useBreakpoints()
   const navigate = useNavigate()
@@ -104,7 +105,8 @@ const FolderViewBody = ({
         routeTo: url => navigate(url),
         isOfficeEnabled: isOfficeEnabled(isDesktop),
         webviewIntent,
-        pathname
+        pathname,
+        fromPublicFolder: isPublic
       })({
         event,
         file,
@@ -119,6 +121,7 @@ const FolderViewBody = ({
       navigate,
       webviewIntent,
       isDesktop,
+      isPublic,
       pathname
     ]
   )

--- a/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/drive/web/modules/views/Folder/createFileOpeningHandler.js
@@ -18,7 +18,8 @@ const createFileOpeningHandler =
     routeTo,
     isOfficeEnabled,
     webviewIntent,
-    pathname
+    pathname,
+    fromPublicFolder = false
   }) =>
   async ({ event, file, isAvailableOffline }) => {
     if (isAvailableOffline) {
@@ -63,13 +64,15 @@ const createFileOpeningHandler =
         openInNewTab(
           makeOnlyOfficeFileRoute(file.id, {
             withoutRouter: true,
-            fromPathname: pathname
+            fromPathname: pathname,
+            fromPublicFolder
           })
         )
       } else {
         routeTo(
           makeOnlyOfficeFileRoute(file.id, {
-            fromPathname: pathname
+            fromPathname: pathname,
+            fromPublicFolder
           })
         )
       }

--- a/src/drive/web/modules/views/OnlyOffice/Create.jsx
+++ b/src/drive/web/modules/views/OnlyOffice/Create.jsx
@@ -12,7 +12,7 @@ import {
   makeOnlyOfficeFileRoute
 } from 'drive/web/modules/views/OnlyOffice/helpers'
 
-const Create = () => {
+const Create = ({ isPublic = false }) => {
   const navigate = useNavigate()
   const { folderId, fileClass } = useParams()
   const { status, fileId } = useCreateFile(folderId, fileClass)
@@ -29,7 +29,8 @@ const Create = () => {
   if (status === 'loaded' && fileId) {
     const url = makeOnlyOfficeFileRoute(fileId, {
       fromCreate: true,
-      fromPathname: folderPath
+      fromPathname: folderPath,
+      fromPublicFolder: isPublic
     })
     return navigate(url, {
       replace: true

--- a/src/drive/web/modules/views/OnlyOffice/helpers.js
+++ b/src/drive/web/modules/views/OnlyOffice/helpers.js
@@ -72,6 +72,7 @@ export const isOfficeEditingEnabled = isDesktop => {
  * @param {boolean} options.fromPathname Hash to redirect the user when he back
  * @param {boolean} options.fromRedirect To forward existing redirectLink
  * @param {boolean} options.fromEdit The document will be opened in edit mode
+ * @param {boolean} options.fromPublicFolder The document is opened from a public folder
  * @returns {string} Path to OnlyOffice
  */
 export const makeOnlyOfficeFileRoute = (
@@ -81,7 +82,8 @@ export const makeOnlyOfficeFileRoute = (
     fromCreate = false,
     fromPathname,
     fromRedirect,
-    fromEdit = false
+    fromEdit = false,
+    fromPublicFolder = false
   } = {}
 ) => {
   const params = new URLSearchParams()
@@ -96,6 +98,9 @@ export const makeOnlyOfficeFileRoute = (
   }
   if (fromEdit) {
     params.append('fromEdit', fromEdit)
+  }
+  if (fromPublicFolder) {
+    params.append('fromPublicFolder', fromPublicFolder)
   }
   const searchParam = params.size > 0 ? `?${params.toString()}` : ''
   return withoutRouter

--- a/src/drive/web/modules/views/Public/index.jsx
+++ b/src/drive/web/modules/views/Public/index.jsx
@@ -255,6 +255,7 @@ const PublicFolderView = () => {
           refreshFolderContent={refreshFolderContent}
           canUpload={hasWritePermissions}
           extraColumns={extraColumns}
+          isPublic={true}
         />
         {isFabDisplayed && (
           <AddMenuProvider


### PR DESCRIPTION
The redirection of the back button requires adaptation when opening an onlyoffice file from a folder shared by a link or the preview of a shared folder. You need to stay on the same cozy and share the pathname and sharecode to remain authenticated during browsing. 

However, this behaviour must be different for public files accessed directly, where you must return to the instance from which you came. 

This PR allows to take in account the first behaviour without breaking the second.

```
### 🐛 Bug Fixes

* OnlyOffice back button redirect when coming from public folder
```
