### PR TITLE
feat: Use new ShareExternal icon for sharings section

### DIFF
--- a/src/modules/navigation/SharingsNavItem.jsx
+++ b/src/modules/navigation/SharingsNavItem.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { useQuery } from 'cozy-client'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/ShareExternal'
 
 import { NavItem } from '@/modules/navigation/NavItem'
 import { buildNewSharingShortcutQuery } from '@/queries'


### PR DESCRIPTION
<img width="156" height="77" alt="image" src="https://github.com/user-attachments/assets/e03a62cf-5007-430e-8b8b-f41d02af132c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the icon in the Sharings navigation menu item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->