### PR TITLE
fix: Home icon takes again customization into account

### DIFF
--- a/src/modules/views/OnlyOffice/Toolbar/HomeIcon.jsx
+++ b/src/modules/views/OnlyOffice/Toolbar/HomeIcon.jsx
@@ -1,12 +1,16 @@
 import React from 'react'
 
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import TwakeWorkplaceIcon from 'cozy-ui/transpiled/react/Icons/TwakeWorkplace'
+import { useClient } from 'cozy-client'
 
 const HomeIcon = () => {
+  const client = useClient()
+
   return (
     <div className="u-h-2 u-w-2 u-ml-1">
-      <Icon icon={TwakeWorkplaceIcon} size={32} />
+      <img
+        className="u-w-100 u-h-100 u-maw-2 u-mah-2"
+        src={`${client.getStackClient().uri}/assets/images/icon-cozy-home.svg`}
+      />
     </div>
   )
 }


### PR DESCRIPTION
In 617fadf1888a4fb7376a40fc5bcd9a2f6d7edcac I removed icon fetched from stack to an icon from cozy-ui. It was a mistake due to a misconfiguration on my local environment. We must keep it like this to be able to customize home icon.