### PR TITLE
fix: Disable update time for addFolder row (VO-391)

### DIFF
--- a/src/modules/filelist/AddFolderRow.jsx
+++ b/src/modules/filelist/AddFolderRow.jsx
@@ -3,16 +3,14 @@ import React from 'react'
 
 import { TableRow, TableCell } from 'cozy-ui/transpiled/react/deprecated/Table'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import FileThumbnail from 'modules/filelist/FileThumbnail'
 import FilenameInput from 'modules/filelist/FilenameInput'
-import { Empty as EmptyCell } from 'modules/filelist/cells'
+import { Empty as EmptyCell, LastUpdate } from 'modules/filelist/cells'
 
 import styles from 'styles/filelist.styl'
 
 const AddFolderRow = ({ isEncrypted, onSubmit, onAbort, extraColumns }) => {
-  const { f } = useI18n()
   const { isMobile } = useBreakpoints()
 
   return (
@@ -41,14 +39,7 @@ const AddFolderRow = ({ isEncrypted, onSubmit, onAbort, extraColumns }) => {
       </TableCell>
       {!isMobile && (
         <>
-          <TableCell
-            className={cx(
-              styles['fil-content-cell'],
-              styles['fil-content-date']
-            )}
-          >
-            <time dateTime="">{f(Date.now(), 'MMM D, YYYY')}</time>
-          </TableCell>
+          <LastUpdate />
           <EmptyCell className={styles['fil-content-size']} />
           {extraColumns &&
             extraColumns.map(column => (

--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -90,7 +90,8 @@ column-width-thumbnail-bigger = 7rem
 // @stylint off
 .fil-content-cell
     &.fil-content-file
-        flex 0 1 "calc(%s - %s)" % (column-width-large column-width-thumbnail)
+        // When the cell is a filename (or new a directory name input), we don't want flex to shrink it
+        flex 0 0 "calc(%s - %s)" % (column-width-large column-width-thumbnail)
         display flex
         align-items center
         padding   0 2rem 0 0


### PR DESCRIPTION
### 🐛 Bug Fixes

* Using LastUpdate component with undefined date,
this will keep homogeneity with other rows
* Also adjust CSS so that input folder name and other existing
folder names keep the same width
and stay aligned

![image](https://github.com/cozy/cozy-drive/assets/12577784/ff3683c3-d903-4d7e-a77d-edc0026a3bc7)

