### PR TITLE
fix: Can create folder in a shared folder

### DIFF
--- a/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
+++ b/src/drive/web/modules/views/Sharings/SharingsFolderView.jsx
@@ -144,6 +144,7 @@ const SharingsFolderView = ({ sharedDocumentIds }) => {
         queryResults={[foldersResult, filesResult]}
         canSort
         extraColumns={extraColumns}
+        currentFolderId={currentFolderId}
       />
       <Outlet />
     </FolderView>


### PR DESCRIPTION
We didn't pass the currentFolderId to the FolderViewBody. So we had currentFolderId undefined and then when we create a folder in a shared folder, then we make a request to POST `/files/undefined`



