### PR TITLE
fix: Hide favorites into navigation without the flag

### DIFF
--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 
+import flag from 'cozy-flags'
 import UINav from 'cozy-ui/transpiled/react/Nav'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
@@ -20,7 +21,7 @@ export const Nav = () => {
         rx={/\/(folder|nextcloud|trash)(\/.*)?/}
         clickState={clickState}
       />
-      {!isDesktop ? (
+      {!isDesktop && flag('drive.show-favorites-dev') ? (
         <NavItem
           to="/favorites"
           icon="star"
@@ -37,7 +38,7 @@ export const Nav = () => {
         clickState={clickState}
       />
       <SharingsNavItem clickState={clickState} />
-      {isDesktop ? (
+      {isDesktop && flag('drive.show-favorites-dev') ? (
         <FavoriteItems clickState={clickState} className="u-mt-half" />
       ) : null}
     </UINav>


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Hide favorites into navigation without the flag
```
