### PR TITLE
fix: Update TopBar API in uploader.component (VO-362)

### DIFF
--- a/src/modules/views/Upload/UploaderComponent.tsx
+++ b/src/modules/views/Upload/UploaderComponent.tsx
@@ -49,8 +49,8 @@ const _UploaderComponent = (props: {
             )}
             <Topbar
               navigateTo={setFolder}
-              currentDir={folderQuery.data}
-              fetchStatus={folderQuery.fetchStatus}
+              folderId={folder._id}
+              showFolderCreation={false}
             />
           </>
         }


### PR DESCRIPTION

### 🐛 Bug Fixes

* The MoveTopbar API changed in terms of props.
Due to that, UploaderComponent which was using the old props names crashed the app. To fix that critical issue we update UploaderComponent to use the updated prop names for Topbar