### PR TITLE
feat: Open shared drive from sharing section :sparkles:

### DIFF
--- a/src/modules/filelist/File.jsx
+++ b/src/modules/filelist/File.jsx
@@ -137,6 +137,7 @@ const File = ({
   let canInteractWithFile =
     attributes._id &&
     attributes._id !== 'io.cozy.files.shared-drives-dir' &&
+    attributes.dir_id !== 'io.cozy.files.shared-drives-dir' &&
     !attributes._id.endsWith('.trash-dir')
   if (typeof canInteractWith === 'function') {
     canInteractWithFile &&= canInteractWith(attributes)
@@ -176,7 +177,11 @@ const File = ({
             styles['fil-file-thumbnail'],
             {
               'u-pl-0': !isMobile,
-              [styles['fil-content-grid-view']]: viewType === 'grid'
+              [styles['fil-content-grid-view']]: viewType === 'grid',
+              'u-ml-half':
+                !canInteractWithFile ||
+                isRowDisabledOrInSyncFromSharing ||
+                disableSelection
             }
           )}
         >

--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -74,7 +74,9 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
     isNextcloudShortcut(file) ||
     isSharedDriveFolder(file)
   ) {
-    return <Icon icon={FileTypeServerIcon} size={size ?? 32} />
+    return (
+      <Icon className="u-mr-half" icon={FileTypeServerIcon} size={size ?? 32} />
+    )
   }
 
   const isSharingShortcut =

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -8,7 +8,7 @@ import {
 import { IOCozyFile } from 'cozy-client/types/types'
 
 import type { File } from '@/components/FolderPicker/types'
-import { TRASH_DIR_ID } from '@/constants/config'
+import { TRASH_DIR_ID, SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { joinPath } from '@/lib/path'
 import { isNextcloudShortcut } from '@/modules/nextcloud/helpers'
 import { makeOnlyOfficeFileRoute } from '@/modules/views/OnlyOffice/helpers'
@@ -25,6 +25,13 @@ interface ComputePathOptions {
   isPublic: boolean
 }
 
+interface FileAttribute {
+  type: string
+  name: string
+  dir_id: string
+  driveId: string
+}
+
 export const computeFileType = (
   file: File,
   {
@@ -37,6 +44,8 @@ export const computeFileType = (
     return 'trash'
   } else if (file._id === 'io.cozy.remote.nextcloud.files.trash-dir') {
     return 'nextcloud-trash'
+  } else if (file.dir_id === SHARED_DRIVES_DIR_ID) {
+    return 'shared-drive'
   } else if (file._type === 'io.cozy.remote.nextcloud.files') {
     return isDirectory(file) ? 'nextcloud-directory' : 'nextcloud-file'
   } else if (isNote(file)) {
@@ -123,6 +132,10 @@ export const computePath = (
         fromPathname: pathname,
         fromPublicFolder: isPublic
       })
+    case 'shared-drive':
+      return `/shareddrive/${(file.attributes as FileAttribute).driveId}/${
+        file._id
+      }`
     default:
       // On mobile, if we are in /favorites tab, we do not want it to appears in computed path
       // so we redirect to root route for files

--- a/src/modules/navigation/hooks/useFileLink.tsx
+++ b/src/modules/navigation/hooks/useFileLink.tsx
@@ -21,6 +21,7 @@ export interface LinkResult {
   href: string
   to: Path
   openInNewTab: boolean
+  isSharedDrive: boolean
 }
 
 interface UseFileLinkResult {


### PR DESCRIPTION
### What has been changed?
Shared drives in the Sharing section only appear as shortcuts and don’t include a root folder id, making them unusable. Since `io.cozy.sharings` provides the needed driveId and root folder id but in an incompatible format, we transform them into directory-like objects with the correct structure. This allows them to be displayed properly in the UI and opened via `shareddrive/:driveId/:rootFolderId`.

### Result:

#### Before:

https://github.com/user-attachments/assets/0f2a7e2f-ea57-447d-96ae-542092aaf731

#### After:

https://github.com/user-attachments/assets/6406e962-909c-44b6-b975-9279cb2ca5bf

### Note:
~~- In recipient's sharing section, the shared drive ID is not correct as shared drive list in sidebar, maybe there was an error from `/files/_all_docs?include_docs=true` endpoint~~