### PR TITLE
feat: Remove `partialIndex` on `getByIds` for sharing request

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -142,10 +142,6 @@ export const buildSharingsQuery: QueryBuilder<buildSharingsQueryParams> = ({
   definition: () =>
     Q('io.cozy.files')
       .getByIds(ids)
-      .partialIndex({
-        trashed: false,
-        dir_id: { $ne: TRASH_DIR_ID }
-      })
       .sortBy([{ type: 'asc' }, { name: 'asc' }]),
   options: {
     as: `sharings-by-ids-${ids.join('')}`,


### PR DESCRIPTION
`partialIndex` doesn't work with `getByIds`, only with `where`

We have to investigate in cozy-sharing, maybe a better approach will be to remove this request and get documents directly from cozy-sharing/SharedDocuments