### PR TITLE
fix: Hide shared drive when flag is disabled :bug:

### DIFF
--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import flag from 'cozy-flags'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ClockIcon from 'cozy-ui/transpiled/react/Icons/Clock'
 import FolderIcon from 'cozy-ui/transpiled/react/Icons/Folder'
@@ -20,6 +21,7 @@ export const Nav = () => {
   const clickState = useNavContext()
   const { isDesktop } = useBreakpoints()
   const { isLoaded: isSharedDriveLoaded, sharedDrives } = useSharedDrives()
+  const isEnabledSharedDrive = flag('drive.shared-drive.enabled')
 
   return (
     <UINav>
@@ -55,7 +57,7 @@ export const Nav = () => {
         clickState={clickState}
       />
       {isDesktop ? <FavoriteList clickState={clickState} /> : null}
-      {isDesktop && isSharedDriveLoaded ? (
+      {isDesktop && isSharedDriveLoaded && isEnabledSharedDrive ? (
         <SharedDriveList clickState={clickState} sharedDrives={sharedDrives} />
       ) : null}
       {isDesktop ? (

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -81,6 +81,8 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
 
   const [tab, setTab] = useState(tabParam)
 
+  const isEnabledSharedDrive = flag('drive.shared-drive.enabled')
+
   const extraColumnsNames = makeExtraColumnsNamesFromMedia({
     isMobile,
     desktopExtraColumnsNames,
@@ -100,6 +102,17 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const result = useQuery(query.definition, query.options)
 
   const filteredResult = useMemo(() => {
+    if (!isEnabledSharedDrive) {
+      const filteredResultData =
+        result.data?.filter(item => !(item.dir_id === SHARED_DRIVES_DIR_ID)) ||
+        []
+      return {
+        ...result,
+        data: filteredResultData,
+        count: filteredResultData.length
+      }
+    }
+
     /**
      * Problem:
      * - In the recipient's Sharing section, shared drives appear only as shortcuts
@@ -165,7 +178,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
       data: combinedData,
       count: combinedData.length
     }
-  }, [sharedDrives, result, tab, isOwner])
+  }, [sharedDrives, result, tab, isOwner, isEnabledSharedDrive])
 
   const actionsOptions = {
     client,
@@ -218,7 +231,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
           <Breadcrumb path={[{ name: t('breadcrumb.title_sharings') }]} />
           <Toolbar canUpload={false} canCreateFolder={false} />
         </FolderViewHeader>
-        <SharingTab tab={tab} setTab={setTab} />
+        {isEnabledSharedDrive && <SharingTab tab={tab} setTab={setTab} />}
         {!allLoaded || !hasQueryBeenLoaded(result) ? (
           <FileListRowsPlaceholder />
         ) : (


### PR DESCRIPTION
### Change:

If flag `drive.shared-drive.enabled` is disabled:
- We cannot create shared drive
- From the recipient side, cannot display shared drive section.
- Sharings section will not display shared drives.
- `Drives` tab in sharings section is disabled.

### Result:

<img width="3024" height="1550" alt="CleanShot 2025-10-06 at 11 57 49@2x" src="https://github.com/user-attachments/assets/c2568975-2855-403d-959a-58b39ebefefd" />

<img width="470" height="1444" alt="CleanShot 2025-10-06 at 11 57 35@2x" src="https://github.com/user-attachments/assets/a22a9877-d879-416b-861e-b7910dba4019" />

<img width="576" height="738" alt="CleanShot 2025-10-06 at 11 57 28@2x" src="https://github.com/user-attachments/assets/7462bda3-d8c5-4182-bc73-ca5737c4337f" />
