### PR TITLE
fix: ensure you can't upload when you're on a trash folder

### DIFF
--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -23,7 +23,8 @@ const EmptyCanvas = ({ type, canUpload, localeKey, hasTextMobileVersion }) => {
   const { displayedFolder } = useDisplayedFolder()
 
   const IconToShow = type === 'trash' ? TrashIllustration : FolderEmptyIllu
-  const showUploadLayout = type === 'drive' || type === 'encrypted'
+  const showUploadLayout =
+    (type === 'drive' || type === 'encrypted') && canUpload
   const showSharedDriveLayout = type === 'sharing'
   const title = localeKey ? t(`empty.${type}_title`) : undefined
   const text =

--- a/src/modules/views/Trash/TrashFolderView.jsx
+++ b/src/modules/views/Trash/TrashFolderView.jsx
@@ -107,6 +107,7 @@ export const TrashFolderView = () => {
             withFilePath={true}
             extraColumns={extraColumns}
             sortOrder={sortOrder}
+            canUpload={false}
           />
         ) : (
           <FolderViewBody
@@ -116,6 +117,7 @@ export const TrashFolderView = () => {
             queryResults={[foldersResult, filesResult]}
             canSort
             extraColumns={extraColumns}
+            canUpload={false}
           />
         )}
         <Outlet />


### PR DESCRIPTION
**Ticket :** https://www.notion.so/linagora/BUG-empty-layout-offer-to-upload-files-in-side-trashed-folders-28c62718bad180c8b92bd20ac68c0cc9?source=copy_link

Fix: canUpload become false when you use TrashFolderView (he was true by default in FolderBody)

**Screen :**
<img width="1592" height="841" alt="Capture d’écran du 2025-10-22 16-01-05" src="https://github.com/user-attachments/assets/c9e56815-0091-4635-be69-8f480c516448" />


**Tested :** 
- Still can upload on empty folders (shared drive too)
- No DnD in trash folders
<img width="1826" height="852" alt="Capture d’écran du 2025-10-22 16-29-44" src="https://github.com/user-attachments/assets/adc27cab-fc78-4026-80b8-8c33e6c501f8" />
<img width="1592" height="841" alt="Capture d’écran du 2025-10-22 16-29-33" src="https://github.com/user-attachments/assets/dbfc2f3e-ec83-49b2-9f15-df219e1dfa85" />

