### PR TITLE
fix: Blank screen in sharing because of shared drive

### DIFF
--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -124,6 +124,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
         name: driveName,
         path: `/Drives/${driveName}`,
         dir_id: SHARED_DRIVES_DIR_ID,
+        driveId: sharing.id,
         attributes: {
           type: 'directory',
           name: driveName,


### PR DESCRIPTION
In 0746c41fd3b5986619850b56469adf0fca991a86, I used file.driveId instead of file.attributes.driveId but forgot to update it in the transformedSharedDrives used in Sharing view.