### PR TITLE
fix: Adjust position of quota in sidebar :bug:

### DIFF
--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -97,15 +97,15 @@ const LayoutContent = () => {
               </div>
             ) : null}
             <Nav />
-            {isDesktop && (
-              <div>
-                <div className="u-p-1-half">
-                  <Storage />
-                </div>
-                <ButtonClient />
-              </div>
-            )}
           </div>
+          {isDesktop && (
+            <div>
+              <div className="u-p-1-half">
+                <Storage />
+              </div>
+              <ButtonClient />
+            </div>
+          )}
         </Sidebar>
         <UploadQueue />
         <SelectionProvider>


### PR DESCRIPTION
### Change:

The position of quota in sidebar is fixed at the bottom now.

### Result:

<img width="494" height="1504" alt="CleanShot 2025-10-15 at 15 07 36@2x" src="https://github.com/user-attachments/assets/06a9539d-0af8-4598-b211-96da2efebfc8" />

<img width="462" height="1436" alt="CleanShot 2025-10-15 at 15 08 02@2x" src="https://github.com/user-attachments/assets/657eddf2-69e8-48b0-bde7-44375e449e38" />
