### PR TITLE
fix: PropTypes.oneOfType not being called correctly 🐛

### DIFF
--- a/src/modules/navigation/NavItem.jsx
+++ b/src/modules/navigation/NavItem.jsx
@@ -49,7 +49,7 @@ const NavItem = ({
 
 NavItem.propTypes = {
   to: PropTypes.string,
-  icon: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   label: PropTypes.string,
   forcedLabel: PropTypes.string,
   rx: PropTypes.shape(RegExp),


### PR DESCRIPTION
### Error

<img width="1256" height="174" alt="image" src="https://github.com/user-attachments/assets/2c778988-620d-4d02-b7c8-9dd50e6a14c7" />


### what's changed

fixed PropTypes.oneOfType call to have an array insead of two params

### Reason

PropTypes.oneOfType is expecting an array and we are passing two params

function signature:

```ts
export function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
```