### PR TITLE
feat: Add external drive section into sidebar :sparkles:

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -10,6 +10,7 @@
     "item_collect": "Administrative",
     "item_shared_drives": "Shared Drives",
     "item_favorites": "Favorites",
+    "item_external_drives": "External drives",
     "item_my_drive": "My Drive",
     "btn-client": "Get Twake Drive for desktop",
     "btn-client-web": "Get Twake",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -10,6 +10,7 @@
     "item_collect": "Administratif",
     "item_shared_drives": "Drives partagés",
     "item_favorites": "Favoris",
+    "item_external_drives": "Disques externes",
     "item_my_drive": "Mon Drive",
     "btn-client": "Télécharger Twake Drive ",
     "btn-client-web": "Obtenez un Twake",

--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -12,6 +12,7 @@ import { FavoriteList } from '@/modules/navigation/FavoriteList'
 import { useNavContext } from '@/modules/navigation/NavContext'
 import { NavItem } from '@/modules/navigation/NavItem'
 import { SharingsNavItem } from '@/modules/navigation/SharingsNavItem'
+import { ExternalDrives } from '@/modules/navigation/components/ExternalDrivesList'
 import { SharedDriveList } from '@/modules/navigation/components/SharedDriveList'
 import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 
@@ -62,6 +63,9 @@ export const Nav = () => {
           className="u-mt-half"
           sharedDrives={sharedDrives}
         />
+      ) : null}
+      {isDesktop ? (
+        <ExternalDrives clickState={clickState} className="u-mt-half" />
       ) : null}
     </UINav>
   )

--- a/src/modules/navigation/components/ExternalDriveListItem.tsx
+++ b/src/modules/navigation/components/ExternalDriveListItem.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react'
+
+import { splitFilename } from 'cozy-client/dist/models/file'
+import type { IOCozyFile } from 'cozy-client/types/types'
+import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
+import { NavIcon, NavLink, NavItem } from 'cozy-ui/transpiled/react/Nav'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import { FileLink } from './FileLink'
+
+import { useFileLink } from '@/modules/navigation/hooks/useFileLink'
+
+interface ExternalDriveListItemProps {
+  file: IOCozyFile
+  setLastClicked: (value: string | undefined) => void
+}
+
+const ExternalDriveListItem: FC<ExternalDriveListItemProps> = ({
+  file,
+  setLastClicked
+}) => {
+  const { link } = useFileLink(file, { forceFolderPath: false })
+  const { filename } = splitFilename(file)
+
+  return (
+    <NavItem key={file._id}>
+      <FileLink
+        link={link}
+        className={NavLink.className}
+        onClick={(): void => setLastClicked(undefined)}
+      >
+        <NavIcon icon={FileTypeServerIcon} />
+        <Typography variant="inherit" color="inherit" noWrap>
+          {filename}
+        </Typography>
+      </FileLink>
+    </NavItem>
+  )
+}
+
+export { ExternalDriveListItem }

--- a/src/modules/navigation/components/ExternalDrivesList.tsx
+++ b/src/modules/navigation/components/ExternalDrivesList.tsx
@@ -1,0 +1,56 @@
+import React, { FC } from 'react'
+
+import { useQuery } from 'cozy-client'
+import { IOCozyFile } from 'cozy-client/types/types'
+import List from 'cozy-ui/transpiled/react/List'
+import ListSubheader from 'cozy-ui/transpiled/react/ListSubheader'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+import { ExternalDriveListItem } from './ExternalDriveListItem'
+
+import { buildExternalDrivesQuery } from '@/queries'
+
+interface ExternalDriveListProps {
+  className?: string
+  clickState: [string, (value: string | undefined) => void]
+}
+
+const ExternalDrives: FC<ExternalDriveListProps> = ({
+  className,
+  clickState
+}) => {
+  const { t } = useI18n()
+  const externalDrivesQuery = buildExternalDrivesQuery({
+    sortAttribute: 'name',
+    sortOrder: 'desc'
+  })
+  const externalDrivesResult = useQuery(
+    externalDrivesQuery.definition,
+    externalDrivesQuery.options
+  ) as {
+    data?: IOCozyFile[] | null
+  }
+
+  if (externalDrivesResult.data && externalDrivesResult.data.length > 0) {
+    return (
+      <List
+        subheader={
+          <ListSubheader>{t('Nav.item_external_drives')}</ListSubheader>
+        }
+        className={className}
+      >
+        {externalDrivesResult.data.map(file => (
+          <ExternalDriveListItem
+            key={file._id}
+            file={file}
+            setLastClicked={clickState[1]}
+          />
+        ))}
+      </List>
+    )
+  }
+
+  return null
+}
+
+export { ExternalDrives }

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -44,7 +44,10 @@ export const computeFileType = (
     return 'trash'
   } else if (file._id === 'io.cozy.remote.nextcloud.files.trash-dir') {
     return 'nextcloud-trash'
-  } else if (file.dir_id === SHARED_DRIVES_DIR_ID) {
+  } else if (
+    file.dir_id === SHARED_DRIVES_DIR_ID &&
+    !isNextcloudShortcut(file)
+  ) {
     return 'shared-drive'
   } else if (file._type === 'io.cozy.remote.nextcloud.files') {
     return isDirectory(file) ? 'nextcloud-directory' : 'nextcloud-file'

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -530,6 +530,25 @@ export const buildFavoritesQuery: QueryBuilder<buildFavoritesQueryParams> = ({
   }
 })
 
+export const buildExternalDrivesQuery: QueryBuilder<
+  buildFavoritesQueryParams
+> = ({ sortAttribute, sortOrder }) => ({
+  definition: () =>
+    Q('io.cozy.files')
+      .where({
+        [sortAttribute]: { $gt: null }
+      })
+      .partialIndex({
+        'cozyMetadata.createdByApp': 'nextcloud'
+      })
+      .indexFields([sortAttribute])
+      .sortBy([{ [sortAttribute]: sortOrder }]),
+  options: {
+    as: 'io.cozy.files/metadata.createdByApp/nextcloud',
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
 interface buildMagicFolderQueryParams {
   id: string
   enabled?: boolean


### PR DESCRIPTION
### What has been changed?

The NextCloud will be displayed in `External drives` section in sidebar.

### Related to:

This PR should be merged before [konnectors/nextcloud#21](https://github.com/konnectors/nextcloud/pull/21), since NextCloud is currently appearing in the Favorites section.

### Result:

<img width="548" height="1494" alt="CleanShot 2025-09-08 at 14 23 33@2x" src="https://github.com/user-attachments/assets/1c038eb0-f19f-4250-9063-52ea6ed0b87c" />
