### PR TITLE
feat: Implement copying and cutting files in public view :sparkles:

### DIFF
--- a/src/components/FolderPicker/FolderPicker.tsx
+++ b/src/components/FolderPicker/FolderPicker.tsx
@@ -30,6 +30,7 @@ interface FolderPickerProps {
   slotProps?: FolderPickerSlotProps
   showNextcloudFolder?: boolean
   canPickEntriesParentFolder?: boolean
+  isPublic?: boolean
 }
 
 const useStyles = makeStyles({
@@ -53,7 +54,8 @@ const FolderPicker: React.FC<FolderPickerProps> = ({
   canCreateFolder = true,
   slotProps,
   showNextcloudFolder = false,
-  canPickEntriesParentFolder = false
+  canPickEntriesParentFolder = false,
+  isPublic = false
 }) => {
   const [folder, setFolder] = useState<File>(currentFolder)
 
@@ -101,6 +103,7 @@ const FolderPicker: React.FC<FolderPickerProps> = ({
           isFolderCreationDisplayed={isFolderCreationDisplayed}
           hideFolderCreation={hideFolderCreation}
           showNextcloudFolder={showNextcloudFolder}
+          isPublic={isPublic}
         />
       }
       actions={

--- a/src/components/FolderPicker/FolderPickerBody.tsx
+++ b/src/components/FolderPicker/FolderPickerBody.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { FolderPickerContentCozy } from '@/components/FolderPicker/FolderPickerContentCozy'
 import { FolderPickerContentNextcloud } from '@/components/FolderPicker/FolderPickerContentNextcloud'
+import { FolderPickerContentPublic } from '@/components/FolderPicker/FolderPickerContentPublic'
 import { File, FolderPickerEntry } from '@/components/FolderPicker/types'
 
 interface FolderPickerBodyProps {
@@ -11,6 +12,7 @@ interface FolderPickerBodyProps {
   isFolderCreationDisplayed: boolean
   hideFolderCreation: () => void
   showNextcloudFolder?: boolean
+  isPublic?: boolean
 }
 
 const FolderPickerBody: React.FC<FolderPickerBodyProps> = ({
@@ -19,7 +21,8 @@ const FolderPickerBody: React.FC<FolderPickerBodyProps> = ({
   navigateTo,
   isFolderCreationDisplayed,
   hideFolderCreation,
-  showNextcloudFolder
+  showNextcloudFolder,
+  isPublic
 }) => {
   if (folder._type === 'io.cozy.remote.nextcloud.files') {
     return (
@@ -27,6 +30,19 @@ const FolderPickerBody: React.FC<FolderPickerBodyProps> = ({
         folder={folder}
         entries={entries}
         navigateTo={navigateTo}
+      />
+    )
+  }
+
+  if (isPublic) {
+    return (
+      <FolderPickerContentPublic
+        folder={folder}
+        isFolderCreationDisplayed={isFolderCreationDisplayed}
+        hideFolderCreation={hideFolderCreation}
+        entries={entries}
+        navigateTo={navigateTo}
+        showNextcloudFolder={showNextcloudFolder}
       />
     )
   }

--- a/src/components/FolderPicker/FolderPickerContentPublic.tsx
+++ b/src/components/FolderPicker/FolderPickerContentPublic.tsx
@@ -1,0 +1,107 @@
+import React, { useMemo } from 'react'
+
+import { useClient } from 'cozy-client'
+import { isDirectory } from 'cozy-client/dist/models/file'
+import { IOCozyFile } from 'cozy-client/types/types'
+import List from 'cozy-ui/transpiled/react/List'
+
+import { FolderPickerListItem } from './FolderPickerListItem'
+
+import { FolderPickerAddFolderItem } from '@/components/FolderPicker/FolderPickerAddFolderItem'
+import { FolderPickerContentLoadMore } from '@/components/FolderPicker/FolderPickerContentLoadMore'
+import { FolderPickerContentLoader } from '@/components/FolderPicker/FolderPickerContentLoader'
+import { isInvalidMoveTarget } from '@/components/FolderPicker/helpers'
+import type { File, FolderPickerEntry } from '@/components/FolderPicker/types'
+import { isEncryptedFolder } from '@/lib/encryption'
+import { FolderUnlocker } from '@/modules/folder/components/FolderUnlocker'
+import usePublicFilesQuery from '@/modules/views/Public/usePublicFilesQuery'
+import { buildFileOrFolderByIdQuery } from '@/queries'
+
+interface FolderPickerContentPublicProps {
+  folder: IOCozyFile
+  isFolderCreationDisplayed: boolean
+  hideFolderCreation: () => void
+  entries: FolderPickerEntry[]
+  navigateTo: (folder: import('./types').File) => void
+  showNextcloudFolder?: boolean
+}
+
+const FolderPickerContentPublic: React.FC<FolderPickerContentPublicProps> = ({
+  folder,
+  isFolderCreationDisplayed,
+  hideFolderCreation,
+  entries,
+  navigateTo
+}) => {
+  const client = useClient()
+  const filesResult = usePublicFilesQuery(folder._id)
+  const {
+    data: filesData,
+    fetchStatus,
+    hasMore,
+    fetchMore
+  } = filesResult as unknown as {
+    fetchStatus: string
+    data?: IOCozyFile[]
+    hasMore: boolean
+    fetchMore: () => void
+  }
+
+  const isEncrypted = isEncryptedFolder(folder)
+
+  const files: IOCozyFile[] = useMemo(() => {
+    return [...(filesData ?? [])]
+  }, [filesData])
+
+  const handleFolderUnlockerDismiss = async (): Promise<void> => {
+    const parentFolderQuery = buildFileOrFolderByIdQuery(folder.dir_id)
+    const parentFolder = (await client?.fetchQueryAndGetFromState({
+      definition: parentFolderQuery.definition(),
+      options: parentFolderQuery.options
+    })) as {
+      data?: IOCozyFile
+    }
+    if (!parentFolder.data) {
+      throw new Error('Parent folder not found')
+    }
+
+    navigateTo(parentFolder.data)
+  }
+
+  const handleClick = (file: File): void => {
+    if (isDirectory(file)) {
+      navigateTo(file)
+    }
+  }
+
+  return (
+    <List>
+      <FolderPickerAddFolderItem
+        isEncrypted={isEncrypted}
+        currentFolderId={folder._id}
+        visible={isFolderCreationDisplayed}
+        afterSubmit={hideFolderCreation}
+        afterAbort={hideFolderCreation}
+      />
+      <FolderPickerContentLoader
+        fetchStatus={fetchStatus}
+        hasNoData={files.length === 0}
+      >
+        <FolderUnlocker folder={folder} onDismiss={handleFolderUnlockerDismiss}>
+          {files.map((file, index) => (
+            <FolderPickerListItem
+              key={file._id}
+              file={file}
+              disabled={isInvalidMoveTarget(entries, file)}
+              onClick={handleClick}
+              showDivider={index !== files.length - 1}
+            />
+          ))}
+        </FolderUnlocker>
+        <FolderPickerContentLoadMore hasMore={hasMore} fetchMore={fetchMore} />
+      </FolderPickerContentLoader>
+    </List>
+  )
+}
+
+export { FolderPickerContentPublic }

--- a/src/hooks/useKeyboardShortcuts.spec.jsx
+++ b/src/hooks/useKeyboardShortcuts.spec.jsx
@@ -382,7 +382,8 @@ describe('useKeyboardShortcuts', () => {
           showAlert: mockShowAlert,
           t: mockT,
           sharingContext: null,
-          showMoveValidationModal: mockShowMoveValidationModal
+          showMoveValidationModal: mockShowMoveValidationModal,
+          isPublic: false
         }
       )
       expect(mockShowAlert).toHaveBeenCalledWith({

--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -32,6 +32,7 @@ interface UseKeyboardShortcutsProps {
   allowCopy?: boolean
   allowCut?: boolean
   isNextCloudFolder?: boolean
+  isPublic?: boolean
   pushModal?: (modal: React.ReactElement) => void
   popModal?: () => void
   refresh?: () => void
@@ -46,6 +47,7 @@ export const useKeyboardShortcuts = ({
   allowCopy = true,
   allowCut = true,
   isNextCloudFolder = false,
+  isPublic = false,
   pushModal,
   popModal,
   refresh
@@ -178,7 +180,8 @@ export const useKeyboardShortcuts = ({
           showAlert,
           t,
           sharingContext,
-          showMoveValidationModal
+          showMoveValidationModal,
+          isPublic
         }
       )
 
@@ -211,16 +214,19 @@ export const useKeyboardShortcuts = ({
     }
   }, [
     hasClipboardData,
-    canPaste,
     client,
     currentFolder,
-    clipboardData,
+    canPaste,
+    clipboardData.operation,
+    clipboardData.sourceFolderIds,
+    clipboardData.files,
     showAlert,
     t,
     sharingContext,
     showMoveValidationModal,
-    clearClipboard,
-    onPaste
+    isPublic,
+    onPaste,
+    clearClipboard
   ])
 
   const handleSelectAll = useCallback(() => {

--- a/src/modules/actions/components/duplicateTo.tsx
+++ b/src/modules/actions/components/duplicateTo.tsx
@@ -16,6 +16,7 @@ interface duplicateToProps {
   pathname: string
   isMobile: boolean
   search?: string
+  canDuplicate?: boolean
 }
 
 const duplicateTo = ({
@@ -23,7 +24,8 @@ const duplicateTo = ({
   pathname,
   navigate,
   isMobile,
-  search
+  search,
+  canDuplicate = true
 }: duplicateToProps): Action => {
   const icon = MultiFilesIcon
   const label = isMobile
@@ -34,7 +36,8 @@ const duplicateTo = ({
     name: 'duplicateTo',
     label,
     icon,
-    displayCondition: docs => docs.length === 1 && isFile(docs[0]),
+    displayCondition: docs =>
+      docs.length === 1 && isFile(docs[0]) && canDuplicate,
     action: (files): void => {
       navigateToModalWithMultipleFile({
         files,

--- a/src/modules/duplicate/components/DuplicateModal.tsx
+++ b/src/modules/duplicate/components/DuplicateModal.tsx
@@ -18,13 +18,15 @@ interface DuplicateModalProps {
   currentFolder: File
   onClose: () => void | Promise<void>
   showNextcloudFolder?: boolean
+  isPublic?: boolean
 }
 
 const DuplicateModal: FC<DuplicateModalProps> = ({
   entries,
   currentFolder,
   onClose,
-  showNextcloudFolder
+  showNextcloudFolder,
+  isPublic
 }) => {
   const { t } = useI18n()
   const { showAlert } = useAlert()
@@ -103,6 +105,7 @@ const DuplicateModal: FC<DuplicateModalProps> = ({
         }
       }}
       canPickEntriesParentFolder
+      isPublic={isPublic}
     />
   )
 }

--- a/src/modules/move/MoveModal.jsx
+++ b/src/modules/move/MoveModal.jsx
@@ -27,7 +27,8 @@ const MoveModal = ({
   currentFolder,
   entries,
   showNextcloudFolder,
-  onMovingSuccess
+  onMovingSuccess,
+  isPublic
 }) => {
   const client = useClient()
   const {
@@ -66,7 +67,8 @@ const MoveModal = ({
     const areMovedFilesShared = hasOneOfEntriesShared(entries, byDocId)
     const isOriginParentShared = hasSharedParent(entries[0].path)
     const isTargetShared = hasSharedParent(targetPath)
-    const isInsideSameSharedFolder = targetPath.startsWith(sharedParentPath)
+    const isInsideSameSharedFolder =
+      targetPath.startsWith(sharedParentPath) || isPublic
 
     if (isInsideSameSharedFolder) {
       moveEntries(folder)
@@ -97,7 +99,7 @@ const MoveModal = ({
       const trashedFiles = []
       await Promise.all(
         entries.map(async entry => {
-          const force = !sharedPaths.includes(folder.path)
+          const force = !sharedPaths?.includes(folder.path)
           const moveResponse = await registerCancelable(
             move(client, entry, folder, {
               force
@@ -214,7 +216,8 @@ const MoveModal = ({
         entries={entries}
         onConfirm={handleConfirm}
         onClose={onClose}
-        isBusy={isMoveInProgress || !allLoaded}
+        isBusy={isMoveInProgress || (!isPublic && !allLoaded)}
+        isPublic={isPublic}
       />
       {isMovingOutsideSharedFolder ? (
         <MoveOutsideSharedFolderModal

--- a/src/modules/paste/index.js
+++ b/src/modules/paste/index.js
@@ -16,7 +16,7 @@ export const handlePasteOperation = async (
   targetFolder,
   options = {}
 ) => {
-  const { showAlert, t, sharingContext } = options
+  const { showAlert, t, sharingContext, isPublic } = options
   const results = []
 
   // For cut operations, resolve name conflicts first
@@ -25,7 +25,8 @@ export const handlePasteOperation = async (
     processedFiles = await resolveNameConflictsForCut(
       client,
       files,
-      targetFolder
+      targetFolder,
+      isPublic
     )
   }
 

--- a/src/modules/paste/index.spec.js
+++ b/src/modules/paste/index.spec.js
@@ -137,7 +137,8 @@ describe('handlePasteOperation', () => {
       expect(resolveNameConflictsForCut).toHaveBeenCalledWith(
         mockClient,
         mockFiles,
-        mockTargetFolder
+        mockTargetFolder,
+        undefined
       )
 
       expect(move).toHaveBeenCalledTimes(2)

--- a/src/modules/views/Folder/PublicFolderDuplicateView.tsx
+++ b/src/modules/views/Folder/PublicFolderDuplicateView.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react'
+import { Navigate, useLocation, useNavigate } from 'react-router-dom'
+
+import usePublicFileByIdsQuery from '../Public/usePublicFileByIdsQuery'
+
+import { LoaderModal } from '@/components/LoaderModal'
+import useDisplayedFolder from '@/hooks/useDisplayedFolder'
+import { DuplicateModal } from '@/modules/duplicate/components/DuplicateModal'
+
+const PublicFolderDuplicateView: FC = () => {
+  const navigate = useNavigate()
+  const { state } = useLocation() as {
+    state: { fileIds?: string[] }
+  }
+  const { displayedFolder } = useDisplayedFolder()
+
+  const hasFileIds = state.fileIds != undefined
+
+  const { files, fetchStatus } = usePublicFileByIdsQuery(
+    state.fileIds ?? ([] as string[])
+  )
+
+  if (!hasFileIds) {
+    return <Navigate to=".." replace={true} />
+  }
+
+  if (fetchStatus === 'loaded' && files.length && displayedFolder) {
+    const onClose = (): void => {
+      navigate('..', { replace: true })
+    }
+
+    return (
+      <DuplicateModal
+        currentFolder={displayedFolder}
+        entries={files}
+        onClose={onClose}
+        isPublic
+      />
+    )
+  }
+
+  return <LoaderModal />
+}
+
+export { PublicFolderDuplicateView }

--- a/src/modules/views/Modal/MovePublicFilesView.tsx
+++ b/src/modules/views/Modal/MovePublicFilesView.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Navigate, useLocation, useNavigate } from 'react-router-dom'
+
+import usePublicFileByIdsQuery from '../Public/usePublicFileByIdsQuery'
+
+import { LoaderModal } from '@/components/LoaderModal'
+import useDisplayedFolder from '@/hooks/useDisplayedFolder'
+import MoveModal from '@/modules/move/MoveModal'
+
+interface LocationState {
+  fileIds?: string[]
+}
+
+const MovePublicFilesView = (): React.ReactElement => {
+  const navigate = useNavigate()
+  const { state } = useLocation() as { state: LocationState | null }
+  const { displayedFolder } = useDisplayedFolder()
+
+  const hasFileIds = state?.fileIds !== undefined
+
+  const { files, fetchStatus } = usePublicFileByIdsQuery(
+    state?.fileIds ?? ([] as string[])
+  )
+
+  if (!hasFileIds) {
+    return <Navigate to=".." replace={true} />
+  }
+
+  if (fetchStatus === 'loaded' && files.length && displayedFolder) {
+    const onClose = (): void => {
+      navigate('..', { replace: true })
+    }
+
+    const onMovingSuccess = (): void => {
+      navigate('..', { replace: true, state: { refresh: true } })
+    }
+
+    return (
+      <MoveModal
+        currentFolder={displayedFolder}
+        entries={files}
+        onClose={onClose}
+        onMovingSuccess={onMovingSuccess}
+        isPublic
+        showNextcloudFolder={false}
+      />
+    )
+  }
+
+  return <LoaderModal />
+}
+
+export { MovePublicFilesView }

--- a/src/modules/views/Public/usePublicFileByIdsQuery.spec.jsx
+++ b/src/modules/views/Public/usePublicFileByIdsQuery.spec.jsx
@@ -1,0 +1,165 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useClient } from 'cozy-client'
+
+// Suppress React act warnings for this test file
+const originalError = console.error
+beforeAll(() => {
+  console.error = (...args) => {
+    if (
+      typeof args[0] === 'string' &&
+      args[0].includes(
+        'Warning: An update to %s inside a test was not wrapped in act'
+      )
+    ) {
+      return
+    }
+    originalError.call(console, ...args)
+  }
+})
+
+afterAll(() => {
+  console.error = originalError
+})
+
+import {
+  fetchFileById,
+  usePublicFileByIdsQuery
+} from './usePublicFileByIdsQuery'
+
+// Mock cozy-client
+jest.mock('cozy-client', () => ({
+  useClient: jest.fn()
+}))
+
+const mockClient = {
+  collection: jest.fn()
+}
+
+const mockFiles = [
+  {
+    _id: 'file1',
+    _type: 'io.cozy.files',
+    name: 'document1.pdf',
+    type: 'file',
+    mime: 'application/pdf',
+    size: 1024
+  },
+  {
+    _id: 'file2',
+    _type: 'io.cozy.files',
+    name: 'document2.pdf',
+    type: 'file',
+    mime: 'application/pdf',
+    size: 2048
+  }
+]
+
+describe('fetchFileById', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should fetch file by id successfully', async () => {
+    const mockStatById = jest.fn().mockResolvedValue({
+      data: [mockFiles[0]]
+    })
+
+    mockClient.collection.mockReturnValue({
+      statById: mockStatById
+    })
+
+    const result = await fetchFileById(mockClient, 'file1')
+
+    expect(mockClient.collection).toHaveBeenCalledWith('io.cozy.files')
+    expect(mockStatById).toHaveBeenCalledWith('file1')
+    expect(result).toEqual([mockFiles[0]])
+  })
+
+  it('should handle errors when fetching file', async () => {
+    const mockStatById = jest.fn().mockRejectedValue(new Error('Network error'))
+
+    mockClient.collection.mockReturnValue({
+      statById: mockStatById
+    })
+
+    await expect(fetchFileById(mockClient, 'file1')).rejects.toThrow(
+      'Network error'
+    )
+  })
+})
+
+describe('usePublicFileByIdsQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useClient.mockReturnValue(mockClient)
+    // Reset mock client
+    mockClient.collection.mockReturnValue({
+      statById: jest.fn().mockResolvedValue({ data: [] })
+    })
+  })
+
+  it('should return initial state', () => {
+    const { result } = renderHook(() => usePublicFileByIdsQuery(['file1']))
+
+    expect(result.current.fetchStatus).toBe('loading')
+    expect(result.current.files).toEqual([])
+  })
+
+  it('should fetch files successfully', () => {
+    const mockStatById = jest
+      .fn()
+      .mockResolvedValueOnce({ data: [mockFiles[0]] })
+      .mockResolvedValueOnce({ data: [mockFiles[1]] })
+
+    // Clear previous calls and set up fresh mock
+    jest.clearAllMocks()
+    mockClient.collection.mockReturnValue({
+      statById: mockStatById
+    })
+
+    const { result } = renderHook(() =>
+      usePublicFileByIdsQuery(['file1', 'file2'])
+    )
+
+    expect(result.current.fetchStatus).toBe('loading')
+    expect(result.current.files).toEqual([])
+    // Verify the function calls were made (may be called multiple times due to React)
+    expect(mockStatById).toHaveBeenCalledWith('file1')
+    expect(mockStatById).toHaveBeenCalledWith('file2')
+  })
+
+  it('should handle empty file ids array', () => {
+    // Clear previous calls
+    jest.clearAllMocks()
+
+    const { result } = renderHook(() => usePublicFileByIdsQuery([]))
+
+    expect(result.current.fetchStatus).toBe('loading')
+    expect(result.current.files).toEqual([])
+    // For empty array, no fetchFileById calls are made, so collection is not called
+    expect(mockClient.collection).not.toHaveBeenCalled()
+  })
+
+  it('should handle fetch errors', () => {
+    const mockStatById = jest.fn().mockRejectedValue(new Error('Network error'))
+
+    mockClient.collection.mockReturnValue({
+      statById: mockStatById
+    })
+
+    const { result } = renderHook(() => usePublicFileByIdsQuery(['file1']))
+
+    expect(result.current.fetchStatus).toBe('loading')
+    expect(result.current.files).toEqual([])
+  })
+
+  it('should handle null client', () => {
+    useClient.mockReturnValue(null)
+
+    const { result } = renderHook(() => usePublicFileByIdsQuery(['file1']))
+
+    expect(result.current.fetchStatus).toBe('pending')
+    expect(result.current.files).toEqual([])
+  })
+})

--- a/src/modules/views/Public/usePublicFileByIdsQuery.tsx
+++ b/src/modules/views/Public/usePublicFileByIdsQuery.tsx
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react'
+
+import CozyClient, { useClient } from 'cozy-client'
+import { IOCozyFile } from 'cozy-client/types/types'
+
+type FetchStatus = 'pending' | 'loading' | 'loaded' | 'error'
+
+interface UsePublicFileByIdsQueryReturn {
+  fetchStatus: FetchStatus
+  files: IOCozyFile[]
+}
+
+interface FileCollection {
+  statById: (fileId: string) => Promise<{ data: IOCozyFile[] }>
+}
+
+export const fetchFileById = async (
+  client: CozyClient,
+  fileId: string
+): Promise<IOCozyFile[]> => {
+  const response = await (
+    client.collection('io.cozy.files') as FileCollection
+  ).statById(fileId)
+
+  return response.data
+}
+
+export const usePublicFileByIdsQuery = (
+  fileIds: string[]
+): UsePublicFileByIdsQueryReturn => {
+  const client = useClient()
+  const [fetchStatus, setFetchStatus] = useState<FetchStatus>('pending')
+  const [data, setData] = useState<IOCozyFile[]>([])
+
+  useEffect(() => {
+    if (!client) return
+
+    const initialFetch = async (): Promise<void> => {
+      try {
+        setFetchStatus('loading')
+
+        const response = await Promise.all(
+          fileIds.map(fileId => fetchFileById(client, fileId))
+        )
+
+        const parsedData = response.flatMap(item => item)
+        setData(parsedData)
+        setFetchStatus('loaded')
+      } catch (error) {
+        setFetchStatus('error')
+      }
+    }
+    void initialFetch()
+  }, [client, fileIds])
+
+  return {
+    fetchStatus,
+    files: data
+  }
+}
+
+export default usePublicFileByIdsQuery

--- a/src/targets/public/components/AppRouter.jsx
+++ b/src/targets/public/components/AppRouter.jsx
@@ -10,6 +10,8 @@ import ExternalRedirect from '@/modules/navigation/ExternalRedirect'
 import { PublicNoteRedirect } from '@/modules/navigation/PublicNoteRedirect'
 import LightFileViewer from '@/modules/public/LightFileViewer'
 import PublicLayout from '@/modules/public/PublicLayout'
+import { PublicFolderDuplicateView } from '@/modules/views/Folder/PublicFolderDuplicateView'
+import { MovePublicFilesView } from '@/modules/views/Modal/MovePublicFilesView'
 import OnlyOfficeView from '@/modules/views/OnlyOffice'
 import OnlyOfficeCreateView from '@/modules/views/OnlyOffice/Create'
 import OnlyOfficePaywallView from '@/modules/views/OnlyOffice/OnlyOfficePaywallView'
@@ -91,6 +93,8 @@ const AppRouter = ({
                 path="paywall"
                 element={<OnlyOfficePaywallView isPublic={true} />}
               />
+              <Route path="move" element={<MovePublicFilesView />} />
+              <Route path="duplicate" element={<PublicFolderDuplicateView />} />
             </Route>
             <Route path="note/:fileId" element={<PublicNoteRedirect />} />
             <Route path="external/:fileId" element={<ExternalRedirect />} />


### PR DESCRIPTION
### Change:

Now, we can do copy / cut in public view which has write access by both shortcut and traditional way. We can only copy, cut in the limit of the public folder.

### Results:

https://github.com/user-attachments/assets/3530a5b7-1a69-4bec-a1b3-ad55d57cb530

https://github.com/user-attachments/assets/9acc09da-ad2a-418c-b208-48fbcbbe3ffb

### Flag:

`drive.copy-cut-in-pubic-view.enabled`

### Note:

~~The refresh folder content issue will be resolved in another PR.~~
After moving/copying files/folders the folder content will be refreshed.