### PR TITLE
feat: Sort trash by updated_at by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "cozy-search": "^0.8.3",
     "cozy-sharing": "^26.2.0",
     "cozy-stack-client": "^57.2.0",
-    "cozy-ui": "^128.8.0",
+    "cozy-ui": "^130.0.0",
     "cozy-viewer": "^23.4.2",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",

--- a/src/modules/navigation/duck/hooks.ts
+++ b/src/modules/navigation/duck/hooks.ts
@@ -4,11 +4,13 @@ import flag from 'cozy-flags'
 
 import { DEFAULT_SORT, SORT_BY_UPDATE_DATE } from '@/config/sort'
 import { sortFolder, getSort } from '@/modules/navigation/duck'
+import { TRASH_DIR_ID } from '@/constants/config'
 
 const useFolderSort = (folderId: string): [Sort, (props: Sort) => void] => {
-  const defaultSort: Sort = flag('drive.default-updated-at-sort.enabled')
-    ? SORT_BY_UPDATE_DATE
-    : DEFAULT_SORT
+  const defaultSort: Sort =
+    flag('drive.default-updated-at-sort.enabled') || folderId === TRASH_DIR_ID
+      ? SORT_BY_UPDATE_DATE
+      : DEFAULT_SORT
   const dispatch = useDispatch()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   const currentSort = (useSelector(state => getSort(state)) ||

--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -34,7 +34,8 @@ const FolderViewBody = ({
   actions,
   canUpload = true,
   canDrag,
-  withFilePath = false
+  withFilePath = false,
+  sortOrder
 }) => {
   const client = useClient()
   const { isDesktop } = useBreakpoints()
@@ -172,6 +173,7 @@ const FolderViewBody = ({
             currentFolderId={currentFolderId}
             withFilePath={withFilePath}
             actions={actions}
+            sortOrder={sortOrder}
           />
         ) : (
           <Grid

--- a/src/modules/views/Trash/TrashFolderView.jsx
+++ b/src/modules/views/Trash/TrashFolderView.jsx
@@ -105,6 +105,7 @@ export const TrashFolderView = () => {
             queryResults={[foldersResult, filesResult]}
             withFilePath={true}
             extraColumns={extraColumns}
+            sortOrder={sortOrder}
           />
         ) : (
           <FolderViewBody

--- a/src/modules/views/Trash/TrashFolderView.spec.jsx
+++ b/src/modules/views/Trash/TrashFolderView.spec.jsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient } from 'cozy-client'
+import AppLike from 'test/components/AppLike'
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => null)
+}))
+
+import { useCurrentFolderId } from '@/hooks'
+import { useFolderSort } from '@/modules/navigation/duck/hooks'
+
+jest.mock('@/hooks', () => ({
+  useCurrentFolderId: jest.fn(() => 'io.cozy.files.trash-dir'),
+  useDisplayedFolder: jest.fn(() => ({
+    displayedFolder: { _id: 'trash' },
+    isNotFound: false
+  }))
+}))
+
+const client = createMockClient({})
+
+function TestComponent({ onResult }) {
+  const currentFolderId = useCurrentFolderId()
+  const [sortOrder] = useFolderSort(currentFolderId)
+
+  React.useEffect(() => {
+    onResult({ currentFolderId, sortOrder })
+  }, [currentFolderId, sortOrder, onResult])
+
+  return null
+}
+
+describe('TrashFolderView', () => {
+  it('uses the updated_at sort for trash folder by default', () => {
+    let result = null
+
+    const handleResult = data => {
+      result = data
+    }
+
+    render(
+      <AppLike client={client}>
+        <TestComponent onResult={handleResult} />
+      </AppLike>
+    )
+
+    expect(result.currentFolderId).toBe('io.cozy.files.trash-dir')
+    expect(result.sortOrder.attribute).toBe('updated_at')
+    expect(result.sortOrder.order).toBe('desc')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5865,10 +5865,10 @@ cozy-tsconfig@^1.8.1:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.8.1.tgz#5f206f4e6e041a4afc6691098264ba630bdeb7e2"
   integrity sha512-/9QBxK8Tc12O2ojuyRpSMjPpXpqldVvzfNB1+/nPD+IkIBkU+mqxpHYJwKWjNYHGraCSy69mIwt9J3aiaJdz9w==
 
-cozy-ui@^128.8.0:
-  version "128.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-128.8.0.tgz#a9319596a29e1985dc1b996694117a452e7fb7fc"
-  integrity sha512-GOGrPuA6/xS3rhH4rCO/wf1hLGVzazV6iTU4vZY5qz5QHUe577XHSM2rpxIko422YwZ0fY0Re1JFIjCYyiXd8Q==
+cozy-ui@^130.0.0:
+  version "130.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-130.0.0.tgz#3fa0b449a2036194465f2fc1390e23f7f7c875f4"
+  integrity sha512-hMpxxWpTAZoHLb5ZJSgHP1db/ioVdLFoqU/rsSQ1+iGhpsLu77h6Ba3FZ2/c6CQgDo3DulFTffSDJKXxMLsnzw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"
@@ -10795,9 +10795,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -13905,7 +13905,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13931,15 +13931,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -14064,7 +14055,7 @@ stringify-clone@^1.0.0:
   resolved "https://registry.yarnpkg.com/stringify-clone/-/stringify-clone-1.1.1.tgz#309a235fb4ecfccd7d388dbe18ba904facaf433b"
   integrity sha512-LIFpvBnQJF3ZGoV770s3feH+wRVCMRSisI8fl1E57WfgKOZKUMaC1r4eJXybwGgXZ/iTTJoK/tsOku1GLPyyxQ==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14084,13 +14075,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -15321,7 +15305,7 @@ worker-loader@2.0.0:
     loader-utils "^1.0.0"
     schema-utils "^0.4.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15342,15 +15326,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Ticket : https://www.notion.so/linagora/Display-files-in-the-trash-by-deletion-date-1c062718bad1803d8aa6c3f51d515d4c?source=copy_link

The trash folder is now sorted by last update desc by default but an issue persist.

When you delete a file/folder, it's not concidered as an update. So currently it's not sorted by the last item deleted but really by the last time the item is modified. 

As discussed with Khaled, apparently it's a back-end problem. 

### changes : 
- use updated_at default sort order in trash folder view

<img width="1595" height="447" alt="image" src="https://github.com/user-attachments/assets/d4255ab8-b944-458c-bad5-751ddcf27235" />
