### PR TITLE
fix: Failing FilesViewer unit test

### DIFF
--- a/src/modules/viewer/FilesViewer.spec.jsx
+++ b/src/modules/viewer/FilesViewer.spec.jsx
@@ -110,7 +110,7 @@ describe('FilesViewer', () => {
       data: generateFile({ i: '51' })
     })
     const fetchMore = jest.fn().mockImplementation(async () => {
-      await sleep(10)
+      await sleep(50)
     })
 
     const hasMore = jest.fn().mockReturnValue(true)


### PR DESCRIPTION
When running all the unit tests, the FilesViewer test would fail
often with fetchMore having been called more than 1 time. like [here](https://github.com/cozy/cozy-drive/actions/runs/19133014313/job/54678176971?pr=3609)
