### PR TITLE
fix: Open correct shared drive view by user :bug:

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "cozy-sharing": "^26.1.1",
     "cozy-stack-client": "^57.2.0",
     "cozy-ui": "^128.8.0",
-    "cozy-viewer": "^23.3.0",
+    "cozy-viewer": "^23.4.2",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",
     "filesize": "10.1.6",

--- a/src/modules/navigation/hooks/helpers.spec.js
+++ b/src/modules/navigation/hooks/helpers.spec.js
@@ -295,11 +295,11 @@ describe('computePath', () => {
     )
   })
 
-  it('should throw error for shared-drive without driveId', () => {
+  it('should return correct for shared-drive in case user is owner', () => {
     const file = { _id: 'file123' }
-    expect(() =>
-      computePath(file, { type: 'shared-drive', pathname: '/any' })
-    ).toThrow('Missing driveId in a shared drive')
+    expect(computePath(file, { type: 'shared-drive', pathname: '/any' })).toBe(
+      '/folder/file123'
+    )
   })
 
   it('should return correct path for default case', () => {

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -130,8 +130,9 @@ export const computePath = (
         fromPublicFolder: isPublic
       })
     case 'shared-drive':
+      // Without driveId, we should use path `/folder/:folderId` because it's shared drive folder of owner
       if (!driveId) {
-        throw new Error('Missing driveId in a shared drive')
+        return `/folder/${file._id}`
       }
 
       return `/shareddrive/${driveId}/${file._id}`

--- a/src/modules/navigation/hooks/useSharedDriveLink.tsx
+++ b/src/modules/navigation/hooks/useSharedDriveLink.tsx
@@ -26,7 +26,18 @@ const useSharedDriveLink = (sharing: SharedDrive): UseFileLinkResult => {
   const cozyUrl = client?.getStackClient().uri as string
 
   const app = 'drive'
-  const path = `shareddrive/${sharing._id}/${sharing.rules[0].values[0]}`
+
+  if (!sharing.rules[0].values[0]) {
+    throw new Error('Missing folder id in shared drive')
+  }
+
+  /** Set shared drive path
+   * if user is owner of this shared drive, the path should be `folder/:folderId`
+   * otherwise the path should be `shareddrive/:driveId/:folderId`
+   */
+  const path = sharing.owner
+    ? `folder/${sharing.rules[0].values[0]}`
+    : `shareddrive/${sharing._id}/${sharing.rules[0].values[0]}`
 
   const currentURL = new URL(window.location.href)
   const currentPathname = currentURL.pathname

--- a/src/modules/shareddrives/helpers.ts
+++ b/src/modules/shareddrives/helpers.ts
@@ -4,6 +4,7 @@ import type { File, FolderPickerEntry } from '@/components/FolderPicker/types'
 export interface SharedDrive {
   _id: string
   rules: Rule[]
+  owner?: boolean
 }
 
 export interface Rule {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5902,14 +5902,14 @@ cozy-ui@^128.8.0:
     react-virtuoso "^4.13.0"
     rooks "7.14.1"
 
-cozy-viewer@^23.3.0:
-  version "23.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-23.3.0.tgz#be4483a3723514ccfce0ff1e8f30322bc2c5eaa9"
-  integrity sha512-X3r7MWgE8LqfB6O0V0scO/w+wxNR/LlgqJh8E/7xC3DFuYe124AawmnWLk5yezaK3gcguJhn0lQR3Ntcz4Xg0w==
+cozy-viewer@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-23.4.2.tgz#1371751c9974d3414f499f67b2e71da9417cbd50"
+  integrity sha512-NrhVWAgwu9T2Xx8NFvxjVSneFcsk90HOYwntgA/ceCef9duZkesH2AiD93QwQWpzO2ngtSv9lj9KRdZcupz6oA==
   dependencies:
-    classnames "^2.2.5"
+    classnames "^2.5.1"
     hammerjs "^2.0.8"
-    lodash "4.17.21"
+    lodash "^4.17.21"
     react-markdown "^4.0.8"
     react-pdf "^5.7.2"
 


### PR DESCRIPTION
### Change:

Set the correct path to open shared drive by user's role.

### Result:

#### User is owner

https://github.com/user-attachments/assets/ff9ae41a-7059-4449-bf02-b524059a5ab1

#### User is the recipient

https://github.com/user-attachments/assets/bbc73a90-86f5-460f-9b39-d61e5088de30

### Need:

[cozy/cozy-viewer#2818](https://github.com/cozy/cozy-libs/pull/2818)
