### PR TITLE
Selection bar now disappear if no more files are selected

### DIFF
--- a/src/modules/drive/DeleteConfirm.jsx
+++ b/src/modules/drive/DeleteConfirm.jsx
@@ -15,6 +15,7 @@ import { DOCTYPE_ALBUMS } from '@/lib/doctypes'
 import { getEntriesTypeTranslated } from '@/lib/entries'
 import { trashFiles } from '@/modules/actions/utils'
 import { buildAlbumByIdQuery } from '@/queries'
+import { useSelectionContext } from '../selection/SelectionProvider'
 
 const Message = ({ type, fileCount }) => {
   const icon =
@@ -48,6 +49,7 @@ export const DeleteConfirm = ({
   const [isDeleting, setDeleting] = useState(false)
   const [isReferencedByManualAlbum, setIsReferencedByManualAlbum] =
     useState(false)
+  const { setSelectedItems } = useSelectionContext()
 
   useEffect(() => {
     const fetchAlbums = async () => {
@@ -84,8 +86,24 @@ export const DeleteConfirm = ({
     setDeleting(true)
     await trashFiles(client, files, { showAlert, t })
     afterConfirmation()
+    setSelectedItems(prevSelectedItems => {
+      const fileIdsToRemove = files.map(file => file.id)
+      return Object.fromEntries(
+        Object.entries(prevSelectedItems).filter(
+          ([id]) => !fileIdsToRemove.includes(id)
+        )
+      )
+    })
     onClose()
-  }, [client, files, afterConfirmation, onClose, showAlert, t])
+  }, [
+    client,
+    files,
+    afterConfirmation,
+    onClose,
+    showAlert,
+    t,
+    setSelectedItems
+  ])
 
   const entriesType = getEntriesTypeTranslated(t, files)
 

--- a/src/modules/selection/SelectionProvider.jsx
+++ b/src/modules/selection/SelectionProvider.jsx
@@ -38,7 +38,6 @@ const SelectionProvider = ({ children }) => {
   const location = useLocation()
   const [selectedItems, setSelectedItems] = useState({})
   const [isSelectionBarOpen, setSelectionBarOpen] = useState(false)
-  const [isSelectAll, setIsSelectAll] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(0)
   const [lastSelectedIndex, setLastSelectedIndex] = useState(null)
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false)
@@ -182,7 +181,6 @@ const SelectionProvider = ({ children }) => {
   }
 
   const selectAll = items => {
-    setIsSelectAll(true)
     const newSelectedItems = items.reduce((acc, item) => {
       acc[item.id] = item
       return acc
@@ -192,7 +190,6 @@ const SelectionProvider = ({ children }) => {
 
   const toggleSelectAllItems = items => {
     if (isSelectAll) {
-      setIsSelectAll(false)
       setSelectedItems({})
       setFocusedIndex(0)
       setLastSelectedIndex(null)
@@ -203,7 +200,6 @@ const SelectionProvider = ({ children }) => {
 
   const showSelectionBar = () => setSelectionBarOpen(true)
   const hideSelectionBar = () => {
-    setIsSelectAll(false)
     setSelectedItems({})
     setSelectionBarOpen(false)
     setLastSelectedIndex(null)
@@ -213,6 +209,13 @@ const SelectionProvider = ({ children }) => {
   const isSelectionBarVisible = useMemo(() => {
     return Object.keys(selectedItems).length !== 0 || isSelectionBarOpen
   }, [isSelectionBarOpen, selectedItems])
+
+  const isSelectAll = useMemo(() => {
+    return (
+      itemsListRef.current.length > 0 &&
+      Object.keys(selectedItems).length === itemsListRef.current.length
+    )
+  }, [selectedItems])
 
   const isItemSelected = id => {
     return selectedItems[id] !== undefined
@@ -240,7 +243,8 @@ const SelectionProvider = ({ children }) => {
         handleShiftArrow,
         focusedIndex,
         setFocusedIndex,
-        isKeyboardNavigating
+        isKeyboardNavigating,
+        setSelectedItems
       }}
     >
       {children}

--- a/src/modules/views/Folder/FolderViewBody.jsx
+++ b/src/modules/views/Folder/FolderViewBody.jsx
@@ -37,7 +37,6 @@ import { FolderUnlocker } from '@/modules/folder/components/FolderUnlocker'
 import { useFolderSort } from '@/modules/navigation/duck'
 import SelectionBar from '@/modules/selection/SelectionBar'
 import { isReferencedByShareInSharingContext } from '@/modules/views/Folder/syncHelpers'
-
 // TODO: extraColumns is then passed to 'FileListHeader', 'AddFolder',
 // and 'File' (this one from a 'syncingFakeFile' and a normal file).
 // It is easy to forget to update one of these components to pass 'extraColumns'.


### PR DESCRIPTION
Ticket : https://www.notion.so/linagora/Selection-bar-does-not-disappear-after-all-selected-items-are-deleted-23162718bad180748157e16ff77366f2

[Capture vidéo du 2025-09-11 13-54-43.webm](https://github.com/user-attachments/assets/aeaf250c-6689-42a7-9e42-08441b0d903e)

Explanation: Update the list of the selectedItems when deleting (other actions work as expected). The update of this list close automatically the selection bar