### PR TITLE
fix: update file upload structure in scanner (VO-115)

### DIFF
--- a/src/drive/web/modules/drive/Toolbar/components/Scanner/Scanner.spec.tsx
+++ b/src/drive/web/modules/drive/Toolbar/components/Scanner/Scanner.spec.tsx
@@ -106,16 +106,24 @@ describe('Scanner', () => {
       )
     })
 
-    // Assert that the mockUploadFiles function was called with the expected arguments
-    expect((mockUploadFiles.mock.calls[0] as [unknown])[0]).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          file: expect.any(Object) as Record<string, unknown>,
-          isDirectory: false,
-          name: expect.stringMatching(/\.jpg$/) as string
-        })
-      ])
-    )
+    // Create a mock File object
+    const mockFile = new File([], 'testfile')
+
+    // Assert that mockUploadFiles was called once with the expected arguments
+    expect(mockUploadFiles).toHaveBeenCalledTimes(1)
+
+    const calls = mockUploadFiles.mock.calls as unknown[][]
+
+    expect(calls[0][0]).toEqual([mockFile]) // File
+    expect(calls[0][1]).toBe('test') // Directory ID
+    expect(calls[0][2]).toEqual({ isScanned: true }) // Upload options
+    expect(typeof calls[0][3]).toBe('function') // Success callback
+    // Dependencies
+    expect(calls[0][4]).toMatchObject({
+      client: expect.anything() as Record<string, unknown>,
+      vaultClient: {},
+      t: expect.anything() as (key: string) => string
+    })
   })
 
   // Test case: Handle unexpected errors gracefully

--- a/src/drive/web/modules/drive/Toolbar/components/Scanner/useScannerService.ts
+++ b/src/drive/web/modules/drive/Toolbar/components/Scanner/useScannerService.ts
@@ -66,14 +66,14 @@ export const useScannerService = (displayedFolder: {
 
       const base64 = await scanDocument()
 
-      const fileName = getUniqueNameFromPrefix('scan')
-      const file = {
-        file: getFileFromBase64(base64, fileName, 'image/jpeg'),
-        isDirectory: false,
-        name: fileName
-      }
       const payload = uploadFiles(
-        [file],
+        [
+          getFileFromBase64(
+            base64,
+            getUniqueNameFromPrefix('scan'),
+            'image/jpeg'
+          )
+        ],
         displayedFolder.id,
         { isScanned: true },
         () => logger('info', `File uploaded successfully`),


### PR DESCRIPTION
First argument shape wasn't correct after refactor.
It has been updated to be the File object directly
