### PR TITLE
fix: Do not show divider in public view selection bar

### DIFF
--- a/src/modules/views/Public/PublicFolderView.jsx
+++ b/src/modules/views/Public/PublicFolderView.jsx
@@ -12,10 +12,7 @@ import {
   useSharingInfos,
   OpenSharingLinkFabButton
 } from 'cozy-sharing'
-import {
-  divider,
-  makeActions
-} from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
+import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -46,7 +43,8 @@ import {
   trash,
   rename,
   versions,
-  selectAllItems
+  selectAllItems,
+  hr
 } from '@/modules/actions'
 import { duplicateTo } from '@/modules/actions/components/duplicateTo'
 import { moveTo } from '@/modules/actions/components/moveTo'
@@ -187,10 +185,10 @@ const PublicFolderView = () => {
       download,
       moveTo,
       duplicateTo,
-      divider,
+      hr,
       rename,
       versions,
-      divider,
+      hr,
       trash
     ],
     actionOptions


### PR DESCRIPTION
https://www.notion.so/linagora/Public-page-tool-bar-broken-button-29a62718bad1808fb554e597ce08c9f4