### PR TITLE
feat: Mutualize queries by id in store

### DIFF
--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -4,7 +4,7 @@ import { useClient, Mutations } from 'cozy-client'
 import { ensureFilePath } from 'cozy-client/dist/models/file'
 import { receiveMutationResult } from 'cozy-client/dist/store'
 
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 /**
  * Normalizes an object representing a CouchDB document
@@ -61,7 +61,7 @@ const dispatchChange = async (
 export const ensureFileHasPath = async (doc, client) => {
   if (doc.path) return doc
 
-  const parentQuery = buildFileByIdQuery(doc.dir_id)
+  const parentQuery = buildFileOrFolderByIdQuery(doc.dir_id)
   const parentResult = await client.fetchQueryAndGetFromState({
     definition: parentQuery.definition(),
     options: parentQuery.options

--- a/src/components/FolderPicker/FolderPicker.spec.jsx
+++ b/src/components/FolderPicker/FolderPicker.spec.jsx
@@ -48,7 +48,7 @@ describe('FolderPicker', () => {
   const setup = () => {
     const mockClient = createMockClient({
       queries: {
-        'onlyfolder-io.cozy.files.root-dir': {
+        'io.cozy.files/io.cozy.files.root-dir': {
           doctype: 'io.cozy.files',
           definition: {
             doctype: 'io.cozy.files',

--- a/src/components/FolderPicker/FolderPickerContentCozy.tsx
+++ b/src/components/FolderPicker/FolderPickerContentCozy.tsx
@@ -18,7 +18,7 @@ import { isEncryptedFolder } from '@/lib/encryption'
 import { FolderUnlocker } from '@/modules/folder/components/FolderUnlocker'
 import {
   buildMoveOrImportQuery,
-  buildOnlyFolderQuery,
+  buildFileOrFolderByIdQuery,
   buildMagicFolderQuery
 } from '@/queries'
 
@@ -80,7 +80,7 @@ const FolderPickerContentCozy: React.FC<FolderPickerContentCozyProps> = ({
   }, [filesData, sharedFolderResult, folder, showNextcloudFolder])
 
   const handleFolderUnlockerDismiss = async (): Promise<void> => {
-    const parentFolderQuery = buildOnlyFolderQuery(folder.dir_id)
+    const parentFolderQuery = buildFileOrFolderByIdQuery(folder.dir_id)
     const parentFolder = (await client?.fetchQueryAndGetFromState({
       definition: parentFolderQuery.definition(),
       options: parentFolderQuery.options

--- a/src/components/FolderPicker/FolderPickerTopbar.spec.jsx
+++ b/src/components/FolderPicker/FolderPickerTopbar.spec.jsx
@@ -57,7 +57,7 @@ describe('FolderPickerTopbar', () => {
   const setup = ({ canCreateFolder = false, folder } = {}) => {
     const mockClient = createMockClient({
       queries: {
-        'onlyfolder-io.cozy.files.root-dir': {
+        'io.cozy.files/io.cozy.files.root-dir': {
           doctype: 'io.cozy.files',
           definition: {
             doctype: 'io.cozy.files',
@@ -65,7 +65,7 @@ describe('FolderPickerTopbar', () => {
           },
           data: [rootCozyFolder]
         },
-        'onlyfolder-io.cozy.files.shared-drives-dir': {
+        'io.cozy.files/io.cozy.files.shared-drives-dir': {
           doctype: 'io.cozy.files',
           definition: {
             doctype: 'io.cozy.files',

--- a/src/components/FolderPicker/helpers.ts
+++ b/src/components/FolderPicker/helpers.ts
@@ -3,7 +3,10 @@ import { IOCozyFile, NextcloudFile } from 'cozy-client/types/types'
 
 import { FolderPickerEntry, File } from '@/components/FolderPicker/types'
 import { getParentPath } from '@/lib/path'
-import { buildOnlyFolderQuery, buildNextcloudFolderQuery } from '@/queries'
+import {
+  buildFileOrFolderByIdQuery,
+  buildNextcloudFolderQuery
+} from '@/queries'
 
 /**
  * Checks if the target is an invalid move target based on the subjects and target provided.
@@ -59,7 +62,7 @@ const getCozyParentFolder = async (
   client: CozyClient | null,
   id: string
 ): Promise<IOCozyFile> => {
-  const parentFolderQuery = buildOnlyFolderQuery(id)
+  const parentFolderQuery = buildFileOrFolderByIdQuery(id)
   const parentFolder = (await client?.fetchQueryAndGetFromState({
     definition: parentFolderQuery.definition(),
     options: parentFolderQuery.options

--- a/src/components/TrashedBanner.jsx
+++ b/src/components/TrashedBanner.jsx
@@ -12,7 +12,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import logger from '@/lib/logger'
 import DestroyConfirm from '@/modules/trash/components/DestroyConfirm'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const TrashedBanner = ({ fileId, isPublic }) => {
   const { t } = useI18n()
@@ -21,7 +21,7 @@ const TrashedBanner = ({ fileId, isPublic }) => {
   const { showAlert } = useAlert()
   const { isMobile } = useBreakpoints()
 
-  const fileQuery = buildFileByIdQuery(fileId)
+  const fileQuery = buildFileOrFolderByIdQuery(fileId)
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
 
   const [isBusy, setBusy] = useState(false)

--- a/src/hooks/useDisplayedFolder.tsx
+++ b/src/hooks/useDisplayedFolder.tsx
@@ -2,7 +2,7 @@ import { useQuery } from 'cozy-client'
 import { IOCozyFile } from 'cozy-client/types/types'
 
 import useCurrentFolderId from '@/hooks/useCurrentFolderId'
-import { buildOnlyFolderQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 interface DisplayedFolderResult {
   isNotFound: boolean
@@ -13,7 +13,7 @@ interface DisplayedFolderResult {
 const useDisplayedFolder = (): DisplayedFolderResult => {
   const folderId = useCurrentFolderId()
 
-  const folderQuery = buildOnlyFolderQuery(folderId)
+  const folderQuery = buildFileOrFolderByIdQuery(folderId)
   const folderResult = useQuery(
     folderQuery.definition,
     folderQuery.options

--- a/src/modules/breadcrumb/utils/fetchFolder.js
+++ b/src/modules/breadcrumb/utils/fetchFolder.js
@@ -1,7 +1,7 @@
-import { buildFolderQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 export const fetchFolder = async ({ client, folderId }) => {
-  const folderQuery = buildFolderQuery(folderId)
+  const folderQuery = buildFileOrFolderByIdQuery(folderId)
   const { options, definition } = folderQuery
   const folderQueryResults = await client.fetchQueryAndGetFromState({
     definition: definition(),

--- a/src/modules/breadcrumb/utils/fetchFolder.spec.js
+++ b/src/modules/breadcrumb/utils/fetchFolder.spec.js
@@ -1,6 +1,6 @@
 import { fetchFolder } from './fetchFolder'
 
-import { buildFolderQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 jest.mock('queries')
 
@@ -14,7 +14,7 @@ describe('fetchFolder', () => {
   const definition = jest.fn().mockReturnValue('definition')
 
   beforeEach(() => {
-    buildFolderQuery.mockReturnValue({
+    buildFileOrFolderByIdQuery.mockReturnValue({
       definition: definition,
       options: 'options'
     })

--- a/src/modules/filelist/icons/BadgeKonnector.jsx
+++ b/src/modules/filelist/icons/BadgeKonnector.jsx
@@ -12,7 +12,7 @@ import Badge from 'cozy-ui/transpiled/react/Badge'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import { DOCTYPE_KONNECTORS } from '@/lib/doctypes'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const getKonnectorSlugFromFile = file => {
   const konnector = getReferencedBy(file, DOCTYPE_KONNECTORS)[0]
@@ -44,7 +44,7 @@ export const BadgeKonnector = ({ file, children }) => {
   const konnectorSlug = getKonnectorSlugFromFile(file)
 
   // Check if the parent folder is a konnector folder, because if have no file in your account folder, its considered as a konnector folder
-  const parentFolderQuery = buildFileByIdQuery(file.dir_id)
+  const parentFolderQuery = buildFileOrFolderByIdQuery(file.dir_id)
   const { data: parentFolder, ...parentFolderQueryLeft } = useQuery(
     parentFolderQuery.definition,
     parentFolderQuery.options

--- a/src/modules/move/MoveInsideSharedFolderModal.jsx
+++ b/src/modules/move/MoveInsideSharedFolderModal.jsx
@@ -8,7 +8,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { LoaderModal } from '@/components/LoaderModal'
 import { getEntriesTypeTranslated } from '@/lib/entries'
-import { buildOnlyFolderQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 /**
  * Alert the user when is trying to move a folder/file outside of a shared folder
@@ -21,7 +21,7 @@ const MoveInsideSharedFolderModal = ({
 }) => {
   const { t } = useI18n()
 
-  const folderQuery = buildOnlyFolderQuery(folderId)
+  const folderQuery = buildFileOrFolderByIdQuery(folderId)
   const { fetchStatus, data } = useQuery(
     folderQuery.definition,
     folderQuery.options

--- a/src/modules/move/MoveModal.spec.jsx
+++ b/src/modules/move/MoveModal.spec.jsx
@@ -85,7 +85,7 @@ describe('MoveModal component', () => {
         doctype: 'io.cozy.files',
         data: []
       },
-      'onlyfolder-destinationFolder': {
+      'io.cozy.files/destinationFolder': {
         doctype: 'io.cozy.files',
         data: [
           {

--- a/src/modules/move/MoveSharedFolderInsideAnotherModal.jsx
+++ b/src/modules/move/MoveSharedFolderInsideAnotherModal.jsx
@@ -10,7 +10,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { LoaderModal } from '@/components/LoaderModal'
 import { getEntriesName } from '@/modules/move/helpers'
-import { buildOnlyFolderQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 /**
  * Alert the user when is trying to move a shared folder/file inside another shared folder
@@ -23,7 +23,7 @@ const MoveSharedFolderInsideAnotherModal = ({
 }) => {
   const { t } = useI18n()
   const { byDocId } = useSharingContext()
-  const folderQuery = buildOnlyFolderQuery(folderId)
+  const folderQuery = buildFileOrFolderByIdQuery(folderId)
   const { fetchStatus, data } = useQuery(
     folderQuery.definition,
     folderQuery.options

--- a/src/modules/viewer/FileOpenerExternal.jsx
+++ b/src/modules/viewer/FileOpenerExternal.jsx
@@ -27,7 +27,7 @@ import {
   isOfficeEnabled,
   makeOnlyOfficeFileRoute
 } from '@/modules/views/OnlyOffice/helpers'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const FileNotFoundError = translate()(({ t }) => (
   <pre className="u-error">{t('FileOpenerExternal.fileNotFoundError')}</pre>
@@ -53,7 +53,7 @@ const FileOpener = props => {
     async id => {
       try {
         setState({ fileNotFound: false, loading: true })
-        const query = buildFileByIdQuery(id)
+        const query = buildFileOrFolderByIdQuery(id)
         const result = await client.query(query.definition(), query.options)
 
         const file = await ensureFileHasPath(result.data, client)

--- a/src/modules/views/Drive/HarvestBanner.jsx
+++ b/src/modules/views/Drive/HarvestBanner.jsx
@@ -7,7 +7,10 @@ import Divider from 'cozy-ui/transpiled/react/Divider'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import useDocument from '@/components/useDocument'
-import { buildTriggersQueryByAccountId, buildFileByIdQuery } from '@/queries'
+import {
+  buildTriggersQueryByAccountId,
+  buildFileOrFolderByIdQuery
+} from '@/queries'
 
 const HarvestBanner = ({ folderId }) => {
   const folder = useDocument('io.cozy.files', folderId)
@@ -17,7 +20,7 @@ const HarvestBanner = ({ folderId }) => {
   let accountId = undefined
 
   const fileId = folder?.relationships?.contents?.data?.[0]?.id
-  const fileQuery = buildFileByIdQuery(fileId)
+  const fileQuery = buildFileOrFolderByIdQuery(fileId)
   const file = useQuery(fileQuery.definition, {
     ...fileQuery.options,
     enabled: Boolean(fileId)

--- a/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
+++ b/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
@@ -4,11 +4,11 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery } from 'cozy-client'
 
 import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
-import { buildFolderQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const FolderViewBreadcrumb = ({ currentFolderId, getBreadcrumbPath }) => {
   const navigate = useNavigate()
-  const currentFolderQuery = buildFolderQuery(currentFolderId)
+  const currentFolderQuery = buildFileOrFolderByIdQuery(currentFolderId)
   const currentFolderQueryResults = useQuery(
     currentFolderQuery.definition,
     currentFolderQuery.options

--- a/src/modules/views/Modal/QualifyFileView.jsx
+++ b/src/modules/views/Modal/QualifyFileView.jsx
@@ -15,7 +15,7 @@ import NestedSelectResponsive from 'cozy-ui/transpiled/react/NestedSelect/Nested
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { LoaderModal } from '@/components/LoaderModal'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const getThemesList = () =>
   flag('hide.healthTheme.enabled')
@@ -76,7 +76,7 @@ export const QualifyFileView = () => {
   const client = useClient()
   const scannerT = getBoundT(lang || 'en')
 
-  const fileQuery = buildFileByIdQuery(fileId)
+  const fileQuery = buildFileOrFolderByIdQuery(fileId)
   const { data: file, ...fileQueryResult } = useQuery(
     fileQuery.definition,
     fileQuery.options

--- a/src/modules/views/Modal/ShareFileView.jsx
+++ b/src/modules/views/Modal/ShareFileView.jsx
@@ -5,13 +5,13 @@ import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
 import { ShareModal } from 'cozy-sharing'
 
 import { LoaderModal } from '@/components/LoaderModal'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const ShareFileView = () => {
   const navigate = useNavigate()
   const { fileId } = useParams()
 
-  const fileQuery = buildFileByIdQuery(fileId)
+  const fileQuery = buildFileOrFolderByIdQuery(fileId)
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
 
   const handleExit = () => {

--- a/src/modules/views/OnlyOffice/Error.jsx
+++ b/src/modules/views/OnlyOffice/Error.jsx
@@ -13,14 +13,14 @@ import Viewer, {
 
 import Oops from '@/components/Error/Oops'
 import { useOnlyOfficeContext } from '@/modules/views/OnlyOffice/OnlyOfficeProvider'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const Error = () => {
   const { t } = useI18n()
   const { fileId } = useOnlyOfficeContext()
   const handleOnClose = useCallback(() => window.history.back(), [])
 
-  const fileQuery = useMemo(() => buildFileByIdQuery(fileId), [fileId])
+  const fileQuery = useMemo(() => buildFileOrFolderByIdQuery(fileId), [fileId])
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
   const files = useMemo(() => [fileResult.data], [fileResult])
 

--- a/src/modules/views/OnlyOffice/OnlyOfficeProvider.jsx
+++ b/src/modules/views/OnlyOffice/OnlyOfficeProvider.jsx
@@ -12,7 +12,7 @@ import { useClient, useQuery } from 'cozy-client'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { officeDefaultMode } from '@/modules/views/OnlyOffice/helpers'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const OnlyOfficeContext = createContext()
 
@@ -41,7 +41,7 @@ const OnlyOfficeProvider = ({
 
   const isEditorModeView = useMemo(() => editorMode === 'view', [editorMode])
 
-  const fileQuery = buildFileByIdQuery(fileId)
+  const fileQuery = buildFileOrFolderByIdQuery(fileId)
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
 
   const handleFileUpdated = useCallback(

--- a/src/modules/views/OnlyOffice/Toolbar/index.jsx
+++ b/src/modules/views/OnlyOffice/Toolbar/index.jsx
@@ -25,7 +25,7 @@ import HomeLinker from '@/modules/views/OnlyOffice/Toolbar/HomeLinker'
 import Separator from '@/modules/views/OnlyOffice/Toolbar/Separator'
 import Sharing from '@/modules/views/OnlyOffice/Toolbar/Sharing'
 import { isOfficeEditingEnabled } from '@/modules/views/OnlyOffice/helpers'
-import { buildFileByIdQuery, buildFileWhereByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery, buildFileWhereByIdQuery } from '@/queries'
 
 const Toolbar = ({ sharingInfos }) => {
   const { isMobile, isDesktop } = useBreakpoints()
@@ -36,7 +36,7 @@ const Toolbar = ({ sharingInfos }) => {
   const { redirectBack, canRedirect } = useRedirectLink({ isPublic })
 
   const fileQuery = isPublic
-    ? buildFileByIdQuery(fileId) // do not return path but return correctly data in public context
+    ? buildFileOrFolderByIdQuery(fileId) // do not return path but return correctly data in public context
     : buildFileWhereByIdQuery(fileId) // return path but get a 403 in public context
 
   const { data } = useQuery(fileQuery.definition, fileQuery.options)

--- a/src/modules/views/Upload/UploaderComponent.tsx
+++ b/src/modules/views/Upload/UploaderComponent.tsx
@@ -11,7 +11,7 @@ import { File, FolderPickerEntry } from '@/components/FolderPicker/types'
 import { ROOT_DIR_ID } from '@/constants/config'
 import { shouldRender } from '@/modules/views/Upload/UploadUtils'
 import { useUploadFromFlagship } from '@/modules/views/Upload/useUploadFromFlagship'
-import { buildOnlyFolderQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const UploaderComponent = (): JSX.Element | null => {
   const { t } = useI18n()
@@ -25,7 +25,7 @@ const UploaderComponent = (): JSX.Element | null => {
     uploadFilesFromFlagship(folder._id)
   }
 
-  const rootFolderQuery = buildOnlyFolderQuery(ROOT_DIR_ID)
+  const rootFolderQuery = buildFileOrFolderByIdQuery(ROOT_DIR_ID)
   const rootFolderResult = useQuery(
     rootFolderQuery.definition,
     rootFolderQuery.options

--- a/src/modules/views/useUpdateDocumentTitle.jsx
+++ b/src/modules/views/useUpdateDocumentTitle.jsx
@@ -5,7 +5,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { TRASH_DIR_PATH } from '@/constants/config'
 import { makeParentFolderPath } from '@/modules/filelist/helpers'
-import { buildFileByIdQuery } from '@/queries'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 export const makeTitle = (file, appFullName, t) => {
   if (!file) return
@@ -53,7 +53,7 @@ const useUpdateDocumentTitle = docId => {
   const { t } = useI18n()
   const client = useClient()
 
-  const fileQuery = buildFileByIdQuery(docId)
+  const fileQuery = buildFileOrFolderByIdQuery(docId)
   const { data: file, fetchStatus } = useQuery(
     fileQuery.definition,
     fileQuery.options

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -248,26 +248,6 @@ export const buildMoveOrImportQuery: QueryBuilder<string> = dirId => ({
   }
 })
 
-export const buildFolderQuery: QueryBuilder<string> = folderId => ({
-  definition: () =>
-    Q('io.cozy.files').getById(folderId).include(['encryption', 'parent']),
-  options: {
-    as: 'folder-' + folderId,
-    singleDocData: true,
-    fetchPolicy: defaultFetchPolicy
-  }
-})
-
-export const buildOnlyFolderQuery: QueryBuilder<string | null> = folderId => ({
-  definition: () => Q('io.cozy.files').getById(folderId ?? 'unknown'),
-  options: {
-    as: 'onlyfolder-' + (folderId ?? 'unknown'),
-    fetchPolicy: defaultFetchPolicy,
-    singleDocData: true,
-    enabled: !!folderId
-  }
-})
-
 interface buildFileWithSpecificMetadataAttributeQueryParams {
   currentFolderId: string
   attribute: string
@@ -301,7 +281,7 @@ export const buildFileWithSpecificMetadataAttributeQuery: QueryBuilder<
   }
 })
 
-export const buildFileByIdQuery: QueryBuilder<string> = fileId => ({
+export const buildFileOrFolderByIdQuery: QueryBuilder<string> = fileId => ({
   definition: () => Q('io.cozy.files').getById(fileId),
   options: {
     as: `io.cozy.files/${fileId}`,
@@ -311,7 +291,7 @@ export const buildFileByIdQuery: QueryBuilder<string> = fileId => ({
   }
 })
 
-// this query should use `getById` instead of `where` as `buildFileByIdQuery` does.
+// this query should use `getById` instead of `where` as `buildFileOrFolderByIdQuery` does.
 // But in this case, due to a stack limitation, the `file.path` is not returned.
 // As we need the `file.path` we do this trick until the stack is updated
 export const buildFileWhereByIdQuery: QueryBuilder<string> = fileId => ({


### PR DESCRIPTION
We had 3 different queries to do the same thing: query a io.cozy.files by its id.
Typically for a directory `abc`, we had 3 queries named:
- `io.cozy.files/abc`
- `onlyfolder-abc`
- `folder-abc`

The only specialization was for the `folder-abc` that was including `parent` and `encryption`, but it does not seem used anymore.

This is useless and hurt performances: as we duplicate such queries, they are kept in the store and reevaluated independently even though the id and the results are the same. It also takes memory for nothing. Thus, let's mutualize.