### PR TITLE
feat: Add accordion behavior to shared drives menu

### DIFF
--- a/src/components/SideBarAccordion.jsx
+++ b/src/components/SideBarAccordion.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+
+import Accordion from 'cozy-ui/transpiled/react/Accordion'
+import AccordionDetails from 'cozy-ui/transpiled/react/AccordionDetails'
+import AccordionSummary from 'cozy-ui/transpiled/react/AccordionSummary'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
+
+const useStyles = makeStyles({
+  accordion: {
+    boxShadow: 'none',
+    border: 'none',
+    backgroundColor: 'transparent',
+    marginTop: '0 !important'
+  },
+  summary: {
+    textTransform: 'none',
+    color: 'var(--coolGrey)',
+    minHeight: '0 !important',
+    border: '0 !important'
+  }
+})
+
+export const SideBarAccordion = ({
+  title,
+  children,
+  defaultExpanded = true,
+  childrenCount,
+  childrenLimit = 5
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+  const classes = useStyles()
+  const shouldShowExpand = childrenCount > childrenLimit
+
+  const handleChange = () => {
+    setIsExpanded(!isExpanded)
+  }
+
+  return (
+    <Accordion
+      className={classes.accordion}
+      defaultExpanded={defaultExpanded}
+      elevation={0}
+      onChange={shouldShowExpand ? handleChange : undefined}
+      expanded={!shouldShowExpand || isExpanded}
+    >
+      <AccordionSummary className={classes.summary} expandIcon={null}>
+        {title}
+        {shouldShowExpand && (
+          <Icon
+            className="u-mh-half"
+            icon={BottomIcon}
+            rotate={isExpanded ? 0 : -90}
+          />
+        )}
+      </AccordionSummary>
+      <AccordionDetails className="u-bdw-0">{children}</AccordionDetails>
+    </Accordion>
+  )
+}

--- a/src/modules/navigation/FavoriteList.tsx
+++ b/src/modules/navigation/FavoriteList.tsx
@@ -3,18 +3,17 @@ import React, { FC } from 'react'
 import { useQuery } from 'cozy-client'
 import { IOCozyFile } from 'cozy-client/types/types'
 import List from 'cozy-ui/transpiled/react/List'
-import ListSubheader from 'cozy-ui/transpiled/react/ListSubheader'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
+import { SideBarAccordion } from '@/components/SideBarAccordion.jsx'
 import { FavoriteListItem } from '@/modules/navigation/FavoriteListItem'
 import { buildFavoritesQuery } from '@/queries'
 
 interface FavoriteListProps {
-  className?: string
   clickState: [string, (value: string | undefined) => void]
 }
 
-const FavoriteList: FC<FavoriteListProps> = ({ className, clickState }) => {
+const FavoriteList: FC<FavoriteListProps> = ({ clickState }) => {
   const { t } = useI18n()
   const favoritesQuery = buildFavoritesQuery({
     sortAttribute: 'name',
@@ -29,18 +28,20 @@ const FavoriteList: FC<FavoriteListProps> = ({ className, clickState }) => {
 
   if (favoritesResult.data && favoritesResult.data.length > 0) {
     return (
-      <List
-        subheader={<ListSubheader>{t('Nav.item_favorites')}</ListSubheader>}
-        className={className}
+      <SideBarAccordion
+        title={t('Nav.item_favorites')}
+        childrenCount={favoritesResult.data.length}
       >
-        {favoritesResult.data.map(file => (
-          <FavoriteListItem
-            key={file._id}
-            file={file}
-            clickState={clickState}
-          />
-        ))}
-      </List>
+        <List className="u-p-0">
+          {favoritesResult.data.map(file => (
+            <FavoriteListItem
+              key={file._id}
+              file={file}
+              clickState={clickState}
+            />
+          ))}
+        </List>
+      </SideBarAccordion>
     )
   }
 

--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -53,15 +53,9 @@ export const Nav = () => {
         rx={/\/trash(\/.*)?/}
         clickState={clickState}
       />
-      {isDesktop ? (
-        <FavoriteList clickState={clickState} className="u-mt-half" />
-      ) : null}
+      {isDesktop ? <FavoriteList clickState={clickState} /> : null}
       {isDesktop && isSharedDriveLoaded ? (
-        <SharedDriveList
-          clickState={clickState}
-          className="u-mt-half"
-          sharedDrives={sharedDrives}
-        />
+        <SharedDriveList clickState={clickState} sharedDrives={sharedDrives} />
       ) : null}
     </UINav>
   )

--- a/src/modules/navigation/components/SharedDriveList.tsx
+++ b/src/modules/navigation/components/SharedDriveList.tsx
@@ -1,8 +1,9 @@
 import React, { FC } from 'react'
 
 import List from 'cozy-ui/transpiled/react/List'
-import ListSubheader from 'cozy-ui/transpiled/react/ListSubheader'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
+import { SideBarAccordion } from '@/components/SideBarAccordion.jsx'
 import { SharedDriveListItem } from '@/modules/navigation/components/SharedDriveListItem'
 import { SharedDrive } from '@/modules/shareddrives/helpers'
 
@@ -14,23 +15,25 @@ interface SharedDriveListProps {
 
 const SharedDriveList: FC<SharedDriveListProps> = ({
   sharedDrives,
-  className,
   clickState
 }) => {
+  const { t } = useI18n()
   if (sharedDrives.length > 0) {
     return (
-      <List
-        subheader={<ListSubheader>Shared drive</ListSubheader>}
-        className={className}
+      <SideBarAccordion
+        title={t('Nav.item_shared_drives')}
+        childrenCount={sharedDrives.length}
       >
-        {sharedDrives.map(sharedDrive => (
-          <SharedDriveListItem
-            key={sharedDrive._id}
-            sharedDrive={sharedDrive}
-            clickState={clickState}
-          />
-        ))}
-      </List>
+        <List className="u-p-0">
+          {sharedDrives.map(sharedDrive => (
+            <SharedDriveListItem
+              key={sharedDrive._id}
+              sharedDrive={sharedDrive}
+              clickState={clickState}
+            />
+          ))}
+        </List>
+      </SideBarAccordion>
     )
   }
 


### PR DESCRIPTION
Now the shared drive menu can be expanded/collapsed when there are more than 5 elements.

Also added this behavior the list of favourites as shown in the mockup.

[Capture vidéo du 2025-09-03 17-10-46.webm](https://github.com/user-attachments/assets/d32ea25f-b71f-46d7-aee1-87ed600d9630)
