### PR TITLE
feat: Implement create, upload files or folders in shared drive :sparkles:

### DIFF
--- a/src/lib/encryption.js
+++ b/src/lib/encryption.js
@@ -37,14 +37,15 @@ export const getEncryptionKeyFromDirId = async (client, dirId) => {
 export const createEncryptedDir = async (
   client,
   vaultClient,
-  { name, dirID }
+  { name, dirID, driveId }
 ) => {
-  // Create the directory
-  const { data: dir } = await client.create(DOCTYPE_FILES, {
-    name,
-    dirId: dirID,
-    type: 'directory'
-  })
+  const { data: dir } = await client
+    .collection(DOCTYPE_FILES, { driveId })
+    .create({
+      name,
+      dirId: dirID,
+      type: 'directory'
+    })
 
   // Create the encryption key
   const docId = `${DOCTYPE_FILES}/${dir._id}`
@@ -64,12 +65,12 @@ export const createEncryptedDir = async (
 export const encryptAndUploadNewFile = async (
   client,
   vaultClient,
-  { file, encryptionKey, fileOptions }
+  { file, encryptionKey, fileOptions, driveId }
 ) => {
   const { name, dirID, onUploadProgress } = fileOptions
   const encryptedFile = await vaultClient.encryptFile(file, encryptionKey)
   const resp = await client
-    .collection(DOCTYPE_FILES)
+    .collection(DOCTYPE_FILES, { driveId })
     .createFile(encryptedFile, {
       name,
       dirId: dirID,

--- a/src/modules/drive/Toolbar/components/UploadItem.jsx
+++ b/src/modules/drive/Toolbar/components/UploadItem.jsx
@@ -17,7 +17,14 @@ import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
 import { useDisplayedFolder } from '@/hooks'
 import { uploadFiles } from '@/modules/navigation/duck'
 
-const UploadItem = ({ t, isDisabled, onUpload, onClick, isReadOnly }) => {
+const UploadItem = ({
+  t,
+  isDisabled,
+  onUpload,
+  onClick,
+  isReadOnly,
+  displayedFolder
+}) => {
   const client = useClient()
   const vaultClient = useVaultClient()
   const { showAlert } = useAlert()
@@ -43,7 +50,14 @@ const UploadItem = ({ t, isDisabled, onUpload, onClick, isReadOnly }) => {
   const handleChange = files => {
     if (isReadOnly || !files || files.length === 0) return
 
-    onUpload(client, vaultClient, files, initialDirId, showAlert)
+    onUpload(
+      client,
+      vaultClient,
+      files,
+      initialDirId,
+      showAlert,
+      displayedFolder?.driveId
+    )
     onClick()
   }
 
@@ -67,14 +81,21 @@ const UploadItem = ({ t, isDisabled, onUpload, onClick, isReadOnly }) => {
 }
 
 const mapDispatchToProps = (dispatch, { sharingState, onUploaded, t }) => ({
-  onUpload: (client, vaultClient, files, initialDirId, showAlert) => {
+  onUpload: (client, vaultClient, files, initialDirId, showAlert, driveId) => {
     dispatch(
-      uploadFiles(files, initialDirId, sharingState, onUploaded, {
-        client,
-        vaultClient,
-        showAlert,
-        t
-      })
+      uploadFiles(
+        files,
+        initialDirId,
+        sharingState,
+        onUploaded,
+        {
+          client,
+          vaultClient,
+          showAlert,
+          t
+        },
+        driveId
+      )
     )
   }
 })

--- a/src/modules/filelist/AddFolder.jsx
+++ b/src/modules/filelist/AddFolder.jsx
@@ -70,7 +70,8 @@ const createFolderAfterSubmit =
           isEncryptedFolder: isEncryptedFolder(getState()),
           showAlert,
           t
-        }
+        },
+        ownProps.driveId
       )
     ).then(() => {
       // eslint-disable-next-line promise/always-return

--- a/src/modules/folder/components/FolderBody.jsx
+++ b/src/modules/folder/components/FolderBody.jsx
@@ -1,11 +1,13 @@
 import React, { useCallback } from 'react'
 
+import { useVaultClient } from 'cozy-keys-lib'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { EmptyDrive } from '@/components/Error/Empty'
 import Oops from '@/components/Error/Oops'
 import { useThumbnailSizeContext } from '@/lib/ThumbnailSizeContext'
 import { useViewSwitcherContext } from '@/lib/ViewSwitcherContext'
+import AddFolder from '@/modules/filelist/AddFolder'
 import { FileWithSelection as File } from '@/modules/filelist/File'
 import { FileList } from '@/modules/filelist/FileList'
 import FileListBody from '@/modules/filelist/FileListBody'
@@ -45,8 +47,10 @@ const FolderBody = ({
   renderEmptyComponent = () => {
     return <EmptyDrive />
   },
-  canInteractWith
+  canInteractWith,
+  driveId
 }) => {
+  const vaultClient = useVaultClient()
   const { isDesktop } = useBreakpoints()
 
   useScrollToTop(folderId)
@@ -87,6 +91,17 @@ const FolderBody = ({
           />
         ) : null}
         <FileListBody selectionModeActive={false}>
+          {!needsToWait && (
+            <div className={!isDesktop ? 'u-ov-hidden' : ''}>
+              <AddFolder
+                vaultClient={vaultClient}
+                refreshFolderContent={refreshFolderContent}
+                extraColumns={extraColumns}
+                currentFolderId={folderId}
+                driveId={driveId}
+              />
+            </div>
+          )}
           {isError ? <Oops /> : null}
           {isLoading || needsToWait ? <FileListRowsPlaceholder /> : null}
           {isEmpty ? renderEmptyComponent() : null}

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -42,7 +42,8 @@ export const uploadFiles =
     dirId,
     sharingState,
     fileUploadedCallback = () => null,
-    { client, vaultClient, showAlert, t }
+    { client, vaultClient, showAlert, t },
+    driveId
   ) =>
   dispatch => {
     let targetDirId = dirId
@@ -82,7 +83,8 @@ export const uploadFiles =
               navigateAfterUpload
             )
           ),
-        { client, vaultClient }
+        { client, vaultClient },
+        driveId
       )
     )
   }
@@ -249,7 +251,8 @@ export const createFolder = (
   vaultClient,
   name,
   currentFolderId,
-  { isEncryptedFolder = false, showAlert, t } = {}
+  { isEncryptedFolder = false, showAlert, t } = {},
+  driveId
 ) => {
   return async (dispatch, getState) => {
     const state = getState()
@@ -280,16 +283,19 @@ export const createFolder = (
     let createdFolder = null
     try {
       if (!isTargetEncrypted) {
-        createdFolder = await client.create('io.cozy.files', {
-          name: name,
-          dirId: targetFolderId,
-          type: 'directory'
-        })
+        createdFolder = await client
+          .collection('io.cozy.files', { driveId })
+          .create({
+            name: name,
+            dirId: targetFolderId,
+            type: 'directory'
+          })
       } else {
         if (targetFolderId === currentFolderId) {
           createdFolder = await createEncryptedDir(client, vaultClient, {
             name,
-            dirID: targetFolderId
+            dirID: targetFolderId,
+            driveId
           })
         } else {
           logger.error(

--- a/src/modules/navigation/duck/actions.spec.jsx
+++ b/src/modules/navigation/duck/actions.spec.jsx
@@ -34,10 +34,14 @@ afterEach(() => {
 describe('createFolder', () => {
   beforeEach(() => {
     jest.spyOn(CozyClient.prototype, 'create').mockImplementation(() => {})
+    jest.spyOn(CozyClient.prototype, 'collection').mockReturnValue({
+      create: jest.fn().mockResolvedValue({})
+    })
   })
 
   afterEach(() => {
     CozyClient.prototype.create.mockRestore()
+    CozyClient.prototype.collection.mockRestore()
   })
 
   it('should not be possible to create a folder with a same name of an existing folder', async () => {
@@ -62,7 +66,11 @@ describe('createFolder', () => {
       createFolder(client, vaultClient, 'foobar5', folderId, { showAlert, t })
     )
 
-    expect(client.create).toHaveBeenCalledWith('io.cozy.files', {
+    expect(client.collection).toHaveBeenCalledWith('io.cozy.files', {
+      driveId: undefined
+    })
+    const mockCollection = client.collection.mock.results[0].value
+    expect(mockCollection.create).toHaveBeenCalledWith({
       dirId: 'folder123456',
       name: 'foobar5',
       type: 'directory'

--- a/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
+++ b/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
@@ -12,7 +12,11 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { download, infos, versions, hr } from '@/modules/actions'
 import { FolderBody } from '@/modules/folder/components/FolderBody'
 
-const SharedDriveFolderBody = ({ folderId, queryResults }) => {
+const SharedDriveFolderBody = ({
+  folderId,
+  queryResults,
+  refreshFolderContent
+}) => {
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const client = useClient()
@@ -45,6 +49,8 @@ const SharedDriveFolderBody = ({ folderId, queryResults }) => {
       queryResults={queryResults}
       actions={actions}
       withFilePath={false}
+      driveId={driveId}
+      refreshFolderContent={refreshFolderContent}
     />
   )
 }

--- a/src/modules/upload/Dropzone.jsx
+++ b/src/modules/upload/Dropzone.jsx
@@ -65,7 +65,8 @@ export const Dropzone = ({
           vaultClient,
           showAlert,
           t
-        }
+        },
+        displayedFolder.driveId
       )
     )
   }

--- a/src/modules/upload/DropzoneDnD.jsx
+++ b/src/modules/upload/DropzoneDnD.jsx
@@ -60,7 +60,8 @@ export const Dropzone = ({ displayedFolder, children }) => {
               vaultClient,
               showAlert,
               t
-            }
+            },
+            displayedFolder.driveId
           )
         )
       },

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -1,19 +1,25 @@
 import React from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 
+import { useSharingContext } from 'cozy-sharing'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
+import { useDisplayedFolder } from '@/hooks'
 import Toolbar from '@/modules/drive/Toolbar'
 import { SharedDriveBreadcrumb } from '@/modules/shareddrives/components/SharedDriveBreadcrumb'
 import { SharedDriveFolderBody } from '@/modules/shareddrives/components/SharedDriveFolderBody'
 import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
+import Dropzone from '@/modules/upload/Dropzone'
+import DropzoneDnD from '@/modules/upload/DropzoneDnD'
 import FolderView from '@/modules/views/Folder/FolderView'
 import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
 
 const SharedDriveFolderView = () => {
   const { isMobile } = useBreakpoints()
   const { driveId, folderId } = useParams()
+  const { hasWriteAccess } = useSharingContext()
+  const { displayedFolder } = useDisplayedFolder()
 
   const { sharedDriveResult } = useSharedDriveFolder({
     driveId,
@@ -24,19 +30,29 @@ const SharedDriveFolderView = () => {
     ? [{ fetchStatus: 'loaded', data: sharedDriveResult.included }]
     : []
 
+  const canWriteToCurrentFolder = hasWriteAccess(folderId)
+
+  const DropzoneComp = !isMobile ? DropzoneDnD : Dropzone
+
   return (
     <FolderView>
-      <Content className={isMobile ? '' : 'u-pt-1'}>
-        <FolderViewHeader>
-          <SharedDriveBreadcrumb driveId={driveId} />
-          <Toolbar canUpload={false} canCreateFolder={false} />
-        </FolderViewHeader>
-        <SharedDriveFolderBody
-          folderId={folderId}
-          queryResults={queryResults}
-        />
-        <Outlet />
-      </Content>
+      <DropzoneComp
+        disabled={!canWriteToCurrentFolder}
+        displayedFolder={displayedFolder}
+      >
+        <Content className={isMobile ? '' : 'u-pt-1'}>
+          <FolderViewHeader>
+            <SharedDriveBreadcrumb driveId={driveId} />
+            <Toolbar canUpload={false} canCreateFolder={false} />
+          </FolderViewHeader>
+
+          <SharedDriveFolderBody
+            folderId={folderId}
+            queryResults={queryResults}
+          />
+          <Outlet />
+        </Content>
+      </DropzoneComp>
     </FolderView>
   )
 }


### PR DESCRIPTION
### What has been changed?

For now, we can create an empty folder, upload files/folders, and drop to upload files/folders in shared drives.

### Result:

https://github.com/user-attachments/assets/df6f2d38-7e6a-4aa8-81c3-f07c6d6c9a8c
