### PR TITLE
fix: New file cannot be selected in grid view :bug:

### DIFF
--- a/src/modules/filelist/virtualized/GridFile.jsx
+++ b/src/modules/filelist/virtualized/GridFile.jsx
@@ -82,8 +82,8 @@ const GridFile = ({
 
   const isRowDisabledOrInSyncFromSharing = disabled || isInSyncFromSharing
 
-  const selected = isItemSelected(attributes.id)
-  const isCut = isItemCut(attributes.id)
+  const selected = isItemSelected(attributes._id)
+  const isCut = isItemCut(attributes._id)
 
   const formattedSize =
     !isDirectory(attributes) && attributes.size


### PR DESCRIPTION
### Change:

Check selected items by using `_id` instead of `id`.