### PR TITLE
feat: Add support for offline navigation in web

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "classnames": "2.3.1",
     "cozy-bar": "^22.1.3",
     "cozy-client": "^60.1.1",
-    "cozy-dataproxy-lib": "^4.1.0",
+    "cozy-dataproxy-lib": "^4.6.0",
     "cozy-device-helper": "^3.7.1",
     "cozy-devtools": "^1.2.1",
     "cozy-doctypes": "1.85.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@sentry/react": "7.119.0",
     "classnames": "2.3.1",
     "cozy-bar": "^22.1.3",
-    "cozy-client": "^59.4.0",
+    "cozy-client": "^60.1.1",
     "cozy-dataproxy-lib": "^4.1.0",
     "cozy-device-helper": "^3.7.1",
     "cozy-devtools": "^1.2.1",

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -5,7 +5,6 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 import { Provider } from 'react-redux'
 
 import { BarProvider } from 'cozy-bar'
-import { DataProxyProvider } from 'cozy-dataproxy-lib'
 import flag from 'cozy-flags'
 import { WebviewIntentProvider } from 'cozy-intent'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -15,7 +14,6 @@ import { AcceptingSharingProvider } from '@/lib/AcceptingSharingContext'
 import DriveProvider from '@/lib/DriveProvider'
 import { ModalContextProvider } from '@/lib/ModalContext'
 import { ViewSwitcherContextProvider } from '@/lib/ViewSwitcherContext'
-import { DOCTYPE_APPS, DOCTYPE_CONTACTS, DOCTYPE_FILES } from '@/lib/doctypes'
 import { PublicProvider } from '@/modules/public/PublicProvider'
 import { onFileUploaded } from '@/modules/views/Upload/UploadUtils'
 
@@ -28,23 +26,17 @@ const Providers = ({ children }) => {
       : [Fragment, {}]
 
   return (
-    <DataProxyProvider
-      options={{
-        doctypes: [DOCTYPE_FILES, DOCTYPE_CONTACTS, DOCTYPE_APPS]
-      }}
-    >
-      <BarProvider>
-        <PushBannerProvider>
-          <AcceptingSharingProvider>
-            <ViewSwitcherContextProvider>
-              <ModalContextProvider>
-                <DnDProvider {...dnDProviderProps}>{children}</DnDProvider>
-              </ModalContextProvider>
-            </ViewSwitcherContextProvider>
-          </AcceptingSharingProvider>
-        </PushBannerProvider>
-      </BarProvider>
-    </DataProxyProvider>
+    <BarProvider>
+      <PushBannerProvider>
+        <AcceptingSharingProvider>
+          <ViewSwitcherContextProvider>
+            <ModalContextProvider>
+              <DnDProvider {...dnDProviderProps}>{children}</DnDProvider>
+            </ModalContextProvider>
+          </ViewSwitcherContextProvider>
+        </AcceptingSharingProvider>
+      </PushBannerProvider>
+    </BarProvider>
   )
 }
 

--- a/src/components/pushClient/index.js
+++ b/src/components/pushClient/index.js
@@ -1,5 +1,3 @@
-import get from 'lodash/get'
-
 import CozyClient, { Q } from 'cozy-client'
 import flag from 'cozy-flags'
 
@@ -32,8 +30,11 @@ export const isClientAlreadyInstalled = async client => {
     }
   }
   const { data } = await client.fetchQueryAndGetFromState(query)
+  if (!data) {
+    return false
+  }
   return Object.values(data).some(
-    device => get(device, 'attributes.software_id') === DESKTOP_SOFTWARE_ID
+    device => device?.software_id === DESKTOP_SOFTWARE_ID
   )
 }
 

--- a/src/components/pushClient/index.spec.js
+++ b/src/components/pushClient/index.spec.js
@@ -8,9 +8,7 @@ describe('isClientAlreadyInstalled', () => {
     client.fetchQueryAndGetFromState = jest.fn().mockResolvedValue({
       data: {
         0: {
-          attributes: {
-            software_id: DESKTOP_SOFTWARE_ID
-          }
+          software_id: DESKTOP_SOFTWARE_ID
         }
       }
     })
@@ -22,9 +20,7 @@ describe('isClientAlreadyInstalled', () => {
     client.fetchQueryAndGetFromState = jest.fn().mockResolvedValue({
       data: {
         0: {
-          attributes: {
-            software_id: test
-          }
+          software_id: test
         }
       }
     })

--- a/src/lib/DriveProvider.jsx
+++ b/src/lib/DriveProvider.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { CozyProvider } from 'cozy-client'
+import { DataProxyProvider } from 'cozy-dataproxy-lib'
 import {
   VaultUnlockProvider,
   VaultProvider,
@@ -15,6 +16,7 @@ import { I18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import RightClickProvider from '@/components/RightClick/RightClickProvider'
 import FabProvider from '@/lib/FabProvider'
+import { DOCTYPE_APPS, DOCTYPE_CONTACTS, DOCTYPE_FILES } from '@/lib/doctypes'
 import { usePublicContext } from '@/modules/public/PublicProvider'
 
 const DriveProvider = ({ client, lang, polyglot, dictRequire, children }) => {
@@ -23,24 +25,30 @@ const DriveProvider = ({ client, lang, polyglot, dictRequire, children }) => {
   return (
     <I18n lang={lang} polyglot={polyglot} dictRequire={dictRequire}>
       <CozyProvider client={client}>
-        <VaultProvider cozyClient={client}>
-          <VaultUnlockProvider>
-            <SharingProvider doctype="io.cozy.files" documentType="Files">
-              <NativeFileSharingProvider>
-                <CozyTheme ignoreCozySettings={isPublic} className="u-w-100">
-                  <BreakpointsProvider>
-                    <AlertProvider>
-                      <VaultUnlockPlaceholder />
-                      <FabProvider>
-                        <RightClickProvider>{children}</RightClickProvider>
-                      </FabProvider>
-                    </AlertProvider>
-                  </BreakpointsProvider>
-                </CozyTheme>
-              </NativeFileSharingProvider>
-            </SharingProvider>
-          </VaultUnlockProvider>
-        </VaultProvider>
+        <DataProxyProvider
+          options={{
+            doctypes: [DOCTYPE_FILES, DOCTYPE_CONTACTS, DOCTYPE_APPS]
+          }}
+        >
+          <VaultProvider cozyClient={client}>
+            <VaultUnlockProvider>
+              <SharingProvider doctype="io.cozy.files" documentType="Files">
+                <NativeFileSharingProvider>
+                  <CozyTheme ignoreCozySettings={isPublic} className="u-w-100">
+                    <BreakpointsProvider>
+                      <AlertProvider>
+                        <VaultUnlockPlaceholder />
+                        <FabProvider>
+                          <RightClickProvider>{children}</RightClickProvider>
+                        </FabProvider>
+                      </AlertProvider>
+                    </BreakpointsProvider>
+                  </CozyTheme>
+                </NativeFileSharingProvider>
+              </SharingProvider>
+            </VaultUnlockProvider>
+          </VaultProvider>
+        </DataProxyProvider>
       </CozyProvider>
     </I18n>
   )

--- a/src/lib/encryption.js
+++ b/src/lib/encryption.js
@@ -3,7 +3,7 @@ import get from 'lodash/get'
 import { models } from 'cozy-client'
 import flag from 'cozy-flags'
 
-import { DOCTYPE_FILES, DOCTYPE_FILES_ENCRYPTION } from '@/lib/doctypes'
+import { DOCTYPE_FILES, DOCTYPE_FILES_ENCRYPTION, schema } from '@/lib/doctypes'
 import { buildEncryptionByIdQuery } from '@/queries'
 const { isEncrypted } = models.file
 
@@ -55,7 +55,9 @@ export const createEncryptedDir = async (
   })
 
   // Add the relationship
-  const hydratedDir = client.hydrateDocument(dir)
+  const hydratedDir = client.hydrateDocument(dir, schema, {
+    forceHydratation: true
+  })
   return hydratedDir.encryption.addById(encryption._id)
 }
 

--- a/src/modules/move/helpers.spec.js
+++ b/src/modules/move/helpers.spec.js
@@ -79,7 +79,7 @@ describe('cancelMove', () => {
       trashedFiles: ['trashed-1', 'trashed-2']
     })
 
-    expect(collectionSpy).toHaveBeenCalledWith('io.cozy.files')
+    expect(collectionSpy).toHaveBeenCalledWith('io.cozy.files', {})
     expect(restoreSpy).toHaveBeenCalledWith('trashed-1')
     expect(restoreSpy).toHaveBeenCalledWith('trashed-2')
     expect(refreshSpy).toHaveBeenCalled()

--- a/src/targets/browser/setupAppContext.js
+++ b/src/targets/browser/setupAppContext.js
@@ -1,7 +1,8 @@
 import memoize from 'lodash/memoize'
 
-import CozyClient from 'cozy-client'
+import CozyClient, { DataProxyLink, StackLink } from 'cozy-client'
 import { Document } from 'cozy-doctypes'
+import flag from 'cozy-flags'
 import { initTranslation } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import appMetadata from '@/lib/appMetadata'
@@ -16,12 +17,24 @@ const setupApp = memoize(() => {
   const protocol = window.location ? window.location.protocol : 'https:'
   const cozyUrl = `${protocol}//${data.domain}`
 
+  const platform = {
+    isOnline: () => window?.navigator?.onLine
+  }
+
+  const links = [new StackLink({ platform })]
+  if (flag('dataproxy.queries.enabled')) {
+    // DataProxy link will be used for offline data queries
+    const dataproxyLink = new DataProxyLink()
+    links.push(dataproxyLink)
+  }
+
   const client = new CozyClient({
     uri: cozyUrl,
     token: data.token,
     appMetadata,
     schema,
-    useCustomStore: true
+    useCustomStore: true,
+    links
   })
 
   if (!Document.cozyClient) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5496,7 +5496,7 @@ cozy-client@^60.1.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-dataproxy-lib@^4.1.0:
+cozy-dataproxy-lib@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.6.0.tgz#0bd112c19cbf851cd3eb92ba328ca522bfc77fe9"
   integrity sha512-XjjHukXl6dIZ4CoTbNiVHMNzT0lgPFs+qlmTXFdHnXeAGb1sAWzG0LipIz73yomVED6iAIOt/qlVh9SG8pytRQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5469,17 +5469,17 @@ cozy-client@^57.7.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^59.4.0:
-  version "59.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-59.4.0.tgz#4157342d69e408405cd94b47a0d467584b64dfe7"
-  integrity sha512-NhAIUr2l4Gjd6Vg9X3mUDYJoXANWyCJjadUY99U1MWHHRpIh/7aJ5OF0Q/GoY3JKh7CNrUCNuHp+OqG2pBkgMA==
+cozy-client@^60.1.1:
+  version "60.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-60.1.1.tgz#6d25155e72602a7660db6d39a8361039013537ba"
+  integrity sha512-Wxej4HBFukzrQdlH4ARaSGumM8t2IqKZtyBLkHecYQEpRsIbhwYgcB/f08f8bmvYEyBDLbGbqBZua1KNm4M88Q==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@fastify/deepmerge" "^2.0.2"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^59.4.0"
+    cozy-stack-client "^60.1.0"
     date-fns "2.29.3"
     fast-deep-equal "^3.1.3"
     json-stable-stringify "^1.0.1"
@@ -5497,9 +5497,9 @@ cozy-client@^59.4.0:
     url-search-params-polyfill "^8.0.0"
 
 cozy-dataproxy-lib@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.1.0.tgz#20d0a38e059fb5924d85f3b5a550d7d28ec9a477"
-  integrity sha512-k5lVjnpPmATEUZaYeK0B8J0+ntiNRmpmTXyDi8p6H7y41LO/yZ0XhbIqxbO4PjPnT8aKFWx3zQ7LGqIXS2Y7LA==
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.6.0.tgz#0bd112c19cbf851cd3eb92ba328ca522bfc77fe9"
+  integrity sha512-XjjHukXl6dIZ4CoTbNiVHMNzT0lgPFs+qlmTXFdHnXeAGb1sAWzG0LipIz73yomVED6iAIOt/qlVh9SG8pytRQ==
   dependencies:
     comlink "4.4.1"
     flexsearch "0.7.43"
@@ -5806,10 +5806,10 @@ cozy-stack-client@^57.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^59.4.0:
-  version "59.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-59.4.0.tgz#b3431e6155ac52c89d505bfd98cc986f2569d3a0"
-  integrity sha512-B958Q19ylRvWYcFAFQxrgqgam1ISxhWw1VyyPvrBLNPDteSoDEQ5xX98c02+iZ71/+xcp2wk3ZBF61m4I5o7sQ==
+cozy-stack-client@^60.1.0:
+  version "60.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-60.1.0.tgz#73efcfc578d012d68ffcf63de76378bba6ca4c90"
+  integrity sha512-LBhbEnEdvn+MgbFHuYgIDzdZm5jUgAQsvdNkFWUlS15xTe1zMY/+/GHPk3+b4sswrveu0JKTF1ptjV8FNzbnGQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
We now support offline navigation thanks to the `DataProxyLink`.  By
default, all request go through the `StackLink`, but it now detects if
the user is offline, and then forward data queries to the DataProxy,
which will run them on PouchDB.

Note this only work for read queries that rely on `io.cozy.files`: we
typically do not support offline download, or write operations such as
renaming yet.