### PR TITLE
feat: Added migration section leading to settings application 

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "cozy-search": "^0.25.3",
     "cozy-sharing": "^30.1.1",
     "cozy-stack-client": "^60.23.0",
-    "cozy-ui": "^138.3.0",
+    "cozy-ui": "^138.5.0",
     "cozy-ui-plus": "^7.0.0",
     "cozy-viewer": "^28.0.7",
     "date-fns": "2.30.0",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,6 +6,7 @@
     "item_shared": "Shared by me",
     "item_activity": "Activity",
     "item_trash": "Bin",
+    "item_migration": "Migration",
     "item_settings": "Settings",
     "item_collect": "Administrative",
     "item_shared_drives": "Shared drives",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -6,6 +6,7 @@
     "item_shared": "Partagés",
     "item_activity": "Activité",
     "item_trash": "Corbeille",
+    "item_migration": "Migration",
     "item_settings": "Paramètres",
     "item_collect": "Administratif",
     "item_shared_drives": "Drives partagés",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -6,6 +6,7 @@
     "item_shared": "Мои отправленные файлы",
     "item_activity": "Активность",
     "item_trash": "Корзина",
+    "item_migration": "Миграция",
     "item_settings": "Настройки",
     "item_collect": "Администрирование",
     "item_shared_drives": "Общие диски",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -6,6 +6,7 @@
     "item_shared": "Chia sẻ bởi tôi",
     "item_activity": "Hoạt động",
     "item_trash": "Thùng rác",
+    "item_migration": "Di chuyển",
     "item_settings": "Cài đặt",
     "item_collect": "Quản trị",
     "item_shared_drives": "Ổ đĩa dùng chung",

--- a/src/modules/navigation/ExternalNavItem.jsx
+++ b/src/modules/navigation/ExternalNavItem.jsx
@@ -1,0 +1,59 @@
+import PropTypes from 'prop-types'
+import React, { useCallback } from 'react'
+
+import { useClient, generateWebLink } from 'cozy-client'
+import { isFlagshipApp } from 'cozy-device-helper'
+import { useWebviewIntent } from 'cozy-intent'
+import {
+  NavLink as UINavLink,
+  NavItem as UINavItem
+} from 'cozy-ui/transpiled/react/Nav'
+import { useI18n } from 'twake-i18n'
+
+import { NavContent } from '@/modules/navigation/NavContent'
+
+const ExternalNavItem = ({ slug, icon, label, path, clickState }) => {
+  const { t } = useI18n()
+  const client = useClient()
+  const webviewIntent = useWebviewIntent()
+
+  const href = generateWebLink({
+    slug,
+    cozyUrl: client.getStackClient().uri,
+    subDomainType: client.getInstanceOptions().subdomain,
+    ...(path && { hash: path })
+  })
+
+  const handleClick = useCallback(
+    e => {
+      e.preventDefault()
+      if (clickState) {
+        clickState[1](undefined)
+      }
+      if (isFlagshipApp()) {
+        webviewIntent.call('openApp', href, { slug })
+      } else {
+        window.location.href = href
+      }
+    },
+    [href, slug, webviewIntent, clickState]
+  )
+
+  return (
+    <UINavItem>
+      <a href={href} onClick={handleClick} className={UINavLink.className}>
+        <NavContent icon={icon} label={t(`Nav.item_${label}`)} />
+      </a>
+    </UINavItem>
+  )
+}
+
+ExternalNavItem.propTypes = {
+  slug: PropTypes.string.isRequired,
+  icon: PropTypes.element.isRequired,
+  label: PropTypes.string.isRequired,
+  path: PropTypes.string,
+  clickState: PropTypes.array
+}
+
+export { ExternalNavItem }

--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -1,13 +1,16 @@
 import React from 'react'
 
+import flag from 'cozy-flags'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ClockIcon from 'cozy-ui/transpiled/react/Icons/ClockOutline'
 import CloudIcon from 'cozy-ui/transpiled/react/Icons/Cloud2'
+import CloudSyncIcon from 'cozy-ui/transpiled/react/Icons/CloudSync'
 import StarIcon from 'cozy-ui/transpiled/react/Icons/Star'
 import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import UINav from 'cozy-ui/transpiled/react/Nav'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
+import { ExternalNavItem } from '@/modules/navigation/ExternalNavItem'
 import { FavoriteList } from '@/modules/navigation/FavoriteList'
 import { useNavContext } from '@/modules/navigation/NavContext'
 import { NavItem } from '@/modules/navigation/NavItem'
@@ -51,6 +54,15 @@ export const Nav = () => {
         rx={/\/trash(\/.*)?/}
         clickState={clickState}
       />
+      {flag('settings.migration.enabled') && (
+        <ExternalNavItem
+          slug="settings"
+          icon={<Icon icon={CloudSyncIcon} />}
+          label="migration"
+          path="/migration"
+          clickState={clickState}
+        />
+      )}
       {isDesktop ? <FavoriteList clickState={clickState} /> : null}
       {isDesktop ? (
         <ExternalDrives clickState={clickState} className="u-mt-half" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7201,10 +7201,10 @@ cozy-ui-plus@^7.0.0:
     react-international-phone "4.7.0"
     rooks "7.14.1"
 
-cozy-ui@^138.3.0:
-  version "138.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-138.3.0.tgz#4c942eac3d4ade742606364aadd686c01cbc4ce8"
-  integrity sha512-qmIDfDROMPzz4xtwFC5rgbxuTw6cR4bBRFAsikBlcdXjLuUlQBHopWghjIWmTQZydWUPwF2eLthNrha6DuFrpQ==
+cozy-ui@^138.5.0:
+  version "138.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-138.5.0.tgz#80e12877b0cedcbc62b5395c4c12611f4fdf8354"
+  integrity sha512-0B/+xRV/+0tExMdD9QmVPl936WXX59HoDy2LWWmzzk5eOcP8DVJyoTucjI9HQipBB6lmLGcatsDQXYEu/axCUQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"
@@ -12551,9 +12551,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
behind settings.migration.enabled flag

<img width="247" height="232" alt="image" src="https://github.com/user-attachments/assets/fbb73d4a-74f0-4624-bd95-d4f26f93bcec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Migration" navigation item in the app header; visible when the related feature flag is enabled. Translations added for English, French, Russian, and Vietnamese.

* **Chores**
  * Bumped cozy-ui dependency to ^138.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->