### PR TITLE
fix: Remove carbonCopy and electronicSafe queries

### DIFF
--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -58,7 +58,8 @@ import {
   buildMagicFolderQuery
 } from '@/queries'
 
-const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
+// Those extra columns names must match a metadata attribute name, e.g. carbonCopy or electronicSafe
+const desktopExtraColumnsNames = []
 const mobileExtraColumnsNames = []
 
 const DriveFolderView = () => {


### PR DESCRIPTION
We used to query files on the `carbonCopy` and `electronicSafe` attributes, to display them as dedicated columns in the files list. However, those columns are no longer displayed, making the queries useless. So let's free some CPU and network.