### PR TITLE
feat: Shared drive recipients can leave a shared drive

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,6 +39,7 @@
     "more": "More"
   },
   "toolbar": {
+    "menu_leave_shared_drive": "Leave shared drive",
     "menu_upload": "Upload files",
     "item_more": "More",
     "menu_new_folder": "Folder",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -39,6 +39,7 @@
     "more": "Plus"
   },
   "toolbar": {
+    "menu_leave_shared_drive": "Quitter le drive partagé",
     "menu_upload": "Importer des fichiers",
     "item_more": "Plus",
     "menu_new_folder": "Dossier",

--- a/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
+++ b/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
@@ -10,6 +10,8 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
+import { getSharingIdFromRelationships } from '@/modules/shareddrives/helpers'
+
 const LeaveSharedDriveButtonItem = ({ files }) => {
   const { t } = useI18n()
   const client = useClient()
@@ -17,7 +19,7 @@ const LeaveSharedDriveButtonItem = ({ files }) => {
   const { showAlert } = useAlert()
   const handleClick = async () => {
     const file = files[0]
-    const sharingId = findSharingId(file)
+    const sharingId = getSharingIdFromRelationships(file)
     if (sharingId) {
       await client.collection('io.cozy.sharings').revokeSelf({ _id: sharingId })
       showAlert({
@@ -39,9 +41,3 @@ const LeaveSharedDriveButtonItem = ({ files }) => {
 }
 
 export default LeaveSharedDriveButtonItem
-
-function findSharingId(folder) {
-  const references = folder.relationships.referenced_by.data
-  const sharingId = references.find(ref => ref.type === 'io.cozy.sharings')?.id
-  return sharingId
-}

--- a/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
+++ b/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useClient } from 'cozy-client'
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+const LeaveSharedDriveButtonItem = ({ files }) => {
+  const { t } = useI18n()
+  const client = useClient()
+  const navigate = useNavigate()
+  const { showAlert } = useAlert()
+  const handleClick = async () => {
+    const file = files[0]
+    const sharingId = findSharingId(file)
+    if (sharingId) {
+      await client.collection('io.cozy.sharings').revokeSelf({ _id: sharingId })
+      showAlert({
+        message: t('Files.share.revokeSelf.success'),
+        severity: 'success',
+      })
+      navigate('/sharings')
+    }
+  }
+
+  return (
+    <ActionsMenuItem onClick={handleClick}>
+      <ListItemIcon>
+        <Icon icon={TrashIcon} className="u-error" />
+      </ListItemIcon>
+      <ListItemText primary={t('toolbar.menu_leave_shared_drive')} />
+    </ActionsMenuItem>
+  )
+}
+
+export default LeaveSharedDriveButtonItem
+
+function findSharingId(folder) {
+  const references = folder.relationships.referenced_by.data
+  const sharingId = references.find(
+    (ref) => ref.type === 'io.cozy.sharings'
+  )?.id
+  return sharingId
+}

--- a/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
+++ b/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
@@ -22,7 +22,7 @@ const LeaveSharedDriveButtonItem = ({ files }) => {
       await client.collection('io.cozy.sharings').revokeSelf({ _id: sharingId })
       showAlert({
         message: t('Files.share.revokeSelf.success'),
-        severity: 'success',
+        severity: 'success'
       })
       navigate('/sharings')
     }
@@ -42,8 +42,6 @@ export default LeaveSharedDriveButtonItem
 
 function findSharingId(folder) {
   const references = folder.relationships.referenced_by.data
-  const sharingId = references.find(
-    (ref) => ref.type === 'io.cozy.sharings'
-  )?.id
+  const sharingId = references.find(ref => ref.type === 'io.cozy.sharings')?.id
   return sharingId
 }

--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -10,6 +10,7 @@ import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import AddMenuItem from '@/modules/drive/Toolbar/components/AddMenuItem'
 import DownloadButtonItem from '@/modules/drive/Toolbar/components/DownloadButtonItem'
 import InsideRegularFolder from '@/modules/drive/Toolbar/components/InsideRegularFolder'
+import LeaveSharedDriveButtonItem from '@/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem'
 import DeleteItem from '@/modules/drive/Toolbar/delete/DeleteItem'
 import SelectableItem from '@/modules/drive/Toolbar/selectable/SelectableItem'
 import ShareItem from '@/modules/drive/Toolbar/share/ShareItem'
@@ -36,7 +37,8 @@ const MoreMenu = ({
   folderId,
   showSelectionBar,
   isSelectionBarVisible,
-  isSharedWithMe
+  isSharedWithMe,
+  isSharedDrive
 }) => {
   const [menuIsVisible, setMenuVisible] = useState(false)
   const anchorRef = useRef()
@@ -88,7 +90,9 @@ const MoreMenu = ({
               displayedFolder={displayedFolder}
               folderId={folderId}
             >
-              <DownloadButtonItem files={[displayedFolder]} />
+              {!isSharedDrive && (
+                <DownloadButtonItem files={[displayedFolder]} />
+              )}
             </InsideRegularFolder>
             {isMobile && hasWriteAccess && <AddMenuItem />}
             <SelectableItem onClick={showSelectionBar} />
@@ -103,6 +107,9 @@ const MoreMenu = ({
                   isSharedWithMe={isSharedWithMe}
                 />
               </InsideRegularFolder>
+            )}
+            {isSharedDrive && isSharedWithMe && (
+              <LeaveSharedDriveButtonItem files={[displayedFolder]} />
             )}
           </ActionsMenu>
         )}

--- a/src/modules/drive/Toolbar/index.jsx
+++ b/src/modules/drive/Toolbar/index.jsx
@@ -32,6 +32,7 @@ const Toolbar = ({
 
   const isDisabled = disabled || isSelectionBarVisible
   const isSharingDisabled = isDisabled || !allLoaded
+  const isSharedDrive = displayedFolder && Boolean(displayedFolder?.driveId)
 
   if (disabled) {
     return null
@@ -47,13 +48,15 @@ const Toolbar = ({
         displayedFolder={displayedFolder}
         folderId={folderId}
       >
-        <SharedRecipients />
+        {!isSharedDrive && <SharedRecipients />}
       </InsideRegularFolder>
       <InsideRegularFolder
         displayedFolder={displayedFolder}
         folderId={folderId}
       >
-        <ShareButton isDisabled={isSharingDisabled} className="u-mr-half" />
+        {!isSharedDrive && (
+          <ShareButton isDisabled={isSharingDisabled} className="u-mr-half" />
+        )}
       </InsideRegularFolder>
       <ViewSwitcher className="u-mr-half" />
       <MoreMenu
@@ -66,6 +69,7 @@ const Toolbar = ({
         displayedFolder={displayedFolder}
         showSelectionBar={showSelectionBar}
         isSelectionBarVisible={isSelectionBarVisible}
+        isSharedDrive={isSharedDrive}
       />
       <BarRightOnMobile>{isMobile && <SearchButton />}</BarRightOnMobile>
     </div>

--- a/src/modules/shareddrives/helpers.ts
+++ b/src/modules/shareddrives/helpers.ts
@@ -11,6 +11,19 @@ export interface Rule {
   values: string[]
 }
 
+/**
+ * Extract the sharing id from a file/folder relationships.referenced_by
+ * Returns undefined if not referenced by a sharing
+ */
+export const getSharingIdFromRelationships = (doc: {
+  relationships?: {
+    referenced_by?: { data?: { id: string; type: string }[] }
+  }
+}): string | undefined =>
+  doc.relationships?.referenced_by?.data?.find(
+    ref => ref.type === 'io.cozy.sharings'
+  )?.id
+
 export const isSharedDriveFolder = (
   file: File | FolderPickerEntry
 ): boolean => {

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -3,7 +3,10 @@ import { Outlet, useParams } from 'react-router-dom'
 
 import { Content } from 'cozy-ui/transpiled/react/Layout'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
+import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
+import Toolbar from '@/modules/drive/Toolbar'
 import { SharedDriveFolderBody } from '@/modules/shareddrives/components/SharedDriveFolderBody'
 import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
 import FolderView from '@/modules/views/Folder/FolderView'
@@ -12,6 +15,7 @@ import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
 const SharedDriveFolderView = () => {
   const { isMobile } = useBreakpoints()
   const { driveId, folderId } = useParams()
+  const { t } = useI18n()
 
   const { sharedDriveResult } = useSharedDriveFolder({
     driveId,
@@ -25,7 +29,10 @@ const SharedDriveFolderView = () => {
   return (
     <FolderView>
       <Content className={isMobile ? '' : 'u-pt-1'}>
-        <FolderViewHeader>TODO</FolderViewHeader>
+        <FolderViewHeader>
+          <Breadcrumb path={[{ name: t('breadcrumb.title_sharings') }]} />
+          <Toolbar canUpload={false} canCreateFolder={false} />
+        </FolderViewHeader>
         <SharedDriveFolderBody
           folderId={folderId}
           queryResults={queryResults}


### PR DESCRIPTION
When a user displays a shared drive, the menu is now available with the "Leave shared drive" command which revokes the current user from the selected shared drive.

<img width="385" height="265" alt="image" src="https://github.com/user-attachments/assets/213346ea-df31-4c3b-92cb-931034453653" />

When done, a success message is displayed and the user is redirected to the list of sharings

<img width="641" height="140" alt="image" src="https://github.com/user-attachments/assets/65e60d9c-d56b-4dbb-9c01-80210d447620" />


- **feat: Add header to shared folder view**
- **feat: Add "leave shared drive" to toolbar**
- **feat: Hide shared recipients and share buttons**
