### PR TITLE
fix(grid view): prevent overflow of long parent folder paths on mobile

### DIFF
--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -211,6 +211,10 @@ column-width-thumbnail-bigger = 7rem
         max-width 6rem
         margin 0 auto
 
+    .fil-file-description
+        max-width 6rem
+        overflow hidden
+
 .fil-file-thumbnail
     position relative
     flex 0 0 column-width-thumbnail - 1rem //width without padding


### PR DESCRIPTION
### the issue

In the Recent view grid layout on mobile, very long parent folder paths were not being truncated properly, causing layout issues.

<img width="401" height="875" alt="mobile-grid" src="https://github.com/user-attachments/assets/604cfca7-f619-4165-b94a-ae89c4775631" />

### what's changed
- Added max-width and overflow constraints to .fil-file-description in grid view

### demo
<img width="402" height="874" alt="image" src="https://github.com/user-attachments/assets/bc31f933-207e-457c-aae3-b3d84d964368" />
