### PR TITLE
fix: skip files.settings query in public OnlyOffice view

### DIFF
--- a/src/modules/views/OnlyOffice/Toolbar/EditButton.jsx
+++ b/src/modules/views/OnlyOffice/Toolbar/EditButton.jsx
@@ -126,10 +126,10 @@ const EditButtonWrapper = () => {
   const { isPublic } = useOnlyOfficeContext()
 
   if (isPublic) {
-    return <EditButtonWithQuery />
+    return <EditButton openTooltip={false} />
   }
 
-  return <EditButton openTooltip={false} />
+  return <EditButtonWithQuery />
 }
 
 export default EditButtonWrapper


### PR DESCRIPTION
## Summary

- The `EditButton` wrapper in the OnlyOffice toolbar had its public/private branches inverted: public viewers were the ones running the `io.cozy.files.settings` `useQuery` while logged-in users skipped it. Public tokens have no permission on that doctype, so every OnlyOffice mount on a `/public` route triggered a 403.
- Swap the branches to match the intent of the original guard: skip the query in public mode, run it for logged-in users.

## Sentry

Primary issue: `DRIVE-ZG2` (117k events, 12.7k users). The same root cause is regrouped across releases as the chunk hash changes, including `DRIVE-ZZ7` (81k / 10.5k), `DRIVE-YYM` (70k / 1.1k), `DRIVE-ZGM` (29k / 3.1k), `DRIVE-ZH7` (22k / 5k), `DRIVE-Z00` (22k / 0.4k), `DRIVE-1021` (20k / 2.5k), `DRIVE-107X` (19k / 5.2k), `DRIVE-10MS` (8k / 2.4k), `DRIVE-10VF` (5.8k / 1.7k), and others. Combined this is the highest-volume unresolved error on the project.