### PR TITLE
[VO-912] fix(Empty): Remove scrollbar on mobile

### DIFF
--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -33,7 +33,7 @@ const EmptyCanvas = ({ type, canUpload, localeKey, hasTextMobileVersion }) => {
         (localeKey && t(`empty.${localeKey}_text`)) ||
         (canUpload && t('empty.text'))
       }
-      className={cx(styles['empty'], 'u-mh-2')}
+      className={cx(styles['empty'])}
     />
   )
 }


### PR DESCRIPTION
The `u-mh-2` class corrected a margin problem that was later corrected in cozy-ui (https://github.com/cozy/cozy-ui/commit/8c036602cf88cbce7dc8e7c00aaec62445e89784). The combination of the two caused a horizontal scroll bar to appear in mobile. I've removed the Drive fix in favour of the cozy-ui fix.

```
### 🐛 Bug Fixes

* Remove scrollbar in empty state on mobile
```
