### PR TITLE
fix: available space in the quota is not displayed correctly

### DIFF
--- a/src/components/Storage/StorageProgress.jsx
+++ b/src/components/Storage/StorageProgress.jsx
@@ -38,7 +38,9 @@ const StorageProgress = () => {
         value={parseInt(percentUsage)}
       />
       <Typography variant="caption">
-        {t('Storage.availability', humanDiskQuota - humanDiskUsage)}
+        {t('Storage.availability', {
+          smart_count: (humanDiskQuota - humanDiskUsage).toFixed(2)
+        })}
       </Typography>
     </>
   )


### PR DESCRIPTION
New pull. 
Ref : https://github.com/cozy/cozy-drive/pull/3447

Before : 
<img width="247" height="113" alt="image" src="https://github.com/user-attachments/assets/4f324047-66ad-47ab-92a4-f25d197d052c" />
 After : 
<img width="247" height="113" alt="image" src="https://github.com/user-attachments/assets/039bfa12-7586-4ef7-986e-d63c7ad43234" />

Ticket : https://www.notion.so/linagora/the-available-space-in-the-quota-is-not-displayed-correctly-23262718bad180388c6bd17b7932f5ec
