### PR TITLE
feat: Files doctype should appear first in search

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cozy-ci": "0.5.2",
     "cozy-client": "^51.6.1",
     "cozy-client-js": "0.20.0",
-    "cozy-dataproxy-lib": "^2.2.0",
+    "cozy-dataproxy-lib": "^2.3.0",
     "cozy-device-helper": "^3.7.1",
     "cozy-devtools": "^1.2.1",
     "cozy-doctypes": "1.85.4",

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -11,6 +11,7 @@ import { AcceptingSharingProvider } from 'lib/AcceptingSharingContext'
 import DriveProvider from 'lib/DriveProvider'
 import { ModalContextProvider } from 'lib/ModalContext'
 import { ThumbnailSizeContextProvider } from 'lib/ThumbnailSizeContext'
+import { DOCTYPE_APPS, DOCTYPE_CONTACTS, DOCTYPE_FILES } from 'lib/doctypes'
 import { PublicProvider } from 'modules/public/PublicProvider'
 import { onFileUploaded } from 'modules/views/Upload/UploadUtils'
 
@@ -26,19 +27,19 @@ const App = ({ isPublic, store, client, lang, polyglot, children }) => {
         <BarProvider>
           <Provider store={store}>
             <DriveProvider client={client} lang={lang} polyglot={polyglot}>
-              <PushBannerProvider>
-                <AcceptingSharingProvider>
-                  <ThumbnailSizeContextProvider>
-                    <ModalContextProvider>
-                      {isPublic ? (
-                        children
-                      ) : (
-                        <DataProxyProvider>{children}</DataProxyProvider>
-                      )}
-                    </ModalContextProvider>
-                  </ThumbnailSizeContextProvider>
-                </AcceptingSharingProvider>
-              </PushBannerProvider>
+              <DataProxyProvider
+                options={{
+                  doctypes: [DOCTYPE_FILES, DOCTYPE_CONTACTS, DOCTYPE_APPS]
+                }}
+              >
+                <PushBannerProvider>
+                  <AcceptingSharingProvider>
+                    <ThumbnailSizeContextProvider>
+                      <ModalContextProvider>{children}</ModalContextProvider>
+                    </ThumbnailSizeContextProvider>
+                  </AcceptingSharingProvider>
+                </PushBannerProvider>
+              </DataProxyProvider>
             </DriveProvider>
           </Provider>
         </BarProvider>

--- a/src/lib/doctypes.js
+++ b/src/lib/doctypes.js
@@ -9,6 +9,7 @@ export const DOCTYPE_FILES_SHORTCUT = 'io.cozy.files.shortcuts'
 export const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 export const DOCTYPE_PHOTOS_SETTINGS = 'io.cozy.photos.settings'
 export const DOCTYPE_APPS = 'io.cozy.apps'
+export const DOCTYPE_CONTACTS = 'io.cozy.contacts'
 export const DOCTYPE_CONTACTS_VERSION = 2
 
 export const schema = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6309,10 +6309,10 @@ cozy-client@^51.6.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-dataproxy-lib@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-2.2.0.tgz#99bcb2ef5ff07476d5168bcd4eda298fba0cfe32"
-  integrity sha512-NE5vi6pKysKdXKlmDU9OCorTetZNgYWH2YsYaX+cOcNE6q9talfNA4QlaDuTMju5u+ksbw3pf8gcd39pMJ+ubw==
+cozy-dataproxy-lib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-2.3.0.tgz#c702c36a674c61edffd31e10d3c9e3665f64c4ef"
+  integrity sha512-rDYd3yOykArExr8Iz/hoP+2jI57NX0Z/LIDsPmH3W9vifXnb1SVBfekxE4vNXj9vJKLSZ8vfKgl3OuqYbOKVow==
   dependencies:
     classnames "2.5.1"
     comlink "4.4.1"


### PR DESCRIPTION
When searching through the dataproxy, the default doctype search order is apps, contacts, files, mainly because of their respective volume. It is assumed to have very few apps, and less contacts than files. Therefore, since there is a limit to displayed results, we prefer to display files in last.
This works in the Home search contexte, but not so much in Drive, where it makes sense to have the files displayed first.