### PR TITLE
Feat: Highlight new items

### DIFF
--- a/src/hooks/useDisplayedFolder.spec.jsx
+++ b/src/hooks/useDisplayedFolder.spec.jsx
@@ -2,6 +2,7 @@ import { useQuery } from 'cozy-client'
 
 import useCurrentFolderId from './useCurrentFolderId'
 import useDisplayedFolder from './useDisplayedFolder'
+
 import { ROOT_DIR_ID } from '@/constants/config'
 
 jest.mock('cozy-client', () => ({

--- a/src/hooks/useDisplayedFolder.tsx
+++ b/src/hooks/useDisplayedFolder.tsx
@@ -1,9 +1,9 @@
 import { useQuery } from 'cozy-client'
 import { IOCozyFile } from 'cozy-client/types/types'
 
+import { ROOT_DIR_ID } from '@/constants/config'
 import useCurrentFolderId from '@/hooks/useCurrentFolderId'
 import { buildFileOrFolderByIdQuery } from '@/queries'
-import { ROOT_DIR_ID } from '@/constants/config'
 
 interface DisplayedFolderResult {
   isNotFound: boolean

--- a/src/hooks/useOnLongPress.js
+++ b/src/hooks/useOnLongPress.js
@@ -7,7 +7,7 @@ import { useUploadContext } from '@/modules/upload/UploadProvider'
 export default function useLongPress({ onPress, selectionModeActive }) {
   const timerRef = useRef()
   const isLongPress = useRef()
-  const { clearNewItems } = useUploadContext() 
+  const { clearNewItems } = useUploadContext()
 
   // used to create the longpress, i.e. delay on click
   function startPressTimer(e) {
@@ -20,9 +20,8 @@ export default function useLongPress({ onPress, selectionModeActive }) {
 
   // first event triggered on Desktop when clicking an item
   // if conditions are met, click is triggered after a certain amount of time
+  // button 0 is left click
   function handleOnMouseDown(e) {
-    // button 0 is left click
-
     // Clear any new items that could be in the upload state
     clearNewItems()
 

--- a/src/hooks/useOnLongPress.js
+++ b/src/hooks/useOnLongPress.js
@@ -2,9 +2,12 @@ import { useRef } from 'react'
 
 import flag from 'cozy-flags'
 
+import { useUploadContext } from '@/modules/upload/UploadProvider'
+
 export default function useLongPress({ onPress, selectionModeActive }) {
   const timerRef = useRef()
   const isLongPress = useRef()
+  const { clearNewItems } = useUploadContext() 
 
   // used to create the longpress, i.e. delay on click
   function startPressTimer(e) {
@@ -19,6 +22,10 @@ export default function useLongPress({ onPress, selectionModeActive }) {
   // if conditions are met, click is triggered after a certain amount of time
   function handleOnMouseDown(e) {
     // button 0 is left click
+
+    // Clear any new items that could be in the upload state
+    clearNewItems()
+
     if (
       selectionModeActive ||
       e.button !== 0 ||

--- a/src/modules/drive/AddMenu/AddMenuContent.jsx
+++ b/src/modules/drive/AddMenu/AddMenuContent.jsx
@@ -19,6 +19,7 @@ import { ScannerMenuItem } from '@/modules/drive/Toolbar/components/Scanner/Scan
 import { useScannerContext } from '@/modules/drive/Toolbar/components/Scanner/ScannerProvider'
 import UploadItem from '@/modules/drive/Toolbar/components/UploadItem'
 import { isOfficeEditingEnabled } from '@/modules/views/OnlyOffice/helpers'
+import { UploadProvider } from '@/modules/upload/UploadProvider'
 
 const AddMenuContent = forwardRef(
   ({
@@ -116,13 +117,15 @@ const AddMenuContent = forwardRef(
         )}
         {canUpload && <Divider className="u-mv-half" />}
         {canUpload && (
-          <UploadItem
-            disabled={isDisabled}
-            onUploaded={refreshFolderContent}
-            displayedFolder={displayedFolder}
-            onClick={onClick}
-            isReadOnly={isReadOnly}
-          />
+          <UploadProvider>
+            <UploadItem
+              disabled={isDisabled}
+              onUploaded={refreshFolderContent}
+              displayedFolder={displayedFolder}
+              onClick={onClick}
+              isReadOnly={isReadOnly}
+            />
+          </UploadProvider>
         )}
         {hasScanner && <ScannerMenuItem onClick={createActionOnClick} />}
       </>

--- a/src/modules/drive/Toolbar/components/UploadItem.jsx
+++ b/src/modules/drive/Toolbar/components/UploadItem.jsx
@@ -16,6 +16,7 @@ import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { useDisplayedFolder } from '@/hooks'
 import { uploadFiles } from '@/modules/navigation/duck'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 const UploadItem = ({
   t,
@@ -29,6 +30,7 @@ const UploadItem = ({
   const vaultClient = useVaultClient()
   const { showAlert } = useAlert()
   const { initialDirId } = useDisplayedFolder()
+  const { addNewItems } = useUploadContext()
 
   const handleMenuItemClick = evt => {
     if (isReadOnly) {
@@ -56,7 +58,8 @@ const UploadItem = ({
       files,
       initialDirId,
       showAlert,
-      displayedFolder?.driveId
+      displayedFolder?.driveId,
+      addNewItems
     )
     onClick()
   }
@@ -81,7 +84,7 @@ const UploadItem = ({
 }
 
 const mapDispatchToProps = (dispatch, { sharingState, onUploaded, t }) => ({
-  onUpload: (client, vaultClient, files, initialDirId, showAlert, driveId) => {
+  onUpload: (client, vaultClient, files, initialDirId, showAlert, driveId, addNewItems) => {
     dispatch(
       uploadFiles(
         files,
@@ -94,7 +97,8 @@ const mapDispatchToProps = (dispatch, { sharingState, onUploaded, t }) => ({
           showAlert,
           t
         },
-        driveId
+        driveId,
+        addNewItems
       )
     )
   }

--- a/src/modules/drive/Toolbar/components/UploadItem.jsx
+++ b/src/modules/drive/Toolbar/components/UploadItem.jsx
@@ -84,7 +84,15 @@ const UploadItem = ({
 }
 
 const mapDispatchToProps = (dispatch, { sharingState, onUploaded, t }) => ({
-  onUpload: (client, vaultClient, files, initialDirId, showAlert, driveId, addNewItems) => {
+  onUpload: (
+    client,
+    vaultClient,
+    files,
+    initialDirId,
+    showAlert,
+    driveId,
+    addNewItems
+  ) => {
     dispatch(
       uploadFiles(
         files,

--- a/src/modules/filelist/AddFolder.jsx
+++ b/src/modules/filelist/AddFolder.jsx
@@ -73,7 +73,7 @@ const createFolderAfterSubmit =
           t
         },
         ownProps.driveId,
-        addNewItems 
+        addNewItems
       )
     ).then(() => {
       // eslint-disable-next-line promise/always-return
@@ -86,7 +86,11 @@ const createFolderAfterSubmit =
 export const addFolderDispatch = (dispatch, ownProps) => ({
   onSubmit: (name, showAlert, t) =>
     dispatch(
-      createFolderAfterSubmit(ownProps, name, { showAlert, t, addNewItems: ownProps.addNewItems })
+      createFolderAfterSubmit(ownProps, name, {
+        showAlert,
+        t,
+        addNewItems: ownProps.addNewItems
+      })
     ),
   onAbort: (accidental, showAlert, t) => {
     if (accidental) {
@@ -113,7 +117,7 @@ const AddFolderWithState = compose(
 
 const AddFolderWithAfter = ({ refreshFolderContent, ...props }) => {
   const dispatch = useDispatch()
-  const { addNewItems } = useUploadContext() 
+  const { addNewItems } = useUploadContext()
 
   const handleAfterSubmit = () => {
     if (refreshFolderContent) {
@@ -130,7 +134,7 @@ const AddFolderWithAfter = ({ refreshFolderContent, ...props }) => {
     <AddFolderWithState
       afterSubmit={handleAfterSubmit}
       afterAbort={handleAfterAbort}
-      addNewItems={addNewItems} 
+      addNewItems={addNewItems}
       {...props}
     />
   )

--- a/src/modules/filelist/AddFolder.jsx
+++ b/src/modules/filelist/AddFolder.jsx
@@ -18,6 +18,7 @@ import {
 } from '@/modules/filelist/duck'
 import AddFolderRowVz from '@/modules/filelist/virtualized/AddFolderRow'
 import { createFolder } from '@/modules/navigation/duck'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 const AddFolder = ({
   visible,
@@ -58,7 +59,7 @@ const mapStateToProps = state => ({
 })
 
 const createFolderAfterSubmit =
-  (ownProps, name, { showAlert, t }) =>
+  (ownProps, name, { showAlert, t, addNewItems }) =>
   async (dispatch, getState) => {
     return dispatch(
       createFolder(
@@ -71,7 +72,8 @@ const createFolderAfterSubmit =
           showAlert,
           t
         },
-        ownProps.driveId
+        ownProps.driveId,
+        addNewItems 
       )
     ).then(() => {
       // eslint-disable-next-line promise/always-return
@@ -83,11 +85,13 @@ const createFolderAfterSubmit =
 
 export const addFolderDispatch = (dispatch, ownProps) => ({
   onSubmit: (name, showAlert, t) =>
-    dispatch(createFolderAfterSubmit(ownProps, name, { showAlert, t })),
+    dispatch(
+      createFolderAfterSubmit(ownProps, name, { showAlert, t, addNewItems: ownProps.addNewItems })
+    ),
   onAbort: (accidental, showAlert, t) => {
     if (accidental) {
       showAlert({
-        message: t('alert.folder_abort'), //
+        message: t('alert.folder_abort'),
         severity: 'secondary'
       })
     }
@@ -109,6 +113,7 @@ const AddFolderWithState = compose(
 
 const AddFolderWithAfter = ({ refreshFolderContent, ...props }) => {
   const dispatch = useDispatch()
+  const { addNewItems } = useUploadContext() 
 
   const handleAfterSubmit = () => {
     if (refreshFolderContent) {
@@ -125,6 +130,7 @@ const AddFolderWithAfter = ({ refreshFolderContent, ...props }) => {
     <AddFolderWithState
       afterSubmit={handleAfterSubmit}
       afterAbort={handleAfterAbort}
+      addNewItems={addNewItems} 
       {...props}
     />
   )

--- a/src/modules/filelist/FileListHeaderDesktop.jsx
+++ b/src/modules/filelist/FileListHeaderDesktop.jsx
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import React from 'react'
-import flag from 'cozy-flags'
 
+import flag from 'cozy-flags'
 import {
   TableHead,
   TableHeader,

--- a/src/modules/filelist/FileListHeaderMobile.jsx
+++ b/src/modules/filelist/FileListHeaderMobile.jsx
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import React, { useState, useCallback } from 'react'
-import flag from 'cozy-flags'
 
+import flag from 'cozy-flags'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ListIcon from 'cozy-ui/transpiled/react/Icons/List'

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -27,6 +27,7 @@ import {
 } from '@/modules/navigation/duck/reducer'
 import { SelectionProvider } from '@/modules/selection/SelectionProvider'
 import UploadQueue from '@/modules/upload/UploadQueue'
+import { UploadProvider } from '../upload/UploadProvider'
 
 initFlags()
 
@@ -88,9 +89,11 @@ const LayoutContent = () => {
         )}
       </Sidebar>
       <UploadQueue />
-      <SelectionProvider>
-        <Outlet />
-      </SelectionProvider>
+      <UploadProvider>
+        <SelectionProvider>
+          <Outlet /> 
+        </SelectionProvider>
+      </UploadProvider>
       <Sprite />
       {flag('debug') && <CozyDevtools />}
     </LayoutUI>

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -26,8 +26,8 @@ import {
   RESET_OPERATION_REDIRECTED
 } from '@/modules/navigation/duck/reducer'
 import { SelectionProvider } from '@/modules/selection/SelectionProvider'
+import { UploadProvider } from '@/modules/upload/UploadProvider'
 import UploadQueue from '@/modules/upload/UploadQueue'
-import { UploadProvider } from '../upload/UploadProvider'
 
 initFlags()
 
@@ -91,7 +91,7 @@ const LayoutContent = () => {
       <UploadQueue />
       <UploadProvider>
         <SelectionProvider>
-          <Outlet /> 
+          <Outlet />
         </SelectionProvider>
       </UploadProvider>
       <Sprite />

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -29,12 +29,16 @@ export const sortFolder = (folderId, sortAttribute, sortOrder = 'asc') => {
 }
 
 /**
- * Upload files to the given directory
- * @param {Array} files - The list of File objects to upload
- * @param {string} dirId - The id of the directory in which we upload the files
- * @param {Object} sharingState - The sharing context (provided by SharingContext.Provider)
- * @param {function} fileUploadedCallback - A callback called when a file is uploaded
- * @returns {function} - A function that dispatches addToUploadQueue action
+ * Dispatches an action to upload files to a specified directory.
+ *
+ * @param {Array<File>} files - The files to upload.
+ * @param {string} dirId - The target directory ID for the upload.
+ * @param {Object} sharingState - Sharing context, if applicable.
+ * @param {function} fileUploadedCallback - Callback invoked after each file upload (optional).
+ * @param {Object} options - Additional options including client, vaultClient, showAlert, and t (translation function).
+ * @param {string} driveId - The drive ID where files are uploaded (optional).
+ * @param {function} addNewItems - Callback to add newly uploaded items to the context.
+ * @returns {function} Thunk action for Redux dispatch.
  */
 export const uploadFiles =
   (
@@ -43,7 +47,8 @@ export const uploadFiles =
     sharingState,
     fileUploadedCallback = () => null,
     { client, vaultClient, showAlert, t },
-    driveId
+    driveId,
+    addNewItems
   ) =>
   dispatch => {
     let targetDirId = dirId
@@ -80,11 +85,13 @@ export const uploadFiles =
               showAlert,
               t,
               fileTooLargeErrors,
-              navigateAfterUpload
+              navigateAfterUpload,
+              addNewItems
             )
           ),
         { client, vaultClient },
-        driveId
+        driveId,
+        addNewItems
       )
     )
   }
@@ -100,7 +107,8 @@ const uploadQueueProcessed =
     showAlert,
     t,
     fileTooLargeErrors,
-    navigateAfterUpload
+    navigateAfterUpload,
+    addNewItems
   ) =>
   dispatch => {
     const conflictCount = conflicts.length
@@ -111,6 +119,12 @@ const uploadQueueProcessed =
       ...updated,
       ...conflicts
     ])
+
+    // Add new items to the NewContext
+    const successfulUploads = [...created, ...updated]
+    if (successfulUploads.length > 0) {
+      addNewItems(successfulUploads)
+    }
 
     // Add logging to debug upload completion
     logger.debug('uploadQueueProcessed called with:', {
@@ -252,7 +266,8 @@ export const createFolder = (
   name,
   currentFolderId,
   { isEncryptedFolder = false, showAlert, t } = {},
-  driveId
+  driveId,
+  addNewItems = () => {}
 ) => {
   return async (dispatch, getState) => {
     const state = getState()
@@ -305,6 +320,11 @@ export const createFolder = (
             'Cannot create encrypted folder in root via redirection.'
           )
         }
+      }
+
+      // Add newly created folder to new items
+      if (createdFolder) {
+        addNewItems([createdFolder.data])
       }
 
       if (navigateAfterCreate && createdFolder) {

--- a/src/modules/navigation/duck/hooks.ts
+++ b/src/modules/navigation/duck/hooks.ts
@@ -1,10 +1,11 @@
 import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+
 import flag from 'cozy-flags'
 
 import { DEFAULT_SORT, SORT_BY_UPDATE_DATE } from '@/config/sort'
-import { sortFolder, getSort } from '@/modules/navigation/duck'
 import { TRASH_DIR_ID } from '@/constants/config'
+import { sortFolder, getSort } from '@/modules/navigation/duck'
 
 const useFolderSort = (folderId: string): [Sort, (props: Sort) => void] => {
   const defaultSort: Sort =

--- a/src/modules/public/PublicLayout.jsx
+++ b/src/modules/public/PublicLayout.jsx
@@ -7,6 +7,7 @@ import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import { Layout } from 'cozy-ui/transpiled/react/Layout'
 
 import { SelectionProvider } from '@/modules/selection/SelectionProvider'
+import { UploadProvider } from '@/modules/upload/UploadProvider'
 import UploadQueue from '@/modules/upload/UploadQueue'
 
 const PublicLayout = () => {
@@ -15,9 +16,11 @@ const PublicLayout = () => {
       <BarComponent replaceTitleOnMobile isPublic disableInternalStore />
       <FlagSwitcher />
       <UploadQueue />
-      <SelectionProvider>
-        <Outlet />
-      </SelectionProvider>
+      <UploadProvider>
+        <SelectionProvider>
+          <Outlet />
+        </SelectionProvider>
+      </UploadProvider>
       <Sprite />
     </Layout>
   )

--- a/src/modules/selection/SelectionProvider.jsx
+++ b/src/modules/selection/SelectionProvider.jsx
@@ -9,6 +9,7 @@ import React, {
 import { useLocation } from 'react-router-dom'
 
 import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 /**
  * @typedef TSelectionContext
@@ -43,11 +44,19 @@ const SelectionProvider = ({ children }) => {
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false)
   const itemsListRef = useRef([])
 
+  // Use UploadProvider context
+  const { newItems, clearNewItems } = useUploadContext()
+
   const setItemsList = items => {
     itemsListRef.current = items
   }
 
   const toggleSelectedItem = (item, index = null) => {
+    // Use UploadProvider's newItems and clearNewItems
+    if (newItems?.length > 0) {
+      clearNewItems()
+    }
+
     if (item.id === SHARED_DRIVES_DIR_ID) {
       return
     }

--- a/src/modules/selection/SelectionProvider.spec.jsx
+++ b/src/modules/selection/SelectionProvider.spec.jsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
 import {
   MemoryRouter,
   Routes,
@@ -14,6 +16,16 @@ import {
   SelectionProvider,
   useSelectionContext
 } from '@/modules/selection/SelectionProvider'
+
+// Create a mock store for testing
+const mockStore = createStore(() => ({
+  // Add any state that SelectionProvider needs
+  upload: {
+    queue: [],
+    newItems: []
+  }
+  // Add other state slices if needed
+}))
 
 const SelectionConsumer = ({ items }) => {
   const {
@@ -81,17 +93,19 @@ describe('SelectionProvider', () => {
 
   const setup = () => {
     return render(
-      <MemoryRouter initialEntries={['/']}>
-        <SelectionProvider>
-          <Routes>
-            <Route path="/" element={<SelectionConsumer items={items} />} />
-            <Route
-              path="/other"
-              element={<SelectionConsumer items={items} />}
-            />
-          </Routes>
-        </SelectionProvider>
-      </MemoryRouter>
+      <Provider store={mockStore}>
+        <MemoryRouter initialEntries={['/']}>
+          <SelectionProvider>
+            <Routes>
+              <Route path="/" element={<SelectionConsumer items={items} />} />
+              <Route
+                path="/other"
+                element={<SelectionConsumer items={items} />}
+              />
+            </Routes>
+          </SelectionProvider>
+        </MemoryRouter>
+      </Provider>
     )
   }
 

--- a/src/modules/selection/SelectionProvider.spec.jsx
+++ b/src/modules/selection/SelectionProvider.spec.jsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Provider } from 'react-redux'
-import { createStore } from 'redux'
 import {
   MemoryRouter,
   Routes,
@@ -9,6 +8,7 @@ import {
   Link,
   useLocation
 } from 'react-router-dom'
+import { createStore } from 'redux'
 
 import { generateFile } from 'test/generate'
 
@@ -16,6 +16,13 @@ import {
   SelectionProvider,
   useSelectionContext
 } from '@/modules/selection/SelectionProvider'
+
+jest.mock('modules/upload/UploadProvider', () => ({
+  ...jest.requireActual('modules/upload/UploadProvider'),
+  useUploadContext: () => ({
+    addNewItems: jest.fn()
+  })
+}))
 
 // Create a mock store for testing
 const mockStore = createStore(() => ({

--- a/src/modules/selection/SelectionProvider.spec.jsx
+++ b/src/modules/selection/SelectionProvider.spec.jsx
@@ -31,7 +31,6 @@ const mockStore = createStore(() => ({
     queue: [],
     newItems: []
   }
-  // Add other state slices if needed
 }))
 
 const SelectionConsumer = ({ items }) => {

--- a/src/modules/upload/Dropzone.jsx
+++ b/src/modules/upload/Dropzone.jsx
@@ -16,6 +16,7 @@ import styles from '@/styles/dropzone.styl'
 import RightClickAddMenu from '@/components/RightClick/RightClickAddMenu'
 import { uploadFiles } from '@/modules/navigation/duck'
 import DropzoneTeaser from '@/modules/upload/DropzoneTeaser'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 // DnD helpers for folder upload
 const canHandleFolders = evt => {
@@ -45,6 +46,7 @@ export const Dropzone = ({
   const sharingState = useSharingContext()
   const vaultClient = useVaultClient()
   const dispatch = useDispatch()
+  const { addNewItems } = useUploadContext()
 
   const fileUploadCallback = refreshFolderContent
     ? refreshFolderContent
@@ -66,7 +68,8 @@ export const Dropzone = ({
           showAlert,
           t
         },
-        displayedFolder.driveId
+        displayedFolder.driveId,
+        addNewItems
       )
     )
   }

--- a/src/modules/upload/DropzoneDnD.jsx
+++ b/src/modules/upload/DropzoneDnD.jsx
@@ -17,6 +17,7 @@ import styles from '@/styles/dropzone.styl'
 import RightClickAddMenu from '@/components/RightClick/RightClickAddMenu'
 import { uploadFiles } from '@/modules/navigation/duck'
 import DropzoneTeaser from '@/modules/upload/DropzoneTeaser'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 // DnD helpers for folder upload
 const canHandleFolders = evt => {
@@ -41,6 +42,7 @@ export const Dropzone = ({ displayedFolder, children }) => {
   const sharingState = useSharingContext()
   const vaultClient = useVaultClient()
   const dispatch = useDispatch()
+  const { addNewItems } = useUploadContext()
   const [{ canDrop, isOver }, dropRef] = useDrop(
     () => ({
       accept: [NativeTypes.FILE],
@@ -61,7 +63,8 @@ export const Dropzone = ({ displayedFolder, children }) => {
               showAlert,
               t
             },
-            displayedFolder.driveId
+            displayedFolder.driveId,
+            addNewItems
           )
         )
       },

--- a/src/modules/upload/UploadButton.jsx
+++ b/src/modules/upload/UploadButton.jsx
@@ -11,9 +11,11 @@ import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { uploadFiles } from '@/modules/navigation/duck'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 const UploadButton = ({ label, disabled, onUpload, className }) => {
   const { showAlert } = useAlert()
+  const { addNewItems } = useUploadContext()
 
   return (
     <FileInput
@@ -21,7 +23,7 @@ const UploadButton = ({ label, disabled, onUpload, className }) => {
       label={label}
       disabled={disabled}
       multiple
-      onChange={files => onUpload(files, showAlert)}
+      onChange={files => onUpload(files, showAlert, addNewItems)} 
       data-testid="upload-btn"
       value={[]} // always erase the value to be able to re-upload the same file
     >
@@ -51,12 +53,20 @@ const mapDispatchToProps = (
   dispatch,
   { displayedFolder, sharingState, onUploaded, t }
 ) => ({
-  onUpload: (files, showAlert) => {
+  onUpload: (files, showAlert, addNewItems) => {
     dispatch(
-      uploadFiles(files, displayedFolder.id, sharingState, onUploaded, {
-        showAlert,
-        t
-      })
+      uploadFiles(
+        files,
+        displayedFolder.id,
+        sharingState,
+        onUploaded,
+        {
+          showAlert,
+          t
+        },
+        displayedFolder?.driveId,
+        addNewItems
+      )
     )
   }
 })

--- a/src/modules/upload/UploadButton.jsx
+++ b/src/modules/upload/UploadButton.jsx
@@ -23,7 +23,7 @@ const UploadButton = ({ label, disabled, onUpload, className }) => {
       label={label}
       disabled={disabled}
       multiple
-      onChange={files => onUpload(files, showAlert, addNewItems)} 
+      onChange={files => onUpload(files, showAlert, addNewItems)}
       data-testid="upload-btn"
       value={[]} // always erase the value to be able to re-upload the same file
     >

--- a/src/modules/upload/UploadProvider.jsx
+++ b/src/modules/upload/UploadProvider.jsx
@@ -1,0 +1,43 @@
+import logger from '@/lib/logger'
+import React, { createContext, useContext, useState, useCallback } from 'react'
+
+const UploadContext = createContext()
+
+export const UploadProvider = ({ children }) => {
+  const [newItems, setNewItems] = useState([])
+
+  const addNewItems = items => {
+    setNewItems(prev => {
+      const existingIds = prev.map(item => item._id)
+      const uniqueItems = (Array.isArray(items) ? items : [items]).filter(
+        item => item && item._id && !existingIds.includes(item._id)
+      )
+      return [...prev, ...uniqueItems]
+    })
+  }
+
+  const clearNewItems = () => setNewItems([])
+
+  const isNewItem = item => {
+    logger.info('item', item)
+    logger.info('newItems', newItems)
+    return newItems.some(newItem => newItem._id === item._id)
+  }
+
+  const value = {
+    newItems,
+    addNewItems,
+    clearNewItems,
+    isNewItem
+  }
+
+  return (
+    <UploadContext.Provider value={value}>
+      {children}
+    </UploadContext.Provider>
+  )
+}
+
+const useUploadContext = () => useContext(UploadContext)
+
+export { UploadProvider, useUploadContext }

--- a/src/modules/upload/UploadProvider.jsx
+++ b/src/modules/upload/UploadProvider.jsx
@@ -1,4 +1,3 @@
-import logger from '@/lib/logger'
 import React, { createContext, useContext, useState, useCallback } from 'react'
 
 const UploadContext = createContext()
@@ -6,7 +5,7 @@ const UploadContext = createContext()
 export const UploadProvider = ({ children }) => {
   const [newItems, setNewItems] = useState([])
 
-  const addNewItems = items => {
+  const addNewItems = useCallback(items => {
     setNewItems(prev => {
       const existingIds = prev.map(item => item._id)
       const uniqueItems = (Array.isArray(items) ? items : [items]).filter(
@@ -14,15 +13,14 @@ export const UploadProvider = ({ children }) => {
       )
       return [...prev, ...uniqueItems]
     })
-  }
+  }, [])
 
-  const clearNewItems = () => setNewItems([])
+  const clearNewItems = useCallback(() => setNewItems([]), [])
 
-  const isNewItem = item => {
-    logger.info('item', item)
-    logger.info('newItems', newItems)
-    return newItems.some(newItem => newItem._id === item._id)
-  }
+  const isNewItem = useCallback(
+    item => newItems.some(newItem => newItem._id === item._id),
+    [newItems]
+  )
 
   const value = {
     newItems,

--- a/src/modules/upload/UploadProvider.jsx
+++ b/src/modules/upload/UploadProvider.jsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useState, useCallback } from 'react'
 
 const UploadContext = createContext()
 
-export const UploadProvider = ({ children }) => {
+const UploadProvider = ({ children }) => {
   const [newItems, setNewItems] = useState([])
 
   const addNewItems = useCallback(items => {
@@ -30,9 +30,7 @@ export const UploadProvider = ({ children }) => {
   }
 
   return (
-    <UploadContext.Provider value={value}>
-      {children}
-    </UploadContext.Provider>
+    <UploadContext.Provider value={value}>{children}</UploadContext.Provider>
   )
 }
 

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -154,7 +154,9 @@ export const queue = (state = [], action) => {
   }
 }
 
-export default combineReducers({ queue })
+export default combineReducers({
+  queue
+})
 
 export const uploadProgress = (file, event, date) => ({
   type: UPLOAD_PROGRESS,
@@ -171,7 +173,8 @@ export const processNextFile =
     dirID,
     sharingState,
     { client, vaultClient },
-    driveId
+    driveId,
+    addNewItems
   ) =>
   async (dispatch, getState) => {
     let error = null
@@ -202,6 +205,7 @@ export const processNextFile =
           },
           driveId
         )
+        if (addNewItems) addNewItems([newDir])
         fileUploadedCallback(newDir)
       } else {
         const withProgress = {
@@ -221,7 +225,7 @@ export const processNextFile =
           },
           driveId
         )
-
+        if (addNewItems) addNewItems([uploadedFile])
         fileUploadedCallback(uploadedFile)
       }
       dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file })
@@ -244,6 +248,7 @@ export const processNextFile =
             },
             driveId
           )
+          if (addNewItems) addNewItems([uploadedFile])
           fileUploadedCallback(uploadedFile)
           dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file, isUpdate: true })
           error = null
@@ -285,7 +290,8 @@ export const processNextFile =
         dirID,
         sharingState,
         { client, vaultClient },
-        driveId
+        driveId,
+        addNewItems
       )
     )
   }
@@ -459,7 +465,8 @@ export const addToUploadQueue =
     fileUploadedCallback,
     queueCompletedCallback,
     { client, vaultClient },
-    driveId
+    driveId,
+    addNewItems
   ) =>
   async dispatch => {
     dispatch({
@@ -473,7 +480,8 @@ export const addToUploadQueue =
         dirID,
         sharingState,
         { client, vaultClient },
-        driveId
+        driveId,
+        addNewItems
       )
     )
   }

--- a/src/modules/upload/index.spec.js
+++ b/src/modules/upload/index.spec.js
@@ -171,6 +171,11 @@ describe('processNextFile function', () => {
     expect(fileUploadedCallbackSpy).toHaveBeenCalledWith(file)
 
     expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
+      type: 'ADD_NEW_ITEMS',
+      payload: [file]
+    })
+
+    expect(dispatchSpy).toHaveBeenNthCalledWith(3, {
       type: 'RECEIVE_UPLOAD_SUCCESS',
       file,
       isUpdate: true

--- a/src/modules/upload/index.spec.js
+++ b/src/modules/upload/index.spec.js
@@ -171,11 +171,6 @@ describe('processNextFile function', () => {
     expect(fileUploadedCallbackSpy).toHaveBeenCalledWith(file)
 
     expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
-      type: 'ADD_NEW_ITEMS',
-      payload: [file]
-    })
-
-    expect(dispatchSpy).toHaveBeenNthCalledWith(3, {
       type: 'RECEIVE_UPLOAD_SUCCESS',
       file,
       isUpdate: true

--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useEffect, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
@@ -22,11 +22,11 @@ import { FolderUnlocker } from '@/modules/folder/components/FolderUnlocker'
 import { useCancelable } from '@/modules/move/hooks/useCancelable'
 import SelectionBar from '@/modules/selection/SelectionBar'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 import AddFolderTable from '@/modules/views/Folder/virtualized/AddFolderTable'
 import EmptyContent from '@/modules/views/Folder/virtualized/EmptyContent'
 import Table from '@/modules/views/Folder/virtualized/Table'
 import { makeRows, onDrop } from '@/modules/views/Folder/virtualized/helpers'
-import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 const FolderViewBody = ({
   currentFolderId,
@@ -39,7 +39,6 @@ const FolderViewBody = ({
   sortOrder
 }) => {
   const client = useClient()
-  const dispatch = useDispatch()
   const { isDesktop } = useBreakpoints()
   const navigate = useNavigate()
   const IsAddingFolder = useSelector(isTypingNewFolderName)
@@ -100,7 +99,7 @@ const FolderViewBody = ({
       window.scroll({ top: 0 })
     }
     clearNewItems()
-  }, [currentFolderId, isDesktop])
+  }, [currentFolderId, isDesktop, clearNewItems])
 
   /**
    * When we mount the component when we already have data in cache,

--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useEffect, useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
@@ -26,6 +26,7 @@ import AddFolderTable from '@/modules/views/Folder/virtualized/AddFolderTable'
 import EmptyContent from '@/modules/views/Folder/virtualized/EmptyContent'
 import Table from '@/modules/views/Folder/virtualized/Table'
 import { makeRows, onDrop } from '@/modules/views/Folder/virtualized/helpers'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 const FolderViewBody = ({
   currentFolderId,
@@ -38,6 +39,7 @@ const FolderViewBody = ({
   sortOrder
 }) => {
   const client = useClient()
+  const dispatch = useDispatch()
   const { isDesktop } = useBreakpoints()
   const navigate = useNavigate()
   const IsAddingFolder = useSelector(isTypingNewFolderName)
@@ -48,6 +50,7 @@ const FolderViewBody = ({
   const { showAlert } = useAlert()
   const { viewType } = useViewSwitcherContext()
   const { t } = useI18n()
+  const { clearNewItems } = useUploadContext()
 
   const isSelectedItem = file => {
     if (file._id === SHARED_DRIVES_DIR_ID) {
@@ -96,6 +99,7 @@ const FolderViewBody = ({
     } else {
       window.scroll({ top: 0 })
     }
+    clearNewItems()
   }, [currentFolderId, isDesktop])
 
   /**

--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, forwardRef, useState, useMemo } from 'react'
+
 import VirtuosoTableDnd from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd'
 import TableRowDnD from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd/TableRow'
 import virtuosoComponentsDnd from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd/virtuosoComponents'

--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -1,5 +1,4 @@
 import React, { useRef, forwardRef, useState, useMemo } from 'react'
-
 import VirtuosoTableDnd from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd'
 import TableRowDnD from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd/TableRow'
 import virtuosoComponentsDnd from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd/virtuosoComponents'
@@ -14,6 +13,7 @@ import RightClickFileMenu from '@/components/RightClick/RightClickFileMenu'
 import { useShiftArrowsSelection } from '@/hooks/useShiftArrowsSelection'
 import Cell from '@/modules/filelist/virtualized/cells/Cell'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+import { useUploadContext } from '@/modules/upload/UploadProvider'
 
 const TableRow = forwardRef(({ item, context, children, ...props }, ref) => {
   return (
@@ -59,6 +59,7 @@ const Table = ({
   const [orderBy, setOrderBy] = useState(
     sortOrder?.attribute || columns?.[0]?.id
   )
+  const { isNewItem } = useUploadContext()
   const sortedRow = useMemo(() => {
     const sortedData = stableSort(rows, getComparator(order, orderBy))
     return secondarySort(sortedData)
@@ -102,6 +103,7 @@ const Table = ({
         selectedItems={selectedItems}
         increaseViewportBy={200}
         onSortChange={handleSort}
+        isNewItem={isNewItem}
         componentsProps={{
           rowContent: {
             children: (

--- a/src/modules/views/Trash/TrashFolderView.spec.jsx
+++ b/src/modules/views/Trash/TrashFolderView.spec.jsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react'
 import React from 'react'
 
 import { createMockClient } from 'cozy-client'
+
 import AppLike from 'test/components/AppLike'
 
 jest.mock('react-redux', () => ({

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -75,7 +75,9 @@ const AppLike = ({
                           <AlertProvider>
                             <PushBannerProvider>
                               <ModalContext.Provider
-                                value={modalContextValue || mockModalContextValue}
+                                value={
+                                  modalContextValue || mockModalContextValue
+                                }
                               >
                                 <FabProvider>
                                   <RightClickProvider>

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -19,6 +19,7 @@ import { ModalContext } from '@/lib/ModalContext'
 import { ViewSwitcherContextProvider } from '@/lib/ViewSwitcherContext'
 import enLocale from '@/locales/en.json'
 import { SelectionProvider } from '@/modules/selection/SelectionProvider'
+import { UploadProvider } from '@/modules/upload/UploadProvider'
 
 const mockStore = createStore(() => ({
   mobile: {
@@ -67,25 +68,27 @@ const AppLike = ({
             <AcceptingSharingProvider>
               <NativeFileSharingProvider>
                 <HashRouter>
-                  <SelectionProvider>
-                    <ViewSwitcherContextProvider>
-                      <BreakpointsProvider>
-                        <AlertProvider>
-                          <PushBannerProvider>
-                            <ModalContext.Provider
-                              value={modalContextValue || mockModalContextValue}
-                            >
-                              <FabProvider>
-                                <RightClickProvider>
-                                  <Layout>{children}</Layout>
-                                </RightClickProvider>
-                              </FabProvider>
-                            </ModalContext.Provider>
-                          </PushBannerProvider>
-                        </AlertProvider>
-                      </BreakpointsProvider>
-                    </ViewSwitcherContextProvider>
-                  </SelectionProvider>
+                  <UploadProvider>
+                    <SelectionProvider>
+                      <ViewSwitcherContextProvider>
+                        <BreakpointsProvider>
+                          <AlertProvider>
+                            <PushBannerProvider>
+                              <ModalContext.Provider
+                                value={modalContextValue || mockModalContextValue}
+                              >
+                                <FabProvider>
+                                  <RightClickProvider>
+                                    <Layout>{children}</Layout>
+                                  </RightClickProvider>
+                                </FabProvider>
+                              </ModalContext.Provider>
+                            </PushBannerProvider>
+                          </AlertProvider>
+                        </BreakpointsProvider>
+                      </ViewSwitcherContextProvider>
+                    </SelectionProvider>
+                  </UploadProvider>
                 </HashRouter>
               </NativeFileSharingProvider>
             </AcceptingSharingProvider>


### PR DESCRIPTION
Hello

Objectif : Highligh new items when they're uploaded.

Why : Because when there are too many elements on the window we can lose them depending on the way the folder is sorted. 

Demonstration : 
[Capture vidéo du 2025-09-25 12-39-59.webm](https://github.com/user-attachments/assets/d46e0d5a-02a3-48fd-b762-a6f98bac85f6)

Now we're using a provider. I'm not familiar with it so feel free to add your recommandations. 
And yes it work with a folderId undefined. 
Yes when selecting just after an upload, all the file are selected. The bug is already reported and under investigation. 
