### PR TITLE
feat: Add a specific table to add folder in empty content

### DIFF
--- a/src/modules/views/Folder/virtualized/AddFolderTable.jsx
+++ b/src/modules/views/Folder/virtualized/AddFolderTable.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import { useVaultClient } from 'cozy-keys-lib'
+import Table from 'cozy-ui/transpiled/react/Table'
+import TableBody from 'cozy-ui/transpiled/react/TableBody'
+import TableCell from 'cozy-ui/transpiled/react/TableCell'
+import TableHead from 'cozy-ui/transpiled/react/TableHead'
+import TableRow from 'cozy-ui/transpiled/react/TableRow'
+
+import AddFolder from '@/modules/filelist/AddFolder'
+
+const AddFolderTable = ({ columns, currentFolderId }) => {
+  const vaultClient = useVaultClient()
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          {columns.map((column, idx) => (
+            <TableCell
+              key={idx}
+              className={column.id === 'name' ? 'u-pl-1' : ''}
+            >
+              {column.label}
+            </TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell className="u-pl-1">
+            <AddFolder
+              vaultClient={vaultClient}
+              currentFolderId={currentFolderId}
+            />
+          </TableCell>
+          <TableCell>—</TableCell>
+          <TableCell>—</TableCell>
+          <TableCell>—</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  )
+}
+
+export default AddFolderTable

--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -19,6 +19,7 @@ import { FolderUnlocker } from '@/modules/folder/components/FolderUnlocker'
 import { useCancelable } from '@/modules/move/hooks/useCancelable'
 import SelectionBar from '@/modules/selection/SelectionBar'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+import AddFolderTable from '@/modules/views/Folder/virtualized/AddFolderTable'
 import EmptyContent from '@/modules/views/Folder/virtualized/EmptyContent'
 import Table from '@/modules/views/Folder/virtualized/Table'
 import { makeRows, onDrop } from '@/modules/views/Folder/virtualized/helpers'
@@ -125,6 +126,9 @@ const FolderViewBody = ({
       onDismiss={handleFolderUnlockerDismiss}
     >
       <SelectionBar actions={actions} />
+      {IsAddingFolder && !showTable && (
+        <AddFolderTable columns={columns} currentFolderId={currentFolderId} />
+      )}
       {isInError && <Oops />}
       {(needsToWait || isLoading) && <FileListRowsPlaceholder />}
       {/* TODO FolderViewBody should not have the responsability to chose


### PR DESCRIPTION
Adding a folder is handle by the main virtualized table, but if a
content is empty (aka empty folder), the main table is not present.
So in this case we were not able to create a folder.