### PR TITLE
fix: show error when files cannot be read during upload

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -359,7 +359,7 @@
       "errors": "Errors occurred during the %{type} upload.",
       "network": "You are currenly offline. Please try again once you're connected.",
       "fileTooLargeErrors": "File too large. Maximum file size: %{max_size_value} GB",
-      "unreadable_files": "Some files could not be read. The file path is probably too long."
+      "unreadable_files": "Some files could not be read. The file path may be too long or the folder was modified during the transfer."
     },
     "limit": {
       "title": "You cannot upload more than %{limit} files at a time.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -358,7 +358,8 @@
       "updated_conflicts": "%{smart_count} %{type} updated with %{conflictCount} conflict(s). |||| %{smart_count} %{type} updated with %{conflictCount} conflict(s).",
       "errors": "Errors occurred during the %{type} upload.",
       "network": "You are currenly offline. Please try again once you're connected.",
-      "fileTooLargeErrors": "File too large. Maximum file size: %{max_size_value} GB"
+      "fileTooLargeErrors": "File too large. Maximum file size: %{max_size_value} GB",
+      "unreadable_files": "Some files could not be read. The file path is probably too long."
     },
     "limit": {
       "title": "You cannot upload more than %{limit} files at a time.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -356,7 +356,7 @@
       "errors": "Une erreur est survenue lors de l’import du %{type}, merci de réessayer plus tard.",
       "network": "Vous ne disposez pas d'une connexion internet. Merci de réessayer quand ce sera le cas.",
       "fileTooLargeErrors": "Fichier trop volumineux. Taille maximale autorisée par fichier : %{max_size_value} Go",
-      "unreadable_files": "Certains fichiers n'ont pas pu être lus. Le chemin de vos fichiers est probablement trop long."
+      "unreadable_files": "Certains fichiers n'ont pas pu être lus. Le chemin est peut-être trop long ou le dossier a été modifié pendant le transfert."
     },
     "limit": {
       "title": "Importation impossible : Ce dossier contient plus de %{limit} fichiers",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -355,7 +355,8 @@
       "updated_conflicts": "%{smart_count} %{type} mis à jour avec %{conflictCount} conflit(s). |||| %{smart_count} %{type} mis à jour avec %{conflictCount} conflit(s).",
       "errors": "Une erreur est survenue lors de l’import du %{type}, merci de réessayer plus tard.",
       "network": "Vous ne disposez pas d'une connexion internet. Merci de réessayer quand ce sera le cas.",
-      "fileTooLargeErrors": "Fichier trop volumineux. Taille maximale autorisée par fichier : %{max_size_value} Go"
+      "fileTooLargeErrors": "Fichier trop volumineux. Taille maximale autorisée par fichier : %{max_size_value} Go",
+      "unreadable_files": "Certains fichiers n'ont pas pu être lus. Le chemin de vos fichiers est probablement trop long."
     },
     "limit": {
       "title": "Importation impossible : Ce dossier contient plus de %{limit} fichiers",

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -108,9 +108,19 @@ export const uploadFiles =
         dispatch(showModal(<UploadLimitDialog maxFileCount={maxFileCount} />))
         return
       }
-    } catch {
+    } catch (error) {
+      if (error?.name === 'NotFoundError') {
+        showAlert({
+          message: t('upload.alert.unreadable_files'),
+          severity: 'secondary'
+        })
+        return
+      }
+      logger.error('Unexpected error while checking upload file limit', error)
       showAlert({
-        message: t('upload.alert.unreadable_files'),
+        message: t('upload.alert.errors', {
+          type: t('upload.documentType.file')
+        }),
         severity: 'secondary'
       })
       return

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -103,8 +103,16 @@ export const uploadFiles =
     // Extract entries synchronously before browser clears dataTransfer
     const entries = extractFilesEntries(files)
 
-    if (await exceedsFileLimit(entries, maxFileCount)) {
-      dispatch(showModal(<UploadLimitDialog maxFileCount={maxFileCount} />))
+    try {
+      if (await exceedsFileLimit(entries, maxFileCount)) {
+        dispatch(showModal(<UploadLimitDialog maxFileCount={maxFileCount} />))
+        return
+      }
+    } catch {
+      showAlert({
+        message: t('upload.alert.unreadable_files'),
+        severity: 'secondary'
+      })
       return
     }
 


### PR DESCRIPTION
## Summary

- On Windows, uploading a directory with deeply nested paths (exceeding the 260 character limit) causes the browser to throw `NotFoundError` during directory enumeration
- This was crashing the upload silently, with no error message and no 500-file limit popup
- Now we catch the error from `exceedsFileLimit` and show a clear message: "Certains fichiers n'ont pas pu être lus. Le chemin de vos fichiers est probablement trop long."
- The upload is blocked so the user knows to shorten their paths before retrying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added English and French translations for an "unreadable files" upload message.

* **Bug Fixes**
  * Improved upload error handling so users are notified when files cannot be read (e.g., path too long or folder changed).
  * Other upload failures now surface a clear generic alert instead of failing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->