### PR TITLE
fix: Change shared drive icon in context menu :bug:

### DIFF
--- a/src/modules/drive/Toolbar/components/AddSharedDriveItem.jsx
+++ b/src/modules/drive/Toolbar/components/AddSharedDriveItem.jsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux'
 import { SharedDriveModal } from 'cozy-sharing'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
+import FileTypeSharedDriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDrive'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
@@ -36,7 +36,7 @@ const AddSharedDriveItem = ({ onClick, isReadOnly }) => {
   return (
     <ActionsMenuItem data-testid="add-folder-link" onClick={handleClick}>
       <ListItemIcon>
-        <Icon icon={FileTypeServerIcon} />
+        <Icon icon={FileTypeSharedDriveIcon} />
       </ListItemIcon>
       <ListItemText primary={t('toolbar.menu_new_shared_drive')} />
     </ActionsMenuItem>


### PR DESCRIPTION
### Change:

Adjust shared drive icon in context menu

### Result:

<img width="646" height="766" alt="CleanShot 2025-10-30 at 19 33 36@2x" src="https://github.com/user-attachments/assets/d8081e44-5ce1-4d11-8e68-1c5ac85e8167" />

<img width="526" height="592" alt="CleanShot 2025-10-30 at 19 33 27@2x" src="https://github.com/user-attachments/assets/1ad1cd40-b3ae-4035-a9bb-325a2ab3c384" />
