### PR TITLE
fix: Move custom theme CSS at end of <head>

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link
       rel="icon"
@@ -31,6 +30,7 @@
     <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>" />
     <% }); %>
+    {{.ThemeCSS}}
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link
       rel="icon"
@@ -26,6 +25,7 @@
     <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
       <link rel="stylesheet" href="<%- file %>" />
     <% }); %>
+    {{.ThemeCSS}}
   </head>
   <div
     id="main"

--- a/src/targets/public/index.ejs
+++ b/src/targets/public/index.ejs
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
     <link rel="apple-touch-icon" sizes="180x180" href="/public/apple-touch-icon.png" />
     <link
       rel="icon"
@@ -28,6 +27,7 @@
     <% } %> <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>" />
     <% }); %>
+    {{.ThemeCSS}}
   </head>
   <body>
     <div


### PR DESCRIPTION
Our custom theme CSS was not taken into account because cozy-ui CSS was inserted after the custom theme CSS.

I did not understand why it was working in <= 1.60.0 (if you want to check https://github.com/cozy/cozy-drive/compare/v1.60.0...v1.61.0).


```
### 🐛 Bug Fixes

* Custom theme colors were not taken into account
```

**Before**

![Screenshot 2024-05-29 at 13 38 19](https://github.com/cozy/cozy-drive/assets/10849491/3a3fe296-01bb-4b48-9572-9cbd66592e68)

**After**

![Screenshot 2024-05-29 at 13 37 49](https://github.com/cozy/cozy-drive/assets/10849491/18c3ecb8-ccb9-4c10-8873-f7b37dec473f)
