### PR TITLE
fix: Suggest to go to photos tab instead of albums tab in iOS after a…

### DIFF
--- a/src/photos/ducks/backup/components/OpenBackupButton.jsx
+++ b/src/photos/ducks/backup/components/OpenBackupButton.jsx
@@ -52,9 +52,9 @@ const OpenBackupButton = () => {
   return (
     <Button
       component={Link}
-      to="/albums"
+      to="/"
       className="u-mt-half"
-      label={t('Backup.actions.seeMyAlbums')}
+      label={t('Backup.actions.viewMyPhotos')}
       variant="secondary"
     />
   )

--- a/src/photos/locales/en.json
+++ b/src/photos/locales/en.json
@@ -291,7 +291,7 @@
       "startBackup": "Backup",
       "backupInProgress": "Backup in progress %{alreadyBackupedCount} / %{totalCount}",
       "openInDrive": "Open in Drive",
-      "seeMyAlbums": "See my albums",
+      "viewMyPhotos": "View my saved photos",
       "saved": "Saved",
       "cancel": "Stop"
     },


### PR DESCRIPTION
… backup

On iOS, a button was sending you to the albums tab after a backup. But if you had no album, which is possible, you saw nothing. So it is more safe to send to the photos tab (default tab).

```
### 🐛 Bug Fixes

* Suggest to go to photos tab instead of albums tab in iOS after a backup
```
