### PR TITLE
fix(backup): Open backup button redirect to '/photos' instead of '/'

### DIFF
--- a/src/photos/ducks/backup/components/OpenBackupButton.jsx
+++ b/src/photos/ducks/backup/components/OpenBackupButton.jsx
@@ -52,7 +52,7 @@ const OpenBackupButton = () => {
   return (
     <Button
       component={Link}
-      to="/"
+      to="/photos"
       className="u-mt-half"
       label={t('Backup.actions.viewMyPhotos')}
       variant="secondary"


### PR DESCRIPTION
'/' can change if we are on flagship or not. So if we want to go to photos page like here, let's go explicitly to '/photos' route.

Fix of https://github.com/cozy/cozy-drive/pull/3021 which has not been released yet. **Nothing to add in changelog.**