### PR TITLE
fix: Broken public sharing pages

### DIFF
--- a/src/lib/DriveProvider.jsx
+++ b/src/lib/DriveProvider.jsx
@@ -25,11 +25,7 @@ const DriveProvider = ({ client, lang, polyglot, dictRequire, children }) => {
   return (
     <I18n lang={lang} polyglot={polyglot} dictRequire={dictRequire}>
       <CozyProvider client={client}>
-        <DataProxyProvider
-          options={{
-            doctypes: [DOCTYPE_FILES, DOCTYPE_CONTACTS, DOCTYPE_APPS]
-          }}
-        >
+        <DataProxyWrapper isPublic={isPublic}>
           <VaultProvider cozyClient={client}>
             <VaultUnlockProvider>
               <SharingProvider doctype="io.cozy.files" documentType="Files">
@@ -48,9 +44,25 @@ const DriveProvider = ({ client, lang, polyglot, dictRequire, children }) => {
               </SharingProvider>
             </VaultUnlockProvider>
           </VaultProvider>
-        </DataProxyProvider>
+        </DataProxyWrapper>
       </CozyProvider>
     </I18n>
+  )
+}
+
+const DataProxyWrapper = ({ children, isPublic }) => {
+  if (isPublic) {
+    // Do not include DataProxy for public sharings
+    return children
+  }
+  return (
+    <DataProxyProvider
+      options={{
+        doctypes: [DOCTYPE_FILES, DOCTYPE_CONTACTS, DOCTYPE_APPS]
+      }}
+    >
+      {children}
+    </DataProxyProvider>
   )
 }
 


### PR DESCRIPTION
The public pages were broken since the upgrade of the `cozy-dataproxy-lib`:
https://github.com/cozy/cozy-drive/commit/2107f71266077ed10ef1671e4c7084ae1e61ae48 
This is because the `DataProxyProvider` renders the children only once the DataProxy is correctly initialized. 
See https://github.com/cozy/cozy-libs/commit/bdb16705103fa222d631750403d951eee61f4868

In the case of public sharing, the initialization fails because we try to get an intent, which redirects to the sso as the recipient is not logged in. And this redirection is blocked by the CSP.

So, to avoid this, we simply do not use the `DataProxyProvider` when we are in a public sharing, as it is not useful for now.

Nevertheless, this DataProxy init behaviour seems error prone and difficult to debug, so, we'll try to simplify it to avoid potential future issues in apps.