### PR TITLE
fix: Now use jsx for colored folder

### DIFF
--- a/src/modules/views/Folder/ColoredFolder.jsx
+++ b/src/modules/views/Folder/ColoredFolder.jsx
@@ -1,0 +1,45 @@
+import React, { useRef } from 'react'
+
+import { shadeColor } from './helpers'
+
+let gradientIdCounter = 0
+
+function ColoredFolder({ color = '#1D7AFF', ...props }) {
+  const gradientIdRef = useRef(null)
+  if (gradientIdRef.current === null) {
+    gradientIdRef.current = `file-type-colored-folder-gradient-${++gradientIdCounter}`
+  }
+  const gradientId = gradientIdRef.current
+  const base = color
+  const dark = shadeColor(base, { to: 'black', factor: 0.1 })
+  const lightStrong = shadeColor(base, { to: 'white', factor: 0.45 })
+  const light = shadeColor(base, { to: 'white', factor: 0.35 })
+  const mid = shadeColor(base, { to: 'white', factor: 0.15 })
+  return (
+    <svg viewBox="0 0 16 14" fill="none" {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 2.125h6.4c.88 0 1.6.731 1.6 1.625v8.125c0 .894-.72 1.625-1.6 1.625H1.6c-.88 0-1.6-.731-1.6-1.625l.008-9.75C.008 1.231.72.5 1.6.5h4.8L8 2.125z"
+        fill={`url(#${gradientId})`}
+      />
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1={8}
+          y1={0.5}
+          x2={8}
+          y2={16.25}
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset={0.044} stopColor={dark} />
+          <stop offset={0.13} stopColor={lightStrong} />
+          <stop offset={0.617} stopColor={light} />
+          <stop offset={1} stopColor={mid} />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+
+export default ColoredFolder

--- a/src/modules/views/Folder/CustomizedIcon.jsx
+++ b/src/modules/views/Folder/CustomizedIcon.jsx
@@ -1,11 +1,9 @@
 import React from 'react'
 
-import foldersvg from 'cozy-ui/assets/icons/ui/folder.svg?raw'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconStack from 'cozy-ui/transpiled/react/IconStack'
-import FolderIcon from 'cozy-ui/transpiled/react/Icons/Files'
 
-import styles from '@/styles/folder-customizer.styl'
+import ColoredFolder from './ColoredFolder'
 
 import { getIcon } from '@/components/IconPicker/IconIndex'
 
@@ -15,34 +13,24 @@ export const CustomizedIcon = ({
   selectedIconColor,
   size
 }) => {
-  const encoded = `url('data:image/svg+xml;utf8,${encodeURIComponent(
-    foldersvg
-  )}')`
-  const maskStyle = {
-    maskImage: encoded,
-    WebkitMaskImage: encoded
-  }
-
+  console.log('CustomizedIcon selectedColor', selectedColor)
   return (
     <div>
       <IconStack
         offset={{ vertical: '3%' }}
         backgroundIcon={
           <div
-            className={`${styles.iconContainer} u-pos-relative u-dib`}
+            className="u-pos-relative u-dib"
             style={{
-              ['--folder-color']: selectedColor,
               width: size,
               height: size
             }}
           >
-            <Icon icon={FolderIcon} size={size || 32} />
-            {maskStyle && (
-              <div
-                className={`${styles.iconOverlay} u-pos-absolute u-top-0 u-left-0 u-w-100 u-h-100`}
-                style={maskStyle}
-              />
-            )}
+            <ColoredFolder
+              color={selectedColor}
+              width={size || 32}
+              height={size || 32}
+            />
           </div>
         }
         foregroundIcon={

--- a/src/modules/views/Folder/helpers.js
+++ b/src/modules/views/Folder/helpers.js
@@ -1,6 +1,73 @@
 import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { getDriveI18n } from '@/locales'
 
+/**
+ * Converts a hex color string to an RGB object.
+ *
+ * @param {string} hex - The hex color string (e.g., "#ff8800" or "ff8800").
+ * @returns {{r: number, g: number, b: number}|null} An object with r, g, b values (0-255), or null if input is invalid.
+ */
+export const hexToRgb = hex => {
+  if (!hex) return null
+  const normalized = hex.replace(/^#/, '')
+  const long = /^(\w{2})(\w{2})(\w{2})$/i
+  const match = normalized.match(long)
+  if (!match) return null
+  const [, r, g, b] = match
+  return {
+    r: parseInt(r, 16),
+    g: parseInt(g, 16),
+    b: parseInt(b, 16)
+  }
+}
+
+/**
+ * Converts an RGB object to a hex color string.
+ *
+ * @param {{r: number, g: number, b: number}} param - The RGB object.
+ * @returns {string} The hex color string (e.g., "#ff8800" or "ff8800").
+ */
+export const rgbToHex = ({ r, g, b }) => {
+  const toHex = n => n.toString(16).padStart(2, '0')
+  return `#${toHex(Math.max(0, Math.min(255, r)))}${toHex(
+    Math.max(0, Math.min(255, g))
+  )}${toHex(Math.max(0, Math.min(255, b)))}`
+}
+
+/**
+ * Mixes two RGB objects with a given factor.
+ *
+ * @param {{r: number, g: number, b: number}} colorRgb - The color RGB object.
+ * @param {{r: number, g: number, b: number}} mixRgb - The mix RGB object.
+ * @param {number} factor - The factor (0-1).
+ * @returns {{r: number, g: number, b: number}} The mixed RGB object.
+ */
+export const mixWith = (colorRgb, mixRgb, factor) => {
+  // Linear blend: result = color * (1 - f) + mix * f
+  const f = Math.max(0, Math.min(1, factor))
+  return {
+    r: Math.round(colorRgb.r * (1 - f) + mixRgb.r * f),
+    g: Math.round(colorRgb.g * (1 - f) + mixRgb.g * f),
+    b: Math.round(colorRgb.b * (1 - f) + mixRgb.b * f)
+  }
+}
+
+/**
+ * Generates a shade of a given hex color string.
+ *
+ * @param {string} baseHex - The base hex color string.
+ * @param {{to?: 'white' | 'black', factor?: number}} options - The options.
+ * @returns {string} The shaded hex color string.
+ */
+export const shadeColor = (baseHex, { to = 'white', factor = 0.2 } = {}) => {
+  const base = hexToRgb(baseHex)
+  if (!base) return baseHex
+  const target =
+    to === 'black' ? { r: 0, g: 0, b: 0 } : { r: 255, g: 255, b: 255 }
+  const mixed = mixWith(base, target, factor)
+  return rgbToHex(mixed)
+}
+
 export const makeColumns = isBigThumbnail => {
   const { t } = getDriveI18n()
 

--- a/src/modules/views/Folder/helpers.spec.js
+++ b/src/modules/views/Folder/helpers.spec.js
@@ -1,0 +1,51 @@
+import { hexToRgb, rgbToHex, mixWith, shadeColor } from './helpers'
+
+// Mock locales to make labels deterministic in tests
+jest.mock('@/locales', () => ({
+  getDriveI18n: () => ({ t: k => k })
+}))
+
+describe('color helpers', () => {
+  test('hexToRgb returns null on falsy/invalid inputs', () => {
+    expect(hexToRgb('')).toBeNull()
+    expect(hexToRgb(null)).toBeNull()
+    expect(hexToRgb(undefined)).toBeNull()
+    expect(hexToRgb('zzz')).toBeNull()
+    expect(hexToRgb('#1234')).toBeNull()
+  })
+
+  test('hexToRgb parses 6-digit hex with or without #', () => {
+    expect(hexToRgb('#ff8800')).toEqual({ r: 255, g: 136, b: 0 })
+    expect(hexToRgb('ff8800')).toEqual({ r: 255, g: 136, b: 0 })
+    expect(hexToRgb('#000000')).toEqual({ r: 0, g: 0, b: 0 })
+    expect(hexToRgb('#ffffff')).toEqual({ r: 255, g: 255, b: 255 })
+  })
+
+  test('rgbToHex converts and clamps values into #rrggbb', () => {
+    expect(rgbToHex({ r: 255, g: 136, b: 0 })).toBe('#ff8800')
+    expect(rgbToHex({ r: 0, g: 0, b: 0 })).toBe('#000000')
+    expect(rgbToHex({ r: 255, g: 255, b: 255 })).toBe('#ffffff')
+    // Clamp below 0 and above 255
+    expect(rgbToHex({ r: -20, g: 500, b: 10 })).toBe('#00ff0a')
+  })
+
+  test('mixWith blends two colors linearly by factor', () => {
+    const red = { r: 255, g: 0, b: 0 }
+    const blue = { r: 0, g: 0, b: 255 }
+    expect(mixWith(red, blue, 0)).toEqual({ r: 255, g: 0, b: 0 })
+    expect(mixWith(red, blue, 1)).toEqual({ r: 0, g: 0, b: 255 })
+    expect(mixWith(red, blue, 0.5)).toEqual({ r: 128, g: 0, b: 128 })
+    // Factor is clamped to [0, 1]
+    expect(mixWith(red, blue, -1)).toEqual({ r: 255, g: 0, b: 0 })
+    expect(mixWith(red, blue, 2)).toEqual({ r: 0, g: 0, b: 255 })
+  })
+
+  test('shadeColor mixes towards white or black', () => {
+    expect(shadeColor('#000000', { to: 'white', factor: 0.5 })).toBe('#808080')
+    expect(shadeColor('#ffffff', { to: 'black', factor: 0.5 })).toBe('#808080')
+    expect(shadeColor('#ff0000', { to: 'white', factor: 0.5 })).toBe('#ff8080')
+    expect(shadeColor('#00ff00', { to: 'black', factor: 0.5 })).toBe('#008000')
+    // Fallback to input if base is invalid
+    expect(shadeColor('zzz', { to: 'white', factor: 0.5 })).toBe('zzz')
+  })
+})

--- a/src/styles/folder-customizer.styl
+++ b/src/styles/folder-customizer.styl
@@ -1,18 +1,3 @@
-.iconContainer
-    svg
-        // Keep only the gradient/lightness to combine nicely with overlay
-        filter grayscale(100%) brightness(.2) contrast(1.1)
-
-.iconOverlay
-    // The color is provided by the React component via CSS variable
-    background-color var(--folder-color)
-    mix-blend-mode screen
-
-    // Mask properties (image URL will be set via inline style)
-    mask-size 110% // avoids black border around folder icon
-    mask-repeat no-repeat
-    mask-position center
-
 .iconColorPopper
     z-index 80
 


### PR DESCRIPTION

<img width="563" height="170" alt="image" src="https://github.com/user-attachments/assets/0405417e-67f5-4217-a5c5-e94cd328094f" />

<img width="563" height="170" alt="image" src="https://github.com/user-attachments/assets/bfc49438-1c1c-4eaf-b4e0-d7cf7c0e3b94" />


Using css mask caused leaking mask visible when in dark mode. And I could not find a solution working for dark mode and light mode.

Now using jsx to draw the folders with a gradient which will render the same way with every themes.