### PR TITLE
fix: show proper error message on upload failure

### DIFF
--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -209,16 +209,8 @@ const uploadQueueProcessed =
       })
     } else if (errors.length > 0) {
       logger.error(`Upload module triggers an error: ${errors}`)
-      // Show more detailed error message
-      const errorMessages = errors
-        .map(err => err.message || JSON.stringify(err))
-        .join(', ')
       showAlert({
-        message: t('upload.alert.errors_detailed', {
-          type,
-          count: errors.length,
-          details: errorMessages
-        }),
+        message: t('upload.alert.errors', { type }),
         severity: 'secondary'
       })
     } else if (updatedCount > 0 && createdCount > 0 && conflictCount > 0) {


### PR DESCRIPTION
## Summary

- Upload errors were showing the raw translation key `upload.alert.errors_detailed` instead of a human-readable message
- This key was introduced in commit 2c5115c88 but never added to any locale file
- Reverts to the existing `upload.alert.errors` key which properly says "Une erreur est survenue lors de l'import..."
- The "detailed" version was dumping raw `err.message` or `JSON.stringify(err)` to the user, which produces internal strings like "Failed to fetch" or JSON blobs that are meaningless to end users