### PR TITLE
fix: Navigation into trash viewer

### DIFF
--- a/src/drive/web/modules/views/Trash/FilesViewerTrash.jsx
+++ b/src/drive/web/modules/views/Trash/FilesViewerTrash.jsx
@@ -30,9 +30,9 @@ const FilesViewerWithQuery = props => {
         {...props}
         files={viewableFiles}
         filesQuery={filesResult}
-        onClose={() => navigate(`/trash/${props.currentFolderId}`)}
+        onClose={() => navigate(`/trash/${currentFolderId}`)}
         onChange={fileId =>
-          navigate(`/trash/${props.currentFolderId}/file/${fileId}`)
+          navigate(`/trash/${currentFolderId}/file/${fileId}`)
         }
       />
     )


### PR DESCRIPTION
@zatteo regression due to react-router v6 migration

```
### 🐛 Bug Fixes

* Correct navigation from trash viewer
```
