### PR TITLE
fix: Resolve wrong view when adding new folder in empty folder :bug:

### DIFF
--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -1,8 +1,10 @@
+import cx from 'classnames'
 import React, { useCallback, useState, useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
+import { useVaultClient } from 'cozy-keys-lib'
 import { useSharingContext } from 'cozy-sharing'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -12,11 +14,14 @@ import Grid from './Grid'
 import { makeColumns } from '../helpers'
 import { useSyncingFakeFile } from '../useSyncingFakeFile'
 
+import styles from '@/styles/folder-view.styl'
+
 import { EmptyWrapper } from '@/components/Error/Empty'
 import Oops from '@/components/Error/Oops'
 import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { useThumbnailSizeContext } from '@/lib/ThumbnailSizeContext'
 import { useViewSwitcherContext } from '@/lib/ViewSwitcherContext'
+import AddFolder from '@/modules/filelist/AddFolder'
 import FileListRowsPlaceholder from '@/modules/filelist/FileListRowsPlaceholder'
 import { isTypingNewFolderName } from '@/modules/filelist/duck'
 import { FolderUnlocker } from '@/modules/folder/components/FolderUnlocker'
@@ -48,6 +53,7 @@ const FolderViewBody = ({
   const { showAlert } = useAlert()
   const { viewType } = useViewSwitcherContext()
   const { t } = useI18n()
+  const vaultClient = useVaultClient()
 
   const isSelectedItem = file => {
     if (file._id === SHARED_DRIVES_DIR_ID) {
@@ -135,7 +141,21 @@ const FolderViewBody = ({
     >
       <SelectionBar actions={actions} />
       {IsAddingFolder && !showTable && (
-        <AddFolderTable columns={columns} currentFolderId={currentFolderId} />
+        <>
+          {viewType === 'grid' ? (
+            <div className={cx(styles['fil-folder-body-grid'])}>
+              <AddFolder
+                vaultClient={vaultClient}
+                currentFolderId={currentFolderId}
+              />
+            </div>
+          ) : (
+            <AddFolderTable
+              columns={columns}
+              currentFolderId={currentFolderId}
+            />
+          )}
+        </>
       )}
       {isInError && <Oops />}
       {(needsToWait || isLoading) && <FileListRowsPlaceholder />}


### PR DESCRIPTION
### Change:

Fix adding folder view is incorrect in an empty folder

### Result:

<img width="3024" height="1458" alt="CleanShot 2025-10-01 at 16 31 00@2x" src="https://github.com/user-attachments/assets/6f53f85a-e4fb-4ea8-85f7-460a543e9fe6" />

<img width="3024" height="1556" alt="CleanShot 2025-10-01 at 16 30 50@2x" src="https://github.com/user-attachments/assets/b889d37b-34ed-4065-85f0-ef50d733da42" />
