### PR TITLE
fix: Highlight "Sharings" section on shared folders

### DIFF
--- a/src/modules/navigation/SharingsNavItem.jsx
+++ b/src/modules/navigation/SharingsNavItem.jsx
@@ -19,7 +19,7 @@ const SharingsNavItem = ({ clickState }) => {
       to="/sharings"
       icon={<Icon icon={ShareIcon} />}
       label="sharings"
-      rx={/\/sharings(\/.*)?/}
+      rx={/\/sharings(\/.*)?|\/shareddrive(\/.*)?/}
       clickState={clickState}
       badgeContent={newSharingShortcutResult.data?.length}
     />


### PR DESCRIPTION
even when reloading the page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation item for shared content now correctly highlights when accessing both shared folders and shared drives, improving menu consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->