### PR TITLE
chore: Remove build photos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,10 +74,6 @@ jobs:
         - <<: *deploy
           on:
             tags: true
-    - <<: *build-web
-      name: "Photos web"
-      env:
-        - COZY_APP_SLUG=photos
 
 env:
   global:

--- a/.tx/config
+++ b/.tx/config
@@ -6,9 +6,3 @@ file_filter = src/drive/locales/<lang>.json
 source_file = src/drive/locales/en.json
 source_lang = en
 type        = KEYVALUEJSON
-
-[o:cozy:p:cozy-photos-v3:r:global]
-file_filter = src/photos/locales/<lang>.json
-source_file = src/photos/locales/en.json
-source_lang = en
-type        = KEYVALUEJSON


### PR DESCRIPTION
We are split Drive & App into there separated repository. In this process, we stop publishing Photos from this repository. After, we will take the time to remove Photos base code from this repository.

You can find photos codebase here now : https://github.com/cozy/cozy-photos

```
### 🔧 Tech

* Remove build photos
```
