### PR TITLE
feat: Exclude build from tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "bundlemon": "3.1.0",
     "cozy-app-publish": "^0.40.1",
     "cozy-jobs-cli": "^2.4.3",
-    "cozy-tsconfig": "1.2.0",
+    "cozy-tsconfig": "^1.8.1",
     "css-mediaquery": "0.1.2",
     "eslint": "8.56.0",
     "eslint-config-cozy-app": "6.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "cozy-tsconfig",
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "build"],
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "jsx": "react",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5837,10 +5837,10 @@ cozy-stack-client@^57.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-tsconfig@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.2.0.tgz#17e61f960f139fae4d26cbac2254b9ab632b269e"
-  integrity sha512-TRHnY9goF3FzVlUbP7BcHxuN2XAA4AmppT4fHHZmTKaSwYTByVR1Al+riFMDbce94kJZ1wzl9WNLWQuqzGZ6Cw==
+cozy-tsconfig@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.8.1.tgz#5f206f4e6e041a4afc6691098264ba630bdeb7e2"
+  integrity sha512-/9QBxK8Tc12O2ojuyRpSMjPpXpqldVvzfNB1+/nPD+IkIBkU+mqxpHYJwKWjNYHGraCSy69mIwt9J3aiaJdz9w==
 
 cozy-ui@^121.2.0:
   version "121.2.0"
@@ -10680,9 +10680,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
To allow back "editor wide feature" by vscode. It was not working because it was trying to watch too many files.

Also removed "jsx": "react" which is already part of cozy-tsconfig.