### PR TITLE
feat: Upgrade date-fns to 2.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cozy-stack-client": "^51.6.0",
     "cozy-ui": "^114.0.1",
     "cozy-viewer": "^10.0.0",
-    "date-fns": "1.30.1",
+    "date-fns": "2.30.0",
     "diacritics": "1.3.0",
     "filesize": "10.1.6",
     "leaflet": "1.9.4",

--- a/src/lib/dacc/dacc-run.js
+++ b/src/lib/dacc/dacc-run.js
@@ -1,4 +1,7 @@
-import { endOfMonth, startOfMonth, format, subMonths } from 'date-fns'
+import endOfMonth from 'date-fns/endOfMonth'
+import format from 'date-fns/format'
+import startOfMonth from 'date-fns/startOfMonth'
+import subMonths from 'date-fns/subMonths'
 
 import CozyClient from 'cozy-client'
 import flag from 'cozy-flags'
@@ -36,17 +39,20 @@ export const run = async () => {
 
   const aggregationDate = new Date(
     maxFileDateQuery || endOfMonth(subMonths(new Date(), 1))
-  ).toISOString()
+  )
 
   const sizesBySlug = await aggregateFilesSize(client, aggregationDate, {
     excludedSlug,
     nonExcludedGroupLabel
   })
   if (Object.keys(sizesBySlug).length < 1) {
-    log('info', `No files found to aggregate with date ${aggregationDate}`)
+    log(
+      'info',
+      `No files found to aggregate with date ${aggregationDate.toISOString()}`
+    )
   }
 
-  const startDateMeasure = format(startOfMonth(aggregationDate), 'YYYY-MM-DD')
+  const startDateMeasure = format(startOfMonth(aggregationDate), 'yyyy-LL-dd')
 
   await sendToRemoteDoctype(client, remoteDoctype, sizesBySlug, {
     measureName,

--- a/src/lib/dacc/dacc-run.spec.js
+++ b/src/lib/dacc/dacc-run.spec.js
@@ -1,4 +1,5 @@
-import { endOfMonth, subMonths } from 'date-fns'
+import endOfMonth from 'date-fns/endOfMonth'
+import subMonths from 'date-fns/subMonths'
 
 import CozyClient from 'cozy-client'
 import flag from 'cozy-flags'
@@ -14,7 +15,7 @@ jest.mock('lib/dacc/dacc')
 
 describe('dacc', () => {
   const maxGivenDate = '2022-01-01'
-  const maxDate = new Date(maxGivenDate).toISOString()
+  const maxDate = new Date(maxGivenDate)
   beforeEach(() => {
     flag.mockReturnValue({
       excludedSlug: 'excludedSlug',
@@ -67,9 +68,7 @@ describe('dacc', () => {
       measureName: 'measureName',
       remoteDoctype: 'remoteDoctype'
     })
-    const endOfThisMonth = new Date(
-      endOfMonth(subMonths(new Date(), 1))
-    ).toISOString()
+    const endOfThisMonth = new Date(endOfMonth(subMonths(new Date(), 1)))
 
     // When
     await run()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,22 +7066,22 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@1.30.1, date-fns@^1.28.5, date-fns@^1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
 date-fns@2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
-date-fns@^2.22.1:
+date-fns@2.30.0, date-fns@^2.22.1:
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
   integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
   dependencies:
     "@babel/runtime" "^7.21.0"
+
+date-fns@^1.28.5, date-fns@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 debounce@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
This update has revealed a mistake in the [aggregateFilesSize](https://github.com/cozy/cozy-drive/blob/1b67de296094c118a09add39d6df56f29e143858/src/lib/dacc/dacc.js#L90-L91) function.
We could end up comparing a Date type with a String type.
