### PR TITLE
feat: close modal confirmTrash and add process trash message

### DIFF
--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -26,6 +26,7 @@ const getParentFolder = async (client, dirId) => {
   }
   return parentDir
 }
+
 export const ensureFileHasPath = async (doc, client) => {
   if (doc.path) return doc
 
@@ -62,7 +63,15 @@ const processEvents = async (client, mutationType) => {
   if (bufferFiles.size === 0) return
 
   const fileIdsToProcess = bufferFiles.keys()
-  const filesByFolder = groupFilesByFolder(bufferFiles)
+  let filesByFolder = {}
+  if (mutationType == 'deleted') {
+    filesByFolder['io.cozy.files.trash-dir'] = Array.from(
+      bufferFiles.values()
+    ).filter(file => file.dir_id === 'io.cozy.files.trash-dir')
+  } else {
+    filesByFolder = groupFilesByFolder(bufferFiles)
+  }
+
   for (const folderId in filesByFolder) {
     const files = []
     const folder = await getParentFolder(client, folderId)

--- a/src/components/TrashedBanner.jsx
+++ b/src/components/TrashedBanner.jsx
@@ -57,7 +57,6 @@ const TrashedBanner = ({ fileId, isPublic }) => {
       message: t('TrashedBanner.destroySuccess'),
       severity: 'secondary'
     })
-    navigate(`/trash/${fileResult.data.dir_id}`)
   }
 
   return (
@@ -95,6 +94,7 @@ const TrashedBanner = ({ fileId, isPublic }) => {
           files={[fileResult.data]}
           onCancel={handleDestroyCancel}
           onConfirm={handleDestroyConfirm}
+          onClose={navigate(`/trash/${fileResult.data.dir_id}`)}
         />
       ) : null}
     </>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -265,7 +265,8 @@
     "cancel": "Cancel",
     "delete": "Delete permanently",
     "success": "The %{type} has been deleted permanently. |||| %{smart_count} %{type} have been deleted permanently.",
-    "error": "An error occurred, please try again."
+    "error": "An error occurred, please try again.",
+    "processing": "The deletion is in progress. This might take a few moments."
   },
   "quotaalert": {
     "title": "Your disk space is full :(",
@@ -308,6 +309,7 @@
     "try_again": "An error has occurred, please try again in a moment.",
     "restore_file_success": "The selection has been successfully restored.",
     "trash_file_success": "The selection has been moved to the Trash.",
+    "trash_file_processing": "The move to Trash is in progress...",
     "trash_shared_drive_success": "The shared drive has been moved to the Trash.",
     "destroy_file_success": "The selection has been deleted permanently.",
     "folder_name": "The element %{folderName} already exists, please choose a new name.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -263,7 +263,8 @@
     "cancel": "Annuler",
     "delete": "Supprimer définitivement",
     "success": "Le %{type} a été supprimé définitivement. |||| %{smart_count} %{type} ont été supprimés définitivement.",
-    "error": "Une erreur est survenue, merci de réessayer."
+    "error": "Une erreur est survenue, merci de réessayer.",
+    "processing": "La suppression est en cours. Cela peut prendre quelques instants."
   },
   "quotaalert": {
     "title": "Votre espace disque est plein :(",
@@ -305,6 +306,7 @@
     "try_again": "Une erreur est survenue, merci de réessayer dans un instant.",
     "restore_file_success": "La sélection a été restaurée avec succès.",
     "trash_file_success": "La sélection a été déplacée dans la Corbeille.",
+    "trash_file_processing": "Le déplacement vers la Corbeille est en cours...",
     "trash_shared_drive_success": "Le drive partagé a été déplacé dans la Corbeille.",
     "destroy_file_success": "La sélection a été supprimée définitivement.",
     "folder_name": "L'élément %{folderName} existe déjà, merci de choisir un nouveau nom.",

--- a/src/modules/drive/DeleteConfirm.jsx
+++ b/src/modules/drive/DeleteConfirm.jsx
@@ -85,7 +85,12 @@ export const DeleteConfirm = ({
   }, [client, files])
 
   const onDelete = useCallback(async () => {
+    // Prevent double executions
+    if (isDeleting) return
+
     setDeleting(true)
+    showAlert({ message: t('alert.trash_file_processing'), severity: 'info' })
+    onClose()
     await trashFiles(client, files, { showAlert, t, driveId })
     afterConfirmation()
     setSelectedItems(prevSelectedItems => {
@@ -96,7 +101,6 @@ export const DeleteConfirm = ({
         )
       )
     })
-    onClose()
   }, [
     client,
     files,
@@ -105,7 +109,8 @@ export const DeleteConfirm = ({
     showAlert,
     t,
     setSelectedItems,
-    driveId
+    driveId,
+    isDeleting
   ])
 
   const entriesType = getEntriesTypeTranslated(t, files)

--- a/src/modules/trash/components/DestroyConfirm.tsx
+++ b/src/modules/trash/components/DestroyConfirm.tsx
@@ -34,8 +34,19 @@ const DestroyConfirm: React.FC<DestroyConfirmProps> = ({
   const entriesType = getEntriesTypeTranslated(t, files)
 
   const handleDestroy = async (): Promise<void> => {
+    // Prevent double executions
+    if (isBusy) return
+
+    setBusy(true)
     try {
-      setBusy(true)
+      showAlert({
+        message: t('DestroyConfirm.processing', {
+          smart_count: files.length,
+          type: entriesType
+        }),
+        severity: 'info'
+      })
+      onClose()
       await onConfirm()
       showAlert({
         message: t('DestroyConfirm.success', {
@@ -51,7 +62,6 @@ const DestroyConfirm: React.FC<DestroyConfirmProps> = ({
       })
     } finally {
       setBusy(false)
-      onClose()
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13977,7 +13977,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14003,15 +14003,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -14136,7 +14127,7 @@ stringify-clone@^1.0.0:
   resolved "https://registry.yarnpkg.com/stringify-clone/-/stringify-clone-1.1.1.tgz#309a235fb4ecfccd7d388dbe18ba904facaf433b"
   integrity sha512-LIFpvBnQJF3ZGoV770s3feH+wRVCMRSisI8fl1E57WfgKOZKUMaC1r4eJXybwGgXZ/iTTJoK/tsOku1GLPyyxQ==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14156,13 +14147,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -15383,7 +15367,7 @@ worker-loader@2.0.0:
     loader-utils "^1.0.0"
     schema-utils "^0.4.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15399,15 +15383,6 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
**Ticket :** https://www.notion.so/linagora/Performance-real-time-display-of-trash-content-during-emptying-to-be-optimized-1c062718bad1802fbd9fc11caabe34de?source=copy_link

The trash message close himself after validating so the user can continue to navigate into the app. 

Also fixed some fetch messages error after the update of cozy-client.
Bug : 
<img width="767" height="246" alt="Capture d’écran du 2025-10-21 14-17-05" src="https://github.com/user-attachments/assets/b1726781-031a-42c7-9b7a-775320e98d56" />

**Videos :** 
[Capture vidéo du 2025-10-22 10-49-13.webm](https://github.com/user-attachments/assets/c0ed5858-aeab-45f9-bab0-5705d8319683)
[Capture vidéo du 2025-10-22 10-49-40.webm](https://github.com/user-attachments/assets/35217d58-0ef6-4c5a-8884-8eb5be8fbf8c)

**Tested :**
- Deleting in one folder
- Deleting in multiples folders in the same time
