### PR TITLE
feat: display sharing badge for new shared drives :sparkles:

### DIFF
--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -115,8 +115,14 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
       const rootFolderId = sharing.rules?.[0]?.values?.[0]
       const driveName = sharing.rules?.[0]?.title
 
+      // Find the file from sharing section that has same `driveId` then override it into directory-like objects
+      const fileInSharingSection = result.data?.find(item => {
+        const driveId = item.relationships?.referenced_by?.data?.[0]?.id
+        return driveId === sharing.id
+      })
+
       return {
-        ...sharing,
+        ...fileInSharingSection,
         _id: rootFolderId,
         id: SHARED_DRIVES_DIR_ID,
         _type: 'io.cozy.files',


### PR DESCRIPTION
### What has been changed?

To show the sharing badge, we need the file's `metadata`. However, in the sharing section, shared drives are taken from `io.cozy.sharings` as `sharedDrives`, which don’t include `metadata`. To fix this, we should look up the file with the same `driveId` as the one in `sharedDrives` and replace it accordingly.

### Evidence

<img width="3020" height="1558" alt="CleanShot 2025-09-04 at 10 28 45@2x" src="https://github.com/user-attachments/assets/7319b590-786c-452e-9dc1-b8f565559ddb" />
