### PR TITLE
fix: handle directory conflict on re-upload

### DIFF
--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -346,6 +346,13 @@ const getExistingDirectory = async (client, dirID, name, driveId) => {
   const statResp = await client
     .collection(DOCTYPE_FILES, { driveId })
     .statByPath(path)
+  if (statResp.data.type !== 'directory') {
+    const err = new Error(
+      `"${path}" already exists and is not a directory`
+    )
+    err.status = CONFLICT_ERROR
+    throw err
+  }
   return statResp.data
 }
 

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -347,9 +347,7 @@ const getExistingDirectory = async (client, dirID, name, driveId) => {
     .collection(DOCTYPE_FILES, { driveId })
     .statByPath(path)
   if (statResp.data.type !== 'directory') {
-    const err = new Error(`"${path}" already exists and is not a directory`)
-    err.status = CONFLICT_ERROR
-    throw err
+    throw new Error(`"${path}" already exists and is not a directory`)
   }
   return statResp.data
 }

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -250,9 +250,7 @@ export const processNextFile =
       error = uploadError
       if (uploadError.status === CONFLICT_ERROR) {
         try {
-          const path = driveId
-            ? await getFullpath(client, dirID, file.name, driveId)
-            : await CozyFile.getFullpath(dirID, file.name)
+          const path = await resolveFullpath(client, dirID, file.name, driveId)
 
           const uploadedFile = await overwriteFile(
             client,
@@ -338,6 +336,19 @@ const readAllEntries = async dirReader => {
   return entries
 }
 
+const resolveFullpath = (client, dirID, name, driveId) =>
+  driveId
+    ? getFullpath(client, dirID, name, driveId)
+    : CozyFile.getFullpath(dirID, name)
+
+const getExistingDirectory = async (client, dirID, name, driveId) => {
+  const path = await resolveFullpath(client, dirID, name, driveId)
+  const statResp = await client
+    .collection(DOCTYPE_FILES, { driveId })
+    .statByPath(path)
+  return statResp.data
+}
+
 const uploadDirectory = async (
   client,
   directory,
@@ -345,7 +356,21 @@ const uploadDirectory = async (
   { vaultClient, encryptionKey },
   driveId
 ) => {
-  const newDir = await createFolder(client, directory.name, dirID, driveId)
+  let newDir
+  try {
+    newDir = await createFolder(client, directory.name, dirID, driveId)
+  } catch (err) {
+    if (err.status === CONFLICT_ERROR) {
+      newDir = await getExistingDirectory(
+        client,
+        dirID,
+        directory.name,
+        driveId
+      )
+    } else {
+      throw err
+    }
+  }
   const dirReader = directory.createReader()
   const options = { vaultClient, encryptionKey }
 

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -347,9 +347,7 @@ const getExistingDirectory = async (client, dirID, name, driveId) => {
     .collection(DOCTYPE_FILES, { driveId })
     .statByPath(path)
   if (statResp.data.type !== 'directory') {
-    const err = new Error(
-      `"${path}" already exists and is not a directory`
-    )
+    const err = new Error(`"${path}" already exists and is not a directory`)
     err.status = CONFLICT_ERROR
     throw err
   }


### PR DESCRIPTION
## Summary

- Re-uploading a directory that already exists was showing "no internet connection" instead of working correctly
- When `createFolder` gets a 409 (directory exists), the error bubbles up to `processNextFile` which assumes all 409s are file conflicts. It tries to resolve the conflict by calling `overwriteFile`, a file-only operation that fails on directories. That secondary failure has no HTTP status code, so it falls through to the `Failed to fetch` regex check and gets misclassified as a network error
- `uploadDirectory` now catches the 409 itself, fetches the existing directory via `statByPath`, and uses it as the parent for uploading contents into it. This way directory conflicts never reach the file-level conflict handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conflict handling when uploading folders so overwrites resolve to the correct target path.
  * When folder creation conflicts with an existing entry, the upload now detects and validates the existing directory and reuses its metadata instead of failing.
  * Other (non-conflict) errors during folder creation continue to be surfaced unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->