### PR TITLE
feat(FileName): Don't load path component if not necessary

### DIFF
--- a/src/modules/filelist/virtualized/cells/FileName.jsx
+++ b/src/modules/filelist/virtualized/cells/FileName.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { isDirectory } from 'cozy-client/dist/models/file'
 import Filename from 'cozy-ui/transpiled/react/Filename'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
@@ -8,7 +9,10 @@ import styles from '@/styles/filelist.styl'
 
 import { useThumbnailSizeContext } from '@/lib/ThumbnailSizeContext'
 import RenameInput from '@/modules/drive/RenameInput'
-import { getFileNameAndExtension } from '@/modules/filelist/helpers'
+import {
+  getFileNameAndExtension,
+  makeParentFolderPath
+} from '@/modules/filelist/helpers'
 import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
 import FileNamePath from '@/modules/filelist/virtualized/cells/FileNamePath'
 
@@ -25,6 +29,11 @@ const FileName = ({
   const { title, filename, extension } = getFileNameAndExtension(attributes, t)
   const { isBigThumbnail } = useThumbnailSizeContext()
   const { isMobile } = useBreakpoints()
+
+  const parentFolderPath = makeParentFolderPath(attributes)
+  const hidePath = withFilePath
+    ? !parentFolderPath
+    : isDirectory(attributes) || !isMobile
 
   if (isRenaming) {
     return (
@@ -73,12 +82,15 @@ const FileName = ({
         extension={extension}
         midEllipsis
         path={
-          <FileNamePath
-            attributes={attributes}
-            withFilePath={withFilePath}
-            formattedSize={formattedSize}
-            formattedUpdatedAt={formattedUpdatedAt}
-          />
+          hidePath ? undefined : (
+            <FileNamePath
+              attributes={attributes}
+              withFilePath={withFilePath}
+              formattedSize={formattedSize}
+              formattedUpdatedAt={formattedUpdatedAt}
+              parentFolderPath={parentFolderPath}
+            />
+          )
         }
       />
     </span>

--- a/src/modules/filelist/virtualized/cells/FileNamePath.jsx
+++ b/src/modules/filelist/virtualized/cells/FileNamePath.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import { isDirectory } from 'cozy-client/dist/models/file'
 import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
@@ -9,37 +8,26 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import styles from '@/styles/filelist.styl'
 
 import CertificationsIcons from '@/modules/filelist/cells/CertificationsIcons.jsx'
-import {
-  getFileNameAndExtension,
-  makeParentFolderPath
-} from '@/modules/filelist/helpers'
+import { getFileNameAndExtension } from '@/modules/filelist/helpers'
 
 const FileNamePath = ({
   attributes,
   withFilePath,
   formattedSize,
-  formattedUpdatedAt
+  formattedUpdatedAt,
+  parentFolderPath
 }) => {
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()
   const { filename, extension } = getFileNameAndExtension(attributes, t)
-  const parentFolderPath = makeParentFolderPath(attributes)
 
   if (!withFilePath) {
-    if (isDirectory(attributes) || !isMobile) {
-      return null
-    }
-
     return (
       <div className={styles['fil-file-infos']}>
         {`${formattedUpdatedAt}${formattedSize ? ` - ${formattedSize}` : ''}`}
         <CertificationsIcons attributes={attributes} />
       </div>
     )
-  }
-
-  if (!parentFolderPath) {
-    return null
   }
 
   if (isMobile) {


### PR DESCRIPTION
Passing a comp returning null as props is not the same than passing
directly undefined, because if we test the prop inside the comp,
first way will return true, second way will return false