### PR TITLE
fix(useOnLongPress): clearTimeout should be inside a func

### DIFF
--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -68,9 +68,9 @@ export const makeDesktopHandlers = ({
 }) => {
   return {
     // first event triggered on Desktop
-    onMouseDown: clearTimeout(timerId.current),
+    onMouseDown: () => clearTimeout(timerId.current),
     // second event triggered on Desktop
-    onMouseUp: clearTimeout(timerId.current),
+    onMouseUp: () => clearTimeout(timerId.current),
     // third event triggered on Desktop
     onClick: event =>
       handleClick({
@@ -145,9 +145,9 @@ export const makeMobileHandlers = ({
     // first event triggered on Mobile when taping an item
     onTouchStart: startPressTimer,
     // second event triggered on Mobile when dragging an item
-    onTouchMove: clearTimeout(timerId.current),
+    onTouchMove: () => clearTimeout(timerId.current),
     // third event triggered on Mobile when taping an item
-    onTouchEnd: clearTimeout(timerId.current),
+    onTouchEnd: () => clearTimeout(timerId.current),
     // fourth event triggered on Mobile
     onClick: event =>
       handlePress({


### PR DESCRIPTION
we previously fix long press detection when scrolling https://github.com/cozy/cozy-drive/pull/3510 but with the all refactoring done for the double click feature https://github.com/cozy/cozy-drive/pull/3545 we replaced `onTouchMove: someFunc` by `onTouchMove: clearTimeout(timerId.current)`, which is not correct.

So doing that, the "long press detection when scrolling" bug appears again. Here we deal with `clearTimeout` correctly