### PR TITLE
fix: Resolve breadcrumb in shared drive :bug:

### DIFF
--- a/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
+++ b/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useClient } from 'cozy-client'
 import log from 'cozy-logger'
 
+import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { fetchFolder } from '@/modules/breadcrumb/utils/fetchFolder'
 
 /**
@@ -23,7 +24,8 @@ import { fetchFolder } from '@/modules/breadcrumb/utils/fetchFolder'
 export const useBreadcrumbPath = ({
   currentFolderId,
   rootBreadcrumbPath,
-  sharedDocumentIds
+  sharedDocumentIds,
+  driveId
 }) => {
   const client = useClient()
   const [paths, setPaths] = useState([])
@@ -39,8 +41,12 @@ export const useBreadcrumbPath = ({
 
     const fetchBreadcrumbs = async () => {
       let id = currentFolderId
-      while (!!id && id !== rootBreadcrumbPath.id) {
-        const folder = await fetchFolder({ client, folderId: id })
+      while (
+        !!id &&
+        id !== rootBreadcrumbPath.id &&
+        id !== SHARED_DRIVES_DIR_ID
+      ) {
+        const folder = await fetchFolder({ client, driveId, folderId: id })
         if (!folder) {
           id = undefined
         } else {
@@ -76,7 +82,7 @@ export const useBreadcrumbPath = ({
     return () => {
       isSubscribed = false
     }
-  }, [currentFolderId, client, sharedDocumentIds, rootBreadcrumbPath])
+  }, [currentFolderId, client, sharedDocumentIds, rootBreadcrumbPath, driveId])
 
   return paths
 }

--- a/src/modules/breadcrumb/utils/fetchFolder.js
+++ b/src/modules/breadcrumb/utils/fetchFolder.js
@@ -1,11 +1,16 @@
-import { buildFileOrFolderByIdQuery } from '@/queries'
+import {
+  buildFileOrFolderByIdQuery,
+  buildSharedDriveFolderQuery
+} from '@/queries'
 
-export const fetchFolder = async ({ client, folderId }) => {
-  const folderQuery = buildFileOrFolderByIdQuery(folderId)
+export const fetchFolder = async ({ client, folderId, driveId }) => {
+  const folderQuery = driveId
+    ? buildSharedDriveFolderQuery({ driveId, folderId })
+    : buildFileOrFolderByIdQuery(folderId)
   const { options, definition } = folderQuery
   const folderQueryResults = await client.fetchQueryAndGetFromState({
     definition: definition(),
     options
   })
-  return folderQueryResults.data
+  return driveId ? folderQueryResults.data?.[0] : folderQueryResults.data
 }

--- a/src/modules/shareddrives/components/SharedDriveBreadcrumb.jsx
+++ b/src/modules/shareddrives/components/SharedDriveBreadcrumb.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from 'cozy-client'
@@ -6,9 +6,10 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { SHARED_DRIVES_DIR_ID } from '@/constants/config.js'
 import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
+import { useBreadcrumbPath } from '@/modules/breadcrumb/hooks/useBreadcrumbPath.jsx'
 import { buildSharedDriveIdQuery } from '@/queries'
 
-const SharedDriveBreadcrumb = ({ driveId }) => {
+const SharedDriveBreadcrumb = ({ driveId, folderId }) => {
   const { t } = useI18n()
   const navigate = useNavigate()
 
@@ -18,13 +19,29 @@ const SharedDriveBreadcrumb = ({ driveId }) => {
     sharedDriveQuery.options
   )
 
+  const rootBreadcrumbPath = useMemo(
+    () => ({
+      id: sharedDrive?.rules?.[0]?.values?.[0],
+      name: sharedDrive?.description
+    }),
+    [sharedDrive]
+  )
+
+  const path = useBreadcrumbPath({
+    currentFolderId: folderId,
+    rootBreadcrumbPath,
+    driveId
+  })
+
   const handleBreadcrumbClick = useCallback(
     ({ id }) => {
       if (id === SHARED_DRIVES_DIR_ID) {
         navigate(`/folder/${SHARED_DRIVES_DIR_ID}`)
+        return
       }
+      navigate(`/shareddrive/${driveId}/${id}`)
     },
-    [navigate]
+    [driveId, navigate]
   )
 
   return (
@@ -34,7 +51,7 @@ const SharedDriveBreadcrumb = ({ driveId }) => {
           id: SHARED_DRIVES_DIR_ID,
           name: t('breadcrumb.title_shared_drives')
         },
-        { id: driveId, name: sharedDrive?.description }
+        ...path
       ]}
       onBreadcrumbClick={handleBreadcrumbClick}
       opening={false}

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -44,7 +44,7 @@ const SharedDriveFolderView = () => {
       >
         <Content className={isMobile ? '' : 'u-pt-1'}>
           <FolderViewHeader>
-            <SharedDriveBreadcrumb driveId={driveId} />
+            <SharedDriveBreadcrumb driveId={driveId} folderId={folderId} />
             <Toolbar
               canUpload={false}
               canCreateFolder={false}


### PR DESCRIPTION
### Change:

Now the breadcrumb in shared drive will display as expected.

### Result:

<img width="798" height="180" alt="CleanShot 2025-10-09 at 15 12 40@2x" src="https://github.com/user-attachments/assets/818d5700-3bf0-46a3-a938-32906587058c" />
