### PR TITLE
fix: sorting on mobile and legacy view when no choice persistance is disabled

### DIFF
--- a/src/hooks/useFolderSort/index.ts
+++ b/src/hooks/useFolderSort/index.ts
@@ -65,6 +65,8 @@ const useFolderSort = (
 
   const setSortOrder = useCallback(
     async ({ attribute, order }: Sort) => {
+      setCurrentSort({ attribute, order })
+
       if (!flag('drive.save-sort-choice.enabled')) {
         logger.warn(
           'Cannot persist sort: flag drive.save-sort-choice.enabled is not enabled'

--- a/src/modules/folder/components/FolderBody.jsx
+++ b/src/modules/folder/components/FolderBody.jsx
@@ -77,8 +77,7 @@ const FolderBody = ({
   const { viewType, switchView } = useViewSwitcherContext()
 
   const changeSortOrder = useCallback(
-    (folderId_legacy, attribute, order) =>
-      setSortOrder({ sortAttribute: attribute, sortOrder: order }),
+    (folderId_legacy, attribute, order) => setSortOrder({ attribute, order }),
     [setSortOrder]
   )
 

--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -268,6 +268,11 @@ const DriveFolderView = () => {
             displayedFolder={displayedFolder}
             extraColumns={extraColumns}
             canUpload={canWriteToCurrentFolder}
+            orderProps={{
+              sortOrder,
+              setOrder: setSortOrder,
+              isSettingsLoaded
+            }}
           />
         )}
         {isFabDisplayed && (

--- a/src/modules/views/Folder/FolderViewBody.jsx
+++ b/src/modules/views/Folder/FolderViewBody.jsx
@@ -61,7 +61,8 @@ const FolderViewBody = ({
   canUpload = true,
   withFilePath = false,
   refreshFolderContent = null,
-  extraColumns
+  extraColumns,
+  orderProps
 }) => {
   const { isDesktop } = useBreakpoints()
   const navigate = useNavigate()
@@ -110,8 +111,13 @@ const FolderViewBody = ({
 
   const { isBigThumbnail } = useThumbnailSizeContext()
   const { sharingsValue } = useContext(AcceptingSharingContext)
-  const [sortOrder, setSortOrder, isSettingsLoaded] =
+  const [internalSortOrder, internalSetSortOrder, internalIsSettingsLoaded] =
     useFolderSort(currentFolderId)
+  const sortOrder = orderProps?.sortOrder ?? internalSortOrder
+  const setSortOrder = orderProps?.setOrder ?? internalSetSortOrder
+  const isSettingsLoaded =
+    orderProps?.isSettingsLoaded ?? internalIsSettingsLoaded
+
   const vaultClient = useVaultClient()
   const changeSortOrder = useCallback(
     (_, attribute, order) => setSortOrder({ attribute, order }),

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -270,6 +270,11 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
                 canSort={false}
                 withFilePath={true}
                 extraColumns={extraColumns}
+                orderProps={{
+                  sortOrder,
+                  setOrder: setSortOrder,
+                  isSettingsLoaded
+                }}
               />
             )}
             <Outlet />

--- a/src/modules/views/Trash/TrashFolderView.jsx
+++ b/src/modules/views/Trash/TrashFolderView.jsx
@@ -130,6 +130,11 @@ export const TrashFolderView = () => {
             canSort
             extraColumns={extraColumns}
             canUpload={false}
+            orderProps={{
+              sortOrder,
+              setOrder: setSortOrder,
+              isSettingsLoaded
+            }}
           />
         )}
         <Outlet />


### PR DESCRIPTION
### issue

When the `drive.save-sort-choice.enabled` flag was disabled, sorting would not work on mobile (or desktop with the legacy view) due to a state management issue between parent and child components.

### changes:
- useFolderSort: Always update local state (setCurrentSort) before
   checking flag, so UI updates immediately regardless of persistence
- DriveFolderView & TrashFolderView: Pass orderProps (sortOrder,
   setOrder, isSettingsLoaded) to legacy FolderViewBody
- FolderViewBody: Use orderProps from parent when provided, fallback
   to an internal hook for backward compatibility.
- Synchronize the mobile and desktop sort ( to not cause saving empty sorting order in the state )

### demo

https://github.com/user-attachments/assets/f3100955-3a6d-4e50-a11d-888a58474171

