### PR TITLE
fix: Hide settings files from recents

### DIFF
--- a/src/hooks/useRecentFiles.jsx
+++ b/src/hooks/useRecentFiles.jsx
@@ -3,8 +3,13 @@ import { useEffect, useState, useMemo } from 'react'
 import { useClient } from 'cozy-client'
 import { useDataProxy } from 'cozy-dataproxy-lib'
 
+import { SETTINGS_DIR_PATH } from '@/constants/config'
 import logger from '@/lib/logger'
 import { buildRecentQuery } from '@/queries'
+
+const filterOutSettingsFiles = files => {
+  return files.filter(file => !file.path?.startsWith(SETTINGS_DIR_PATH))
+}
 
 const useDataProxyRecents = () => {
   const [data, setData] = useState([])
@@ -23,7 +28,7 @@ const useDataProxyRecents = () => {
       if (dataProxy.dataProxyServicesAvailable) {
         try {
           const data = await dataProxy.recents()
-          setData(data || [])
+          setData(filterOutSettingsFiles(data || []))
           setFetchStatus('loaded')
           return
         } catch (err) {
@@ -37,7 +42,7 @@ const useDataProxyRecents = () => {
             definition: recentQuery.definition(),
             options: recentQuery.options
           })
-          setData(result?.data || [])
+          setData(filterOutSettingsFiles(result?.data || []))
           setFetchStatus('loaded')
         } catch (err) {
           logger.warn('Error fetching recents from fallback query', err)


### PR DESCRIPTION
We should hide those files in recents since we already hide theme in the other screens.

I first tried to filter out settings files in the dataproxy request, but files don't have paths in couchdb ou pouchdb databases. Looks like it will not be a big deal to have a little bit less thant 50 files in the results.

https://www.notion.so/linagora/In-recent-view-tab-i-see-my-files-shortcut-homepage-2c862718bad18095bb2bc32515872edf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recent files list now excludes entries from the settings directory, yielding a cleaner, more relevant recent-items view.
* **Tests**
  * Added tests to ensure settings-directory entries are filtered from both primary and fallback recent-data sources and that items lacking a path are preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->