### PR TITLE
fix: Hide back icon in public viewer

### DIFF
--- a/src/modules/public/LightFileViewer.jsx
+++ b/src/modules/public/LightFileViewer.jsx
@@ -64,7 +64,7 @@ const LightFileViewer = ({ files, isPublic }) => {
               isEnabled: isOfficeEnabled(isDesktop),
               opener: onlyOfficeOpener
             },
-            toolbarProps: { showToolbar: isDesktop }
+            toolbarProps: { showToolbar: isDesktop, showClose: false }
           }}
         >
           <FooterActionButtons>


### PR DESCRIPTION
In the Public view, no return is possible, as there is none.