### PR TITLE
fix: Hide first part of backup description if a backup is running or has already been made

### DIFF
--- a/src/photos/ducks/backup/components/BackupDescription.jsx
+++ b/src/photos/ducks/backup/components/BackupDescription.jsx
@@ -2,15 +2,25 @@ import React from 'react'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+import { useBackupData } from '../hooks/useBackupData'
 
 const BackupDescription = () => {
   const { t } = useI18n()
 
+  const { backupInfo } = useBackupData()
+
+  const hasAlreadyStartedABackup =
+    backupInfo?.currentBackup?.status === 'running' ||
+    backupInfo?.currentBackup?.status === 'done' ||
+    backupInfo?.lastBackup
+
   return (
     <>
-      <Typography className="u-mt-1-half" align={'center'}>
-        {t('Backup.description.first')}
-      </Typography>
+      {!hasAlreadyStartedABackup && (
+        <Typography className="u-mt-1-half" align={'center'}>
+          {t('Backup.description.first')}
+        </Typography>
+      )}
       <Typography variant="caption" className="u-mt-1" align={'center'}>
         {t('Backup.description.second')}
       </Typography>

--- a/src/photos/ducks/backup/components/BackupInfo.jsx
+++ b/src/photos/ducks/backup/components/BackupInfo.jsx
@@ -11,6 +11,12 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import styles from '../../../styles/backup.styl'
 import { useBackupData } from '../hooks/useBackupData'
 
+const formatLastBackupMessage = message => {
+  if (!message) return ''
+
+  return message.charAt(0).toUpperCase() + message.slice(1) + '. '
+}
+
 const BackupInfo = () => {
   const { t } = useI18n()
 
@@ -69,11 +75,8 @@ const BackupInfo = () => {
         <div className={cx('u-mt-1-half', styles['pho-backup-info-wrapper'])}>
           <Alert severity="error">
             <AlertTitle>{t('Backup.info.errorTitle')}</AlertTitle>
+            {formatLastBackupMessage(lastBackup.message)}
             {t('Backup.info.errorDescription', {
-              message: lastBackup.message
-                ? lastBackup.message.charAt(0).toUpperCase() +
-                  lastBackup.message.slice(1)
-                : '',
               smart_count: lastBackup.totalMediasToBackupCount,
               backedUpMediaCount: lastBackup.backedUpMediaCount
             })}

--- a/src/photos/locales/en.json
+++ b/src/photos/locales/en.json
@@ -306,7 +306,7 @@
       "successTitle": "Backup successful",
       "successDescription": "The photos and videos on your mobile have been successfully backed up.",
       "errorTitle": "Backup interrupted",
-      "errorDescription": "%{message}. %{backedUpMediaCount}/%{smart_count} element backed up. |||| %{message}. %{backedUpMediaCount}/%{smart_count} elements backed up."
+      "errorDescription": "%{backedUpMediaCount}/%{smart_count} element backed up. |||| %{backedUpMediaCount}/%{smart_count} elements backed up."
     },
     "InstallAppAlert": {
       "description": "Backup automatically all your photos and videos from your mobile devices",


### PR DESCRIPTION
```
### ✨ Features

* Hide first part of backup description if a backup is running or has already been made
```

I also added a small fix for this PR https://github.com/cozy/cozy-drive/pull/3016 which has been merged but not released yet.