### PR TITLE
Improve performances of mutliple updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@sentry/react": "7.119.0",
     "classnames": "2.3.1",
     "cozy-bar": "^22.1.3",
-    "cozy-client": "^58.4.0",
+    "cozy-client": "^59.1.1",
     "cozy-dataproxy-lib": "^4.1.0",
     "cozy-device-helper": "^3.7.1",
     "cozy-devtools": "^1.2.1",

--- a/src/modules/views/Trash/TrashDestroyView.tsx
+++ b/src/modules/views/Trash/TrashDestroyView.tsx
@@ -44,7 +44,11 @@ const TrashDestroyView: FC = () => {
     refresh()
   }
 
-  if (hasQueryBeenLoaded(fileResult) && fileResult.data) {
+  const hasData = Array.isArray(fileResult.data)
+    ? fileResult.data.length > 0
+    : fileResult.data
+
+  if (hasQueryBeenLoaded(fileResult) && hasData) {
     return (
       <DestroyConfirm
         files={fileResult.data}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5469,17 +5469,17 @@ cozy-client@^57.7.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^58.4.0:
-  version "58.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-58.4.0.tgz#1d47ffaa74e3704efc805a312ed023f2cc46acda"
-  integrity sha512-IXpQPbMzhhJAXCMKH3jy1fC/810j8+/SA7U88kG5+yHha70mCEs8bqKIaAMWZr5Rj1kcGxvk3X53yrG0ZrLCag==
+cozy-client@^59.1.1:
+  version "59.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-59.1.1.tgz#ad71dd5fae1272c6828761a96cf51d2941a9cc9a"
+  integrity sha512-oNtZ7lxICEmKP4UR1+K+yfJi0VP+DYMCBis9lrv9S9ZOBL7FAmJHjCvrwJXwhIisQEJwHQ50cEQpVxfU4fPEbQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@fastify/deepmerge" "^2.0.2"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^58.4.0"
+    cozy-stack-client "^59.0.0"
     date-fns "2.29.3"
     fast-deep-equal "^3.1.3"
     json-stable-stringify "^1.0.1"
@@ -5806,10 +5806,10 @@ cozy-stack-client@^57.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^58.4.0:
-  version "58.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-58.4.0.tgz#44a2237dd7d817fc62cf35521b6e53367b9a4802"
-  integrity sha512-GATZVzKTSpw4R4wP1hR7g8R1yRoYe734JEQgEauebltwuo6b4LP22O63/sg7Tcfd4LtZtVtzYsJ5eJ6Y7PpUKw==
+cozy-stack-client@^59.0.0:
+  version "59.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-59.0.0.tgz#9be33eaef3b2686dfccbaf157366c8b4af801e6a"
+  integrity sha512-xzGj4SDlmdAP0q1MOrnz34Oo5fqSnGcGaDAac7E0Qk0U1OL4tQ2qzELE5WX3ZF+eirSyMt0n9WSqsn295D2erQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
When receiving a batch of realtime events, we used to treat them
sequentially and do the following:
- Query the parent folder if it's a file to compute the path
- Dispatch the mutation

This was highly inefficient, because the dispatch is a costful
operation, especially if the store is filled with documents and queries.
Indeed, each dispatch will trigger the full reevaluation of the existing
queries against the documents in the store.

So, to improve this behaviour we now introduce a debounce mechanism for
relatime events: we wait a fixed amount of time before processing the
events all at once.
To do this, each new realtime event is temporarily stored in a buffer,
and removed once treated.

This impact all treatments involving multiple realtime events, such as
trash, restore, or deletion from trash.

Note the debounce does not negatively affect single realtime events, as
we force the first event to be treated immediatly (and debounce only the
next ones if they occur less than 500ms after).

To show how impactful this is, we measured how long takes a folder to be
put in the trash. The folder contains 1K files.

- Before : ~61000 ms :turtle: 
- After : ~700 ms :rabbit2: 

=> This is a x87 improvements :rocket: 