### PR TITLE
[VO-759] refactor: Extract to modal to pick folder into a component calle FolderPicker

### DIFF
--- a/src/components/Button/BackButton.jsx
+++ b/src/components/Button/BackButton.jsx
@@ -3,8 +3,11 @@ import React from 'react'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-export const BackButton = ({ onClick, t, ...props }) => {
+export const BackButton = ({ onClick, ...props }) => {
+  const { t } = useI18n()
+
   return (
     <IconButton onClick={onClick} {...props} aria-label={t('button.back')}>
       <Icon icon={PreviousIcon} />

--- a/src/components/FolderPicker/FolderPicker.jsx
+++ b/src/components/FolderPicker/FolderPicker.jsx
@@ -1,0 +1,102 @@
+import { useDisplayedFolder } from 'hooks'
+import React, { useState } from 'react'
+
+import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
+
+import { FolderPickerBody } from 'components/FolderPicker/FolderPickerBody'
+import { FolderPickerFooter } from 'components/FolderPicker/FolderPickerFooter'
+import { FolderPickerHeader } from 'components/FolderPicker/FolderPickerHeader'
+import { FolderPickerTopbar } from 'components/FolderPicker/FolderPickerTopbar'
+import { ROOT_DIR_ID } from 'constants/config'
+
+const useStyles = makeStyles(() => ({
+  paper: {
+    height: '100%',
+    '& .MuiDialogContent-root': {
+      padding: '0'
+    },
+    '& .MuiDialogTitle-root': {
+      padding: '0'
+    }
+  }
+}))
+
+const FolderPicker = ({
+  title,
+  subtitle,
+  entries,
+  onConfirm,
+  onClose,
+  isBusy
+}) => {
+  const { displayedFolder } = useDisplayedFolder()
+  const [folderId, setFolderId] = useState(
+    displayedFolder ? displayedFolder._id : ROOT_DIR_ID
+  )
+  const [isFolderCreationDisplayed, setFolderCreationDisplayed] =
+    useState(false)
+  const classes = useStyles()
+
+  const showFolderCreation = () => {
+    setFolderCreationDisplayed(true)
+  }
+
+  const hideFolderCreation = () => {
+    setFolderCreationDisplayed(false)
+  }
+
+  const navigateTo = folder => {
+    setFolderId(folder._id)
+    setFolderCreationDisplayed(false)
+  }
+
+  return (
+    <React.Fragment>
+      <FixedDialog
+        className="u-p-0"
+        open
+        onClose={onClose}
+        size="large"
+        classes={{
+          paper: classes.paper
+        }}
+        title={
+          <>
+            <FolderPickerHeader
+              entries={entries}
+              title={title}
+              subTitle={subtitle}
+            />
+            <FolderPickerTopbar
+              navigateTo={navigateTo}
+              folderId={folderId}
+              showFolderCreation={showFolderCreation}
+            />
+          </>
+        }
+        content={
+          <FolderPickerBody
+            folderId={folderId}
+            navigateTo={navigateTo}
+            entries={entries}
+            isFolderCreationDisplayed={isFolderCreationDisplayed}
+            hideFolderCreation={hideFolderCreation}
+          />
+        }
+        actions={
+          <FolderPickerFooter
+            onConfirm={onConfirm}
+            onClose={onClose}
+            targets={entries}
+            currentDirId={folderId}
+            isMoving={isBusy}
+            isLoading={isBusy}
+          />
+        }
+      />
+    </React.Fragment>
+  )
+}
+
+export { FolderPicker }

--- a/src/components/FolderPicker/FolderPicker.jsx
+++ b/src/components/FolderPicker/FolderPicker.jsx
@@ -23,12 +23,12 @@ const useStyles = makeStyles(() => ({
 }))
 
 const FolderPicker = ({
-  title,
-  subtitle,
   entries,
   onConfirm,
   onClose,
-  isBusy
+  isBusy,
+  canCreateFolder = true,
+  slotProps
 }) => {
   const { displayedFolder } = useDisplayedFolder()
   const [folderId, setFolderId] = useState(
@@ -63,14 +63,11 @@ const FolderPicker = ({
         }}
         title={
           <>
-            <FolderPickerHeader
-              entries={entries}
-              title={title}
-              subTitle={subtitle}
-            />
+            <FolderPickerHeader entries={entries} {...slotProps?.header} />
             <FolderPickerTopbar
               navigateTo={navigateTo}
               folderId={folderId}
+              canCreateFolder={canCreateFolder}
               showFolderCreation={showFolderCreation}
             />
           </>
@@ -92,6 +89,7 @@ const FolderPicker = ({
             currentDirId={folderId}
             isMoving={isBusy}
             isLoading={isBusy}
+            {...slotProps?.footer}
           />
         }
       />

--- a/src/components/FolderPicker/FolderPickerBody.jsx
+++ b/src/components/FolderPicker/FolderPickerBody.jsx
@@ -10,7 +10,7 @@ import LoadMore from 'modules/move/LoadMore'
 import Loader from 'modules/move/Loader'
 import { buildMoveOrImportQuery, buildOnlyFolderQuery } from 'modules/queries'
 
-const MoveModalContent = ({
+const FolderPickerBody = ({
   folderId,
   entries,
   navigateTo,
@@ -51,4 +51,4 @@ const MoveModalContent = ({
   )
 }
 
-export { MoveModalContent }
+export { FolderPickerBody }

--- a/src/components/FolderPicker/FolderPickerFooter.jsx
+++ b/src/components/FolderPicker/FolderPickerFooter.jsx
@@ -9,7 +9,7 @@ import { areTargetsInCurrentDir } from 'modules/move/helpers'
 /**
  * List of actions for the move modal
  */
-const Footer = ({
+const FolderPickerFooter = ({
   onConfirm,
   onClose,
   targets,
@@ -40,7 +40,7 @@ const Footer = ({
   )
 }
 
-Footer.propTypes = {
+FolderPickerFooter.propTypes = {
   onConfirm: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   targets: PropTypes.array.isRequired,
@@ -51,9 +51,9 @@ Footer.propTypes = {
   isLoading: PropTypes.bool
 }
 
-Footer.defaultProps = {
+FolderPickerFooter.defaultProps = {
   isMoving: false,
   isLoading: false
 }
 
-export default Footer
+export { FolderPickerFooter }

--- a/src/components/FolderPicker/FolderPickerFooter.jsx
+++ b/src/components/FolderPicker/FolderPickerFooter.jsx
@@ -15,15 +15,13 @@ const FolderPickerFooter = ({
   targets,
   currentDirId,
   isMoving,
-  primaryTextAction,
-  secondaryTextAction,
+  confirmLabel,
+  cancelLabel,
   isLoading
 }) => {
   const { t } = useI18n()
-  const primaryText = primaryTextAction ? primaryTextAction : t('Move.action')
-  const secondaryText = secondaryTextAction
-    ? secondaryTextAction
-    : t('Move.cancel')
+  const primaryText = confirmLabel ? confirmLabel : t('Move.action')
+  const secondaryText = cancelLabel ? cancelLabel : t('Move.cancel')
 
   const handleClick = () => {
     onConfirm(currentDirId)

--- a/src/components/FolderPicker/FolderPickerFooter.jsx
+++ b/src/components/FolderPicker/FolderPickerFooter.jsx
@@ -25,12 +25,16 @@ const FolderPickerFooter = ({
     ? secondaryTextAction
     : t('Move.cancel')
 
+  const handleClick = () => {
+    onConfirm(currentDirId)
+  }
+
   return (
     <>
       <Buttons variant="secondary" label={secondaryText} onClick={onClose} />
       <Buttons
         label={primaryText}
-        onClick={onConfirm}
+        onClick={handleClick}
         disabled={
           areTargetsInCurrentDir(targets, currentDirId) || isMoving || isLoading
         }

--- a/src/components/FolderPicker/FolderPickerHeader.jsx
+++ b/src/components/FolderPicker/FolderPickerHeader.jsx
@@ -2,46 +2,11 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import Card from 'cozy-ui/transpiled/react/Card'
-import Circle from 'cozy-ui/transpiled/react/Circle'
-import Counter from 'cozy-ui/transpiled/react/Counter'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import DriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeFolder'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { Media, Img, Bd } from 'cozy-ui/transpiled/react/deprecated/Media'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import FileThumbnail from '../filelist/FileThumbnail'
-import getMimeTypeIcon from 'lib/getMimeTypeIcon'
-const HeaderIlustration = ({ entries }) => {
-  if (entries.length === 1) {
-    const firstItem = entries[0]
-
-    // this is a cozy files
-    if (firstItem.class) {
-      return <FileThumbnail file={firstItem} />
-    }
-
-    // this is a cozy-flagship file, doesn't have a class yet
-    if (firstItem.fromFlagship) {
-      return (
-        <Icon
-          icon={getMimeTypeIcon(false, firstItem.fileName, firstItem.mimeType)}
-          size={32}
-        />
-      )
-    }
-
-    return <Icon icon={DriveIcon} size={32} />
-  }
-  if (entries.length > 1) {
-    return (
-      <Circle>
-        <Counter count={entries.length} />
-      </Circle>
-    )
-  }
-  return null
-}
+import { FolderPickerHeaderIllustration } from 'components/FolderPicker/FolderPickerHeaderIllustration'
 
 const specificCardStyle = {
   marginLeft: '2rem',
@@ -49,7 +14,8 @@ const specificCardStyle = {
   marginTop: '1rem',
   marginBottom: '1rem'
 }
-const Header = ({ entries, title, subTitle }) => {
+
+const FolderPickerHeader = ({ entries, title, subTitle }) => {
   const { t } = useI18n()
   const titleToUse = title
     ? title
@@ -60,7 +26,7 @@ const Header = ({ entries, title, subTitle }) => {
     <Card inset className="u-bg-paleGrey" style={specificCardStyle}>
       <Media>
         <Img className="u-mr-1">
-          <HeaderIlustration entries={entries} />
+          <FolderPickerHeaderIllustration entries={entries} />
         </Img>
         <Bd>
           <Typography variant="h6" noWrap>
@@ -75,7 +41,7 @@ const Header = ({ entries, title, subTitle }) => {
   )
 }
 
-Header.propTypes = {
+FolderPickerHeader.propTypes = {
   entries: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string
@@ -85,4 +51,4 @@ Header.propTypes = {
   subTitle: PropTypes.string
 }
 
-export default Header
+export { FolderPickerHeader }

--- a/src/components/FolderPicker/FolderPickerHeader.spec.js
+++ b/src/components/FolderPicker/FolderPickerHeader.spec.js
@@ -3,10 +3,10 @@ import React from 'react'
 
 import CozyClient from 'cozy-client'
 
-import Header from './Header'
+import { FolderPickerHeader } from './FolderPickerHeader'
 import AppLike from 'test/components/AppLike'
 
-describe('Header', () => {
+describe('FolderPickerHeader', () => {
   const setupComponent = ({ entries = [], title, subTitle }) => {
     const props = {
       entries,
@@ -18,7 +18,7 @@ describe('Header', () => {
 
     return render(
       <AppLike client={client}>
-        <Header {...props} />
+        <FolderPickerHeader {...props} />
       </AppLike>
     )
   }

--- a/src/components/FolderPicker/FolderPickerHeaderIllustration.jsx
+++ b/src/components/FolderPicker/FolderPickerHeaderIllustration.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import Circle from 'cozy-ui/transpiled/react/Circle'
+import Counter from 'cozy-ui/transpiled/react/Counter'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import DriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeFolder'
+
+import getMimeTypeIcon from 'lib/getMimeTypeIcon'
+import FileThumbnail from 'modules/filelist/FileThumbnail'
+
+const FolderPickerHeaderIllustration = ({ entries }) => {
+  if (entries.length === 1) {
+    const firstItem = entries[0]
+
+    // this is a cozy files
+    if (firstItem.class) {
+      return <FileThumbnail file={firstItem} />
+    }
+
+    // this is a cozy-flagship file, doesn't have a class yet
+    if (firstItem.fromFlagship) {
+      return (
+        <Icon
+          icon={getMimeTypeIcon(false, firstItem.fileName, firstItem.mimeType)}
+          size={32}
+        />
+      )
+    }
+
+    return <Icon icon={DriveIcon} size={32} />
+  }
+  if (entries.length > 1) {
+    return (
+      <Circle>
+        <Counter count={entries.length} />
+      </Circle>
+    )
+  }
+  return null
+}
+
+export { FolderPickerHeaderIllustration }

--- a/src/components/FolderPicker/FolderPickerTopbar.jsx
+++ b/src/components/FolderPicker/FolderPickerTopbar.jsx
@@ -14,7 +14,7 @@ import { getBreadcrumbPath } from 'modules/move/helpers'
 import Breadcrumb from 'modules/navigation/Breadcrumb/Breadcrumb'
 import { buildOnlyFolderQuery } from 'modules/queries'
 
-const MoveTopbar = ({ navigateTo, folderId, showFolderCreation }) => {
+const FolderPickerTopbar = ({ navigateTo, folderId, showFolderCreation }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const folderQuery = buildOnlyFolderQuery(folderId)
@@ -44,9 +44,9 @@ const MoveTopbar = ({ navigateTo, folderId, showFolderCreation }) => {
   )
 }
 
-MoveTopbar.propTypes = {
+FolderPickerTopbar.propTypes = {
   navigateTo: PropTypes.func.isRequired,
   folderId: PropTypes.string.isRequired
 }
 
-export default MoveTopbar
+export { FolderPickerTopbar }

--- a/src/components/FolderPicker/FolderPickerTopbar.jsx
+++ b/src/components/FolderPicker/FolderPickerTopbar.jsx
@@ -14,7 +14,12 @@ import { getBreadcrumbPath } from 'modules/move/helpers'
 import Breadcrumb from 'modules/navigation/Breadcrumb/Breadcrumb'
 import { buildOnlyFolderQuery } from 'modules/queries'
 
-const FolderPickerTopbar = ({ navigateTo, folderId, showFolderCreation }) => {
+const FolderPickerTopbar = ({
+  navigateTo,
+  folderId,
+  showFolderCreation,
+  canCreateFolder
+}) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const folderQuery = buildOnlyFolderQuery(folderId)
@@ -37,9 +42,14 @@ const FolderPickerTopbar = ({ navigateTo, folderId, showFolderCreation }) => {
         opening={false}
         inlined
       />
-      <IconButton onClick={showFolderCreation} aria-label={t('Move.addFolder')}>
-        <Icon icon={FolderAddIcon} />
-      </IconButton>
+      {canCreateFolder ? (
+        <IconButton
+          onClick={showFolderCreation}
+          aria-label={t('Move.addFolder')}
+        >
+          <Icon icon={FolderAddIcon} />
+        </IconButton>
+      ) : null}
     </Topbar>
   )
 }

--- a/src/modules/move/MoveModal.jsx
+++ b/src/modules/move/MoveModal.jsx
@@ -14,11 +14,11 @@ import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { withStyles } from 'cozy-ui/transpiled/react/styles'
 
+import { FolderPickerFooter } from 'components/FolderPicker/FolderPickerFooter'
 import { FolderPickerHeader } from 'components/FolderPicker/FolderPickerHeader'
 import { FolderPickerTopbar } from 'components/FolderPicker/FolderPickerTopbar'
 import { ROOT_DIR_ID } from 'constants/config'
 import logger from 'lib/logger'
-import Footer from 'modules/move/Footer'
 import { MoveInsideSharedFolderModal } from 'modules/move/MoveInsideSharedFolderModal'
 import { MoveModalContent } from 'modules/move/MoveModalContent'
 import { MoveOutsideSharedFolderModal } from 'modules/move/MoveOutsideSharedFolderModal'
@@ -271,7 +271,7 @@ const MoveModal = ({ onClose, entries, classes }) => {
           />
         }
         actions={
-          <Footer
+          <FolderPickerFooter
             onConfirm={handleConfirmation}
             onClose={onClose}
             targets={entries}

--- a/src/modules/move/MoveModal.jsx
+++ b/src/modules/move/MoveModal.jsx
@@ -14,15 +14,15 @@ import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { withStyles } from 'cozy-ui/transpiled/react/styles'
 
+import { FolderPickerHeader } from 'components/FolderPicker/FolderPickerHeader'
+import { FolderPickerTopbar } from 'components/FolderPicker/FolderPickerTopbar'
 import { ROOT_DIR_ID } from 'constants/config'
 import logger from 'lib/logger'
 import Footer from 'modules/move/Footer'
-import Header from 'modules/move/Header'
 import { MoveInsideSharedFolderModal } from 'modules/move/MoveInsideSharedFolderModal'
 import { MoveModalContent } from 'modules/move/MoveModalContent'
 import { MoveOutsideSharedFolderModal } from 'modules/move/MoveOutsideSharedFolderModal'
 import { MoveSharedFolderInsideAnotherModal } from 'modules/move/MoveSharedFolderInsideAnotherModal'
-import Topbar from 'modules/move/Topbar'
 import { cancelMove, hasOneOfEntriesShared } from 'modules/move/helpers'
 
 const styles = () => ({
@@ -253,8 +253,8 @@ const MoveModal = ({ onClose, entries, classes }) => {
         }}
         title={
           <>
-            <Header entries={entries} />
-            <Topbar
+            <FolderPickerHeader entries={entries} />
+            <FolderPickerTopbar
               navigateTo={navigateTo}
               folderId={folderId}
               showFolderCreation={showFolderCreation}

--- a/src/modules/move/MoveModal.jsx
+++ b/src/modules/move/MoveModal.jsx
@@ -14,13 +14,13 @@ import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { withStyles } from 'cozy-ui/transpiled/react/styles'
 
+import { FolderPickerBody } from 'components/FolderPicker/FolderPickerBody'
 import { FolderPickerFooter } from 'components/FolderPicker/FolderPickerFooter'
 import { FolderPickerHeader } from 'components/FolderPicker/FolderPickerHeader'
 import { FolderPickerTopbar } from 'components/FolderPicker/FolderPickerTopbar'
 import { ROOT_DIR_ID } from 'constants/config'
 import logger from 'lib/logger'
 import { MoveInsideSharedFolderModal } from 'modules/move/MoveInsideSharedFolderModal'
-import { MoveModalContent } from 'modules/move/MoveModalContent'
 import { MoveOutsideSharedFolderModal } from 'modules/move/MoveOutsideSharedFolderModal'
 import { MoveSharedFolderInsideAnotherModal } from 'modules/move/MoveSharedFolderInsideAnotherModal'
 import { cancelMove, hasOneOfEntriesShared } from 'modules/move/helpers'
@@ -262,7 +262,7 @@ const MoveModal = ({ onClose, entries, classes }) => {
           </>
         }
         content={
-          <MoveModalContent
+          <FolderPickerBody
             folderId={folderId}
             navigateTo={navigateTo}
             entries={entries}

--- a/src/modules/move/Topbar.jsx
+++ b/src/modules/move/Topbar.jsx
@@ -29,7 +29,7 @@ const MoveTopbar = ({ navigateTo, folderId, showFolderCreation }) => {
   return (
     <Topbar hideOnMobile={false}>
       {showPreviousButton && (
-        <BackButton onClick={() => navigateTo(path[path.length - 2])} t={t} />
+        <BackButton onClick={() => navigateTo(path[path.length - 2])} />
       )}
       <Breadcrumb
         path={path}

--- a/src/modules/navigation/Breadcrumb/components/MobileBreadcrumb/MobileBreadcrumb.jsx
+++ b/src/modules/navigation/Breadcrumb/components/MobileBreadcrumb/MobileBreadcrumb.jsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react'
 
 import { BarCenter, BarLeft } from 'cozy-bar'
-import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import Breadcrumb from '../../Breadcrumb'
 import BackButton from 'components/Button/BackButton'
@@ -11,13 +10,12 @@ const MobileBreadcrumb = ({ onBreadcrumbClick, path, ...props }) => {
     const parentFolder = path[path.length - 2]
     onBreadcrumbClick(parentFolder)
   }, [onBreadcrumbClick, path])
-  const { t } = useI18n()
 
   return (
     <div>
       {path.length >= 2 && (
         <BarLeft>
-          <BackButton onClick={navigateBack} t={t} />
+          <BackButton onClick={navigateBack} />
         </BarLeft>
       )}
       <BarCenter>

--- a/src/modules/views/Search/SearchView.jsx
+++ b/src/modules/views/Search/SearchView.jsx
@@ -90,7 +90,7 @@ const SearchView = () => {
     <>
       {isMobile && (
         <BarLeft>
-          <BackButton onClick={navigateBack} t={t} />
+          <BackButton onClick={navigateBack} />
         </BarLeft>
       )}
       <BarSearch>

--- a/src/modules/views/Upload/UploadTypes.ts
+++ b/src/modules/views/Upload/UploadTypes.ts
@@ -1,9 +1,3 @@
-import { UseQueryReturnValue } from 'cozy-client/types/types'
-
-export interface Folder {
-  _id: string
-}
-
 export interface FileForQueue {
   name: string
   file?: { name: string }
@@ -30,16 +24,8 @@ export interface FileFromNative {
 
 export interface UploadFromFlagship {
   items?: FileFromNative['file'][]
-  uploadFilesFromFlagship: (fileOptions: {
-    name: string
-    dirId: string
-    conflictStrategy: string
-  }) => void
+  uploadFilesFromFlagship: (folderId: string) => void
   resetFilesToHandle: () => Promise<void>
   onClose: () => Promise<void>
   uploadInProgress: boolean
-  contentQuery: UseQueryReturnValue
-  folderQuery: UseQueryReturnValue
-  setFolder: React.Dispatch<React.SetStateAction<Folder>>
-  folder: Folder
 }

--- a/src/modules/views/Upload/UploadUtils.ts
+++ b/src/modules/views/Upload/UploadUtils.ts
@@ -39,14 +39,14 @@ export const shouldRender = (
 
 export const getFilesToHandle = async (
   webviewIntent: WebviewService
-): Promise<Array<FileFromNative['file'] & { name: string }>> => {
+): Promise<(FileFromNative['file'] & { name: string })[]> => {
   logger('info', 'getFilesToHandle called')
 
-  const files = (await webviewIntent?.call(
+  const files = (await webviewIntent.call(
     'getFilesToHandle'
   )) as unknown as FileFromNative[]
 
-  if (files?.length === 0) throw new Error('No files to upload')
+  if (files.length === 0) throw new Error('No files to upload')
 
   if (files.length > 0) {
     logger('info', 'getFilesToHandle success')
@@ -64,7 +64,7 @@ export const getFilesToHandle = async (
 export const sendFilesToHandle = (
   filesForQueue: FileForQueue[],
   webviewIntent: WebviewService,
-  folder: { _id: string }
+  folderId: string
 ): void => {
   const filesToUpload = filesForQueue.map(file => {
     if (!file.file) throw new Error('No file to upload')
@@ -72,14 +72,14 @@ export const sendFilesToHandle = (
     return {
       fileOptions: {
         name: file.file.name,
-        dirId: folder._id
+        dirId: folderId
       }
     }
   })
 
   logger('info', 'uploadFilesFromFlagship called')
 
-  void webviewIntent?.call('uploadFiles', JSON.stringify(filesToUpload))
+  void webviewIntent.call('uploadFiles', JSON.stringify(filesToUpload))
 
   logger('info', 'uploadFilesFromFlagship success')
 }

--- a/src/modules/views/Upload/UploaderComponent.tsx
+++ b/src/modules/views/Upload/UploaderComponent.tsx
@@ -4,11 +4,11 @@ import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { withStyles } from 'cozy-ui/transpiled/react/styles'
 
+import { FolderPickerFooter } from 'components/FolderPicker/FolderPickerFooter'
 import { FolderPickerHeader } from 'components/FolderPicker/FolderPickerHeader'
 import { FolderPickerTopbar } from 'components/FolderPicker/FolderPickerTopbar'
 import Explorer from 'modules/move/Explorer'
 import FileList from 'modules/move/FileList'
-import Footer from 'modules/move/Footer'
 import Loader from 'modules/move/Loader'
 import { shouldRender } from 'modules/views/Upload/UploadUtils'
 import { styles } from 'modules/views/Upload/UploaderComponent.styles'
@@ -79,7 +79,7 @@ const _UploaderComponent = (props: {
         }
         actions={
           shouldRender(items) && (
-            <Footer
+            <FolderPickerFooter
               onConfirm={uploadFilesFromFlagship}
               onClose={onClose}
               targets={items}

--- a/src/modules/views/Upload/UploaderComponent.tsx
+++ b/src/modules/views/Upload/UploaderComponent.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 
-import { withStyles } from 'cozy-ui/transpiled/react/styles'
-import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+import { withStyles } from 'cozy-ui/transpiled/react/styles'
 
-import Header from 'modules/move/Header'
+import { FolderPickerHeader } from 'components/FolderPicker/FolderPickerHeader'
+import { FolderPickerTopbar } from 'components/FolderPicker/FolderPickerTopbar'
 import Explorer from 'modules/move/Explorer'
 import FileList from 'modules/move/FileList'
-import Loader from 'modules/move/Loader'
 import Footer from 'modules/move/Footer'
-import Topbar from 'modules/move/Topbar'
-import { useUploadFromFlagship } from 'modules/views/Upload/useUploadFromFlagship'
+import Loader from 'modules/move/Loader'
 import { shouldRender } from 'modules/views/Upload/UploadUtils'
 import { styles } from 'modules/views/Upload/UploaderComponent.styles'
+import { useUploadFromFlagship } from 'modules/views/Upload/useUploadFromFlagship'
 
 const _UploaderComponent = (props: {
   classes: Record<string, unknown>
@@ -40,13 +40,13 @@ const _UploaderComponent = (props: {
         title={
           <>
             {shouldRender(items) && (
-              <Header
+              <FolderPickerHeader
                 entries={items}
                 title={t('ImportToDrive.title', { smart_count: items.length })}
                 subTitle={t('ImportToDrive.to')}
               />
             )}
-            <Topbar
+            <FolderPickerTopbar
               navigateTo={setFolder}
               folderId={folder._id}
               showFolderCreation={false}


### PR DESCRIPTION
This first technical step will make it easier to add shared drives. The component has a single function: to pick a folder. And those who use it no longer have to worry about implementation. So I could change the way it moves to match the design requirements for opening a Nextcloud folder