### PR TITLE
feat: Added breadcrumb for shared drives

### DIFF
--- a/src/modules/shareddrives/components/SharedDriveBreadcrumb.jsx
+++ b/src/modules/shareddrives/components/SharedDriveBreadcrumb.jsx
@@ -1,0 +1,45 @@
+import React, { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useQuery } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+import { SHARED_DRIVES_DIR_ID } from '@/constants/config.js'
+import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
+import { buildSharedDriveIdQuery } from '@/queries'
+
+const SharedDriveBreadcrumb = ({ driveId }) => {
+  const { t } = useI18n()
+  const navigate = useNavigate()
+
+  const sharedDriveQuery = buildSharedDriveIdQuery({ driveId })
+  const { data: sharedDrive } = useQuery(
+    sharedDriveQuery.definition,
+    sharedDriveQuery.options
+  )
+
+  const handleBreadcrumbClick = useCallback(
+    ({ id }) => {
+      if (id === SHARED_DRIVES_DIR_ID) {
+        navigate(`/folder/${SHARED_DRIVES_DIR_ID}`)
+      }
+    },
+    [navigate]
+  )
+
+  return (
+    <Breadcrumb
+      path={[
+        {
+          id: SHARED_DRIVES_DIR_ID,
+          name: t('breadcrumb.title_shared_drives')
+        },
+        { id: driveId, name: sharedDrive?.rules[0]?.title }
+      ]}
+      onBreadcrumbClick={handleBreadcrumbClick}
+      opening={false}
+    />
+  )
+}
+
+export { SharedDriveBreadcrumb }

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -3,10 +3,9 @@ import { Outlet, useParams } from 'react-router-dom'
 
 import { Content } from 'cozy-ui/transpiled/react/Layout'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
 import Toolbar from '@/modules/drive/Toolbar'
+import { SharedDriveBreadcrumb } from '@/modules/shareddrives/components/SharedDriveBreadcrumb'
 import { SharedDriveFolderBody } from '@/modules/shareddrives/components/SharedDriveFolderBody'
 import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
 import FolderView from '@/modules/views/Folder/FolderView'
@@ -15,7 +14,6 @@ import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
 const SharedDriveFolderView = () => {
   const { isMobile } = useBreakpoints()
   const { driveId, folderId } = useParams()
-  const { t } = useI18n()
 
   const { sharedDriveResult } = useSharedDriveFolder({
     driveId,
@@ -30,7 +28,7 @@ const SharedDriveFolderView = () => {
     <FolderView>
       <Content className={isMobile ? '' : 'u-pt-1'}>
         <FolderViewHeader>
-          <Breadcrumb path={[{ name: t('breadcrumb.title_sharings') }]} />
+          <SharedDriveBreadcrumb driveId={driveId} />
           <Toolbar canUpload={false} canCreateFolder={false} />
         </FolderViewHeader>
         <SharedDriveFolderBody

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -543,6 +543,10 @@ interface buildSharedDriveFolderQueryParams {
   folderId: string
 }
 
+interface buildSharedDriveIdQueryParams {
+  driveId: string
+}
+
 export const buildSharedDriveFolderQuery: QueryBuilder<
   buildSharedDriveFolderQueryParams
 > = ({ driveId, folderId }) => ({
@@ -551,5 +555,17 @@ export const buildSharedDriveFolderQuery: QueryBuilder<
     as: `io.cozy.files/driveId/${driveId}/folderId/${folderId}`,
     fetchPolicy: defaultFetchPolicy,
     enabled: !!driveId && !!folderId
+  }
+})
+
+export const buildSharedDriveIdQuery: QueryBuilder<
+  buildSharedDriveIdQueryParams
+> = ({ driveId }) => ({
+  definition: () => Q('io.cozy.sharings').getById(driveId),
+  options: {
+    as: `io.cozy.sharings/driveId/${driveId}`,
+    fetchPolicy: defaultFetchPolicy,
+    singleDocData: true,
+    enabled: !!driveId
   }
 })


### PR DESCRIPTION
Now the breadcrumb is display with shared drive for sender and recipient

<img width="641" height="140" alt="image" src="https://github.com/user-attachments/assets/64ed70d7-0f14-4115-b119-65493184cf88" />

And when the user clicks on the shared drive image, he navigates to the list of shared drives