### PR TITLE
feat: Implement uploading new version of file in shared drive :sparkles:

### DIFF
--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux'
 
+import { getFullpath } from 'cozy-client/dist/models/file'
 import flag from 'cozy-flags'
 
 import { MAX_PAYLOAD_SIZE } from '@/constants/config'
@@ -228,12 +229,21 @@ export const processNextFile =
       error = uploadError
       if (uploadError.status === CONFLICT_ERROR) {
         try {
-          const path = await CozyFile.getFullpath(dirID, file.name)
-          const uploadedFile = await overwriteFile(client, file, path, {
-            onUploadProgress: event => {
-              dispatch(uploadProgress(file, event))
-            }
-          })
+          const path = driveId
+            ? await getFullpath(client, dirID, file.name, driveId)
+            : await CozyFile.getFullpath(dirID, file.name)
+
+          const uploadedFile = await overwriteFile(
+            client,
+            file,
+            path,
+            {
+              onUploadProgress: event => {
+                dispatch(uploadProgress(file, event))
+              }
+            },
+            driveId
+          )
           fileUploadedCallback(uploadedFile)
           dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file, isUpdate: true })
           error = null
@@ -416,13 +426,20 @@ const uploadFile = async (client, file, dirID, options = {}, driveId) => {
  * @param {Object} file - The uploaded javascript File object
  * @param {string} path - The file's path in the cozy
  * @param {{onUploadProgress}} options
+ * @param {string} driveId - The drive ID for shared drives
  * @return {Object} - The updated io.cozy.files
  */
-export const overwriteFile = async (client, file, path, options = {}) => {
+export const overwriteFile = async (
+  client,
+  file,
+  path,
+  options = {},
+  driveId = null
+) => {
   const statResp = await client.collection(DOCTYPE_FILES).statByPath(path)
   const { id: fileId, dir_id: dirId } = statResp.data
   const resp = await client
-    .collection(DOCTYPE_FILES)
+    .collection(DOCTYPE_FILES, { driveId })
     .updateFile(file, { dirId, fileId, options })
 
   return resp.data


### PR DESCRIPTION
### Change:

Update upload function to handle upload new version of file in shared drive

### Need:

[cozy/cozy-client#1630](https://github.com/cozy/cozy-client/pull/1630)

### Note:

Currently, this PR will be set to Draft because the API get file by path for shared drive does not available