### PR TITLE
[VO-910] fix: Open in new tab OnlyOffice file in public

### DIFF
--- a/src/modules/filelist/FileOpener.jsx
+++ b/src/modules/filelist/FileOpener.jsx
@@ -3,10 +3,10 @@ import propagating from 'propagating-hammerjs'
 import React, { useEffect, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { models } from 'cozy-client'
+import { models, useClient } from 'cozy-client'
 
 import styles from './fileopener.styl'
-import { makeOnlyOfficeFileRoute } from 'modules/views/OnlyOffice/helpers'
+import { makeOnlyOfficeURL } from 'modules/views/OnlyOffice/helpers'
 
 const getParentDiv = element => {
   if (element.nodeName.toLowerCase() === 'div') {
@@ -60,6 +60,7 @@ const FileOpener = ({
 }) => {
   const rowRef = useRef()
   const { pathname } = useLocation()
+  const client = useClient()
 
   useEffect(() => {
     if (!rowRef || !rowRef.current) return
@@ -95,16 +96,16 @@ const FileOpener = ({
   ])
 
   if (models.file.shouldBeOpenedByOnlyOffice(file)) {
+    const onlyOfficeURL = makeOnlyOfficeURL(file, client, {
+      fromPathname: pathname
+    })
     return (
       <a
         data-testid="onlyoffice-link"
         className={`${styles['file-opener']} ${styles['file-opener__a']}`}
         ref={rowRef}
         id={file.id}
-        href={makeOnlyOfficeFileRoute(file.id, {
-          withoutRouter: true,
-          fromPathname: pathname
-        })}
+        href={onlyOfficeURL}
         onClick={ev => {
           ev.preventDefault()
         }}

--- a/src/modules/filelist/FileOpener.spec.jsx
+++ b/src/modules/filelist/FileOpener.spec.jsx
@@ -13,7 +13,11 @@ jest.mock('cozy-client/dist/models/file', () => ({
   shouldBeOpenedByOnlyOffice: jest.fn()
 }))
 
-const client = createMockClient({})
+const client = createMockClient({
+  clientOptions: {
+    uri: 'http://cozy.tools:8080'
+  }
+})
 const file = generateFile({ i: 0 })
 
 const setup = ({ file }) => {

--- a/src/modules/views/Folder/createFileOpeningHandler.js
+++ b/src/modules/views/Folder/createFileOpeningHandler.js
@@ -5,7 +5,10 @@ import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
 
 import { DOCTYPE_FILES_SHORTCUT } from 'lib/doctypes'
 import generateShortcutUrl from 'modules/views/Folder/generateShortcutUrl'
-import { makeOnlyOfficeFileRoute } from 'modules/views/OnlyOffice/helpers'
+import {
+  makeOnlyOfficeFileRoute,
+  makeOnlyOfficeURL
+} from 'modules/views/OnlyOffice/helpers'
 
 const createFileOpeningHandler =
   ({
@@ -66,13 +69,11 @@ const createFileOpeningHandler =
       }
     } else if (isOnlyOffice && isOfficeEnabled) {
       if (event.ctrlKey || event.metaKey || event.shiftKey) {
-        openInNewTab(
-          makeOnlyOfficeFileRoute(file.id, {
-            withoutRouter: true,
-            fromPathname: pathname,
-            fromPublicFolder
-          })
-        )
+        const onlyOfficeURL = makeOnlyOfficeURL(file, client, {
+          fromPathname: pathname,
+          fromPublicFolder
+        })
+        openInNewTab(onlyOfficeURL)
       } else {
         routeTo(
           makeOnlyOfficeFileRoute(file.id, {

--- a/src/modules/views/OnlyOffice/helpers.js
+++ b/src/modules/views/OnlyOffice/helpers.js
@@ -1,3 +1,4 @@
+import { generateWebLink } from 'cozy-client'
 import { isMobile } from 'cozy-device-helper'
 import flag from 'cozy-flags'
 import FileTypeSheetIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSheet'
@@ -69,21 +70,24 @@ export const isOfficeEditingEnabled = isDesktop => {
 }
 
 /**
+ * @typedef {Object} OnlyOfficeFileRouteOptions
+ * @property {boolean} [fromCreate] The document will be opened in edit mode
+ * @property {boolean} [fromPathname] Hash to redirect the user when he back
+ * @property {boolean} [fromRedirect] To forward existing redirectLink
+ * @property {boolean} [fromEdit] The document will be opened in edit mode
+ * @property {boolean} [fromPublicFolder] The document is opened from a public folder
+ */
+
+/**
  * Make hash to redirect user to an OnlyOffice file
  * @param {string} fileId Id of the OnlyOffice file
- * @param {object} options
- * @param {boolean} options.withoutRouter To return an path without the hash prefix
- * @param {boolean} options.fromCreate The document will be opened in edit mode
- * @param {boolean} options.fromPathname Hash to redirect the user when he back
- * @param {boolean} options.fromRedirect To forward existing redirectLink
- * @param {boolean} options.fromEdit The document will be opened in edit mode
- * @param {boolean} options.fromPublicFolder The document is opened from a public folder
+ * @param {OnlyOfficeFileRouteOptions} [options] Options
+
  * @returns {string} Path to OnlyOffice
  */
 export const makeOnlyOfficeFileRoute = (
   fileId,
   {
-    withoutRouter = false,
     fromCreate = false,
     fromPathname,
     fromRedirect,
@@ -107,10 +111,30 @@ export const makeOnlyOfficeFileRoute = (
   if (fromPublicFolder) {
     params.append('fromPublicFolder', fromPublicFolder)
   }
+
   const searchParam = params.size > 0 ? `?${params.toString()}` : ''
-  return withoutRouter
-    ? `/#/onlyoffice/${fileId}${searchParam}`
-    : `/onlyoffice/${fileId}${searchParam}`
+  return `/onlyoffice/${fileId}${searchParam}`
+}
+
+/**
+ * Generates the OnlyOffice URL for a given file.
+ *
+ * @param {import('cozy-client/types/types').IOCozyFile} file - The file object.
+ * @param {import('cozy-client/types').CozyClient} client - The client object.
+ * @param {OnlyOfficeFileRouteOptions} routeOptions - The route options object (optional).
+ * @returns {string} The OnlyOffice URL.
+ */
+export const makeOnlyOfficeURL = (file, client, routeOptions = {}) => {
+  const onlyOfficeRoute = makeOnlyOfficeFileRoute(file.id, routeOptions)
+  const currentURL = new URL(window.location)
+  return generateWebLink({
+    slug: 'drive',
+    cozyUrl: client.getStackClient().uri,
+    subDomainType: client.getInstanceOptions().subdomain,
+    pathname: currentURL.pathname,
+    searchParams: currentURL.searchParams,
+    hash: onlyOfficeRoute
+  })
 }
 
 /**


### PR DESCRIPTION
OnlyOffice files can be opened with ctrl + right click for quick access. This didn't work in public because we hadn't kept the sharecode in the generated urls.

```
### 🐛 Bug Fixes

* Open in new tab OnlyOffice file in public
```
