### PR TITLE
fix: Add view switcher to public page

### DIFF
--- a/src/modules/public/PublicToolbarByLink.jsx
+++ b/src/modules/public/PublicToolbarByLink.jsx
@@ -13,6 +13,7 @@ import { useDisplayedFolder } from '@/hooks'
 import { addItems, download, hr, select } from '@/modules/actions'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import AddButton from '@/modules/drive/Toolbar/components/AddButton'
+import ViewSwitcher from '@/modules/drive/Toolbar/components/ViewSwitcher'
 import { DownloadFilesButton } from '@/modules/public/DownloadFilesButton'
 import PublicToolbarMoreMenu from '@/modules/public/PublicToolbarMoreMenu'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
@@ -78,6 +79,7 @@ const PublicToolbarByLink = ({
               </>
             )}
             {files.length > 0 && <DownloadFilesButton files={files} />}
+            <ViewSwitcher className="u-ml-half" />
           </>
         )}
         {isMoreMenuDisplayed && (

--- a/src/modules/public/PublicToolbarCozyToCozy.jsx
+++ b/src/modules/public/PublicToolbarCozyToCozy.jsx
@@ -16,6 +16,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { BarRightOnMobile } from '@/components/Bar'
 import useCurrentFolderId from '@/hooks/useCurrentFolderId'
 import { download, hr, select } from '@/modules/actions'
+import ViewSwitcher from '@/modules/drive/Toolbar/components/ViewSwitcher'
 import { DownloadFilesButton } from '@/modules/public/DownloadFilesButton'
 import PublicToolbarMoreMenu from '@/modules/public/PublicToolbarMoreMenu'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
@@ -63,13 +64,18 @@ const PublicToolbarCozyToCozy = ({ sharingInfos, files }) => {
 
   return (
     <BarRightOnMobile>
-      {!isMobile && files.length > 0 && <DownloadFilesButton files={files} />}
-      {!isMobile && !isSharingShortcutCreated && isOnSharedFolder && (
-        <OpenSharingLinkButton
-          className="u-ml-half"
-          link={addSharingLink}
-          isSharingShortcutCreated={isSharingShortcutCreated}
-        />
+      {!isMobile && (
+        <>
+          {files.length > 0 && <DownloadFilesButton files={files} />}
+          {!isSharingShortcutCreated && isOnSharedFolder && (
+            <OpenSharingLinkButton
+              className="u-ml-half"
+              link={addSharingLink}
+              isSharingShortcutCreated={isSharingShortcutCreated}
+            />
+          )}
+          <ViewSwitcher className="u-ml-half" />
+        </>
       )}
       <PublicToolbarMoreMenu
         files={files}


### PR DESCRIPTION
Now we can change the view in public folder view

<img width="1201" height="439" alt="image" src="https://github.com/user-attachments/assets/e3907cd8-16a2-42a6-a2c1-3e0f8a8dda3b" />

https://www.notion.so/linagora/Drive-cannot-switch-between-table-and-grid-view-in-public-page-2af62718bad180f88335e11e5650fe7e
