### PR TITLE
feat: Change shared drive icon :sparkles:

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "cozy-search": "^0.11.0",
     "cozy-sharing": "^26.7.0",
     "cozy-stack-client": "^60.16.1",
-    "cozy-ui": "^130.7.2",
+    "cozy-ui": "^132.1.0",
     "cozy-viewer": "^23.5.0",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",

--- a/src/modules/breadcrumb/components/DesktopBreadcrumb.jsx
+++ b/src/modules/breadcrumb/components/DesktopBreadcrumb.jsx
@@ -4,7 +4,7 @@ import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import BreadcrumbMui from 'cozy-ui/transpiled/react/Breadcrumbs'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
+import FileTypeSharedDriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDriveGrey'
 import FolderIcon from 'cozy-ui/transpiled/react/Icons/Folder'
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
@@ -100,7 +100,7 @@ const DesktopBreadcrumb = ({ onBreadcrumbClick, path }) => {
                 onClick={onBreadcrumbClick}
                 item={breadcrumbPath}
                 isCurrent={index === pathToDisplay.length - 1}
-                icon={FileTypeServerIcon}
+                icon={FileTypeSharedDriveIcon}
               />
             )
           }

--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -7,6 +7,7 @@ import Box from 'cozy-ui/transpiled/react/Box'
 import GhostFileBadge from 'cozy-ui/transpiled/react/GhostFileBadge'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
+import FileTypeSharedDriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDrive'
 import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 import TrashDuotoneIcon from 'cozy-ui/transpiled/react/Icons/TrashDuotone'
 import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
@@ -71,9 +72,18 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
 
   if (
     file._id === 'io.cozy.files.shared-drives-dir' ||
-    isNextcloudShortcut(file) ||
     isSharedDriveFolder(file)
   ) {
+    return (
+      <Icon
+        className="u-mr-half"
+        icon={FileTypeSharedDriveIcon}
+        size={size ?? 32}
+      />
+    )
+  }
+
+  if (isNextcloudShortcut(file)) {
     return (
       <Icon className="u-mr-half" icon={FileTypeServerIcon} size={size ?? 32} />
     )

--- a/src/modules/navigation/components/SharedDriveListItem.tsx
+++ b/src/modules/navigation/components/SharedDriveListItem.tsx
@@ -1,7 +1,9 @@
 import cx from 'classnames'
 import React, { FC, useState } from 'react'
+import { useParams } from 'react-router-dom'
 
-import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
+import FileTypeSharedDriveActiveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDrive'
+import FileTypeSharedDriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDriveGrey'
 import { NavIcon, NavLink, NavItem } from 'cozy-ui/transpiled/react/Nav'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
@@ -38,6 +40,8 @@ const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
 }) => {
   const classes = useStyles()
 
+  const { driveId } = useParams()
+
   const { link } = useSharedDriveLink(sharedDrive)
   const [isMenuAvailable, setIsMenuAvailable] = useState(false)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -55,7 +59,13 @@ const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
         className={cx(NavLink.className, isMenuAvailable && classes.withMenu)}
         onClick={(): void => setLastClicked(undefined)}
       >
-        <NavIcon icon={FileTypeServerIcon} />
+        <NavIcon
+          icon={
+            driveId === sharedDrive._id
+              ? FileTypeSharedDriveActiveIcon
+              : FileTypeSharedDriveIcon
+          }
+        />
         <Typography variant="inherit" color="inherit" noWrap>
           {sharedDrive.description}
         </Typography>

--- a/src/modules/views/Sharings/SharingTab.jsx
+++ b/src/modules/views/Sharings/SharingTab.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import FileTypeFolderIcon from 'cozy-ui/transpiled/react/Icons/FileTypeFolder'
-import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
+import FileTypeSharedDriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDriveGrey'
 import Tab from 'cozy-ui/transpiled/react/Tab'
 import Tabs from 'cozy-ui/transpiled/react/Tabs'
 import ToggleButton from 'cozy-ui/transpiled/react/ToggleButton'
@@ -58,7 +58,7 @@ const SharingTab = ({ tab, setTab }) => {
                 icon={
                   tabItem === 'sharings_tab_all'
                     ? FileTypeFolderIcon
-                    : FileTypeServerIcon
+                    : FileTypeSharedDriveIcon
                 }
                 className={cx(styles['fil-tab-icon'], 'u-mr-1')}
               />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5930,10 +5930,10 @@ cozy-tsconfig@^1.8.1:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.8.1.tgz#5f206f4e6e041a4afc6691098264ba630bdeb7e2"
   integrity sha512-/9QBxK8Tc12O2ojuyRpSMjPpXpqldVvzfNB1+/nPD+IkIBkU+mqxpHYJwKWjNYHGraCSy69mIwt9J3aiaJdz9w==
 
-cozy-ui@^130.7.2:
-  version "130.11.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-130.11.1.tgz#91ba6022a42f0a3afea301b6a0724116e51e7907"
-  integrity sha512-8CtNqMP1qWjJv/8t/seLibcopW+rruS961y7nUo9L+KuWNlIkRonDBSbmEhVgM6GuzD9P9xLrwC/Zdv0nT7/0g==
+cozy-ui@^132.1.0:
+  version "132.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-132.1.0.tgz#41bdb3914ecd0c87a51bd4d6f0ac60d97fed38df"
+  integrity sha512-uZUpGvGG7nhyXogQzB4VZhYssZONK5XcMFApHaJmbW+9/tCtfcSMuAuWlDML7b45O3AhBjoy417hw8t8I0F5gA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"
@@ -10920,9 +10920,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
### Change:

The new icon of shared drive is applied.

### Results:

<img width="3016" height="1618" alt="CleanShot 2025-10-29 at 15 14 32@2x" src="https://github.com/user-attachments/assets/588d9026-46ad-43ab-8427-9d4d6c8ba8a7" />

<img width="2546" height="1000" alt="CleanShot 2025-10-29 at 15 15 00@2x" src="https://github.com/user-attachments/assets/98ae1ae0-47da-4a12-8570-aec7821396cd" />

<img width="662" height="320" alt="CleanShot 2025-10-29 at 15 15 39@2x" src="https://github.com/user-attachments/assets/fc60c123-2574-4760-996e-0ef6187bc34b" />

<img width="2512" height="928" alt="CleanShot 2025-10-29 at 16 41 22@2x" src="https://github.com/user-attachments/assets/4ec54647-6848-42ca-a852-808c967fdebe" />

<img width="442" height="530" alt="CleanShot 2025-10-29 at 16 41 12@2x" src="https://github.com/user-attachments/assets/059e2ce9-21e7-4441-97fe-069033a336e6" />

### Need:

https://github.com/cozy/cozy-ui/pull/2883
