### PR TITLE
fix: FilesViewerLoading was imported from a file that did not export it

### DIFF
--- a/src/modules/views/Drive/FilesViewerDrive.jsx
+++ b/src/modules/views/Drive/FilesViewerDrive.jsx
@@ -4,9 +4,10 @@ import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from 'cozy-client'
 
+import { FilesViewerLoading } from 'components/FilesViewerLoading'
 import { useFolderSort } from 'modules/navigation/duck'
 import { getFolderPath } from 'modules/routeUtils'
-import FilesViewer, { FilesViewerLoading } from 'modules/viewer/FilesViewer'
+import FilesViewer from 'modules/viewer/FilesViewer'
 import { buildDriveQuery } from 'queries'
 
 const FilesViewerDrive = () => {
@@ -20,13 +21,15 @@ const FilesViewerDrive = () => {
     sortAttribute: sortOrder.attribute,
     sortOrder: sortOrder.order
   })
+
   const filesQuery = useQuery(
     buildedFilesQuery.definition,
     buildedFilesQuery.options
   )
 
-  if (filesQuery.data) {
-    const viewableFiles = filesQuery.data
+  const viewableFiles = filesQuery.data
+
+  if (viewableFiles) {
     return (
       <FilesViewer
         files={viewableFiles}
@@ -37,9 +40,9 @@ const FilesViewerDrive = () => {
         }
       />
     )
-  } else {
-    return <FilesViewerLoading />
   }
+
+  return <FilesViewerLoading />
 }
 
 export default FilesViewerDrive

--- a/src/modules/views/Recent/FilesViewerRecent.jsx
+++ b/src/modules/views/Recent/FilesViewerRecent.jsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from 'cozy-client'
 
-import FilesViewer, { FilesViewerLoading } from 'modules/viewer/FilesViewer'
+import { FilesViewerLoading } from 'components/FilesViewerLoading'
+import FilesViewer from 'modules/viewer/FilesViewer'
 import { buildRecentQuery } from 'queries'
 
 const FilesViewerRecent = () => {

--- a/src/modules/views/Sharings/FilesViewerSharings.jsx
+++ b/src/modules/views/Sharings/FilesViewerSharings.jsx
@@ -5,7 +5,8 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery } from 'cozy-client'
 
 import withSharedDocumentIds from './withSharedDocumentIds'
-import FilesViewer, { FilesViewerLoading } from 'modules/viewer/FilesViewer'
+import { FilesViewerLoading } from 'components/FilesViewerLoading'
+import FilesViewer from 'modules/viewer/FilesViewer'
 import { buildSharingsQuery } from 'queries'
 
 const FilesViewerSharing = ({ sharedDocumentIds }) => {

--- a/src/modules/views/Trash/FilesViewerTrash.jsx
+++ b/src/modules/views/Trash/FilesViewerTrash.jsx
@@ -4,8 +4,9 @@ import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from 'cozy-client'
 
+import { FilesViewerLoading } from 'components/FilesViewerLoading'
 import { useFolderSort } from 'modules/navigation/duck'
-import FilesViewer, { FilesViewerLoading } from 'modules/viewer/FilesViewer'
+import FilesViewer from 'modules/viewer/FilesViewer'
 import { buildTrashQuery } from 'queries'
 
 const FilesViewerTrash = () => {


### PR DESCRIPTION
ça ne posait pas de souci avec un usage classique de l'app : chargement de la home, puis navigation dans les dossier/fichier. Car la requête de récupération des fichiers est exécuté au lancement de l'app, et donc la navigation se fait sur le cache. Usequery dans les composants retourne alors toujours un tableau et non un null. On ne passe donc jamais dans le FilesViewerLoading.

Sauf qu'avec un refresh sur la visualisation d'un fichier, la query est réinitialisée, donc on passe par un null, donc l'app plantait car l'import n'était pas bon.