### PR TITLE
fix: Recent view query was malformed

### DIFF
--- a/src/modules/queries.js
+++ b/src/modules/queries.js
@@ -71,20 +71,17 @@ const buildRecentQuery = () => ({
   definition: () =>
     Q('io.cozy.files')
       .where({
-        type: 'file',
-        trashed: false,
-        dir_id: { $ne: SHARED_DRIVES_DIR_ID },
         updated_at: {
           $gt: null
         }
       })
-      .indexFields(['type', 'trashed', 'dir_id', 'updated_at'])
-      .sortBy([
-        { type: 'desc' },
-        { trashed: 'desc' },
-        { dir_id: 'desc' },
-        { updated_at: 'desc' }
-      ])
+      .partialIndex({
+        type: 'file',
+        trashed: false,
+        dir_id: { $ne: SHARED_DRIVES_DIR_ID }
+      })
+      .indexFields(['updated_at'])
+      .sortBy([{ updated_at: 'desc' }])
       .limitBy(50),
   options: {
     as: 'recent-view-query',


### PR DESCRIPTION
After 6e1041f2c21c6dbc0802464af3c57f30ffedb4a9, the recent view was broken, because it introduced the `dir_id` sort before the `updated_at` sort, which is problematic, as the `dir_id` is meaningless for the user. Thus, we fix this by using a (type, updated_at) sort.

Furthermore, we now use a partial index for better performances.



```
### ✨ Features

*

### 🐛 Bug Fixes

* Recent view was not displaying in correct order

### 🔧 Tech

*
```
