### PR TITLE
fix: skip i18n format on falsy file row dates

### DIFF
--- a/src/modules/filelist/File.jsx
+++ b/src/modules/filelist/File.jsx
@@ -34,6 +34,7 @@ import {
 } from '@/modules/drive/rename'
 import FileOpener from '@/modules/filelist/FileOpener'
 import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
+import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 
 const FileWrapper = ({ children, viewType, className, onContextMenu }) =>
@@ -64,7 +65,6 @@ const ThumbnailWrapper = ({ children, viewType, className }) =>
 
 const File = ({
   t,
-  f,
   attributes,
   actions,
   isRenaming,
@@ -75,7 +75,7 @@ const File = ({
   refreshFolderContent,
   isInSyncFromSharing,
   extraColumns,
-  breakpoints: { isExtraLarge, isMobile },
+  breakpoints: { isMobile },
   disableSelection = false,
   canInteractWith,
   onContextMenu,
@@ -129,12 +129,7 @@ const File = ({
       : undefined
 
   const updatedAt = attributes.updated_at || attributes.created_at
-  const formattedUpdatedAt = f(
-    updatedAt,
-    isExtraLarge
-      ? t('table.row_update_format_full')
-      : t('table.row_update_format')
-  )
+  const formattedUpdatedAt = useFormattedUpdatedAt(updatedAt)
 
   // We don't allow any action on shared drives and trash
   // because they are magic folder created by the stack
@@ -274,7 +269,6 @@ const File = ({
 
 File.propTypes = {
   t: PropTypes.func,
-  f: PropTypes.func,
   attributes: PropTypes.object.isRequired,
   actions: PropTypes.array,
   isRenaming: PropTypes.bool,
@@ -294,10 +288,10 @@ File.propTypes = {
 }
 
 export const DumbFile = props => {
-  const { t, f } = useI18n()
+  const { t } = useI18n()
   const breakpoints = useBreakpoints()
 
-  return <File t={t} f={f} breakpoints={breakpoints} {...props} />
+  return <File t={t} breakpoints={breakpoints} {...props} />
 }
 
 export const FileWithSelection = props => {

--- a/src/modules/filelist/useFormattedUpdatedAt.js
+++ b/src/modules/filelist/useFormattedUpdatedAt.js
@@ -1,0 +1,30 @@
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'twake-i18n'
+
+/**
+ * Returns the formatted "last updated" string for a file row, or undefined
+ * when the date is falsy.
+ *
+ * The guard matters: twake-i18n's `f()` calls date-fns `format()`, which
+ * throws on falsy/invalid dates. The library catches the throw but logs it
+ * via `console.error('Error in initFormat', ...)`, which our Sentry config
+ * captures. Synthetic rows in the file list (shared-drive entries, sharing
+ * placeholders) often lack `updated_at`/`created_at`, so we'd otherwise
+ * emit a Sentry event for every such row.
+ *
+ * @param {string | undefined} updatedAt
+ * @returns {string | undefined}
+ */
+export const useFormattedUpdatedAt = updatedAt => {
+  const { f, t } = useI18n()
+  const { isExtraLarge } = useBreakpoints()
+
+  if (!updatedAt) return undefined
+
+  return f(
+    updatedAt,
+    isExtraLarge
+      ? t('table.row_update_format_full')
+      : t('table.row_update_format')
+  )
+}

--- a/src/modules/filelist/virtualized/GridFile.jsx
+++ b/src/modules/filelist/virtualized/GridFile.jsx
@@ -30,12 +30,12 @@ import {
 } from '@/modules/drive/rename'
 import FileOpener from '@/modules/filelist/FileOpener'
 import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
+import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightProvider'
 
 const GridFile = ({
   t,
-  f,
   attributes,
   actions,
   isRenaming,
@@ -44,7 +44,7 @@ const GridFile = ({
   disabled,
   refreshFolderContent,
   isInSyncFromSharing,
-  breakpoints: { isExtraLarge, isMobile },
+  breakpoints: { isMobile },
   disableSelection = false,
   canInteractWith,
   onContextMenu,
@@ -86,12 +86,7 @@ const GridFile = ({
       : undefined
 
   const updatedAt = attributes.updated_at || attributes.created_at
-  const formattedUpdatedAt = f(
-    updatedAt,
-    isExtraLarge
-      ? t('table.row_update_format_full')
-      : t('table.row_update_format')
-  )
+  const formattedUpdatedAt = useFormattedUpdatedAt(updatedAt)
 
   // We don't allow any action on shared drives and trash
   // because they are magic folder created by the stack
@@ -213,7 +208,6 @@ const GridFile = ({
 
 GridFile.propTypes = {
   t: PropTypes.func,
-  f: PropTypes.func,
   attributes: PropTypes.object.isRequired,
   actions: PropTypes.array,
   isRenaming: PropTypes.bool,
@@ -233,10 +227,10 @@ GridFile.propTypes = {
 }
 
 export const DumbGridFile = props => {
-  const { t, f } = useI18n()
+  const { t } = useI18n()
   const breakpoints = useBreakpoints()
 
-  return <GridFile t={t} f={f} breakpoints={breakpoints} {...props} />
+  return <GridFile t={t} breakpoints={breakpoints} {...props} />
 }
 
 export const GridFileWithSelection = props => {

--- a/src/modules/filelist/virtualized/cells/Cell.jsx
+++ b/src/modules/filelist/virtualized/cells/Cell.jsx
@@ -7,8 +7,6 @@ import { isDirectory } from 'cozy-client/dist/models/file'
 import { isSharingShortcut } from 'cozy-client/dist/models/file'
 import { useVaultClient } from 'cozy-keys-lib'
 import { useSharingContext } from 'cozy-sharing'
-import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'twake-i18n'
 
 import AcceptingSharingContext from '@/lib/AcceptingSharingContext'
 import { ActionMenuWithHeader } from '@/modules/actionmenu/ActionMenuWithHeader'
@@ -20,6 +18,7 @@ import {
 } from '@/modules/drive/rename'
 import AddFolder from '@/modules/filelist/AddFolder'
 import FileOpener from '@/modules/filelist/FileOpener'
+import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
 import FileAction from '@/modules/filelist/virtualized/cells/FileAction'
 import FileName from '@/modules/filelist/virtualized/cells/FileName'
 import LastUpdate from '@/modules/filelist/virtualized/cells/LastUpdate'
@@ -39,10 +38,8 @@ const Cell = ({
   refreshFolderContent,
   driveId
 }) => {
-  const { f, t } = useI18n()
   const vaultClient = useVaultClient()
 
-  const { isExtraLarge } = useBreakpoints()
   const { sharingsValue } = useContext(AcceptingSharingContext)
   const { byDocId } = useSharingContext()
   const filerowMenuToggleRef = useRef()
@@ -56,6 +53,9 @@ const Cell = ({
     state =>
       isRenamingSelector(state) && get(getRenamingFile(state), 'id') === row.id
   )
+
+  const updatedAt = row.updated_at || row.created_at
+  const formattedUpdatedAt = useFormattedUpdatedAt(updatedAt)
 
   if (row.type === 'tempDirectory') {
     if (column.id === 'name') {
@@ -78,13 +78,6 @@ const Cell = ({
 
   const formattedSize =
     !isDirectory(row) && row.size ? filesize(row.size, { base: 10 }) : undefined
-  const updatedAt = row.updated_at || row.created_at
-  const formattedUpdatedAt = f(
-    updatedAt,
-    isExtraLarge
-      ? t('table.row_update_format_full')
-      : t('table.row_update_format')
-  )
   const isSharingContextEmpty = Object.keys(sharingsValue).length <= 0
   const isInSyncFromSharing =
     !isSharingContextEmpty &&

--- a/src/modules/filelist/virtualized/cells/LastUpdate.jsx
+++ b/src/modules/filelist/virtualized/cells/LastUpdate.jsx
@@ -7,7 +7,10 @@ const LastUpdate = ({ date, formatted }) => {
   const { f, t } = useI18n()
 
   return (
-    <time dateTime={date} title={f(date, t('LastUpdate.titleFormat'))}>
+    <time
+      dateTime={date}
+      {...(formatted && { title: f(date, t('LastUpdate.titleFormat')) })}
+    >
       {formatted}
     </time>
   )


### PR DESCRIPTION
## Problem

File rows in the drive list were emitting one Sentry event per render when their row had no `updated_at` or `created_at`. Hits concentrated on `/sharings` and the shared-drives view, where synthetic entries often lack timestamps.

## Cause

Row components called the i18n date formatter unconditionally. twake-i18n's `initFormat` calls date-fns `format()`, which throws on falsy dates; the library catches the throw but logs it via `console.error`. Our Sentry init runs `captureConsoleIntegration({ levels: ['error'] })`, so every such catch becomes an event.

## Fix

A small `useFormattedUpdatedAt` hook returns `undefined` for falsy dates. The three row sites (`File`, `GridFile`, virtualized `Cell`) use it instead of calling the formatter directly, and the virtualized `LastUpdate` cell only sets `title` when there is a value.

## Sentry

`RangeError: Invalid time value` cluster, all logged with the `Error in initFormat` prefix from twake-i18n: `DRIVE-ZV5` (10 users / 427 events), `DRIVE-ZV6` (10 / 205), `DRIVE-ZV7` (10 / 215), `DRIVE-ZV8` (5 / 125), `DRIVE-10MM` (2 / 136). Concentrated on the `/sharings` and `/folder/io.cozy.files.shared-drives-dir` routes where synthetic rows lacking timestamps render through the file list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized date formatting for file listings into a shared hook, simplifying components and ensuring consistent "last updated" text across views.
* **Bug Fixes**
  * Avoids formatting when no update timestamp is available and stops rendering empty title attributes on last-update timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->