### PR TITLE
fix: Enable rslib sideEffects on react-spring

### DIFF
--- a/rsbuild.config.mjs
+++ b/rsbuild.config.mjs
@@ -30,6 +30,18 @@ const mergedConfig = mergeRsbuildConfig(config, {
     alias: {
       'react-pdf$': 'react-pdf/dist/esm/entry.webpack'
     }
+  },
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /react-spring/,
+            sideEffects: true
+          }
+        ]
+      }
+    }
   }
 })
 


### PR DESCRIPTION
Since the rslib migration, the mui-bottom-sheet component would not work anymore due to `.willAdvance is not a function` error

This is due to library's side effects that are erased by the tree shaking mechanism

To prevent that we change the rsbuild configuration to handle those side effects

More info: pmndrs/react-spring#1078