### PR TITLE
fix(file viewer): not loading more items when reaching the end of current query result 🐛

### DIFF
--- a/src/modules/viewer/FilesViewer.jsx
+++ b/src/modules/viewer/FilesViewer.jsx
@@ -131,12 +131,11 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange }) => {
 
       setFetchingMore(true)
       try {
-        const fileCount = filesQuery.count
-
         const currentIndex = files.findIndex(f => f.id === fileId)
+
         if (
-          files.length !== fileCount &&
-          files.length - currentIndex <= 5 &&
+          (filesQuery.data.length - currentIndex <= 5 || currentIndex === -1) &&
+          filesQuery.hasMore &&
           isMounted
         ) {
           await filesQuery.fetchMore()

--- a/src/modules/viewer/FilesViewer.spec.jsx
+++ b/src/modules/viewer/FilesViewer.spec.jsx
@@ -109,13 +109,16 @@ describe('FilesViewer', () => {
       await sleep(10)
     })
 
+    const hasMore = jest.fn().mockReturnValue(true)
+
     setup({
       client,
       nbFiles: 50,
       totalCount: 100,
       fileId: 'file-foobar48',
       useQueryResultAttributes: {
-        fetchMore
+        fetchMore,
+        hasMore
       }
     })
 

--- a/src/modules/views/Public/PublicFileViewer.jsx
+++ b/src/modules/views/Public/PublicFileViewer.jsx
@@ -42,7 +42,13 @@ const PublicFileViewer = () => {
       setFetchingMore(true)
       try {
         const currentIndex = viewableFiles.findIndex(f => f.id === fileId)
-        if (currentIndex === -1 && filesResult.hasMore && isMounted) {
+
+        if (
+          (currentIndex === -1 ||
+            currentIndex === filesResult.data.length - 1) &&
+          filesResult.hasMore &&
+          isMounted
+        ) {
           await filesResult.fetchMore()
         }
       } finally {


### PR DESCRIPTION
issue: https://www.notion.so/linagora/Browsing-files-through-viewer-is-limited-to-displayed-files-22462718bad1802d9d6df2847f1210d7

fixes:
- Public file viewer not loading more than the currently loaded files ( 30 files limit )
- File viewer is not loading more than the currently loaded files (100 files limit )
