### PR TITLE
fix: Switch between grid and normal view in trash

### DIFF
--- a/src/modules/trash/components/TrashToolbar.tsx
+++ b/src/modules/trash/components/TrashToolbar.tsx
@@ -15,6 +15,7 @@ import { selectable } from '@/modules/actions/components/selectable'
 import SearchButton from '@/modules/drive/Toolbar/components/SearchButton'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import { emptyTrash } from '@/modules/trash/components/actions/emptyTrash'
+import ViewSwitcher from '@/modules/drive/Toolbar/components/ViewSwitcher'
 
 const TrashToolbar: FC = () => {
   const { t } = useI18n()
@@ -47,6 +48,7 @@ const TrashToolbar: FC = () => {
       className={cx('u-flex', 'u-flex-items-center', 'u-ml-auto')}
       role="toolbar"
     >
+      <ViewSwitcher className="u-mr-half" />
       <Button
         variant="secondary"
         color="error"


### PR DESCRIPTION
Big fix ohlala.

Ticket : https://www.notion.so/linagora/drive-cannot-switch-between-grid-and-normal-views-in-trash-28562718bad1801b9e82c626eb643030?source=copy_link

[Capture vidéo du 2025-10-13 10-16-36.webm](https://github.com/user-attachments/assets/d3e049b8-61d6-41ed-afb2-4ebe8974e5e6)
