### PR TITLE
fix(Public): Show filename only in viewer

### DIFF
--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { BarRight, BarCenter } from 'cozy-bar'
+import { BarRight } from 'cozy-bar'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 export const BarRightOnMobile = ({ children }) => {
@@ -8,16 +8,6 @@ export const BarRightOnMobile = ({ children }) => {
 
   if (isMobile) {
     return <BarRight>{children}</BarRight>
-  }
-
-  return children
-}
-
-export const BarCenterOnMobile = ({ children }) => {
-  const { isMobile } = useBreakpoints()
-
-  if (isMobile) {
-    return <BarCenter>{children}</BarCenter>
   }
 
   return children

--- a/src/modules/public/LightFileViewer.jsx
+++ b/src/modules/public/LightFileViewer.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { BarCenter } from 'cozy-bar'
 import { SharingBannerPlugin, useSharingInfos } from 'cozy-sharing'
+import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import FooterActionButtons from 'cozy-ui/transpiled/react/Viewer/Footer/FooterActionButtons'
 import ForwardOrDownloadButton from 'cozy-ui/transpiled/react/Viewer/Footer/ForwardOrDownloadButton'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -35,6 +38,13 @@ const LightFileViewer = ({ files, isPublic }) => {
 
   return (
     <div className={styles['viewer-wrapper-with-bar']}>
+      {isMobile && (
+        <BarCenter>
+          <Typography variant="h3" noWrap className="u-ph-1 u-pt-half">
+            <MidEllipsis text={files[0].name} />
+          </Typography>
+        </BarCenter>
+      )}
       <SharingBannerPlugin />
       {!isDesktop && (
         <PublicToolbar

--- a/src/modules/public/PublicToolbarByLink.jsx
+++ b/src/modules/public/PublicToolbarByLink.jsx
@@ -2,13 +2,11 @@ import { useDisplayedFolder } from 'hooks'
 import React from 'react'
 
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
-import Typography from 'cozy-ui/transpiled/react/Typography'
 import { ActionMenuItem } from 'cozy-ui/transpiled/react/deprecated/ActionMenu'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import { BarCenterOnMobile, BarRightOnMobile } from 'components/Bar'
+import { BarRightOnMobile } from 'components/Bar'
 import { HOME_LINK_HREF } from 'constants/config'
 import AddMenuProvider from 'modules/drive/AddMenu/AddMenuProvider'
 import AddButton from 'modules/drive/Toolbar/components/AddButton'
@@ -32,13 +30,6 @@ const PublicToolbarByLink = ({
 
   return (
     <>
-      {isFile && (
-        <BarCenterOnMobile>
-          <Typography variant="h3" noWrap className="u-ph-1 u-pt-half">
-            <MidEllipsis text={files[0].name} />
-          </Typography>
-        </BarCenterOnMobile>
-      )}
       <BarRightOnMobile>
         <AddMenuProvider
           canCreateFolder={hasWriteAccess}


### PR DESCRIPTION
The fix #3159 had two side effect when there was only one file inside a share folder : 
- in desktop, we showed the filename inside the toolbar
- in mobile, we showed the filename inside the cozy-bar instead of the folder name

This commit aims to correct these problems

```
### 🐛 Bug Fixes

* Show filename only in public viewer instead of folder view
```
