### PR TITLE
fix: Selecting files after uploading them selected wrong files

### DIFF
--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -53,7 +53,7 @@ const FolderViewBody = ({
     if (file._id === SHARED_DRIVES_DIR_ID) {
       return false
     }
-    return selectedItems.some(item => item.id === file.id)
+    return selectedItems.some(item => item._id === file._id)
   }
 
   const isInError = queryResults.some(query => query.fetchStatus === 'failed')


### PR DESCRIPTION
We should always rely on `file._id` and not `file.id`. Because the first one cames from database, and the second one from cozy-client.

When uploading a file, the file is usable but `file.id` is not present yet.