### PR TITLE
feat: Hide sharing banner for the synchronize action 

### DIFF
--- a/src/modules/actions/index.jsx
+++ b/src/modules/actions/index.jsx
@@ -22,6 +22,7 @@ import { isEncryptedFolder, isEncryptedFile } from 'lib/encryption'
 import { navigateToModal } from 'modules/actions/helpers'
 import DeleteConfirm from 'modules/drive/DeleteConfirm'
 import { startRenamingAsync } from 'modules/drive/rename'
+import { openExternalLink as openExtLink } from 'modules/public/helpers'
 
 export { share } from './share'
 
@@ -241,7 +242,7 @@ export const openExternalLink = ({ t, isSharingShortcutCreated, link }) => {
     label,
     icon,
     action: () => {
-      openExternalLink(link)
+      openExtLink(link)
     },
     Component: forwardRef(function OpenExternalLink(props, ref) {
       return (

--- a/src/modules/public/PublicToolbarByLink.jsx
+++ b/src/modules/public/PublicToolbarByLink.jsx
@@ -42,6 +42,8 @@ const PublicToolbarByLink = ({
     actionOptions
   )
 
+  const isMoreMenuDisplayed = actions.length > 0 || files.length > 1
+
   return (
     <BarRightOnMobile>
       <AddMenuProvider
@@ -60,15 +62,17 @@ const PublicToolbarByLink = ({
             )}
           </>
         )}
-        <PublicToolbarMoreMenu
-          files={files}
-          hasWriteAccess={hasWriteAccess}
-          showSelectionBar={showSelectionBar}
-          actions={actions}
-        >
-          {isMobile && hasWriteAccess && <AddMenuItem />}
-          {files.length > 1 && <SelectableItem onClick={showSelectionBar} />}
-        </PublicToolbarMoreMenu>
+        {isMoreMenuDisplayed && (
+          <PublicToolbarMoreMenu
+            files={files}
+            hasWriteAccess={hasWriteAccess}
+            showSelectionBar={showSelectionBar}
+            actions={actions}
+          >
+            {isMobile && hasWriteAccess && <AddMenuItem />}
+            {files.length > 1 && <SelectableItem onClick={showSelectionBar} />}
+          </PublicToolbarMoreMenu>
+        )}
       </AddMenuProvider>
     </BarRightOnMobile>
   )

--- a/src/modules/views/Public/PublicFolderView.jsx
+++ b/src/modules/views/Public/PublicFolderView.jsx
@@ -155,11 +155,14 @@ const PublicFolderView = () => {
   const isOldBreadcrumb =
     !showNewBreadcrumbFlag || showNewBreadcrumbFlag !== true
 
+  // Check if the sharing shortcut has already been created (but not synced)
+  const isShareAlreadyAdded = sharingInfos?.isSharingShortcutCreated
+
   return (
     <Main isPublic={true}>
       <ModalStack />
       <ModalManager />
-      <SharingBannerPlugin />
+      {!isShareAlreadyAdded && <SharingBannerPlugin />}
       <span className={cx({ 'u-pt-2': !isMobile })} />
       <FolderViewHeader>
         {currentFolderId && (


### PR DESCRIPTION
We no longer wish to highlight this action, but it remains in the 3-point menu.