### PR TITLE
refactor(Table): Remove useless `handleShiftArrow` prop

### DIFF
--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -49,7 +49,6 @@ const Table = ({
 }) => {
   const {
     handleShiftClick,
-    handleShiftArrow,
     focusedIndex,
     toggleSelectedItem,
     isKeyboardNavigating
@@ -101,7 +100,6 @@ const Table = ({
         onSelect={handleRowSelect}
         isSelectedItem={isSelectedItem}
         selectedItems={selectedItems}
-        handleShiftArrow={handleShiftArrow}
         increaseViewportBy={200}
         onSortChange={handleSort}
         componentsProps={{


### PR DESCRIPTION
not used in the comp, only passed to the DOM as is