### PR TITLE
feat: Add realtime to shared drives files

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cozy-logger": "^1.17.0",
     "cozy-minilog": "3.9.1",
     "cozy-pouch-link": "^57.7.0",
-    "cozy-realtime": "5.6.4",
+    "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.8.3",
     "cozy-sharing": "^26.1.1",
     "cozy-stack-client": "^57.2.0",

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -176,3 +176,23 @@ declare module '*.styl' {
   const content: Record<string, string>
   export default content
 }
+
+declare module 'cozy-realtime' {
+  export default class CozyRealtime {
+    constructor(options: {
+      client: import('cozy-client').default
+      sharedDriveId?: string
+    })
+    subscribe: (
+      event: string,
+      doctype: string,
+      callback: () => void | Promise<void>
+    ) => void
+    unsubscribe: (
+      event: string,
+      doctype: string,
+      callback: () => void | Promise<void>
+    ) => void
+    stop: () => void
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5800,10 +5800,10 @@ cozy-pouch-link@^57.7.0:
     pouchdb-browser "^7.2.2"
     pouchdb-find "^7.2.2"
 
-cozy-realtime@5.6.4:
-  version "5.6.4"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-5.6.4.tgz#8546ffbd4882243bd785ef29f33bb0c74e444e16"
-  integrity sha512-kI43e4lDi8MXAkGF5id5joZco6rQVH/acTuW0tCp7FklM2ZT02mujwIBnDE59QWAn5nmaSakL7VA6dqdgfP6hQ==
+cozy-realtime@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-5.8.0.tgz#88af55ce680da4e263b9514e20062fb5097a4c11"
+  integrity sha512-B/308fMd+RFKj4VBsefqmaCnbata+ToJxCXAqMaD9iYbkW1sE7BoLN7CqyU9YPrQUZsZAqZ2/7rc30ugh4zaGw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
 


### PR DESCRIPTION
This is a naive implementation of realtime for shared drives files.
A better approach is expected later using the storage of cozy-client
But for this we need to fix
https://github.com/cozy/cozy-client/issues/1620 first.