### PR TITLE
fix: Resolve sorting in mobile view :bug:

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,5 +131,6 @@
     "redux-mock-store": "1.5.4",
     "redux-thunk": "2.4.2",
     "whatwg-fetch": "3.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/hooks/useFolderSort/index.spec.jsx
+++ b/src/hooks/useFolderSort/index.spec.jsx
@@ -1,7 +1,9 @@
 import { renderHook, act } from '@testing-library/react-hooks'
+import React from 'react'
 
 import { useClient } from 'cozy-client'
 import flag from 'cozy-flags'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { useFolderSort } from './index'
 
@@ -29,6 +31,12 @@ jest.mock('@/modules/public/PublicProvider', () => ({
   usePublicContext: jest.fn()
 }))
 
+jest.mock('cozy-ui/transpiled/react/providers/Breakpoints', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ isMobile: false })),
+  BreakpointsProvider: ({ children }) => children
+}))
+
 const mockUseClient = useClient
 const mockFlag = flag
 const mockUsePublicContext = usePublicContext
@@ -36,6 +44,10 @@ const mockUsePublicContext = usePublicContext
 describe('useFolderSort', () => {
   let mockClient
   let consoleErrorSpy
+
+  const wrapper = ({ children }) => (
+    <BreakpointsProvider>{children}</BreakpointsProvider>
+  )
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -71,7 +83,7 @@ describe('useFolderSort', () => {
         data: []
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [currentSort] = result.current
       expect(currentSort).toEqual(DEFAULT_SORT)
@@ -83,7 +95,7 @@ describe('useFolderSort', () => {
         data: []
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [currentSort] = result.current
       expect(currentSort).toEqual(SORT_BY_UPDATE_DATE)
@@ -95,7 +107,7 @@ describe('useFolderSort', () => {
         data: []
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [currentSort] = result.current
       expect(currentSort).toEqual(SORT_BY_UPDATE_DATE)
@@ -118,8 +130,9 @@ describe('useFolderSort', () => {
         data: [existingSettings]
       })
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useFolderSort(folderId)
+      const { result, waitForNextUpdate } = renderHook(
+        () => useFolderSort(folderId),
+        { wrapper }
       )
 
       await waitForNextUpdate()
@@ -142,7 +155,7 @@ describe('useFolderSort', () => {
         data: [existingSettings]
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [currentSort] = result.current
       expect(currentSort).toEqual(DEFAULT_SORT)
@@ -163,8 +176,9 @@ describe('useFolderSort', () => {
         data: [existingSettings]
       })
 
-      const { result, rerender, waitForNextUpdate } = renderHook(() =>
-        useFolderSort(folderId)
+      const { result, rerender, waitForNextUpdate } = renderHook(
+        () => useFolderSort(folderId),
+        { wrapper }
       )
 
       await waitForNextUpdate()
@@ -194,7 +208,7 @@ describe('useFolderSort', () => {
         data: []
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [, setSortOrder] = result.current
       await act(async () => {
@@ -204,7 +218,6 @@ describe('useFolderSort', () => {
       expect(mockClient.save).toHaveBeenCalledWith({
         _type: DOCTYPE_DRIVE_SETTINGS,
         attributes: {
-          ...DEFAULT_SORT,
           attribute: 'updated_at',
           order: 'desc'
         }
@@ -232,8 +245,9 @@ describe('useFolderSort', () => {
         data: [existingSettings]
       })
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useFolderSort(folderId)
+      const { result, waitForNextUpdate } = renderHook(
+        () => useFolderSort(folderId),
+        { wrapper }
       )
 
       // Wait for the settings to load
@@ -268,7 +282,7 @@ describe('useFolderSort', () => {
         data: []
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [, setSortOrder] = result.current
       await act(async () => {
@@ -302,7 +316,7 @@ describe('useFolderSort', () => {
         data: [existingSettings]
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [currentSort] = result.current
 
@@ -319,7 +333,7 @@ describe('useFolderSort', () => {
         isPublic: true
       })
 
-      const { result } = renderHook(() => useFolderSort(folderId))
+      const { result } = renderHook(() => useFolderSort(folderId), { wrapper })
 
       const [, setSortOrder] = result.current
       await act(async () => {

--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -268,6 +268,11 @@ const DriveFolderView = () => {
             displayedFolder={displayedFolder}
             extraColumns={extraColumns}
             canUpload={canWriteToCurrentFolder}
+            orderProps={{
+              sortOrder,
+              setOrder: setSortOrder,
+              isSettingsLoaded
+            }}
           />
         )}
         {isFabDisplayed && (

--- a/src/modules/views/Recent/index.jsx
+++ b/src/modules/views/Recent/index.jsx
@@ -166,6 +166,11 @@ export const RecentView = () => {
             canSort={false}
             withFilePath={true}
             extraColumns={extraColumns}
+            orderProps={{
+              sortOrder,
+              setOrder: setSortOrder,
+              isSettingsLoaded
+            }}
           />
         )}
         <Outlet />

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -270,6 +270,11 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
                 canSort={false}
                 withFilePath={true}
                 extraColumns={extraColumns}
+                orderProps={{
+                  sortOrder,
+                  setOrder: setSortOrder,
+                  isSettingsLoaded
+                }}
               />
             )}
             <Outlet />

--- a/src/modules/views/Trash/TrashFolderView.jsx
+++ b/src/modules/views/Trash/TrashFolderView.jsx
@@ -130,6 +130,11 @@ export const TrashFolderView = () => {
             canSort
             extraColumns={extraColumns}
             canUpload={false}
+            orderProps={{
+              sortOrder,
+              setOrder: setSortOrder,
+              isSettingsLoaded
+            }}
           />
         )}
         <Outlet />


### PR DESCRIPTION
### Problem:

Since mobile view does not use virtualized folder view, we don't have frontend sort. The sort in mobile only works when fetching API again.

### Solution:

To keep sorting behavior in mobile view, we need to update `currentSort` so the query could trigger every time changing the sorting choice.