### PR TITLE
fix: Remove broken service trigger

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -83,9 +83,7 @@
   "services": {
     "qualificationMigration": {
       "type": "node",
-      "file": "services/qualificationMigration/drive.js",
-      "trigger": "@event io.cozy.files:CREATED,UPDATED",
-      "debounce": "24h"
+      "file": "services/qualificationMigration/drive.js"
     },
     "dacc": {
       "type": "node",


### PR DESCRIPTION
The `qualificationMigration` service is broken. So let's disable it, waiting for its complete removal.