### PR TITLE
fix(favorites view): background color not being applied correctly on mobile

### DIFF
--- a/src/modules/views/Favorites/FavoritesView.tsx
+++ b/src/modules/views/Favorites/FavoritesView.tsx
@@ -10,6 +10,7 @@ import {
   shareNative
 } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
+import { Content } from 'cozy-ui/transpiled/react/Layout'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
@@ -132,35 +133,37 @@ const FavoritesView: FC = () => {
   )
   return (
     <FolderView isNotFound={false}>
-      <FolderViewHeader>
-        <Breadcrumb path={[{ name: t('breadcrumb.title_favorites') }]} />
-        <Toolbar canUpload={false} canCreateFolder={false} />
-      </FolderViewHeader>
-      <FolderBody
-        folderId="io.cozy.files.shared-drives-dir"
-        queryResults={[favoritesResult]}
-        extraColumns={extraColumns}
-        actions={actions}
-        canSort={true}
-        canInteractWith={handleInteractWith}
-      />
-      <Outlet />
-      {isMobile && (
-        <AddMenuProvider
-          canCreateFolder={true}
-          canUpload={true}
-          disabled={false}
-          displayedFolder={null}
-          isSelectionBarVisible={isSelectionBarVisible}
-          isPublic={false}
-          isReadOnly={false}
-          refreshFolderContent={(): void => {
-            // Empty function needed because this props is required
-          }}
-        >
-          <FabWithAddMenuContext noSidebar={false} />
-        </AddMenuProvider>
-      )}
+      <Content className={isMobile ? '' : 'u-pt-1'}>
+        <FolderViewHeader>
+          <Breadcrumb path={[{ name: t('breadcrumb.title_favorites') }]} />
+          <Toolbar canUpload={false} canCreateFolder={false} />
+        </FolderViewHeader>
+        <FolderBody
+          folderId="io.cozy.files.shared-drives-dir"
+          queryResults={[favoritesResult]}
+          extraColumns={extraColumns}
+          actions={actions}
+          canSort={true}
+          canInteractWith={handleInteractWith}
+        />
+        <Outlet />
+        {isMobile && (
+          <AddMenuProvider
+            canCreateFolder={true}
+            canUpload={true}
+            disabled={false}
+            displayedFolder={null}
+            isSelectionBarVisible={isSelectionBarVisible}
+            isPublic={false}
+            isReadOnly={false}
+            refreshFolderContent={(): void => {
+              // Empty function needed because this props is required
+            }}
+          >
+            <FabWithAddMenuContext noSidebar={false} />
+          </AddMenuProvider>
+        )}
+      </Content>
     </FolderView>
   )
 }


### PR DESCRIPTION
### the issue
The Favorites view was missing the Content component wrapper from cozy-ui/transpiled/react/Layout.

Without this wrapper, the Favorites view was showing through to the transparent background of the Main component, which revealed the black background behind it on mobile

### what's changed
- added the Content component wrapper to the Favorites view

### demo

<img width="401" height="876" alt="image" src="https://github.com/user-attachments/assets/da00ad8a-19aa-493d-9218-028bd17a957c" />
