### PR TITLE
[VIO-14] feat: Add HarvestBanner

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -75,7 +75,7 @@
     },
     {
       "path": "drive/vendors/drive.<hash>.js",
-      "maxSize": "1.6 MB"
+      "maxSize": "1.7 MB"
     },
     {
       "path": "drive/app-drive.<hash>.min.css",
@@ -108,32 +108,25 @@
   ],
   "groups": [
     {
-      "path": "drive/app/**",
-      "maxPercentIncrease": 10
+      "path": "drive/app/**"
     },
     {
-      "path": "drive/img/**",
-      "maxPercentIncrease": 0.4
+      "path": "drive/img/**"
     },
     {
-      "path": "drive/intents/**",
-      "maxPercentIncrease": 15
+      "path": "drive/intents/**"
     },
     {
-      "path": "drive/onlyOffice/**",
-      "maxPercentIncrease": 0.4
+      "path": "drive/onlyOffice/**"
     },
     {
-      "path": "drive/public/**",
-      "maxPercentIncrease": 7
+      "path": "drive/public/**"
     },
     {
-      "path": "drive/services/**",
-      "maxPercentIncrease": 3
+      "path": "drive/services/**"
     },
     {
-      "path": "drive/vendors/**",
-      "maxPercentIncrease": 15
+      "path": "drive/vendors/**"
     }
   ],
   "reportOutput": [

--- a/src/drive/targets/manifest.webapp
+++ b/src/drive/targets/manifest.webapp
@@ -158,12 +158,16 @@
     "accounts": {
       "description": "Required to display additional information in the viewer for files automatically retrieved by services",
       "type": "io.cozy.accounts",
-      "verbs": ["GET"]
+      "verbs": ["ALL"]
+    },
+    "jobs": {
+      "type": "io.cozy.jobs",
+      "verbs": ["ALL"]
     },
     "triggers": {
       "description": "Required to display additional information in the viewer for files automatically retrieved by services",
       "type": "io.cozy.triggers",
-      "verbs": ["GET"]
+      "verbs": ["ALL"]
     },
     "dacc": {
       "type": "cc.cozycloud.dacc_v2",

--- a/src/drive/web/modules/queries.js
+++ b/src/drive/web/modules/queries.js
@@ -370,3 +370,17 @@ export const buildNewSharingShortcutQuery = () => ({
     fetchPolicy: defaultFetchPolicy
   }
 })
+
+export const buildTriggersQueryByAccountId = (accountId, enabled) => ({
+  definition: () =>
+    Q('io.cozy.triggers')
+      .where({
+        'message.account': accountId
+      })
+      .indexFields(['message.account']),
+  options: {
+    as: `${'io.cozy.triggers'}/accounts/${accountId}`,
+    enabled: enabled,
+    fetchPolicy: defaultFetchPolicy
+  }
+})

--- a/src/drive/web/modules/views/Drive/HarvestBanner.jsx
+++ b/src/drive/web/modules/views/Drive/HarvestBanner.jsx
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { useQuery, isQueryLoading, Q } from 'cozy-client'
+import { LaunchTriggerCard } from 'cozy-harvest-lib'
+import Divider from 'cozy-ui/transpiled/react/Divider'
+
+import { buildTriggersQueryByAccountId } from 'drive/web/modules/queries'
+import useDocument from 'components/useDocument'
+
+const HarvestBanner = ({ folderId }) => {
+  const folder = useDocument('io.cozy.files', folderId)
+  const konnectorSlug = folder?.cozyMetadata?.createdByApp
+  const accountId = folder?.cozyMetadata?.sourceAccount
+  const queryTriggers = buildTriggersQueryByAccountId(
+    accountId,
+    Boolean(accountId)
+  )
+  const { data: triggers, ...triggersQueryLeft } = useQuery(
+    queryTriggers.definition,
+    queryTriggers.options
+  )
+  const isTriggersLoading = isQueryLoading(triggersQueryLeft)
+
+  const konnector = useQuery(
+    Q('io.cozy.konnectors').getById(konnectorSlug || ' '),
+    {
+      as: `io.cozy.konnectors/${konnectorSlug}`,
+      enabled: Boolean(konnectorSlug),
+      singleDocData: true
+    }
+  )
+  if (!konnector.data || konnector.data.length === 0 || isTriggersLoading) {
+    return null
+  }
+  return (
+    <>
+      <LaunchTriggerCard
+        flowProps={{
+          initialTrigger: triggers[0],
+          konnector: konnector.data
+        }}
+        konnectorRoot={`harvest/${konnectorSlug}`}
+      />
+      <Divider />
+    </>
+  )
+}
+
+HarvestBanner.propTypes = {
+  folderId: PropTypes.string.isRequired
+}
+
+export default HarvestBanner

--- a/src/drive/web/modules/views/Drive/index.jsx
+++ b/src/drive/web/modules/views/Drive/index.jsx
@@ -9,6 +9,8 @@ import { useQuery, useClient } from 'cozy-client'
 import { useVaultClient } from 'cozy-keys-lib'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import flag from 'cozy-flags'
+
 import Dropzone from 'drive/web/modules/upload/Dropzone'
 import { ModalContext } from 'drive/lib/ModalContext'
 import useActions from 'drive/web/modules/actions/useActions'
@@ -51,6 +53,7 @@ import AddMenuProvider from 'drive/web/modules/drive/AddMenu/AddMenuProvider'
 import useHead from 'components/useHead'
 import { useSelectionContext } from 'drive/web/modules/selection/SelectionProvider'
 import { useResumeUploadFromFlagship } from 'drive/web/modules/views/Upload/useResumeFromFlagship'
+import HarvestBanner from './HarvestBanner'
 
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
@@ -213,6 +216,9 @@ const DriveView = () => {
         disabled={__TARGET__ === 'mobile' || !canWriteToCurrentFolder}
         displayedFolder={displayedFolder}
       >
+        {flag('drive.show.harvest-banner') && (
+          <HarvestBanner folderId={currentFolderId} />
+        )}
         <FolderViewBody
           navigateToFolder={navigateToFolder}
           navigateToFile={navigateToFile}

--- a/src/drive/web/modules/views/Drive/index.spec.jsx
+++ b/src/drive/web/modules/views/Drive/index.spec.jsx
@@ -4,6 +4,9 @@ import { setupStoreAndClient } from 'test/setup'
 import AppLike from 'test/components/AppLike'
 import AppRoute from 'drive/web/modules/navigation/AppRoute'
 
+jest.mock('cozy-harvest-lib', () => ({
+  LaunchTriggerCard: jest.fn()
+}))
 jest.mock('drive/web/modules/views/Drive/useTrashRedirect', () => ({
   useTrashRedirect: jest.fn()
 }))


### PR DESCRIPTION
Display the HarvestBanner in order to be able to run the associated konnector when displaying a folder.

Behind the flag `drive.show.harvest-banner`



```
### ✨ Features

* Display the Harvest Banner if the flag `drive.show.harvest-banner` is activated. No design ATM. Just to check if it works.


```
