### PR TITLE
fix(FilesRealTimeQueries): MapIterator.forEach not being compatible with outdated browsers 🐛

### DIFF
--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -59,7 +59,7 @@ const processEvents = async (client, mutationType) => {
     mutationFn = Mutations.deleteDocument
     multipleMutationFn = Mutations.deleteDocuments
   }
-  if (bufferFiles.length === 0) return
+  if (bufferFiles.size === 0) return
 
   const fileIdsToProcess = bufferFiles.keys()
   const filesByFolder = groupFilesByFolder(bufferFiles)


### PR DESCRIPTION
### The bug

- in sentry we started to notice an Exception being fired `TypeError: a.forEach is not a function`

<img width="593" height="95" alt="image" src="https://github.com/user-attachments/assets/62073712-a612-40e7-ae97-149e58cfa985" />

<img width="741" height="145" alt="image" src="https://github.com/user-attachments/assets/41e657e4-ac3d-4680-a473-9ec2095742a9" />

### The cause

in the FilesRealTimeQueries we use a Map as a Buffer for the file operations and then we get the list of processed files by calling the `Map.keys()` which returns a `MapIterator`

```ts
const bufferCreatedFiles = new Map()

.... // later on

const fileIdsToProcess = bufferFiles.keys() // <-- returns MapIterator

// later on

fileIdsToProcess.forEach(fileId => bufferFiles.delete(fileId))
```

the MapIterator.forEach method was added in 2024 ( in ES2024 ) [mdn page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/forEach)

<img width="780" height="295" alt="image" src="https://github.com/user-attachments/assets/cca90798-6294-4943-a44a-5e019d6ab260" />

so for browsers with versions earlier than supported ones the `MapIterator.forEach` is undefined ( and the buffer is never cleared ).

#### checking affected browsers

<img width="321" height="78" alt="image" src="https://github.com/user-attachments/assets/19f7fd90-d44e-4720-b48a-0ef42c421bd5" />
<img width="374" height="67" alt="image" src="https://github.com/user-attachments/assets/202a3ae0-5ca9-4f16-9cf2-b170509408db" />
<img width="345" height="78" alt="image" src="https://github.com/user-attachments/assets/3681392c-0375-4796-b201-726eaff373b2" />
<img width="299" height="61" alt="image" src="https://github.com/user-attachments/assets/ec259484-6660-412a-8bd8-610b13523df5" />

all the browsers who had the issue are outdated

#### replicating the bug using an outdated browser ( firefox 102 )


https://github.com/user-attachments/assets/011d1fbb-7118-4024-8fc5-bba77b805ab7



### what's changed

- Replaced `forEach` with `for...of` loop (ES2015 compatible)
- Fixed Map size check: used `bufferFiles.size` instead of `bufferFiles.length` 