### PR TITLE
fix: Display correct right click menu in file viewer :bug:

### DIFF
--- a/src/components/RightClick/RightClickAddMenu.jsx
+++ b/src/components/RightClick/RightClickAddMenu.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { useSharingContext } from 'cozy-sharing'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -14,9 +15,12 @@ const AddMenu = ({ children, ...props }) => {
   const { onOpen } = useRightClick()
   const { handleToggle, handleOfflineClick, isOffline } =
     useContext(AddMenuContext)
+  const location = useLocation()
+
+  const isInViewerMode = location.pathname.includes('/file/')
 
   if (!children) return null
-  if (!isDesktop)
+  if (!isDesktop || isInViewerMode)
     return React.Children.map(children, child =>
       React.isValidElement(child)
         ? React.cloneElement(child, {
@@ -46,10 +50,14 @@ const RightClickAddMenu = ({ children, ...props }) => {
   const { isOpen, position } = useRightClick()
   const { displayedFolder } = useDisplayedFolder()
   const { hasWriteAccess } = useSharingContext()
+  const location = useLocation()
 
   const isFolderReadOnly = displayedFolder
     ? !hasWriteAccess(displayedFolder._id, displayedFolder.driveId)
     : false
+
+  const isInViewerMode = location.pathname.includes('/file/')
+  const shouldShowAddMenu = isOpen('AddMenu') && !isInViewerMode
 
   return (
     <AddMenuProvider
@@ -62,7 +70,7 @@ const RightClickAddMenu = ({ children, ...props }) => {
       componentsProps={{
         AddMenu: {
           anchorReference: 'anchorPosition',
-          anchorPosition: isOpen('AddMenu')
+          anchorPosition: shouldShowAddMenu
             ? { top: position.mouseY, left: position.mouseX }
             : undefined
         }

--- a/src/components/RightClick/RightClickFileMenu.jsx
+++ b/src/components/RightClick/RightClickFileMenu.jsx
@@ -4,12 +4,22 @@ import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { useRightClick } from '@/components/RightClick/RightClickProvider'
+import { getContextMenuActions } from '@/modules/actions/helpers'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 
-const RightClickFileMenu = ({ doc, actions, disabled, children, ...props }) => {
+const RightClickFileMenu = ({
+  doc,
+  actions,
+  disabled,
+  children,
+  prefixMenuId,
+  ...props
+}) => {
   const { position, isOpen, onOpen, onClose } = useRightClick()
   const { isDesktop } = useBreakpoints()
   const { selectedItems, isItemSelected } = useSelectionContext()
+
+  const contextMenuActions = getContextMenuActions(actions)
 
   if (!children) return null
   if (disabled || !isDesktop)
@@ -28,16 +38,18 @@ const RightClickFileMenu = ({ doc, actions, disabled, children, ...props }) => {
           ? React.cloneElement(child, {
               ...props,
               onContextMenu: ev => {
-                onOpen(ev, `FileMenu-${doc._id}`)
+                onOpen(ev, `${prefixMenuId ?? 'FileMenu'}-${doc._id}}`)
+                ev.preventDefault()
+                ev.stopPropagation()
               }
             })
           : null
       )}
-      {isOpen(`FileMenu-${doc._id}`) && (
+      {isOpen(`${prefixMenuId ?? 'FileMenu'}-${doc._id}}`) && (
         <ActionsMenu
           open
           docs={isItemSelected(doc._id) ? selectedItems : [doc]}
-          actions={actions}
+          actions={contextMenuActions}
           anchorReference="anchorPosition"
           anchorPosition={{ top: position.mouseY, left: position.mouseX }}
           autoClose

--- a/src/hooks/useMoreMenuActions.jsx
+++ b/src/hooks/useMoreMenuActions.jsx
@@ -50,7 +50,6 @@ export const useMoreMenuActions = file => {
   const showPrintAction = isPDFDoc && isPrintAvailable
   const isCozySharing = window.location.pathname === '/preview'
   const isSharedDrive = window.location.href.includes('/shareddrive/')
-  const isDisplayInSharedDrive = !(isSharedDrive && !canWriteToCurrentFolder)
 
   const actions = makeActions(
     [
@@ -61,10 +60,10 @@ export const useMoreMenuActions = file => {
       download,
       showPrintAction && print,
       hr,
-      moveTo,
-      isDisplayInSharedDrive && duplicateTo,
-      isDisplayInSharedDrive && addToFavorites,
-      isDisplayInSharedDrive && removeFromFavorites,
+      !isSharedDrive && moveTo, // TO DO: Remove condtion when moving is available in shared drive
+      !isSharedDrive && duplicateTo, // TO DO: Remove condtion when duplicating is available in shared drive
+      addToFavorites,
+      removeFromFavorites,
       hr,
       versions,
       hr,
@@ -80,7 +79,7 @@ export const useMoreMenuActions = file => {
       refresh: () => navigate('..'),
       navigate,
       hasWriteAccess: canWriteToCurrentFolder,
-      canMove: isDisplayInSharedDrive,
+      canMove: canWriteToCurrentFolder,
       isPublic: false,
       allLoaded,
       showAlert,

--- a/src/modules/actions/components/addToFavorites.tsx
+++ b/src/modules/actions/components/addToFavorites.tsx
@@ -32,7 +32,9 @@ const addToFavorites = ({
     label,
     icon,
     displayCondition: docs =>
-      docs.length > 0 && docs.every(doc => !doc.cozyMetadata?.favorite),
+      docs.length > 0 &&
+      docs.every(doc => !doc.cozyMetadata?.favorite) &&
+      !docs[0]?.driveId,
     action: async (files): Promise<void> => {
       try {
         for (const file of files) {

--- a/src/modules/actions/components/removeFromFavorites.tsx
+++ b/src/modules/actions/components/removeFromFavorites.tsx
@@ -28,7 +28,9 @@ const removeFromFavorites = ({
     label,
     icon,
     displayCondition: docs =>
-      docs.length > 0 && docs.every(doc => doc.cozyMetadata?.favorite),
+      docs.length > 0 &&
+      docs.every(doc => doc.cozyMetadata?.favorite) &&
+      !docs[0]?.driveId,
     action: async (files): Promise<void> => {
       try {
         for (const file of files) {

--- a/src/modules/actions/helpers.js
+++ b/src/modules/actions/helpers.js
@@ -25,3 +25,14 @@ export const navigateToModalWithMultipleFile = ({
     }
   )
 }
+
+/**
+ * Returns the context menu visible actions
+ *
+ * @param {Object[]} actions - the list of actions
+ * @returns {Object[]} - the list of actions to be displayed
+ */
+export const getContextMenuActions = (actions = []) =>
+  actions.filter(
+    action => Object.values(action)[0]?.displayInContextMenu !== false
+  )

--- a/src/modules/actions/helpers.spec.js
+++ b/src/modules/actions/helpers.spec.js
@@ -1,0 +1,173 @@
+import {
+  navigateToModal,
+  navigateToModalWithMultipleFile,
+  getContextMenuActions
+} from './helpers'
+
+jest.mock('@/lib/path', () => ({
+  joinPath: jest.fn((...paths) => paths.join('/'))
+}))
+
+describe('actions helpers', () => {
+  describe('navigateToModal', () => {
+    let mockNavigate
+
+    beforeEach(() => {
+      mockNavigate = jest.fn()
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should navigate to modal with pathname and single file', () => {
+      const params = {
+        navigate: mockNavigate,
+        pathname: '/folder/123',
+        files: { id: 'file-123', name: 'test.pdf' },
+        path: 'preview'
+      }
+
+      navigateToModal(params)
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/folder/123/file/file-123/preview'
+      )
+    })
+
+    it('should navigate to modal with pathname and array of files', () => {
+      const params = {
+        navigate: mockNavigate,
+        pathname: '/folder/456',
+        files: [
+          { id: 'file-1', name: 'first.pdf' },
+          { id: 'file-2', name: 'second.pdf' }
+        ],
+        path: 'edit'
+      }
+
+      navigateToModal(params)
+
+      expect(mockNavigate).toHaveBeenCalledWith('/folder/456/file/file-1/edit')
+    })
+  })
+
+  describe('navigateToModalWithMultipleFile', () => {
+    let mockNavigate
+
+    beforeEach(() => {
+      mockNavigate = jest.fn()
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should navigate with pathname, multiple files, and search params', () => {
+      const params = {
+        navigate: mockNavigate,
+        pathname: '/folder/123',
+        files: [
+          { id: 'file-1', name: 'doc1.pdf' },
+          { id: 'file-2', name: 'doc2.pdf' },
+          { id: 'file-3', name: 'doc3.pdf' }
+        ],
+        path: 'share',
+        search: 'tab=link'
+      }
+
+      navigateToModalWithMultipleFile(params)
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        {
+          pathname: '/folder/123/share',
+          search: '?tab=link'
+        },
+        {
+          state: { fileIds: ['file-1', 'file-2', 'file-3'] }
+        }
+      )
+    })
+
+    it('should navigate with pathname and multiple files without search params', () => {
+      const params = {
+        navigate: mockNavigate,
+        pathname: '/recent',
+        files: [
+          { id: 'file-a', name: 'image1.jpg' },
+          { id: 'file-b', name: 'image2.jpg' }
+        ],
+        path: 'move'
+      }
+
+      navigateToModalWithMultipleFile(params)
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        {
+          pathname: '/recent/move',
+          search: ''
+        },
+        {
+          state: { fileIds: ['file-a', 'file-b'] }
+        }
+      )
+    })
+
+    it('should handle empty search parameter', () => {
+      const params = {
+        navigate: mockNavigate,
+        pathname: '/folder/456',
+        files: [
+          { id: 'file-1', name: 'test1.pdf' },
+          { id: 'file-2', name: 'test2.pdf' }
+        ],
+        path: 'delete',
+        search: ''
+      }
+
+      navigateToModalWithMultipleFile(params)
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        {
+          pathname: '/folder/456/delete',
+          search: ''
+        },
+        {
+          state: { fileIds: ['file-1', 'file-2'] }
+        }
+      )
+    })
+  })
+
+  describe('getContextMenuActions', () => {
+    it('should return all actions when all have displayInContextMenu !== false', () => {
+      const actions = [
+        { download: { displayInContextMenu: true, name: 'Download' } },
+        { share: { name: 'Share' } }, // undefined displayInContextMenu should be included
+        { rename: { displayInContextMenu: undefined, name: 'Rename' } }
+      ]
+
+      const result = getContextMenuActions(actions)
+
+      expect(result).toEqual(actions)
+      expect(result).toHaveLength(3)
+    })
+
+    it('should filter out actions with displayInContextMenu: false', () => {
+      const actions = [
+        { download: { displayInContextMenu: true, name: 'Download' } },
+        { share: { displayInContextMenu: false, name: 'Share' } },
+        { rename: { name: 'Rename' } },
+        { delete: { displayInContextMenu: false, name: 'Delete' } }
+      ]
+
+      const result = getContextMenuActions(actions)
+
+      expect(result).toEqual([
+        { download: { displayInContextMenu: true, name: 'Download' } },
+        { rename: { name: 'Rename' } }
+      ])
+      expect(result).toHaveLength(2)
+    })
+  })
+})

--- a/src/modules/actions/selectAll.jsx
+++ b/src/modules/actions/selectAll.jsx
@@ -32,6 +32,8 @@ export const selectAllItems = ({ t, selectAll, isSelectAll, isMobile }) => {
     name: 'selectAllItems',
     label,
     icon,
+    displayInSelectionBar: true,
+    displayInContextMenu: false,
     displayCondition: files => files.length > 0,
     action: () => selectAll(),
     Component: makeComponent(label, icon)

--- a/src/modules/actions/share.jsx
+++ b/src/modules/actions/share.jsx
@@ -26,7 +26,8 @@ const share = ({ t, hasWriteAccess, navigate, pathname, allLoaded }) => {
         hasWriteAccess &&
         files?.length === 1 &&
         !isEncryptedFileOrFolder(files[0]) &&
-        !isSharedDriveFolder(files[0])
+        !isSharedDriveFolder(files[0]) &&
+        !files[0]?.driveId
       )
     },
     action: files =>

--- a/src/modules/filelist/File.jsx
+++ b/src/modules/filelist/File.jsx
@@ -26,6 +26,7 @@ import styles from '@/styles/filelist.styl'
 import { useClipboardContext } from '@/contexts/ClipboardProvider'
 import { useViewSwitcherContext } from '@/lib/ViewSwitcherContext'
 import { ActionMenuWithHeader } from '@/modules/actionmenu/ActionMenuWithHeader'
+import { getContextMenuActions } from '@/modules/actions/helpers'
 import { extraColumnsPropTypes } from '@/modules/certifications'
 import {
   isRenaming as isRenamingReducer,
@@ -138,6 +139,8 @@ const File = ({
     canInteractWithFile &&= canInteractWith(attributes)
   }
 
+  const contextMenuActions = getContextMenuActions(actions)
+
   return (
     <FileWrapper
       viewType={viewType}
@@ -148,7 +151,9 @@ const File = ({
     >
       <SelectBox
         viewType={viewType}
-        withSelectionCheckbox={withSelectionCheckbox && actions?.length > 0}
+        withSelectionCheckbox={
+          withSelectionCheckbox && contextMenuActions?.length > 0
+        }
         selected={selected}
         onClick={toggle}
         disabled={
@@ -234,7 +239,7 @@ const File = ({
         )}
         <SharingShortcutBadge file={attributes} />
       </FileOpener>
-      {actions && canInteractWithFile && (
+      {contextMenuActions && canInteractWithFile && (
         <FileAction
           t={t}
           ref={filerowMenuToggleRef}
@@ -245,11 +250,11 @@ const File = ({
           }}
         />
       )}
-      {actions && actionMenuVisible && (
+      {contextMenuActions && actionMenuVisible && (
         <ActionMenuWithHeader
           file={attributes}
           anchorElRef={filerowMenuToggleRef}
-          actions={actions.filter(action => !action.selectAllItems)}
+          actions={contextMenuActions}
           onClose={hideActionMenu}
         />
       )}

--- a/src/modules/filelist/virtualized/GridFile.jsx
+++ b/src/modules/filelist/virtualized/GridFile.jsx
@@ -22,6 +22,7 @@ import styles from '@/styles/filelist.styl'
 
 import { useClipboardContext } from '@/contexts/ClipboardProvider'
 import { ActionMenuWithHeader } from '@/modules/actionmenu/ActionMenuWithHeader'
+import { getContextMenuActions } from '@/modules/actions/helpers'
 import { extraColumnsPropTypes } from '@/modules/certifications'
 import {
   isRenaming as isRenamingReducer,
@@ -102,6 +103,8 @@ const GridFile = ({
     canInteractWithFile &&= canInteractWith(attributes)
   }
 
+  const contextMenuActions = getContextMenuActions(actions)
+
   return (
     <Card
       className={cx(
@@ -119,7 +122,9 @@ const GridFile = ({
     >
       <SelectBox
         viewType="grid"
-        withSelectionCheckbox={withSelectionCheckbox && actions?.length > 0}
+        withSelectionCheckbox={
+          withSelectionCheckbox && contextMenuActions?.length > 0
+        }
         selected={selected}
         onClick={e => toggle(e)}
         disabled={
@@ -177,7 +182,7 @@ const GridFile = ({
         />
         <SharingShortcutBadge file={attributes} />
       </FileOpener>
-      {actions && canInteractWithFile && (
+      {contextMenuActions && canInteractWithFile && (
         <FileAction
           t={t}
           ref={filerowMenuToggleRef}
@@ -188,11 +193,11 @@ const GridFile = ({
           }}
         />
       )}
-      {actions && actionMenuVisible && (
+      {contextMenuActions && actionMenuVisible && (
         <ActionMenuWithHeader
           file={attributes}
           anchorElRef={filerowMenuToggleRef}
-          actions={actions.filter(action => !action.selectAllItems)}
+          actions={contextMenuActions}
           onClose={hideActionMenu}
         />
       )}

--- a/src/modules/filelist/virtualized/cells/Cell.jsx
+++ b/src/modules/filelist/virtualized/cells/Cell.jsx
@@ -12,6 +12,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import AcceptingSharingContext from '@/lib/AcceptingSharingContext'
 import { ActionMenuWithHeader } from '@/modules/actionmenu/ActionMenuWithHeader'
+import { getContextMenuActions } from '@/modules/actions/helpers'
 import {
   isRenaming as isRenamingSelector,
   getRenamingFile
@@ -150,6 +151,8 @@ const Cell = ({
       row._id !== 'io.cozy.files.shared-drives-dir' &&
       !row._id.endsWith('.trash-dir')
 
+    const contextMenuActions = getContextMenuActions(actions)
+
     if (!actions || !canInteractWithFile) {
       return null
     }
@@ -162,11 +165,11 @@ const Cell = ({
           disabled={isInSyncFromSharing}
           onClick={toggleShowActionMenu}
         />
-        {actions && showActionMenu && (
+        {contextMenuActions && showActionMenu && (
           <ActionMenuWithHeader
             file={row}
             anchorElRef={filerowMenuToggleRef}
-            actions={actions}
+            actions={contextMenuActions}
             onClose={toggleShowActionMenu}
           />
         )}

--- a/src/modules/folder/components/FolderBody.jsx
+++ b/src/modules/folder/components/FolderBody.jsx
@@ -140,9 +140,7 @@ const FolderBody = ({
                       <RightClickFileMenu
                         key={file._id}
                         doc={file}
-                        actions={actions.filter(
-                          action => !action.selectAllItems
-                        )}
+                        actions={actions}
                       >
                         <File
                           key={file._id}

--- a/src/modules/move/MoveModal.jsx
+++ b/src/modules/move/MoveModal.jsx
@@ -26,7 +26,8 @@ const MoveModal = ({
   onClose,
   currentFolder,
   entries,
-  showNextcloudFolder
+  showNextcloudFolder,
+  onMovingSuccess
 }) => {
   const client = useClient()
   const {
@@ -129,6 +130,8 @@ const MoveModal = ({
       })
 
       if (refreshSharing) refreshSharing()
+
+      onMovingSuccess?.()
     } catch (e) {
       logger.warn(e)
       showAlert({

--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -89,7 +89,7 @@ const AppRoute = () => (
         >
           <Route path="v/revision" element={<FileHistory />} />
           <Route path="v/share" element={<ShareFileView />} />
-          <Route path="v/move" element={<MoveFilesView />} />
+          <Route path="v/move" element={<MoveFilesView isOpenInViewer />} />
           <Route path="v/duplicate" element={<FolderDuplicateView />} />
         </Route>
         <Route path="file/:fileId/revision" element={<FileHistory />} />
@@ -153,7 +153,7 @@ const AppRoute = () => (
         >
           <Route path="v/revision" element={<FileHistory />} />
           <Route path="v/share" element={<ShareFileView />} />
-          <Route path="v/move" element={<MoveFilesView />} />
+          <Route path="v/move" element={<MoveFilesView isOpenInViewer />} />
           <Route path="v/duplicate" element={<FolderDuplicateView />} />
         </Route>
         <Route path="file/:fileId/revision" element={<FileHistory />} />
@@ -184,7 +184,7 @@ const AppRoute = () => (
           >
             <Route path="v/revision" element={<FileHistory />} />
             <Route path="v/share" element={<ShareFileView />} />
-            <Route path="v/move" element={<MoveFilesView />} />
+            <Route path="v/move" element={<MoveFilesView isOpenInViewer />} />
             <Route path="v/duplicate" element={<FolderDuplicateView />} />
           </Route>
           {/* This route must be a child of SharingsView so the modal opens on top of the sharing view */}

--- a/src/modules/viewer/FilesViewer.jsx
+++ b/src/modules/viewer/FilesViewer.jsx
@@ -14,7 +14,9 @@ import Viewer, {
 } from 'cozy-viewer'
 
 import { FilesViewerLoading } from '@/components/FilesViewerLoading'
+import RightClickFileMenu from '@/components/RightClick/RightClickFileMenu'
 import { useCurrentFileId } from '@/hooks'
+import { useMoreMenuActions } from '@/hooks/useMoreMenuActions'
 import {
   isEncryptedFile,
   getEncryptionKeyFromDirId,
@@ -160,6 +162,8 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange, viewerProps }) => {
     [hasCurrentIndex, currentIndex]
   )
 
+  const actions = useMoreMenuActions(currentFile ?? {})
+
   // If we can't find the file, we fallback to the (potentially loading)
   // direct stat made by the viewer
   if (currentIndex === -1 && !currentFile) {
@@ -167,34 +171,42 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange, viewerProps }) => {
   }
 
   return (
-    <RemoveScroll>
-      <Viewer
-        files={viewerFiles}
-        currentURL={currentDecryptedFileURL}
-        currentIndex={viewerIndex}
-        onChangeRequest={handleOnChange}
-        onCloseRequest={handleOnClose}
-        renderFallbackExtraContent={file => <Fallback file={file} t={t} />}
-        componentsProps={{
-          OnlyOfficeViewer: {
-            isEnabled: isOfficeEnabled(isDesktop),
-            opener: file => navigate(makeOnlyOfficeFileRoute(file.id))
-          },
-          toolbarProps: {
-            showFilePath: true
-          },
-          ...(viewerProps || {})
-        }}
-      >
-        <ToolbarButtons>
-          <MoreMenu />
-        </ToolbarButtons>
-        <FooterActionButtons>
-          <SharingButton />
-          <ForwardOrDownloadButton variant="buttonIcon" />
-        </FooterActionButtons>
-      </Viewer>
-    </RemoveScroll>
+    <RightClickFileMenu
+      key={viewerFiles[viewerIndex]?._id}
+      doc={viewerFiles[viewerIndex]}
+      actions={actions}
+      disabled={!viewerFiles[viewerIndex]}
+      prefixMenuId="FileViewerMenu"
+    >
+      <RemoveScroll>
+        <Viewer
+          files={viewerFiles}
+          currentURL={currentDecryptedFileURL}
+          currentIndex={viewerIndex}
+          onChangeRequest={handleOnChange}
+          onCloseRequest={handleOnClose}
+          renderFallbackExtraContent={file => <Fallback file={file} t={t} />}
+          componentsProps={{
+            OnlyOfficeViewer: {
+              isEnabled: isOfficeEnabled(isDesktop),
+              opener: file => navigate(makeOnlyOfficeFileRoute(file.id))
+            },
+            toolbarProps: {
+              showFilePath: true
+            },
+            ...(viewerProps || {})
+          }}
+        >
+          <ToolbarButtons>
+            <MoreMenu file={viewerFiles[viewerIndex]} />
+          </ToolbarButtons>
+          <FooterActionButtons>
+            <SharingButton />
+            <ForwardOrDownloadButton variant="buttonIcon" />
+          </FooterActionButtons>
+        </Viewer>
+      </RemoveScroll>
+    </RightClickFileMenu>
   )
 }
 

--- a/src/modules/views/Folder/FolderViewBody.jsx
+++ b/src/modules/views/Folder/FolderViewBody.jsx
@@ -243,9 +243,7 @@ const FolderViewBody = ({
                             <RightClickFileMenu
                               key={file._id}
                               doc={file}
-                              actions={actions.filter(
-                                action => !action.selectAllItems
-                              )}
+                              actions={actions}
                             >
                               <File
                                 key={file._id}

--- a/src/modules/views/Folder/virtualized/Grid.jsx
+++ b/src/modules/views/Folder/virtualized/Grid.jsx
@@ -58,7 +58,7 @@ const Grid = forwardRef(
                 <RightClickFileMenu
                   key={file?._id}
                   doc={file}
-                  actions={actions.filter(action => !action.selectAllItems)}
+                  actions={actions}
                 >
                   <GridFile
                     key={file?._id}

--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -15,9 +15,10 @@ import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightPro
 const TableRow = forwardRef(({ item, context, children, ...props }, ref) => {
   const { isItemCut } = useClipboardContext()
   const isCut = isItemCut(item._id)
+  const { actions } = context
 
   return (
-    <RightClickFileMenu doc={item} actions={context.actions} {...props}>
+    <RightClickFileMenu doc={item} actions={actions} {...props}>
       <TableRowDnD
         ref={ref}
         item={item}

--- a/src/modules/views/Modal/MoveFilesView.jsx
+++ b/src/modules/views/Modal/MoveFilesView.jsx
@@ -8,7 +8,7 @@ import useDisplayedFolder from '@/hooks/useDisplayedFolder'
 import MoveModal from '@/modules/move/MoveModal'
 import { buildParentsByIdsQuery } from '@/queries'
 
-const MoveFilesView = () => {
+const MoveFilesView = ({ isOpenInViewer }) => {
   const navigate = useNavigate()
   const { state } = useLocation()
   const { displayedFolder } = useDisplayedFolder()
@@ -30,6 +30,14 @@ const MoveFilesView = () => {
       navigate('..', { replace: true })
     }
 
+    const onMovingSuccess = () => {
+      /**
+       * In file viewer, after moving success the file will not exist in the current folder,
+       * we should navigate to current folder view instead.
+       * */
+      navigate(isOpenInViewer ? '../..' : '..', { replace: true })
+    }
+
     const showNextcloudFolder = !fileResult.data.some(
       file => file.type === 'directory'
     )
@@ -39,6 +47,7 @@ const MoveFilesView = () => {
         currentFolder={displayedFolder}
         entries={fileResult.data}
         onClose={onClose}
+        onMovingSuccess={onMovingSuccess}
         showNextcloudFolder={showNextcloudFolder}
       />
     )


### PR DESCRIPTION
### Change:

In file viewer, we need to display `RightClickFileMenu` instead of `RightClickAddMenu`.

### Results:

#### Normal file viewer:

<img width="3018" height="1622" alt="CleanShot 2025-10-31 at 15 46 43@2x" src="https://github.com/user-attachments/assets/f11eff9c-5740-4a21-a7e5-75b9c7c648e9" />

#### Shared drive file viewer:

<img width="3024" height="1618" alt="CleanShot 2025-10-31 at 15 40 52@2x" src="https://github.com/user-attachments/assets/09e79a70-2b9b-4f60-b87d-e756d300f314" />
