### PR TITLE
fix: Hide ".url" in suggestionItem (VO-647)

### DIFF
--- a/src/modules/search/components/BarSearchAutosuggest.jsx
+++ b/src/modules/search/components/BarSearchAutosuggest.jsx
@@ -7,6 +7,7 @@ import { isFlagshipApp } from 'cozy-device-helper'
 import { useWebviewIntent } from 'cozy-intent'
 import List from 'cozy-ui/transpiled/react/List'
 
+import { SHARED_DRIVES_DIR_ID } from 'constants/config'
 import BarSearchInputGroup from 'modules/search/components/BarSearchInputGroup'
 import SuggestionItem from 'modules/search/components/SuggestionItem'
 import SuggestionListSkeleton from 'modules/search/components/SuggestionListSkeleton'
@@ -46,6 +47,12 @@ const BarSearchAutosuggest = ({ t }) => {
   }
 
   const onSuggestionSelected = async (event, { suggestion }) => {
+    // Open the shared drive in a new tab
+    if (suggestion.parentUrl?.includes(SHARED_DRIVES_DIR_ID)) {
+      window.open(`/#/external/${suggestion.id}`, '_blank')
+      return cleanSearch()
+    }
+
     let url = `${window.location.origin}/#${suggestion.url}`
     if (suggestion.openOn === 'notes') {
       url = await models.note.fetchURL(client, {

--- a/src/modules/search/components/SuggestionItem.jsx
+++ b/src/modules/search/components/SuggestionItem.jsx
@@ -18,11 +18,6 @@ const SuggestionItem = ({
   isMobile = false
 }) => {
   const openSuggestion = useCallback(() => {
-    // Open the shared drive in a new tab
-    if (suggestion.parentUrl?.includes(SHARED_DRIVES_DIR_ID)) {
-      window.open(`/#/external/${suggestion.id}`, '_blank')
-    }
-
     if (typeof onClick == 'function') {
       onClick(suggestion)
     }
@@ -32,7 +27,7 @@ const SuggestionItem = ({
     class: suggestion.class,
     type: suggestion.type,
     mime: suggestion.mime,
-    name: suggestion.title,
+    name: suggestion.title.replace(/\.url$/, ''), // Not using `splitFileName()` because we don't have access to the full file here.
     parentUrl: suggestion.parentUrl
   }
 
@@ -47,10 +42,7 @@ const SuggestionItem = ({
       </ListItemIcon>
       <ListItemText
         primary={
-          <SuggestionItemTextHighlighted
-            text={suggestion.title}
-            query={query}
-          />
+          <SuggestionItemTextHighlighted text={file.name} query={query} />
         }
         secondary={
           file.parentUrl?.includes(SHARED_DRIVES_DIR_ID) ? null : (


### PR DESCRIPTION
Not using `splitFileName()` because
we don't have access to the full file here.
Using a more low level approach but still safe.
