### PR TITLE
fix: stop querying /konnectors for non-konnector apps

### DIFF
--- a/src/lib/konnectors.js
+++ b/src/lib/konnectors.js
@@ -1,0 +1,24 @@
+import { getReferencedBy } from 'cozy-client'
+
+import { DOCTYPE_KONNECTORS } from '@/lib/doctypes'
+
+/**
+ * Returns the slug of the konnector that produced the given file, or null
+ * if the file is not referenced by any konnector.
+ *
+ * Konnector-created files carry an explicit `io.cozy.konnectors/<slug>`
+ * entry in their `referenced_by` list. We read the first such reference
+ * and strip the doctype prefix to recover the bare slug (e.g. "edf").
+ *
+ * `cozyMetadata.createdByApp` is intentionally not used: it is set by any
+ * app or konnector that creates files (drive, notes, ...), so its value
+ * can be an app slug that does not exist as a konnector and would 404
+ * against `GET /konnectors/<slug>` on cozy-stack.
+ *
+ * @param {import('cozy-client/types/types').IOCozyFile} file - A file doc with its references hydrated.
+ * @returns {string|null} The konnector slug, or null when the file has no konnector reference.
+ */
+export const getKonnectorSlugFromFile = file => {
+  const ref = getReferencedBy(file, DOCTYPE_KONNECTORS)[0]
+  return ref?.id?.replace(`${DOCTYPE_KONNECTORS}/`, '') ?? null
+}

--- a/src/modules/filelist/icons/BadgeKonnector.jsx
+++ b/src/modules/filelist/icons/BadgeKonnector.jsx
@@ -1,26 +1,14 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import {
-  getReferencedBy,
-  isQueryLoading,
-  isReferencedBy,
-  useQuery
-} from 'cozy-client'
+import { isQueryLoading, isReferencedBy, useQuery } from 'cozy-client'
 import Badge from 'cozy-ui/transpiled/react/Badge'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 import AppIcon from 'cozy-ui-plus/dist/AppIcon'
 
 import { DOCTYPE_KONNECTORS } from '@/lib/doctypes'
+import { getKonnectorSlugFromFile } from '@/lib/konnectors'
 import { buildFileOrFolderByIdQuery } from '@/queries'
-
-const getKonnectorSlugFromFile = file => {
-  const konnector = getReferencedBy(file, DOCTYPE_KONNECTORS)[0]
-  if (konnector) {
-    return konnector.id.split('/')[1]
-  }
-  return null
-}
 
 const useStyle = makeStyles({
   badge: {

--- a/src/modules/views/Drive/HarvestBanner.jsx
+++ b/src/modules/views/Drive/HarvestBanner.jsx
@@ -7,6 +7,7 @@ import Divider from 'cozy-ui/transpiled/react/Divider'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import useDocument from '@/components/useDocument'
+import { getKonnectorSlugFromFile } from '@/lib/konnectors'
 import {
   buildTriggersQueryByAccountId,
   buildFileOrFolderByIdQuery
@@ -26,7 +27,7 @@ const HarvestBanner = ({ folderId }) => {
     enabled: Boolean(fileId)
   })
   if (file.data) {
-    konnectorSlug = file.data.cozyMetadata?.createdByApp
+    konnectorSlug = getKonnectorSlugFromFile(file.data)
     accountId = file.data.cozyMetadata?.sourceAccount
   }
   const queryTriggers = buildTriggersQueryByAccountId(accountId)


### PR DESCRIPTION
## Summary

- `HarvestBanner` derived the konnector slug from `cozyMetadata.createdByApp`, but that field is set by any app or konnector that creates files (e.g. `drive`, `notes`). Every folder navigation in the drive view fired `GET /konnectors/<slug>` against cozy-stack, which returned 404 "Application is not installed" for app slugs, and the unhandled rejection bubbled up.
- Switch to the file's `io.cozy.konnectors` reference, which only exists for files actually produced by a konnector. Same canonical signal that `BadgeKonnector` already uses.
- Extract the helper to `@/lib/konnectors` so both call sites share it.

## Sentry

This is the second highest-volume cluster. Across roughly fifteen issue groups (regrouped per release as the chunk hash changes) it accounts for about 17k unique users and 60k+ events. Top representatives: `DRIVE-ZDY` (3.2k / 15k), `DRIVE-ZGK` (2.4k / 18k), `DRIVE-ZT2` (1.8k / 12k), `DRIVE-ZHA` (1.5k / 4k), `DRIVE-ZYC` (1.1k / 3k), `DRIVE-10MT` (786 / 2.5k), `DRIVE-10VE` (587 / 1.7k, still firing). All share the same `GET /konnectors/<slug>` 404 trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized konnector identifier extraction into a shared helper; file badges and the harvest banner now use this shared logic. The components preserve existing behavior (including when konnector data is absent or loading) and there are no visible UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->