### PR TITLE
Display shared drives in "Drives" section

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -82,6 +82,7 @@
           "rw": "You can view, update, delete and add this content to your Cozy. Updates you make will be seen on other Cozies."
         }
       },
+      "shared": "Shared",
       "sharedByMe": "Shared by me",
       "sharedWithMe": "Shared with me",
       "sharedBy": "Shared by %{name}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -82,6 +82,7 @@
           "rw": "Vous pouvez consulter, modifier et supprimer du contenu. Les modifications sur le contenu seront répercutées automatiquement entre vos Cozy."
         }
       },
+      "shared": "Partagé",
       "sharedByMe": "Partagé",
       "sharedWithMe": "Partagé avec moi",
       "sharedBy": "Partagé par %{name}",

--- a/src/modules/filelist/cells/FileName.jsx
+++ b/src/modules/filelist/cells/FileName.jsx
@@ -8,6 +8,7 @@ import { isDirectory } from 'cozy-client/dist/models/file'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import CarbonCopyIcon from 'cozy-ui/transpiled/react/Icons/CarbonCopy'
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
 import { TableCell } from 'cozy-ui/transpiled/react/deprecated/Table'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
@@ -16,6 +17,7 @@ import styles from '@/styles/filelist.styl'
 
 import RenameInput from '@/modules/drive/RenameInput'
 import { getFileNameAndExtension } from '@/modules/filelist/helpers'
+import { isSharedDriveFolder } from '@/modules/shareddrives/helpers'
 
 export const CertificationsIcons = ({ attributes }) => {
   const isCarbonCopy = get(attributes, 'metadata.carbonCopy')
@@ -147,6 +149,16 @@ const FileName = ({
                 {isMobile && <CertificationsIcons attributes={attributes} />}
               </div>
             ))}
+          {!withFilePath && isSharedDriveFolder(attributes) && (
+            <div className={styles['fil-file-shared']}>
+              <Icon
+                icon={ShareIcon}
+                size="10"
+                className={styles['fil-file-shared-icon']}
+              />
+              {t('Files.share.shared')}
+            </div>
+          )}
         </div>
       )}
     </TableCell>

--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -24,6 +24,7 @@ import {
   isNextcloudShortcut,
   isNextcloudFile
 } from '@/modules/nextcloud/helpers'
+import { isSharedDriveFolder } from '@/modules/shareddrives/helpers'
 
 interface FileThumbnailProps {
   file: File | FolderPickerEntry
@@ -70,7 +71,8 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
 
   if (
     file._id === 'io.cozy.files.shared-drives-dir' ||
-    isNextcloudShortcut(file)
+    isNextcloudShortcut(file) ||
+    isSharedDriveFolder(file)
   ) {
     return <Icon icon={IconServer} size={size ?? 32} />
   }

--- a/src/modules/shareddrives/components/AddSharedDriveButton.tsx
+++ b/src/modules/shareddrives/components/AddSharedDriveButton.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from 'react'
+
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+interface AddSharedDriveButtonProps {
+  onClick: () => void
+}
+
+const AddSharedDriveButton: FC<AddSharedDriveButtonProps> = ({ onClick }) => {
+  const { t } = useI18n()
+
+  return (
+    <Button
+      onClick={onClick}
+      startIcon={<Icon icon={PlusIcon} />}
+      label={t('toolbar.menu_add')}
+    />
+  )
+}
+
+export default AddSharedDriveButton

--- a/src/modules/shareddrives/components/AddSharedDriveFab.tsx
+++ b/src/modules/shareddrives/components/AddSharedDriveFab.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from 'react'
+
+import Fab from 'cozy-ui/transpiled/react/Fab'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
+
+interface AddSharedDriveFabProps {
+  onClick: () => void
+}
+
+const AddSharedDriveFab: FC<AddSharedDriveFabProps> = ({ onClick }) => {
+  return (
+    <div className="u-pos-absolute u-bottom-s u-right-s">
+      <Fab color="primary" onClick={onClick}>
+        <Icon icon={PlusIcon} />
+      </Fab>
+    </div>
+  )
+}
+
+export default AddSharedDriveFab

--- a/src/modules/shareddrives/helpers.ts
+++ b/src/modules/shareddrives/helpers.ts
@@ -1,0 +1,11 @@
+import type { File, FolderPickerEntry } from '@/components/FolderPicker/types'
+
+export const isSharedDriveFolder = (
+  file: File | FolderPickerEntry
+): boolean => {
+  return (
+    file._type === 'io.cozy.files' &&
+    file.dir_id === 'io.cozy.files.shared-drives-dir' &&
+    file.type === 'directory'
+  )
+}

--- a/src/modules/views/Drive/SharedDrivesFolderView.tsx
+++ b/src/modules/views/Drive/SharedDrivesFolderView.tsx
@@ -1,7 +1,9 @@
-import React, { FC, useMemo } from 'react'
+import React, { FC, useState, useMemo } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { useQuery } from 'cozy-client'
+import flag from 'cozy-flags'
+import { SharedDriveModal } from 'cozy-sharing'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
@@ -14,6 +16,8 @@ import {
 } from '@/modules/certifications/useExtraColumns'
 import { FolderBody } from '@/modules/folder/components/FolderBody'
 import { useFolderSort } from '@/modules/navigation/duck'
+import AddSharedDriveButton from '@/modules/shareddrives/components/AddSharedDriveButton'
+import AddSharedDriveFab from '@/modules/shareddrives/components/AddSharedDriveFab'
 import FolderView from '@/modules/views/Folder/FolderView'
 import FolderViewBreadcrumb from '@/modules/views/Folder/FolderViewBreadcrumb'
 import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
@@ -29,6 +33,7 @@ const SharedDrivesFolderView: FC = () => {
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()
   const { isNotFound } = useDisplayedFolder()
+  const [isSharedDriveModalOpen, setIsSharedDriveModalOpen] = useState(false)
 
   const extraColumnsNames = makeExtraColumnsNamesFromMedia({
     isMobile,
@@ -70,6 +75,13 @@ const SharedDrivesFolderView: FC = () => {
     [t]
   )
 
+  const showSharedDriveModal = (): void => setIsSharedDriveModalOpen(true)
+  const hideSharedDriveModal = (): void => setIsSharedDriveModalOpen(false)
+
+  const showAddSharedDriveButton =
+    flag('drive.shared-drive.enabled') && !isMobile
+  const showAddSharedDriveFab = flag('drive.shared-drive.enabled') && isMobile
+
   return (
     <FolderView isNotFound={isNotFound}>
       <FolderViewHeader>
@@ -77,12 +89,21 @@ const SharedDrivesFolderView: FC = () => {
           rootBreadcrumbPath={rootBreadcrumbPath}
           currentFolderId="io.cozy.files.shared-drives-dir"
         />
+        {showAddSharedDriveButton && (
+          <AddSharedDriveButton onClick={showSharedDriveModal} />
+        )}
       </FolderViewHeader>
       <FolderBody
         folderId="io.cozy.files.shared-drives-dir"
         queryResults={queryResults}
         extraColumns={extraColumns}
       />
+      {showAddSharedDriveFab && (
+        <AddSharedDriveFab onClick={showSharedDriveModal} />
+      )}
+      {isSharedDriveModalOpen && (
+        <SharedDriveModal onClose={hideSharedDriveModal} />
+      )}
       <Outlet />
     </FolderView>
   )

--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -259,6 +259,13 @@ column-width-thumbnail-bigger = 7rem
 .fil-file-infos
     display none
 
+.fil-file-shared
+    color var(--actionColorActive)
+    font-size .75rem
+
+.fil-file-shared-icon
+    margin-right 0.2rem
+
 @keyframes placeHolderShimmer
     0%
         background-position -20rem 0


### PR DESCRIPTION
## What is it ?

Shared drive are being added in cozy-stack in https://github.com/cozy/cozy-stack/pull/4511. Here we display them in "Drives" section and we add buttons to create them.

It is behind a flag `drive.enable-shared-drive` so it can be safely merged and send to production.

## What does it look ?

![image](https://github.com/user-attachments/assets/d539bfca-8de4-4fca-ab9a-1bf895097d15)

## Prerequisites 
- [x] merge and include https://github.com/cozy/cozy-client/pull/1590 
- [x] merge and include https://github.com/cozy/cozy-libs/pull/2735

See : https://github.com/cozy/cozy-drive/pull/3323