### PR TITLE
feat: add Nextcloud migration progress banner

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -228,6 +228,11 @@
       "description": "Required to access the drive settings",
       "type": "io.cozy.drive.settings",
       "verbs": ["ALL"]
+    },
+    "nextcloud_migrations": {
+      "description": "Read Nextcloud migration documents and subscribe to updates",
+      "type": "io.cozy.nextcloud.migrations",
+      "verbs": ["GET"]
     }
   },
   "accept_from_flagship": true,

--- a/src/components/Migration/MigrationProgressBanner.jsx
+++ b/src/components/Migration/MigrationProgressBanner.jsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useEffect, useState } from 'react'
+
+import { useClient, useQuery } from 'cozy-client'
+import Buttons from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Upload from 'cozy-ui/transpiled/react/Icons/Upload'
+import ProgressionBanner from 'cozy-ui/transpiled/react/ProgressionBanner'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+import { useI18n } from 'twake-i18n'
+
+import { NEXTCLOUD_MIGRATIONS_DOCTYPE } from '@/lib/doctypes'
+import logger from '@/lib/logger'
+import { buildRunningMigrationQuery } from '@/queries'
+
+const SNACKBAR_AUTO_HIDE_MS = 6000
+
+const DumbMigrationProgressBanner = ({ migrationDoc }) => {
+  const { t } = useI18n()
+  const client = useClient()
+  const { showAlert } = useAlert()
+
+  const migrationId = migrationDoc?._id
+
+  const [isCanceling, setIsCanceling] = useState(false)
+
+  useEffect(() => {
+    if (!migrationId) return
+
+    const handleUpdate = doc => {
+      if (doc.status === 'completed') {
+        showAlert({
+          title: t('MigrationProgressBanner.done.title'),
+          message: t('MigrationProgressBanner.done.body', {
+            count: doc.progress?.files_total ?? 0
+          }),
+          severity: 'success',
+          duration: SNACKBAR_AUTO_HIDE_MS
+        })
+      }
+    }
+
+    client.plugins.realtime.subscribe(
+      'updated',
+      NEXTCLOUD_MIGRATIONS_DOCTYPE,
+      migrationId,
+      handleUpdate
+    )
+    return () => {
+      client.plugins.realtime.unsubscribe(
+        'updated',
+        NEXTCLOUD_MIGRATIONS_DOCTYPE,
+        migrationId,
+        handleUpdate
+      )
+    }
+  }, [client, migrationId, showAlert, t])
+
+  const handleCancel = useCallback(async () => {
+    if (!migrationId || isCanceling) return
+    setIsCanceling(true)
+    try {
+      await client
+        .getStackClient()
+        .fetchJSON('POST', `/remote/nextcloud/migration/${migrationId}/cancel`)
+    } catch (e) {
+      if (e.status !== 409) logger.error('Migration cancel failed', e)
+    } finally {
+      setIsCanceling(false)
+    }
+  }, [client, migrationId, isCanceling])
+
+  const progress = migrationDoc?.progress
+  const percent =
+    progress?.bytes_total > 0
+      ? Math.round((progress.bytes_imported / progress.bytes_total) * 100)
+      : 0
+
+  return (
+    <ProgressionBanner
+      icon={<Icon icon={Upload} size={16} />}
+      text={
+        <>
+          {t('MigrationProgressBanner.title')}
+          {' · '}
+          <span data-testid="migration-progress-banner-percent">
+            {t('MigrationProgressBanner.percent', { percent })}
+          </span>
+        </>
+      }
+      value={percent}
+      button={
+        <>
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            data-testid="migration-progress-banner-importing"
+          >
+            {t('MigrationProgressBanner.importing', {
+              count: progress?.files_total ?? 0
+            })}
+          </Typography>
+          <Buttons
+            variant="text"
+            size="small"
+            label={t('MigrationProgressBanner.cancel')}
+            onClick={handleCancel}
+            disabled={isCanceling}
+            busy={isCanceling}
+            data-testid="migration-progress-banner-cancel"
+          />
+        </>
+      }
+    />
+  )
+}
+
+export const MigrationProgressBanner = () => {
+  const runningMigrationQuery = buildRunningMigrationQuery()
+  const { data: runningMigrations } = useQuery(
+    runningMigrationQuery.definition,
+    runningMigrationQuery.options
+  )
+  const migrationDoc = runningMigrations?.[0] ?? null
+
+  if (!migrationDoc) return null
+
+  return <DumbMigrationProgressBanner migrationDoc={migrationDoc} />
+}

--- a/src/components/Migration/MigrationProgressBanner.jsx
+++ b/src/components/Migration/MigrationProgressBanner.jsx
@@ -15,50 +15,64 @@ import { buildRunningMigrationQuery } from '@/queries'
 
 const SNACKBAR_AUTO_HIDE_MS = 6000
 
-const DumbMigrationProgressBanner = ({ migrationDoc }) => {
-  const { t } = useI18n()
+const computeMigrationPercent = progress => {
+  if (!progress?.bytes_total) return 0
+
+  return Math.round((progress.bytes_imported / progress.bytes_total) * 100)
+}
+
+const showCompletedMigrationAlert = ({ doc, showAlert, t }) => {
+  if (doc.status !== 'completed') return
+
+  showAlert({
+    title: t('MigrationProgressBanner.done.title'),
+    message: t('MigrationProgressBanner.done.body', {
+      count: doc.progress?.files_total ?? 0
+    }),
+    severity: 'success',
+    duration: SNACKBAR_AUTO_HIDE_MS
+  })
+}
+
+const useMigrationCompletionAlert = ({ migrationId }) => {
   const client = useClient()
   const { showAlert } = useAlert()
-
-  const migrationId = migrationDoc?._id
-
-  const [isCanceling, setIsCanceling] = useState(false)
+  const { t } = useI18n()
 
   useEffect(() => {
     if (!migrationId) return
 
-    const handleUpdate = doc => {
-      if (doc.status === 'completed') {
-        showAlert({
-          title: t('MigrationProgressBanner.done.title'),
-          message: t('MigrationProgressBanner.done.body', {
-            count: doc.progress?.files_total ?? 0
-          }),
-          severity: 'success',
-          duration: SNACKBAR_AUTO_HIDE_MS
-        })
-      }
+    const handleMigrationUpdate = doc => {
+      showCompletedMigrationAlert({ doc, showAlert, t })
     }
 
     client.plugins.realtime.subscribe(
       'updated',
       NEXTCLOUD_MIGRATIONS_DOCTYPE,
       migrationId,
-      handleUpdate
+      handleMigrationUpdate
     )
+
     return () => {
       client.plugins.realtime.unsubscribe(
         'updated',
         NEXTCLOUD_MIGRATIONS_DOCTYPE,
         migrationId,
-        handleUpdate
+        handleMigrationUpdate
       )
     }
   }, [client, migrationId, showAlert, t])
+}
+
+const useMigrationCancel = ({ migrationId }) => {
+  const client = useClient()
+  const [isCanceling, setIsCanceling] = useState(false)
 
   const handleCancel = useCallback(async () => {
     if (!migrationId || isCanceling) return
+
     setIsCanceling(true)
+
     try {
       await client
         .getStackClient()
@@ -68,13 +82,23 @@ const DumbMigrationProgressBanner = ({ migrationDoc }) => {
     } finally {
       setIsCanceling(false)
     }
-  }, [client, migrationId, isCanceling])
+  }, [client, isCanceling, migrationId])
 
+  return { isCanceling, handleCancel }
+}
+
+const DumbMigrationProgressBanner = ({ migrationDoc }) => {
+  const { t } = useI18n()
+
+  const migrationId = migrationDoc?._id
   const progress = migrationDoc?.progress
-  const percent =
-    progress?.bytes_total > 0
-      ? Math.round((progress.bytes_imported / progress.bytes_total) * 100)
-      : 0
+  const percent = computeMigrationPercent(progress)
+
+  useMigrationCompletionAlert({ migrationId })
+
+  const { isCanceling, handleCancel } = useMigrationCancel({
+    migrationId
+  })
 
   return (
     <ProgressionBanner

--- a/src/components/Migration/MigrationProgressBanner.jsx
+++ b/src/components/Migration/MigrationProgressBanner.jsx
@@ -16,9 +16,13 @@ import { buildRunningMigrationQuery } from '@/queries'
 const SNACKBAR_AUTO_HIDE_MS = 6000
 
 const computeMigrationPercent = progress => {
-  if (!progress?.bytes_total) return 0
+  const imported = Number(progress?.bytes_imported) || 0
+  const total = Number(progress?.bytes_total) || 0
 
-  return Math.round((progress.bytes_imported / progress.bytes_total) * 100)
+  if (total <= 0) return 0
+
+  const percent = Math.round((imported / total) * 100)
+  return Number.isFinite(percent) ? Math.min(100, Math.max(0, percent)) : 0
 }
 
 const showCompletedMigrationAlert = ({ doc, showAlert, t }) => {

--- a/src/components/Migration/MigrationProgressBanner.spec.jsx
+++ b/src/components/Migration/MigrationProgressBanner.spec.jsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient, useQuery } from 'cozy-client'
+
+import { MigrationProgressBanner } from './MigrationProgressBanner'
+import AppLike from 'test/components/AppLike'
+
+import logger from '@/lib/logger'
+
+jest.mock('cozy-client', () => {
+  const actual = jest.requireActual('cozy-client')
+  return {
+    __esModule: true,
+    ...actual,
+    default: actual.default,
+    useQuery: jest.fn()
+  }
+})
+
+jest.mock('@/lib/logger', () => ({ error: jest.fn() }))
+
+const RUNNING_DOC = {
+  _id: 'migration-1',
+  status: 'running',
+  progress: {
+    files_imported: 10,
+    files_total: 100,
+    bytes_imported: 1_000_000,
+    bytes_total: 5_000_000
+  }
+}
+
+const buildMockClient = ({ fetchJSON } = {}) => {
+  const client = createMockClient({})
+  const subscribers = {}
+  const keyOf = (event, doctype, idOrHandler) =>
+    typeof idOrHandler === 'string'
+      ? `${event}:${doctype}:${idOrHandler}`
+      : `${event}:${doctype}`
+  client.plugins = {
+    realtime: {
+      subscribe: jest.fn((event, doctype, idOrHandler, handler) => {
+        const key = keyOf(event, doctype, idOrHandler)
+        subscribers[key] = handler || idOrHandler
+      }),
+      unsubscribe: jest.fn((event, doctype, idOrHandler) => {
+        delete subscribers[keyOf(event, doctype, idOrHandler)]
+      })
+    }
+  }
+  client.__emit = (event, doctype, doc) => {
+    const handler =
+      subscribers[`${event}:${doctype}:${doc._id}`] ||
+      subscribers[`${event}:${doctype}`]
+    if (handler) handler(doc)
+  }
+  client.getStackClient = () => ({
+    fetchJSON: fetchJSON || jest.fn().mockResolvedValue({})
+  })
+  return client
+}
+
+const setup = ({ runningMigration = null, fetchJSON } = {}) => {
+  const client = buildMockClient({ fetchJSON })
+  useQuery.mockReturnValue({
+    data: runningMigration ? [runningMigration] : [],
+    fetchStatus: 'loaded'
+  })
+  const utils = render(
+    <AppLike client={client}>
+      <MigrationProgressBanner />
+    </AppLike>
+  )
+  const rerenderWith = nextRunning => {
+    useQuery.mockReturnValue({
+      data: nextRunning ? [nextRunning] : [],
+      fetchStatus: 'loaded'
+    })
+    utils.rerender(
+      <AppLike client={client}>
+        <MigrationProgressBanner />
+      </AppLike>
+    )
+  }
+  return { client, rerenderWith, ...utils }
+}
+
+describe('MigrationProgressBanner', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe('idle state', () => {
+    it('does not render the banner when no migration is running', () => {
+      setup()
+      expect(
+        screen.queryByTestId('migration-progress-banner-percent')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('running state', () => {
+    it('renders the banner when a migration is running', () => {
+      // The ProgressionBanner of the cozy-ui version currently bundled in cozy-drive
+      // declares `text: PropTypes.string` while we pass a fragment to keep the
+      // `data-testid` wrapping. The next cozy-ui upgrade widens this to PropTypes.node.
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+      try {
+        setup({ runningMigration: RUNNING_DOC })
+        expect(
+          screen.getByTestId('migration-progress-banner-percent')
+        ).toBeInTheDocument()
+        expect(
+          screen.getByTestId('migration-progress-banner-percent')
+        ).toHaveTextContent('20% complete')
+        expect(
+          screen.getByTestId('migration-progress-banner-importing')
+        ).toHaveTextContent('100 files')
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
+
+    it('shows the banner when the query starts returning a running migration', () => {
+      const { rerenderWith } = setup()
+      expect(
+        screen.queryByTestId('migration-progress-banner-percent')
+      ).not.toBeInTheDocument()
+      rerenderWith(RUNNING_DOC)
+      expect(
+        screen.getByTestId('migration-progress-banner-percent')
+      ).toBeInTheDocument()
+    })
+
+    it('updates progress when the query data changes', () => {
+      const { rerenderWith } = setup({ runningMigration: RUNNING_DOC })
+      rerenderWith({
+        ...RUNNING_DOC,
+        progress: { ...RUNNING_DOC.progress, bytes_imported: 2_500_000 }
+      })
+      expect(
+        screen.getByTestId('migration-progress-banner-percent')
+      ).toHaveTextContent('50% complete')
+    })
+  })
+
+  describe('terminal states', () => {
+    it('hides the banner and shows the snackbar on completed', () => {
+      const { client, rerenderWith } = setup({ runningMigration: RUNNING_DOC })
+      act(() =>
+        client.__emit('updated', 'io.cozy.nextcloud.migrations', {
+          ...RUNNING_DOC,
+          status: 'completed'
+        })
+      )
+      rerenderWith(null)
+      expect(
+        screen.queryByTestId('migration-progress-banner-percent')
+      ).not.toBeInTheDocument()
+      expect(screen.getByText('Migration Complete!')).toBeInTheDocument()
+    })
+
+    it('hides the banner without snackbar when the running query empties', () => {
+      const { rerenderWith } = setup({ runningMigration: RUNNING_DOC })
+      rerenderWith(null)
+      expect(
+        screen.queryByTestId('migration-progress-banner-percent')
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText('Migration Complete!')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('cancel', () => {
+    it('calls the cancel endpoint when the cancel button is clicked', async () => {
+      const fetchJSON = jest.fn().mockResolvedValue({})
+      setup({ runningMigration: RUNNING_DOC, fetchJSON })
+      fireEvent.click(screen.getByTestId('migration-progress-banner-cancel'))
+      await waitFor(() =>
+        expect(fetchJSON).toHaveBeenCalledWith(
+          'POST',
+          '/remote/nextcloud/migration/migration-1/cancel'
+        )
+      )
+    })
+
+    it('silently ignores a 409 response', async () => {
+      const fetchJSON = jest.fn().mockRejectedValue({ status: 409 })
+      setup({ runningMigration: RUNNING_DOC, fetchJSON })
+      fireEvent.click(screen.getByTestId('migration-progress-banner-cancel'))
+      await waitFor(() => expect(fetchJSON).toHaveBeenCalled())
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    it('logs other errors', async () => {
+      const fetchJSON = jest.fn().mockRejectedValue({ status: 500 })
+      setup({ runningMigration: RUNNING_DOC, fetchJSON })
+      fireEvent.click(screen.getByTestId('migration-progress-banner-cancel'))
+      await waitFor(() => expect(logger.error).toHaveBeenCalled())
+    })
+  })
+})

--- a/src/lib/doctypes.js
+++ b/src/lib/doctypes.js
@@ -11,6 +11,7 @@ export const DOCTYPE_PHOTOS_SETTINGS = 'io.cozy.photos.settings'
 export const DOCTYPE_APPS = 'io.cozy.apps'
 export const DOCTYPE_CONTACTS = 'io.cozy.contacts'
 export const DOCTYPE_KONNECTORS = 'io.cozy.konnectors'
+export const NEXTCLOUD_MIGRATIONS_DOCTYPE = 'io.cozy.nextcloud.migrations'
 export const DOCTYPE_CONTACTS_VERSION = 2
 
 export const schema = {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -634,6 +634,16 @@
     "restoreError": "An error has occurred, please try again.",
     "destroySuccess": "The item has been deleted"
   },
+  "MigrationProgressBanner": {
+    "title": "Migration from Nextcloud in progress",
+    "percent": "%{percent}% complete",
+    "importing": "Importing %{count} files from Nextcloud...",
+    "cancel": "Cancel",
+    "done": {
+      "title": "Migration Complete!",
+      "body": "Successfully imported %{count} files from Nextcloud"
+    }
+  },
   "EntriesType": {
     "file": "file |||| files",
     "directory": "folder |||| folders",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -631,6 +631,16 @@
     "restoreError": "Une erreur est survenue, merci de réessayer.",
     "destroySuccess": "L’élément a bien été supprimé"
   },
+  "MigrationProgressBanner": {
+    "title": "Migration depuis Nextcloud en cours",
+    "percent": "%{percent}% terminé",
+    "importing": "Importation de %{count} fichiers depuis Nextcloud ...",
+    "cancel": "Annuler",
+    "done": {
+      "title": "Migration terminée !",
+      "body": "%{count} fichiers importés avec succès depuis Nextcloud"
+    }
+  },
   "EntriesType": {
     "file": "fichier |||| fichiers",
     "directory": "dossier |||| dossiers",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -611,6 +611,16 @@
     "restoreError": "Произошла ошибка, попробуйте ещё раз.",
     "destroySuccess": "Элемент удалён"
   },
+  "MigrationProgressBanner": {
+    "title": "Миграция с Nextcloud в процессе",
+    "percent": "%{percent}% завершено",
+    "importing": "Импорт %{count} файлов из Nextcloud...",
+    "cancel": "Отменить",
+    "done": {
+      "title": "Миграция завершена!",
+      "body": "Успешно импортировано %{count} файлов из Nextcloud"
+    }
+  },
   "EntriesType": {
     "file": "файл |||| файлы",
     "directory": "папка |||| папки",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -610,6 +610,16 @@
     "restoreError": "Đã xảy ra lỗi, vui lòng thử lại.",
     "destroySuccess": "Mục đã được xóa vĩnh viễn"
   },
+  "MigrationProgressBanner": {
+    "title": "Đang di chuyển dữ liệu từ Nextcloud",
+    "percent": "Hoàn tất %{percent}%",
+    "importing": "Đang nhập %{count} tệp từ Nextcloud...",
+    "cancel": "Hủy",
+    "done": {
+      "title": "Di chuyển hoàn tất !",
+      "body": "Đã nhập thành công %{count} tệp từ Nextcloud"
+    }
+  },
   "EntriesType": {
     "file": "tệp |||| các tệp",
     "directory": "thư mục |||| các thư mục",

--- a/src/modules/layout/Main.jsx
+++ b/src/modules/layout/Main.jsx
@@ -1,13 +1,22 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { RealTimeQueries } from 'cozy-client'
 import { Main as MainUI } from 'cozy-ui/transpiled/react/Layout'
 
+import { MigrationProgressBanner } from '@/components/Migration/MigrationProgressBanner'
 import PushBanner from '@/components/PushBanner'
+import { NEXTCLOUD_MIGRATIONS_DOCTYPE } from '@/lib/doctypes'
 
 const Main = ({ children, isPublic = false }) => (
   <MainUI>
     <PushBanner isPublic={isPublic} />
+    {!isPublic && (
+      <>
+        <RealTimeQueries doctype={NEXTCLOUD_MIGRATIONS_DOCTYPE} />
+        <MigrationProgressBanner />
+      </>
+    )}
     {children}
   </MainUI>
 )

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -7,7 +7,11 @@ import {
   TRASH_DIR_ID,
   SETTINGS_DIR_PATH
 } from '@/constants/config'
-import { DOCTYPE_ALBUMS, DOCTYPE_FILES_SETTINGS } from '@/lib/doctypes'
+import {
+  DOCTYPE_ALBUMS,
+  DOCTYPE_FILES_SETTINGS,
+  NEXTCLOUD_MIGRATIONS_DOCTYPE
+} from '@/lib/doctypes'
 import { formatFolderQueryId } from '@/lib/queries'
 
 export interface QueryConfig {
@@ -658,4 +662,14 @@ export const buildSharedDriveIdQuery: QueryBuilder<
     singleDocData: true,
     enabled: !!driveId
   }
+})
+
+export const buildRunningMigrationQuery: QueryBuilder = () => ({
+  definition: () =>
+    Q(NEXTCLOUD_MIGRATIONS_DOCTYPE)
+      .where({ status: 'running' })
+      .indexFields(['status', 'cozyMetadata.createdAt'])
+      .sortBy([{ status: 'desc' }, { 'cozyMetadata.createdAt': 'desc' }])
+      .limitBy(1),
+  options: { as: `${NEXTCLOUD_MIGRATIONS_DOCTYPE}/running` }
 })


### PR DESCRIPTION
Show a progression banner across cozy-drive views while a Nextcloud migration is running, with a snackbar on completion and a cancel action.

<img width="1066" height="127" alt="Capture d’écran du 2026-05-04 17-50-56" src="https://github.com/user-attachments/assets/9f4d5675-abae-4766-a49c-268dbfa48f92" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Migration Progress banner showing Nextcloud import progress (percent, file count), live realtime updates, a cancel action, and an auto-hiding completion notification. The banner appears only in non-public sessions.

* **Documentation**
  * Added MigrationProgressBanner translations in English, French, Russian, and Vietnamese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->