### PR TITLE
fix(shared drives): upload button and create menu was not disabled when in read-only 🐛

### DIFF
--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -50,6 +50,7 @@ const EmptyCanvas = ({ type, canUpload, localeKey, hasTextMobileVersion }) => {
           {showUploadLayout && (
             <span className="u-db u-mt-1">
               <UploadButton
+                disabled={!canUpload}
                 componentsProps={{
                   button: { variant: 'secondary' }
                 }}

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -71,11 +71,12 @@ const LayoutContent = () => {
                 componentsProps={{ button: { className: 'u-w-100 u-bdrs-6' } }}
                 label={t('upload.label')}
                 displayedFolder={displayedFolder}
+                disabled={isFolderReadOnly}
               />
               <AddMenuProvider
                 canCreateFolder={true}
-                canUpload={true}
-                disabled={false}
+                canUpload={!isFolderReadOnly}
+                disabled={isFolderReadOnly}
                 displayedFolder={displayedFolder}
                 isSelectionBarVisible={false}
                 isReadOnly={isFolderReadOnly}

--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -229,6 +229,7 @@ const DriveFolderView = () => {
             displayedFolder={displayedFolder}
             extraColumns={extraColumns}
             canDrag
+            canUpload={canWriteToCurrentFolder}
           />
         ) : (
           <FolderViewBody
@@ -238,6 +239,7 @@ const DriveFolderView = () => {
             currentFolderId={currentFolderId}
             displayedFolder={displayedFolder}
             extraColumns={extraColumns}
+            canUpload={canWriteToCurrentFolder}
           />
         )}
         {isFabDisplayed && (


### PR DESCRIPTION
### changes

- Properly propagate writing permission to child components; previously, it was true by default
- Disable the new upload button on the emptyWrapper component
- Disable the create menu & upload button on the layout when the shared drive is read-only