### PR TITLE
fix: not being able to scroll on mobile 🐛

### DIFF
--- a/src/modules/views/Folder/FolderViewBody.jsx
+++ b/src/modules/views/Folder/FolderViewBody.jsx
@@ -125,12 +125,11 @@ const FolderViewBody = ({
     navigate('/folder')
   }, [navigate])
 
-  const FileListBodyWrapper = ({ viewType, isDesktop, children }) => {
+  const FileListBodyWrapper = ({ viewType, children }) => {
     return (
       <div
         className={cx(
-          viewType === 'grid' ? styles['fil-folder-body-grid'] : '',
-          !isDesktop ? 'u-ov-hidden' : ''
+          viewType === 'grid' ? styles['fil-folder-body-grid'] : ''
         )}
       >
         {children}

--- a/src/modules/views/Folder/virtualized/GridWrapper.jsx
+++ b/src/modules/views/Folder/virtualized/GridWrapper.jsx
@@ -1,26 +1,13 @@
 import cx from 'classnames'
 import React, { forwardRef } from 'react'
 
-import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-
 import styles from '@/styles/folder-view.styl'
 
-const GridWrapper = forwardRef(({ style, children }, ref) => {
-  const { isDesktop } = useBreakpoints()
-
-  return (
-    <div
-      ref={ref}
-      className={cx(
-        styles['fil-folder-body-grid'],
-        !isDesktop ? 'u-ov-hidden' : ''
-      )}
-      style={style}
-    >
-      {children}
-    </div>
-  )
-})
+const GridWrapper = forwardRef(({ style, children }, ref) => (
+  <div ref={ref} className={cx(styles['fil-folder-body-grid'])} style={style}>
+    {children}
+  </div>
+))
 
 GridWrapper.displayName = 'GridWrapper'
 


### PR DESCRIPTION
fixes scroll on mobile for both grid and list view.

root issue:
`overflow: hidden` was added when on mobile to the folder body, which clips the content, disables scrolling, touch dragging, etc

## demo


https://github.com/user-attachments/assets/56f3a095-658f-49ba-90ed-2f12a49c2dc0

