### PR TITLE
feat: persist the file view preference

### DIFF
--- a/src/lib/ViewSwitcherContext.tsx
+++ b/src/lib/ViewSwitcherContext.tsx
@@ -1,22 +1,89 @@
-import React, { useState, useCallback, useContext, createContext } from 'react'
+import React, { useState, useCallback, useContext, createContext, useEffect} from 'react'
+
+import { useClient, Q } from 'cozy-client'
+import logger from './logger'
+import { DOCTYPE_FILES_SETTINGS } from '@/lib/doctypes'
+
+// Constants
+const DEFAULT_VIEW_TYPE = 'list'
 
 interface ViewSwitcherContextProps {
   viewType: string
-  switchView: (viewTypeParam: string) => void
+  switchView: (viewTypeParam: string) => Promise<void>
 }
 
 const ViewSwitcherContext = createContext<ViewSwitcherContextProps>({
-  viewType: 'list',
-  switchView: () => {} // eslint-disable-line @typescript-eslint/no-empty-function
+  viewType: DEFAULT_VIEW_TYPE,
+  switchView: async () => Promise.resolve() 
 })
 
 const ViewSwitcherContextProvider: React.FC = ({ children }) => {
-  const [viewType, setViewType] = useState('list')
+  const client = useClient()
+  const [viewType, setViewType] = useState(DEFAULT_VIEW_TYPE)
+
+  const fetchSettings = useCallback(async () => {
+    if (!client) return null
+
+    try {
+      const { data } = await client.query(Q(DOCTYPE_FILES_SETTINGS))
+      return data?.[0] || null
+    } catch (error) {
+      logger.error('Failed to fetch settings:', error)
+      return null
+    }
+  }, [client])
 
   const switchView = useCallback(
-    (viewTypeParam: string) => setViewType(viewTypeParam),
-    [setViewType]
+    async (viewTypeParam: string) => {
+      setViewType(viewTypeParam)
+
+      if (!client) {
+        logger.warn('Client not available, cannot save view preference')
+        return
+      }
+
+      try {
+        const settings = await fetchSettings()
+
+        if (settings) {
+          await client.save({
+            ...settings,
+            attributes: {
+              ...settings.attributes,
+              preferredDriveViewType: viewTypeParam
+            }
+          })
+        } else {
+          await client.save({
+            _type: DOCTYPE_FILES_SETTINGS,
+            attributes: {
+              preferredDriveViewType: viewTypeParam
+            }
+          })
+        }
+      } catch (error) {
+        logger.error('Failed to save view preference:', error)
+      }
+    },
+    [client, fetchSettings]
   )
+
+  useEffect(() => {
+    const fetchPreferences = async (): Promise<void> => {
+      if (!client) return
+
+      try {
+        const settings = await fetchSettings()
+        const preferredViewType = settings?.attributes
+          ?.preferredDriveViewType as string
+        setViewType(preferredViewType || DEFAULT_VIEW_TYPE)
+      } catch (error) {
+        setViewType(DEFAULT_VIEW_TYPE)
+      }
+    }
+
+    void fetchPreferences()
+  }, [client, fetchSettings])
 
   return (
     <ViewSwitcherContext.Provider value={{ viewType, switchView }}>


### PR DESCRIPTION
Ticket : https://www.notion.so/linagora/persist-store-the-grid-list-view-in-user-drive-settings-23162718bad180cd816be87920c357ba?source=copy_link

[Capture vidéo du 2025-08-29 14-38-33.webm](https://github.com/user-attachments/assets/2c3660fa-7570-46c6-8f0e-1af2befa9342)

Steps:
- When arriving on the page, use `useEffect` to fetch the stored view type from the database.
- If no value is found, default to 'list'.
- When `switchView` is triggered, update the state and persist the new value in the database.

:warning:  Note:
I try to resolve `yarn lint` with a major error :
```Unsafe assignment of an 'any' value```
But I fail :disappointed: 