### PR TITLE
fix: Stop long press detection when scrolling

### DIFF
--- a/src/hooks/useOnLongPress.js
+++ b/src/hooks/useOnLongPress.js
@@ -55,6 +55,10 @@ export default function useLongPress({ onPress, selectionModeActive }) {
     startPressTimer(e)
   }
 
+  function handleOnTouchMove() {
+    clearTimeout(timerRef.current)
+  }
+
   function handleOnTouchEnd() {
     clearTimeout(timerRef.current)
   }
@@ -65,7 +69,8 @@ export default function useLongPress({ onPress, selectionModeActive }) {
       onMouseDown: handleOnMouseDown,
       onMouseUp: handleOnMouseUp,
       onTouchStart: handleOnTouchStart,
-      onTouchEnd: handleOnTouchEnd
+      onTouchEnd: handleOnTouchEnd,
+      onTouchMove: handleOnTouchMove
     }
   }
 }


### PR DESCRIPTION
On mobile, when we scroll on the folder view, it was selecting the item where we start the scroll because it was detected as a long press.