### PR TITLE
chore: Add conditional SSH setup for master and tags

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,6 +37,7 @@ jobs:
         uses: lironer/bundlemon-action@v1
         continue-on-error: true
       - name: Set SSH for downcloud
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DOWNCLOUD_SSH_KEY }}


### PR DESCRIPTION
Since ssh key is only needed for cozyPublish, we should not try to run this stuff if not publishing.

It'll fix CI issue with fork contribution 
(cf https://github.com/cozy/cozy-drive/pull/3447)