### PR TITLE
feat(shareddrives): Add realtime on shared drives list

### DIFF
--- a/src/modules/shareddrives/hooks/useSharedDrives.js
+++ b/src/modules/shareddrives/hooks/useSharedDrives.js
@@ -1,6 +1,10 @@
 import { useState, useEffect } from 'react'
 
-import { useClient } from 'cozy-client'
+import { useClient, useQuery } from 'cozy-client'
+
+import { DEFAULT_SORT } from '@/config/sort'
+import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
+import { buildDriveQuery } from '@/queries'
 
 export const useSharedDrives = () => {
   const client = useClient()
@@ -8,23 +12,41 @@ export const useSharedDrives = () => {
   const [isLoaded, setIsLoaded] = useState(false)
   const [sharedDrives, setSharedDrives] = useState([])
 
+  const folderQuery = buildDriveQuery({
+    currentFolderId: SHARED_DRIVES_DIR_ID,
+    type: 'directory',
+    sortAttribute: DEFAULT_SORT.attribute,
+    sortOrder: DEFAULT_SORT.order
+  })
+  const { lastUpdate } = useQuery(folderQuery.definition, folderQuery.options)
+
   useEffect(() => {
+    let isCancelled = false
+
     const fetchSharedDrives = async () => {
       setIsLoading(true)
+      try {
+        const { data: sharedDrives } = await client
+          .collection('io.cozy.sharings')
+          .fetchSharedDrives()
 
-      const { data: sharedDrives } = await client
-        .collection('io.cozy.sharings')
-        .fetchSharedDrives()
-
-      setSharedDrives(sharedDrives)
-      setIsLoading(false)
-      setIsLoaded(true)
+        if (!isCancelled) {
+          setSharedDrives(sharedDrives)
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false)
+          setIsLoaded(true)
+        }
+      }
     }
 
-    if (!isLoading && !isLoaded) {
-      void fetchSharedDrives()
+    void fetchSharedDrives()
+
+    return () => {
+      isCancelled = true
     }
-  })
+  }, [client, lastUpdate])
 
   return { isLoading, isLoaded, sharedDrives }
 }


### PR DESCRIPTION
Since there is no realtime on sharings, we use realtime on shared drives folder list of folders. Whenever a change is done in the list of folders in this directory, a request to the list of shared drive is done.
