### PR TITLE
fix: Can open shortcut even on preview page

### DIFF
--- a/src/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/modules/views/Folder/createFileOpeningHandler.js
@@ -35,7 +35,12 @@ const createFileOpeningHandler =
           Alerter.error('alert.could_not_open_file')
         }
       } else {
-        const url = generateShortcutUrl({ file, client, isFlatDomain })
+        const url = generateShortcutUrl({
+          file,
+          client,
+          isFlatDomain,
+          fromPublicFolder
+        })
         openInNewTab(url)
       }
     } else if (isNote) {

--- a/src/modules/views/Folder/generateShortcutUrl.js
+++ b/src/modules/views/Folder/generateShortcutUrl.js
@@ -1,12 +1,17 @@
 import { generateWebLink } from 'cozy-client'
 
-const generateShortcutUrl = ({ file, client, isFlatDomain }) => {
+const generateShortcutUrl = ({
+  file,
+  client,
+  isFlatDomain,
+  fromPublicFolder
+}) => {
   const currentURL = new URL(window.location)
   let webLink = ''
-  if (currentURL.pathname === '/public') {
+  if (fromPublicFolder) {
     webLink = generateWebLink({
       cozyUrl: client.getStackClient().uri,
-      pathname: '/public',
+      pathname: currentURL.pathname,
       slug: 'drive',
       hash: `external/${file.id}`,
       searchParams: currentURL.searchParams,


### PR DESCRIPTION
We had a bug that caused an issue where if we wanted to open a shortcut from the preview page, it wouldn't work.

Indeed, since we were only testing the public case and forgetting the preview case, it couldn't work.

So now, we rely on the props to be able to know if we are public or not instead of just checking the url.



```
### ✨ Features

*

### 🐛 Bug Fixes

* We had a bug that caused an issue where if we wanted to open a shortcut from the preview page, it wouldn't work.

### 🔧 Tech

*
```
