### PR TITLE
chore: Upgrade cozy-sharing to version 26.6.0 :arrow_up:

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cozy-pouch-link": "^57.7.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.11.0",
-    "cozy-sharing": "^26.5.2",
+    "cozy-sharing": "^26.6.0",
     "cozy-stack-client": "^57.2.0",
     "cozy-ui": "^130.6.0",
     "cozy-viewer": "^23.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5802,10 +5802,10 @@ cozy-search@^0.11.0:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-26.5.2.tgz#0bf2f881a8e64fc1149349db5845cfdf0d6dce39"
-  integrity sha512-jlD/JzoDjCplZKP4kKNbD8L4WAVpzOG6JZ2vVX2qs4CoCsXCEzTabIDXgRASUFs+Dy02BJI0H6eK6aSmhSv4mw==
+cozy-sharing@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-26.6.0.tgz#eb9efa588011683eb864b658bd3c45c1061cb5d4"
+  integrity sha512-NlUorZrudMelINbFG7l51OytjTU2WA82iu+ZGo+Bfiuh88L3PDPzvEeNjPHD6ZLqcw30tYoJ5pU45dyfNceUrA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
### Change:

Update to the newest version of `cozy-sharing` to apply toggle sharing deadline by flag.

### flag added

`sharing.date-toggle.enabled` 

### Relate to:

https://github.com/cozy/cozy-libs/pull/2839