### PR TITLE
feat: Remove sharing users in grid view :sparkles:

### DIFF
--- a/src/modules/filelist/File.jsx
+++ b/src/modules/filelist/File.jsx
@@ -182,13 +182,6 @@ const File = ({
               }
             }}
           />
-          {viewType === 'grid' && (
-            <Status
-              file={attributes}
-              disabled={isRowDisabledOrInSyncFromSharing}
-              isInSyncFromSharing={isInSyncFromSharing}
-            />
-          )}
         </ThumbnailWrapper>
         <FileName
           attributes={attributes}

--- a/src/modules/filelist/virtualized/GridFile.jsx
+++ b/src/modules/filelist/virtualized/GridFile.jsx
@@ -10,13 +10,7 @@ import Card from 'cozy-ui/transpiled/react/Card'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import {
-  SelectBox,
-  FileName,
-  Status,
-  FileAction,
-  SharingShortcutBadge
-} from '../cells'
+import { SelectBox, FileName, FileAction, SharingShortcutBadge } from '../cells'
 
 import styles from '@/styles/filelist.styl'
 
@@ -148,11 +142,6 @@ const GridFile = ({
                 className: styles['fil-content-shared']
               }
             }}
-          />
-          <Status
-            file={attributes}
-            disabled={isRowDisabledOrInSyncFromSharing}
-            isInSyncFromSharing={isInSyncFromSharing}
           />
         </div>
         <FileName


### PR DESCRIPTION
### Before
<img width="1374" height="354" alt="CleanShot 2025-08-19 at 13 52 39@2x" src="https://github.com/user-attachments/assets/e6299ca5-b98a-441c-bd34-c8a0ec28d47d" />

### After
<img width="1396" height="388" alt="CleanShot 2025-08-19 at 13 51 53@2x" src="https://github.com/user-attachments/assets/a1e8c62a-8c54-4e35-956d-2f92928f38df" />
