### PR TITLE
Drive E2E tests (Playwright)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,65 @@
+name: E2E Tests
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+jobs:
+  e2e:
+    name: Drive E2E
+    if: >
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'e2e')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Drive app
+        run: yarn build
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+
+      - name: Run E2E tests
+        run: yarn e2e
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload test traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ konnector-dev-config.json
 
 # eslint
 .eslintcache
+
+# E2E test artifacts
+e2e/.auth-state.json
+playwright-report/
+test-results/

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,35 @@
+services:
+  couchdb:
+    image: couchdb:3
+    environment:
+      COUCHDB_USER: admin
+      COUCHDB_PASSWORD: password
+    ports:
+      - "5984:5984"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:5984/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  cozystack:
+    image: cozy/cozy-stack
+    depends_on:
+      couchdb:
+        condition: service_healthy
+    environment:
+      COZY_ADMIN_PASSPHRASE: cozy
+      COZY_COUCHDB_URL: http://admin:password@couchdb:5984/
+      COZY_FS_URL: file:///var/lib/cozy/storage
+      COZY_HOST: 0.0.0.0
+      COZY_PORT: "80"
+      COZY_ADMIN_HOST: 0.0.0.0
+      COZY_ADMIN_PORT: "6060"
+      COZY_SUBDOMAINS: flat
+    command: ["cozy-stack", "serve", "--dev"]
+    volumes:
+      - ./build:/app/drive
+      - ./e2e/cozy.yml:/etc/cozy/cozy.yml
+    ports:
+      - "80:80"
+      - "6060:6060"

--- a/e2e/cozy.yml
+++ b/e2e/cozy.yml
@@ -1,0 +1,30 @@
+host: 0.0.0.0
+port: 80
+
+admin:
+  host: 0.0.0.0
+  port: 6060
+
+subdomains: flat
+
+fs:
+  url: file:///var/lib/cozy/storage
+
+couchdb:
+  url: http://admin:password@couchdb:5984/
+
+mail:
+  disable_tls: true
+  skip_certificate_validation: true
+  host: localhost
+  port: 25
+  noreply_address: noreply@cozy.localhost
+  noreply_name: Cozy Test
+
+contexts:
+  default:
+    sharing:
+      auto_accept_trusted: true
+      auto_accept_trusted_contacts: true
+      trusted_domains:
+        - cozy.localhost

--- a/e2e/fixtures/notes.txt
+++ b/e2e/fixtures/notes.txt
@@ -1,0 +1,1 @@
+second fixture for multi-upload tests

--- a/e2e/fixtures/sample.txt
+++ b/e2e/fixtures/sample.txt
@@ -1,0 +1,1 @@
+hello from twake-drive e2e

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import type { Page } from '@playwright/test'
+
+const AUTH_STATE_PATH = path.join(__dirname, '..', '.auth-state.json')
+
+export interface AuthState {
+  [user: string]: {
+    domain: string
+    cookieName: string
+    cookieValue: string
+  }
+}
+
+export function loadAuthState(): AuthState {
+  return JSON.parse(fs.readFileSync(AUTH_STATE_PATH, 'utf-8'))
+}
+
+export function saveAuthState(state: AuthState): void {
+  fs.writeFileSync(AUTH_STATE_PATH, JSON.stringify(state, null, 2))
+}
+
+export async function authenticate(page: Page, user: string): Promise<void> {
+  const { cookieName, cookieValue } = loadAuthState()[user]
+  // Cookie is pinned to the parent domain so it covers both the instance
+  // (alice.cozy.localhost) and its app subdomain (alice-drive.cozy.localhost).
+  await page.context().addCookies([
+    {
+      name: cookieName,
+      value: cookieValue,
+      domain: '.cozy.localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax'
+    }
+  ])
+}

--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -1,0 +1,51 @@
+import { execSync } from 'child_process'
+
+export const COMPOSE_FILE = 'docker-compose.e2e.yml'
+export const STACK_HOST = 'localhost'
+export const STACK_PORT = 80
+export const STACK_URL = `http://${STACK_HOST}:${STACK_PORT}`
+export const ADMIN_PORT = 6060
+export const ADMIN_URL = `http://${STACK_HOST}:${ADMIN_PORT}`
+export const ADMIN_USER = 'admin'
+export const ADMIN_PASSPHRASE = 'cozy'
+
+// Tying both instances to the same (OrgID, OrgDomain) makes them count as
+// trusted contacts of each other for cozy-to-cozy sharing — combined with the
+// `auto_accept_trusted_contacts` context option, invitations no longer need
+// an SMTP delivery to be accepted.
+export const ORG_ID = 'twake-drive-e2e'
+export const ORG_DOMAIN = 'cozy.localhost'
+
+export type UserLabel = 'alice' | 'bob'
+
+export interface User {
+  label: UserLabel
+  instance: string
+  appUrl: string
+  email: string
+  passphrase: string
+}
+
+export const USERS: Record<UserLabel, User> = {
+  alice: {
+    label: 'alice',
+    instance: 'alice.cozy.localhost',
+    appUrl: 'http://alice-drive.cozy.localhost',
+    email: 'alice@cozy.localhost',
+    passphrase: 'alice1234'
+  },
+  bob: {
+    label: 'bob',
+    instance: 'bob.cozy.localhost',
+    appUrl: 'http://bob-drive.cozy.localhost',
+    email: 'bob@cozy.localhost',
+    passphrase: 'bob1234'
+  }
+}
+
+export function stackExec(cmd: string): string {
+  return execSync(
+    `docker compose -f ${COMPOSE_FILE} exec -T -e COZY_ADMIN_PASSPHRASE=cozy -e COZY_ADMIN_HOST=${STACK_HOST} cozystack cozy-stack ${cmd}`,
+    { encoding: 'utf-8', cwd: process.cwd() }
+  ).trim()
+}

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,0 +1,98 @@
+import { unlink } from 'fs/promises'
+import { test as base, expect } from '@playwright/test'
+import type { Page, TestInfo } from '@playwright/test'
+
+import { authenticate } from './auth'
+import { DrivePage } from '../pages/DrivePage'
+
+type AuthedFixtures = {
+  alicePage: Page
+  bobPage: Page
+  aliceDrive: DrivePage
+  bobDrive: DrivePage
+}
+
+// Console messages we never want to fail on — benign in the test stack
+const IGNORED_CONSOLE = [
+  /Failed to load resource: the server responded with a status of 404/,
+  /<svg> attribute width: Expected length/
+]
+
+const attachIfAny = async (
+  testInfo: TestInfo,
+  name: string,
+  lines: string[]
+): Promise<void> => {
+  if (lines.length === 0) return
+  await testInfo.attach(name, {
+    body: lines.join('\n'),
+    contentType: 'text/plain'
+  })
+}
+
+const userPageFixture =
+  (user: 'alice' | 'bob') =>
+  async (
+    { browser }: { browser: import('@playwright/test').Browser },
+    use: (page: Page) => Promise<void>,
+    testInfo: TestInfo
+  ): Promise<void> => {
+    const ctx = await browser.newContext()
+    const consoleErrors: string[] = []
+    const pageErrors: string[] = []
+    try {
+      const page = await ctx.newPage()
+      page.on('console', msg => {
+        if (msg.type() !== 'error') return
+        const text = msg.text()
+        if (IGNORED_CONSOLE.some(re => re.test(text))) return
+        const loc = msg.location()
+        consoleErrors.push(`[${user}] ${text}  (${loc.url}:${loc.lineNumber})`)
+      })
+      page.on('pageerror', err => {
+        pageErrors.push(
+          `[${user}] ${err.name}: ${err.message}\n${err.stack ?? ''}`
+        )
+      })
+      await authenticate(page, user)
+      await use(page)
+    } finally {
+      if (testInfo.status !== testInfo.expectedStatus) {
+        await attachIfAny(testInfo, `${user}-console-errors.log`, consoleErrors)
+        await attachIfAny(testInfo, `${user}-page-errors.log`, pageErrors)
+      }
+      await ctx.close()
+    }
+  }
+
+export const test = base.extend<AuthedFixtures>({
+  alicePage: userPageFixture('alice'),
+  bobPage: userPageFixture('bob'),
+  aliceDrive: async ({ alicePage }, use) => {
+    await use(new DrivePage(alicePage))
+  },
+  bobDrive: async ({ bobPage }, use) => {
+    await use(new DrivePage(bobPage))
+  }
+})
+
+export { expect }
+
+let stampCounter = 0
+/** Monotonic, collision-resistant identifier for unique fixture names. */
+export const stamp = (): string =>
+  `${Date.now()}-${process.pid}-${++stampCounter}`
+
+/** Best-effort file deletion — swallows ENOENT so finally-blocks stay clean,
+ *  but lets permission / path errors propagate so they aren't silently lost. */
+export const safeUnlink = async (filePath: string): Promise<void> => {
+  try {
+    await unlink(filePath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+  }
+}
+
+/** Escape regex metacharacters so a literal name can be used in a RegExp. */
+export const escapeRegExp = (text: string): string =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/e2e/helpers/flags.ts
+++ b/e2e/helpers/flags.ts
@@ -1,0 +1,8 @@
+import { stackExec } from './config'
+
+export function setFlags(
+  instance: string,
+  flags: Record<string, boolean | string | number>
+): void {
+  stackExec(`features flags --domain ${instance} '${JSON.stringify(flags)}'`)
+}

--- a/e2e/pages/DrivePage.ts
+++ b/e2e/pages/DrivePage.ts
@@ -1,0 +1,51 @@
+import type { Page, Locator } from '@playwright/test'
+
+import { FileRow } from './FileRow'
+
+/**
+ * Page object for the Drive file list view (My Drive, Trash, Favorites,
+ * inside a folder or shared drive — anything that renders the standard
+ * fil-content-body table). Per-row actions live on `FileRow` so callers
+ * write `drive.row('foo').rename('bar')` instead of passing names through
+ * many separate methods.
+ */
+export class DrivePage {
+  private readonly page: Page
+  private readonly fileList: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.fileList = page.getByTestId('fil-content-body')
+  }
+
+  row(name: string): FileRow {
+    return new FileRow(this.page, this.fileList, name)
+  }
+
+  /** Locator for the file list cell whose filename contains the substring —
+   *  use for "the original and its (1) copy" style multi-row assertions. */
+  matching(stem: string): Locator {
+    return this.fileList
+      .getByTestId('fil-file-filename-and-ext')
+      .filter({ hasText: stem })
+  }
+
+  async createFolder(name: string): Promise<void> {
+    await this.page.getByRole('button', { name: 'Create' }).click()
+    await this.page.getByTestId('add-folder-link').click()
+    const input = this.page.getByTestId('name-input').locator('input')
+    await input.waitFor({ state: 'visible' })
+    await input.fill(name)
+    await input.press('Enter')
+    await this.row(name).waitVisible()
+  }
+
+  /** cozy-ui's FileInput spreads extra props onto the underlying <input
+   * type=file>, so the `upload-btn` testid lives on the input itself. */
+  async uploadFiles(filePaths: string | string[]): Promise<void> {
+    await this.page
+      .locator('input[data-testid="upload-btn"]')
+      .first()
+      .setInputFiles(filePaths)
+  }
+}

--- a/e2e/pages/FileRow.ts
+++ b/e2e/pages/FileRow.ts
@@ -1,0 +1,154 @@
+import type { Page, Locator } from '@playwright/test'
+
+import { escapeRegExp } from '../helpers/fixtures'
+
+interface ConfirmDialog {
+  button: RegExp
+  /** `required`: the dialog always shows up. `optional`: only confirm when
+   * a dialog appears within a short grace window (some actions skip the
+   * dialog when there's nothing to warn about). */
+  wait: 'required' | 'optional'
+}
+
+const OPTIONAL_DIALOG_TIMEOUT = 2_000
+
+/**
+ * Handle for a single row in the Drive file list. Returned from
+ * `DrivePage.row(name)` so per-name action methods need only the values
+ * specific to the action — the row already knows which file it is.
+ *
+ * Note: every menuitem regex below assumes the UI is in English.
+ */
+export class FileRow {
+  private readonly anchored: RegExp
+
+  constructor(
+    private readonly page: Page,
+    private readonly fileList: Locator,
+    private readonly name: string
+  ) {
+    this.anchored = new RegExp(`^${escapeRegExp(name)}$`)
+  }
+
+  /** Locator for the row's filename cell — exposed so tests can assert
+   * visibility / count without going through a wrapper method. Anchored
+   * so similar names ("Folder 1" vs "Folder 12") don't collide. */
+  get cell(): Locator {
+    return this.fileList
+      .getByTestId('fil-file-filename-and-ext')
+      .filter({ hasText: this.anchored })
+  }
+
+  private get rowEl(): Locator {
+    // Each row is a plain <div> with no semantic role; locate the closest
+    // ancestor that contains the per-row "More" button — that's the row.
+    return this.cell.locator(
+      'xpath=ancestor::*[.//button[@aria-label="More"]][1]'
+    )
+  }
+
+  async waitVisible(opts?: { timeout?: number }): Promise<void> {
+    await this.cell.waitFor({ state: 'visible', timeout: opts?.timeout })
+  }
+
+  async waitHidden(opts?: { timeout?: number }): Promise<void> {
+    await this.cell.waitFor({ state: 'hidden', timeout: opts?.timeout })
+  }
+
+  /** cozy-drive desktop semantics: single-click selects, double-click
+   * navigates / opens. See src/hooks/useOnLongPress/helpers.js handleClick. */
+  async open(): Promise<void> {
+    // The row's link includes the value of every column in its accessible
+    // name ("Foo — — —"), so we locate the row through the filename cell
+    // and dblclick whichever link sits inside.
+    await this.rowEl.getByRole('link').first().dblclick()
+  }
+
+  async openMenu(): Promise<Locator> {
+    await this.rowEl.getByRole('button', { name: 'More' }).click()
+    return this.page.getByRole('menu')
+  }
+
+  private async runAction(
+    menuItem: RegExp,
+    confirm?: ConfirmDialog
+  ): Promise<void> {
+    const menu = await this.openMenu()
+    await menu.getByRole('menuitem', { name: menuItem }).click()
+    if (!confirm) return
+
+    const dialog = this.page.getByRole('dialog')
+    if (confirm.wait === 'required') {
+      await dialog.waitFor({ state: 'visible' })
+    } else {
+      // Brief grace period for the dialog to appear; if it doesn't, the
+      // action skipped the confirm and we're already done. Only swallow
+      // the timeout — anything else (page detached, closed context,
+      // strict-mode violation) should propagate.
+      const appeared = await dialog
+        .waitFor({ state: 'visible', timeout: OPTIONAL_DIALOG_TIMEOUT })
+        .then(() => true)
+        .catch((err: Error) => {
+          if (err.name === 'TimeoutError') return false
+          throw err
+        })
+      if (!appeared) return
+    }
+    await dialog.getByRole('button', { name: confirm.button }).click()
+    await dialog.waitFor({ state: 'hidden' })
+  }
+
+  async rename(newName: string): Promise<void> {
+    const menu = await this.openMenu()
+    await menu.getByRole('menuitem', { name: /^rename$/i }).click()
+    const input = this.page.getByTestId('name-input').locator('input')
+    await input.waitFor({ state: 'visible' })
+    await input.fill(newName)
+    await input.press('Enter')
+    await this.fileList
+      .getByTestId('fil-file-filename-and-ext')
+      .filter({ hasText: new RegExp(`^${escapeRegExp(newName)}$`) })
+      .waitFor({ state: 'visible' })
+  }
+
+  async moveTo(targetFolder: string): Promise<void> {
+    const menu = await this.openMenu()
+    await menu.getByRole('menuitem', { name: /move to/i }).click()
+    const dialog = this.page.getByRole('dialog')
+    await dialog.waitFor({ state: 'visible' })
+    // No .first() here — if the folder name is ambiguous in the picker,
+    // surface that as a Playwright strict-mode error instead of silently
+    // operating on whichever match the DOM happened to put first.
+    await dialog
+      .getByRole('button', {
+        name: new RegExp(`^${escapeRegExp(targetFolder)}$`)
+      })
+      .dblclick()
+    await dialog.getByRole('button', { name: /^move$/i }).click()
+    await dialog.waitFor({ state: 'hidden' })
+  }
+
+  async duplicate(): Promise<void> {
+    await this.runAction(/duplicate/i, {
+      button: /duplicate|confirm|ok/i,
+      wait: 'optional'
+    })
+  }
+
+  async sendToTrash(): Promise<void> {
+    await this.runAction(/^remove$/i, {
+      button: /^remove$/i,
+      wait: 'required'
+    })
+    await this.waitHidden()
+  }
+
+  async addToFavorites(): Promise<void> {
+    await this.runAction(/add to favorites/i)
+  }
+
+  async restore(): Promise<void> {
+    await this.runAction(/^restore$/i)
+    await this.waitHidden()
+  }
+}

--- a/e2e/pages/FileViewerPage.ts
+++ b/e2e/pages/FileViewerPage.ts
@@ -1,0 +1,22 @@
+import type { Page } from '@playwright/test'
+
+export class FileViewerPage {
+  private readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /** The viewer route always contains `/file/<id>` in the URL fragment. */
+  async waitForOpen(): Promise<void> {
+    await this.page.waitForURL(/\/file\/[^/]+/, { timeout: 10_000 })
+  }
+
+  /** Closes the viewer by navigating back, then waits for the file route to drop. */
+  async close(): Promise<void> {
+    await this.page.goBack()
+    await this.page.waitForURL(url => !/\/file\/[^/]+/.test(url.toString()), {
+      timeout: 5_000
+    })
+  }
+}

--- a/e2e/pages/ShareModalPage.ts
+++ b/e2e/pages/ShareModalPage.ts
@@ -1,0 +1,47 @@
+import type { Page, Locator } from '@playwright/test'
+
+export class ShareModalPage {
+  private readonly page: Page
+  private readonly dialog: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.dialog = page.getByRole('dialog')
+  }
+
+  async waitForOpen(): Promise<void> {
+    await this.dialog.waitFor({ state: 'visible' })
+  }
+
+  async addMember(email: string): Promise<void> {
+    const contactInput = this.dialog.getByRole('textbox').first()
+    await contactInput.fill(email)
+    // Either click a matching autocomplete suggestion (existing contact) or
+    // press Enter (free-form email input). The suggestion listbox is
+    // portal'd outside the dialog so we have to match on the page; the
+    // hasText filter keeps the lookup scoped to options that actually
+    // contain the email we typed.
+    const suggestion = this.page
+      .getByRole('option')
+      .filter({ hasText: email })
+      .first()
+    if (await suggestion.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await suggestion.click()
+    } else {
+      await contactInput.press('Enter')
+    }
+  }
+
+  /** Submits the share form and waits for the modal to close (success). */
+  async share(): Promise<void> {
+    await this.dialog
+      .getByRole('button', { name: /share|send|confirm|ok/i })
+      .click()
+    await this.dialog.waitFor({ state: 'hidden', timeout: 15_000 })
+  }
+
+  async close(): Promise<void> {
+    await this.dialog.getByRole('button', { name: /close/i }).click()
+    await this.dialog.waitFor({ state: 'hidden', timeout: 10_000 })
+  }
+}

--- a/e2e/pages/SharedDriveModalPage.ts
+++ b/e2e/pages/SharedDriveModalPage.ts
@@ -1,0 +1,30 @@
+import type { Page, Locator } from '@playwright/test'
+
+export class SharedDriveModalPage {
+  private readonly page: Page
+  private readonly dialog: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.dialog = page.getByRole('dialog')
+  }
+
+  async waitForOpen(): Promise<void> {
+    await this.dialog.waitFor({ state: 'visible' })
+  }
+
+  async setName(name: string): Promise<void> {
+    const input = this.dialog.getByRole('textbox').first()
+    await input.fill(name)
+  }
+
+  async confirm(): Promise<void> {
+    await this.dialog
+      .getByRole('button', { name: /create|confirm|ok/i })
+      .click()
+  }
+
+  async waitForClose(): Promise<void> {
+    await this.dialog.waitFor({ state: 'hidden', timeout: 15_000 })
+  }
+}

--- a/e2e/pages/SharedDrivePage.ts
+++ b/e2e/pages/SharedDrivePage.ts
@@ -1,0 +1,21 @@
+import type { Page, Locator } from '@playwright/test'
+
+export class SharedDrivePage {
+  private readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  getCreateButton(): Locator {
+    // The CreateSharedDriveButton renders inside the empty-folder container.
+    // Scoping avoids matching the sidebar "Create" button.
+    return this.page
+      .getByTestId('empty-folder')
+      .getByRole('button', { name: /create/i })
+  }
+
+  async clickCreate(): Promise<void> {
+    await this.getCreateButton().click()
+  }
+}

--- a/e2e/pages/SidebarPage.ts
+++ b/e2e/pages/SidebarPage.ts
@@ -1,0 +1,32 @@
+import type { Page, Locator } from '@playwright/test'
+
+/** Sidebar / global navigation helpers. Routes that don't have a sidebar
+ * entry (Favorites, Search) fall back to a hash-based goto on the current
+ * origin so tests don't have to special-case them. */
+export class SidebarPage {
+  private readonly page: Page
+  private readonly nav: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.nav = page.locator('nav')
+  }
+
+  private async goToHash(hash: string): Promise<void> {
+    const url = new URL(this.page.url())
+    url.hash = hash
+    await this.page.goto(url.toString())
+  }
+
+  async goToRecent(): Promise<void> {
+    await this.nav.getByRole('link', { name: /recents?/i }).first().click()
+  }
+
+  async goToFavorites(): Promise<void> {
+    await this.goToHash('#/favorites')
+  }
+
+  async goToTrash(): Promise<void> {
+    await this.nav.getByRole('link', { name: /(bin|trash)/i }).first().click()
+  }
+}

--- a/e2e/pages/UploadQueuePage.ts
+++ b/e2e/pages/UploadQueuePage.ts
@@ -1,0 +1,27 @@
+import type { Page, Locator } from '@playwright/test'
+
+import { escapeRegExp } from '../helpers/fixtures'
+
+export class UploadQueuePage {
+  private readonly page: Page
+  private readonly queue: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.queue = page.getByTestId('upload-queue')
+  }
+
+  async waitForOpen(): Promise<void> {
+    await this.queue.waitFor({ state: 'visible', timeout: 15_000 })
+  }
+
+  getItemByName(name: string): Locator {
+    return this.queue
+      .getByTestId('upload-queue-item-name')
+      .filter({ hasText: new RegExp(`^${escapeRegExp(name)}$`) })
+  }
+
+  async waitForItem(name: string): Promise<void> {
+    await this.getItemByName(name).waitFor({ state: 'visible', timeout: 15_000 })
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'html' : 'list',
+  globalSetup: './setup/global-setup.ts',
+  globalTeardown: './setup/global-teardown.ts',
+  use: {
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+  },
+  timeout: 60_000,
+  globalTimeout: 300_000,
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+})

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -1,0 +1,225 @@
+import { execSync } from 'child_process'
+import { pbkdf2Sync } from 'crypto'
+
+import { saveAuthState } from '../helpers/auth'
+import {
+  ADMIN_PASSPHRASE,
+  ADMIN_URL,
+  ADMIN_USER,
+  COMPOSE_FILE,
+  ORG_DOMAIN,
+  ORG_ID,
+  STACK_URL,
+  USERS,
+  User,
+  stackExec
+} from '../helpers/config'
+import { setFlags } from '../helpers/flags'
+
+const ADMIN_AUTH = `Basic ${Buffer.from(`${ADMIN_USER}:${ADMIN_PASSPHRASE}`).toString('base64')}`
+
+async function createInstance(user: User): Promise<void> {
+  const params = new URLSearchParams({
+    Domain: user.instance,
+    Email: user.email,
+    Locale: 'en',
+    Passphrase: user.passphrase,
+    ContextName: 'default',
+    OrgID: ORG_ID,
+    OrgDomain: ORG_DOMAIN
+  })
+  const res = await fetch(`${ADMIN_URL}/instances?${params}`, {
+    method: 'POST',
+    headers: { Authorization: ADMIN_AUTH, Accept: 'application/json' }
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(
+      `Failed to create instance ${user.instance} (${res.status}): ${body}`
+    )
+  }
+}
+
+const FEATURE_FLAGS = {
+  'cozy.hide-sharing-cozy-to-cozy': true,
+  'drive.shared-drive.enabled': true,
+  'drive.federated-shared-folder.enabled': true,
+  'drive.federated-shared-modal.enabled': true
+}
+
+async function waitForStack(url: string, timeoutMs = 60_000): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${url}/version`)
+      if (res.ok) return
+    } catch {
+      // stack not up yet
+    }
+    await new Promise(r => setTimeout(r, 500))
+  }
+  throw new Error(`cozy-stack did not become ready within ${timeoutMs}ms`)
+}
+
+interface LoginParams {
+  csrfToken: string
+  iterations: number
+  salt: string
+}
+
+function parseLoginParams(html: string, instance: string): LoginParams {
+  const find = (pattern: RegExp, label: string): string => {
+    const m = html.match(pattern)
+    if (!m) throw new Error(`Could not find ${label} for ${instance}`)
+    return m[1]
+  }
+  return {
+    csrfToken: find(/name="csrf_token"\s+value="([^"]+)"/, 'CSRF token'),
+    iterations: parseInt(find(/data-iterations="(\d+)"/, 'PBKDF2 iterations'), 10),
+    salt: find(/data-salt="([^"]+)"/, 'PBKDF2 salt')
+  }
+}
+
+async function getSessionCookie(
+  user: User
+): Promise<{ name: string; value: string }> {
+  const { instance, passphrase } = user
+  const loginPageRes = await fetch(`http://${instance}:80/auth/login`)
+  if (!loginPageRes.ok) {
+    throw new Error(
+      `GET /auth/login on ${instance} failed (${loginPageRes.status}): ${await loginPageRes.text()}`
+    )
+  }
+  const params = parseLoginParams(await loginPageRes.text(), instance)
+
+  // Two-step PBKDF2 hash matching cozy-stack's password-helpers.js:
+  // 1. master = PBKDF2(password, salt, iterations, 32, sha256)
+  // 2. hashed = PBKDF2(master, password, 1, 32, sha256) — base64-encoded.
+  const master = pbkdf2Sync(passphrase, params.salt, params.iterations, 32, 'sha256')
+  const hashed = pbkdf2Sync(Uint8Array.from(master), passphrase, 1, 32, 'sha256')
+
+  const initialCookies = loginPageRes.headers.getSetCookie?.() ?? []
+  const res = await fetch(`http://${instance}:80/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Cookie: initialCookies.map(c => c.split(';')[0]).join('; ')
+    },
+    body: new URLSearchParams({
+      passphrase: hashed.toString('base64'),
+      csrf_token: params.csrfToken
+    }),
+    redirect: 'manual'
+  })
+
+  // Session cookie name is dynamic: sess-<hash> with Domain=cozy.localhost.
+  const setCookies = res.headers.getSetCookie?.() ?? []
+  const sess = setCookies.find(c => c.startsWith('sess-'))
+  const m = sess?.match(/^([^=]+)=([^;]+)/)
+  if (!m) {
+    throw new Error(
+      `POST /auth/login on ${instance} did not return a session cookie (status ${res.status}): ${await res.text()}`
+    )
+  }
+  return { name: m[1], value: m[2] }
+}
+
+async function setupUser(
+  user: User
+): Promise<{ cookieName: string; cookieValue: string }> {
+  console.log(`[e2e] Creating instance for ${user.label} (${user.instance})...`)
+  await createInstance(user)
+
+  console.log(`[e2e] Installing Drive app for ${user.label}...`)
+  stackExec(`apps install drive file:///app/drive --domain ${user.instance}`)
+
+  console.log(`[e2e] Setting feature flags for ${user.label}...`)
+  setFlags(user.instance, FEATURE_FLAGS)
+
+  console.log(`[e2e] Getting session cookie for ${user.label}...`)
+  const cookie = await getSessionCookie(user)
+  return { cookieName: cookie.name, cookieValue: cookie.value }
+}
+
+// Pre-populate each instance's address book with a contact for every other
+// org member. Without this, the cozy-sharing modal only knows the recipient's
+// email, and `Sharing.SendInvitations` fails over to SMTP. With the contact
+// in place the modal stamps the recipient's instance URL on the share, so
+// cozy-stack does a direct stack-to-stack PUT and the trusted-domain rule on
+// the receiving side fires `auto_accept_trusted`.
+async function createContact(hostUser: User, peer: User): Promise<void> {
+  const token = stackExec(
+    `instances token-cli ${hostUser.instance} io.cozy.contacts`
+  )
+  const res = await fetch(
+    `http://${hostUser.instance}/data/io.cozy.contacts/`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        fullname: peer.instance.split('.')[0],
+        name: { givenName: peer.instance.split('.')[0] },
+        email: [{ address: peer.email, primary: true }],
+        cozy: [{ url: `http://${peer.instance}`, primary: true }]
+      })
+    }
+  )
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(
+      `Failed to create contact for ${peer.email} on ${hostUser.instance} (${res.status}): ${body}`
+    )
+  }
+}
+
+async function syncContacts(): Promise<void> {
+  const entries = Object.values(USERS)
+  await Promise.all(
+    entries.flatMap(host =>
+      entries
+        .filter(peer => peer.instance !== host.instance)
+        .map(peer => createContact(host, peer))
+    )
+  )
+}
+
+export default async function globalSetup(): Promise<void> {
+  if (process.env.E2E_SKIP_TEARDOWN === '1') {
+    console.log(
+      '[e2e] E2E_SKIP_TEARDOWN=1 — skipping pre-run cleanup. ' +
+        'Provisioning will fail if state from a previous run conflicts; ' +
+        '`docker compose -f docker-compose.e2e.yml down -v` to reset.'
+    )
+  } else {
+    console.log('[e2e] Cleaning up previous containers...')
+    execSync(`docker compose -f ${COMPOSE_FILE} down -v`, {
+      encoding: 'utf-8',
+      cwd: process.cwd()
+    })
+  }
+
+  console.log('[e2e] Starting Docker containers...')
+  execSync(`docker compose -f ${COMPOSE_FILE} up -d --wait`, {
+    encoding: 'utf-8',
+    cwd: process.cwd()
+  })
+
+  console.log('[e2e] Waiting for cozy-stack...')
+  await waitForStack(STACK_URL)
+
+  const results = await Promise.all(
+    Object.values(USERS).map(async user => {
+      const cookie = await setupUser(user)
+      return [user.label, { domain: user.instance, ...cookie }] as const
+    })
+  )
+  saveAuthState(Object.fromEntries(results))
+
+  console.log('[e2e] Cross-populating org contacts...')
+  await syncContacts()
+
+  console.log('[e2e] Setup complete.')
+}

--- a/e2e/setup/global-teardown.ts
+++ b/e2e/setup/global-teardown.ts
@@ -1,0 +1,15 @@
+import { execSync } from 'child_process'
+
+import { COMPOSE_FILE } from '../helpers/config'
+
+export default async function globalTeardown(): Promise<void> {
+  if (process.env.E2E_SKIP_TEARDOWN === '1') {
+    console.log('[e2e] E2E_SKIP_TEARDOWN=1 — leaving containers up.')
+    return
+  }
+  console.log('[e2e] Tearing down Docker containers...')
+  execSync(`docker compose -f ${COMPOSE_FILE} down -v`, {
+    stdio: 'inherit',
+    cwd: process.cwd()
+  })
+}

--- a/e2e/tests/folder-crud.spec.ts
+++ b/e2e/tests/folder-crud.spec.ts
@@ -1,0 +1,99 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { test, expect, stamp, safeUnlink } from '../helpers/fixtures'
+import { SidebarPage } from '../pages/SidebarPage'
+
+const FIXTURE = path.resolve(__dirname, '..', 'fixtures', 'sample.txt')
+const ALICE_ROOT = `${USERS.alice.appUrl}/#/folder`
+
+test.describe('Folder CRUD', () => {
+  test('creates a folder via the Add menu', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const name = `Folder ${stamp()}`
+    await aliceDrive.createFolder(name)
+    await expect(aliceDrive.row(name).cell).toBeVisible()
+  })
+
+  test('renames a folder via the row action menu', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const original = `Old ${stamp()}`
+    const renamed = `Renamed ${stamp()}`
+    await aliceDrive.createFolder(original)
+    await aliceDrive.row(original).rename(renamed)
+    await expect(aliceDrive.row(renamed).cell).toBeVisible()
+  })
+
+  test('moves a folder into a sibling folder', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const target = `Destination ${stamp()}`
+    const moved = `Movable ${stamp()}`
+    await aliceDrive.createFolder(target)
+    await aliceDrive.createFolder(moved)
+    await aliceDrive.row(moved).moveTo(target)
+    await aliceDrive.row(moved).waitHidden()
+    await aliceDrive.row(target).open()
+    await alicePage.waitForURL(/\/folder\/[^/]+$/)
+    await expect(aliceDrive.row(moved).cell).toBeVisible()
+  })
+
+  test('duplicates a file via the row action menu', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    // Folder duplication isn't a feature (see actions/components/duplicateTo —
+    // displayCondition gates the entry on `isFile(...)`); upload a file first.
+    await alicePage.goto(ALICE_ROOT)
+
+    const fileName = `dup-${stamp()}.txt`
+    const stem = fileName.replace(/\.txt$/, '')
+    const filePath = path.join(path.dirname(FIXTURE), fileName)
+    await copyFile(FIXTURE, filePath)
+    try {
+      await aliceDrive.uploadFiles(filePath)
+      await aliceDrive.row(fileName).waitVisible()
+      await aliceDrive.row(fileName).duplicate()
+      // cozy-drive auto-renames the copy ("dup-XXX (2).txt"); match by stem.
+      await expect(aliceDrive.matching(stem)).toHaveCount(2, {
+        timeout: 10_000
+      })
+    } finally {
+      await safeUnlink(filePath)
+    }
+  })
+
+  test('deletes a folder to trash and restores it', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const sidebar = new SidebarPage(alicePage)
+    const name = `Trashable ${stamp()}`
+
+    await aliceDrive.createFolder(name)
+    await aliceDrive.row(name).sendToTrash()
+    await expect(aliceDrive.row(name).cell).toHaveCount(0)
+
+    await sidebar.goToTrash()
+    await alicePage.waitForURL(/\/trash/)
+    await aliceDrive.row(name).waitVisible()
+
+    await aliceDrive.row(name).restore()
+    await alicePage.goto(ALICE_ROOT)
+    await expect(aliceDrive.row(name).cell).toBeVisible()
+  })
+})

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,0 +1,88 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { test, expect, stamp, safeUnlink } from '../helpers/fixtures'
+import { SidebarPage } from '../pages/SidebarPage'
+
+const ALICE_ROOT = `${USERS.alice.appUrl}/#/folder`
+const FIXTURE = path.resolve(__dirname, '..', 'fixtures', 'sample.txt')
+
+test.describe('Navigation surfaces', () => {
+  test('Recent: a freshly uploaded file shows up at /#/recent', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+    const sidebar = new SidebarPage(alicePage)
+    const file = path.join(path.dirname(FIXTURE), `recent-${stamp()}.txt`)
+    await copyFile(FIXTURE, file)
+    try {
+      const fileName = path.basename(file)
+      await aliceDrive.uploadFiles(file)
+      await aliceDrive.row(fileName).waitVisible()
+
+      await sidebar.goToRecent()
+      await alicePage.waitForURL(/\/recent/)
+      await aliceDrive.row(fileName).waitVisible()
+    } finally {
+      await safeUnlink(file)
+    }
+  })
+
+  test('Favorites: a favourited file appears in /#/favorites', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+    const sidebar = new SidebarPage(alicePage)
+    const file = path.join(path.dirname(FIXTURE), `fav-${stamp()}.txt`)
+    await copyFile(FIXTURE, file)
+    try {
+      const fileName = path.basename(file)
+      await aliceDrive.uploadFiles(file)
+      const row = aliceDrive.row(fileName)
+      await row.waitVisible()
+      await row.addToFavorites()
+
+      await sidebar.goToFavorites()
+      await alicePage.waitForURL(/\/favorites/)
+      await aliceDrive.row(fileName).waitVisible()
+    } finally {
+      await safeUnlink(file)
+    }
+  })
+
+  test('Search: a default folder shows up as a suggestion', async ({
+    alicePage
+  }) => {
+    // "Photos" is created on instance bootstrap, so the search index already
+    // knows about it — this avoids racing the indexer for a freshly-uploaded
+    // fixture.
+    await alicePage.goto(`${USERS.alice.appUrl}/#/search`)
+    const searchInput = alicePage.getByRole('textbox', { name: /search/i }).first()
+    await searchInput.waitFor({ state: 'visible' })
+    await searchInput.fill('Photos')
+    // The suggestion list shows the file path as a secondary line — using
+    // the full path makes the assertion immune to "Photos" appearing as a
+    // breadcrumb label or sidebar shortcut.
+    await expect(alicePage.getByText('/Photos').first()).toBeVisible({
+      timeout: 15_000
+    })
+  })
+
+  test('Trash: a deleted folder is reachable from the Bin sidebar entry', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+    const sidebar = new SidebarPage(alicePage)
+    const name = `Trashable ${stamp()}`
+    await aliceDrive.createFolder(name)
+    await aliceDrive.row(name).sendToTrash()
+
+    await sidebar.goToTrash()
+    await alicePage.waitForURL(/\/trash/)
+    await aliceDrive.row(name).waitVisible()
+  })
+})

--- a/e2e/tests/shared-drives.spec.ts
+++ b/e2e/tests/shared-drives.spec.ts
@@ -1,0 +1,77 @@
+import { USERS } from '../helpers/config'
+import { test, expect, stamp } from '../helpers/fixtures'
+import { ShareModalPage } from '../pages/ShareModalPage'
+import { SharedDriveModalPage } from '../pages/SharedDriveModalPage'
+import { SharedDrivePage } from '../pages/SharedDrivePage'
+
+// Shared across .serial tests in this describe — do not enable fullyParallel.
+const SHARED_DRIVE_NAME = `Shared Drive ${stamp()}`
+const FOLDER_INSIDE = `Inside Folder ${stamp()}`
+
+test.describe.serial('Shared Drives', () => {
+  test('Alice creates a shared drive and it shows up in Sharings', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings?tab=1`)
+    const sharedDrive = new SharedDrivePage(alicePage)
+    const modal = new SharedDriveModalPage(alicePage)
+
+    await sharedDrive.clickCreate()
+    await modal.waitForOpen()
+    await modal.setName(SHARED_DRIVE_NAME)
+    await modal.confirm()
+    await modal.waitForClose()
+
+    await expect(aliceDrive.row(SHARED_DRIVE_NAME).cell).toBeVisible({
+      timeout: 15_000
+    })
+  })
+
+  test('Alice invites Bob and the share auto-accepts on his side', async ({
+    alicePage,
+    aliceDrive,
+    bobPage,
+    bobDrive
+  }) => {
+    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings?tab=1`)
+    await aliceDrive.row(SHARED_DRIVE_NAME).open()
+    // Owner sees /folder/<id>; recipient sees /shareddrive/... — assert on
+    // the breadcrumb instead of the URL so this works for both.
+    await expect(alicePage.getByText(SHARED_DRIVE_NAME).first()).toBeVisible()
+
+    await alicePage.getByRole('button', { name: /share/i }).click()
+    const shareModal = new ShareModalPage(alicePage)
+    await shareModal.waitForOpen()
+    await shareModal.addMember(USERS.bob.email)
+    await shareModal.share()
+
+    await expect(async () => {
+      await bobPage.goto(`${USERS.bob.appUrl}/#/sharings?tab=1`)
+      await expect(bobDrive.row(SHARED_DRIVE_NAME).cell).toBeVisible({
+        timeout: 5_000
+      })
+    }).toPass({ timeout: 30_000 })
+  })
+
+  test('Bob can browse content Alice puts inside the shared drive', async ({
+    alicePage,
+    aliceDrive,
+    bobPage,
+    bobDrive
+  }) => {
+    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings?tab=1`)
+    await aliceDrive.row(SHARED_DRIVE_NAME).open()
+    await expect(alicePage.getByText(SHARED_DRIVE_NAME).first()).toBeVisible()
+    await aliceDrive.createFolder(FOLDER_INSIDE)
+
+    await expect(async () => {
+      await bobPage.goto(`${USERS.bob.appUrl}/#/sharings?tab=1`)
+      await bobDrive.row(SHARED_DRIVE_NAME).open()
+      await expect(bobPage.getByText(SHARED_DRIVE_NAME).first()).toBeVisible({
+        timeout: 5_000
+      })
+      await bobDrive.row(FOLDER_INSIDE).waitVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000 })
+  })
+})

--- a/e2e/tests/upload-and-viewer.spec.ts
+++ b/e2e/tests/upload-and-viewer.spec.ts
@@ -1,0 +1,77 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { test, expect, stamp, safeUnlink } from '../helpers/fixtures'
+import { FileViewerPage } from '../pages/FileViewerPage'
+import { UploadQueuePage } from '../pages/UploadQueuePage'
+
+const ALICE_ROOT = `${USERS.alice.appUrl}/#/folder`
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+const NOTES = path.join(FIXTURE_DIR, 'notes.txt')
+
+test.describe('Upload & file viewer', () => {
+  test('uploads a single file via the Upload button', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const uniqueName = `sample-${stamp()}.txt`
+    const fixturePath = path.join(FIXTURE_DIR, uniqueName)
+    await copyFile(SAMPLE, fixturePath)
+    try {
+      await aliceDrive.uploadFiles(fixturePath)
+      await aliceDrive.row(uniqueName).waitVisible()
+    } finally {
+      await safeUnlink(fixturePath)
+    }
+  })
+
+  test('uploads several files and watches the queue', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const queue = new UploadQueuePage(alicePage)
+    const a = path.join(FIXTURE_DIR, `a-${stamp()}.txt`)
+    const b = path.join(FIXTURE_DIR, `b-${stamp()}.txt`)
+    await copyFile(SAMPLE, a)
+    await copyFile(NOTES, b)
+    try {
+      await aliceDrive.uploadFiles([a, b])
+      await queue.waitForOpen()
+      await queue.waitForItem(path.basename(a))
+      await queue.waitForItem(path.basename(b))
+      await aliceDrive.row(path.basename(a)).waitVisible()
+      await aliceDrive.row(path.basename(b)).waitVisible()
+    } finally {
+      await Promise.all([safeUnlink(a), safeUnlink(b)])
+    }
+  })
+
+  test('opens an uploaded file in the viewer and closes it', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const viewer = new FileViewerPage(alicePage)
+    const file = path.join(FIXTURE_DIR, `viewable-${stamp()}.txt`)
+    await copyFile(SAMPLE, file)
+    try {
+      const fileName = path.basename(file)
+      await aliceDrive.uploadFiles(file)
+      const row = aliceDrive.row(fileName)
+      await row.waitVisible()
+      await row.open()
+      await viewer.waitForOpen()
+      await viewer.close()
+      await expect(row.cell).toBeVisible()
+    } finally {
+      await safeUnlink(file)
+    }
+  })
+})

--- a/e2e/tests/z-folder-sharing.spec.ts
+++ b/e2e/tests/z-folder-sharing.spec.ts
@@ -1,0 +1,39 @@
+import { USERS } from '../helpers/config'
+import { test, expect, stamp } from '../helpers/fixtures'
+import { ShareModalPage } from '../pages/ShareModalPage'
+
+// Shared across .serial tests in this describe — do not enable fullyParallel.
+const FOLDER_NAME = `Shared Folder ${stamp()}`
+
+test.describe.serial('Folder sharing', () => {
+  test('Alice creates a folder, enters it, and shares it with Bob', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+
+    await aliceDrive.createFolder(FOLDER_NAME)
+    await aliceDrive.row(FOLDER_NAME).open()
+    await alicePage.waitForURL(/\/folder\/[^/]+$/)
+
+    await alicePage.getByRole('button', { name: /share/i }).click()
+
+    const shareModal = new ShareModalPage(alicePage)
+    await shareModal.waitForOpen()
+    await shareModal.addMember(USERS.bob.email)
+    await shareModal.share()
+  })
+
+  test('Bob sees the shared folder in his Sharings section', async ({
+    bobPage,
+    bobDrive
+  }) => {
+    await bobPage.goto(`${USERS.bob.appUrl}/#/sharings`)
+
+    // Sharing propagates asynchronously across instances; reload until it lands.
+    await expect(async () => {
+      await bobPage.reload()
+      await bobDrive.row(FOLDER_NAME).waitVisible({ timeout: 3_000 })
+    }).toPass({ timeout: 30_000 })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "lint:styles": "stylint src --config ./node_modules/stylus-config-cozy-app/.stylintrc",
     "lint:js": "eslint --concurrency 4 --cache --cache-strategy=content '{src,test}/**/*.{js,jsx,ts,tsx}'",
     "test": "env NODE_ENV='test' jest",
+    "e2e": "playwright test --config e2e/playwright.config.ts",
+    "e2e:setup": "playwright install chromium",
+    "e2e:debug": "playwright test --config e2e/playwright.config.ts --headed --debug",
+    "e2e:report": "playwright show-report playwright-report",
     "service": "yarn cozy-konnector-dev -m ./manifest.webapp"
   },
   "repository": {
@@ -39,6 +43,7 @@
   },
   "homepage": "https://github.com/cozy/cozy-drive#readme",
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@rsbuild/core": "^1.5.15",
     "@swc-contrib/mut-cjs-exports": "^14.7.0",
     "@swc/core": "^1.15.18",
@@ -74,7 +79,7 @@
     "@sentry/react": "7.119.0",
     "classnames": "2.3.1",
     "cozy-bar": "^33.3.0",
-    "cozy-client": "^60.23.1",
+    "cozy-client": "^60.24.0",
     "cozy-dataproxy-lib": "^4.13.0",
     "cozy-device-helper": "^4.0.1",
     "cozy-devtools": "^1.2.1",
@@ -90,7 +95,7 @@
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
     "cozy-sharing": "^31.2.0",
-    "cozy-stack-client": "^60.23.0",
+    "cozy-stack-client": "^60.24.0",
     "cozy-ui": "^138.12.0",
     "cozy-ui-plus": "^7.1.0",
     "cozy-viewer": "^28.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,6 +2783,13 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@playwright/test@^1.58.2":
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
+  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+  dependencies:
+    playwright "1.58.2"
+
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.28"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.28.tgz#d45e01c4a56f143ee69c54dd6b12eade9e270a73"
@@ -6834,17 +6841,17 @@ cozy-client@^60.20.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^60.23.1:
-  version "60.23.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-60.23.1.tgz#009d056973769af69c0e9fe7386cda6c3d0aea3c"
-  integrity sha512-6Kw3exQxvfKCgmemdh8NqX9IZECj/W+QP+DYF8E4lniadXGWsY3drg2oNhyKwHHea+lRU2fEt776Pr0de6ZjTg==
+cozy-client@^60.24.0:
+  version "60.24.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-60.24.0.tgz#2de0b8e61bf14e555527292d4bddb20319c0f05d"
+  integrity sha512-rVcgOvgjYrczG9zfm4Mi+LQ9rO5kTpnqS5hXRqBQkDJKpEPOvbsYFGgN2r51RuKtDtnIVSDxAUNZoPjZoYCdBA==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@fastify/deepmerge" "^2.0.2"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^60.23.0"
+    cozy-stack-client "^60.24.0"
     date-fns "^2.30.0"
     fast-deep-equal "^3.1.3"
     json-stable-stringify "^1.0.1"
@@ -7171,10 +7178,10 @@ cozy-stack-client@^60.19.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^60.23.0:
-  version "60.23.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-60.23.0.tgz#14741377fdc407f1f65db37b24dccf4372afd148"
-  integrity sha512-KUo3JzLP1V2FGpoDehhsWsrFWWcJTsev+1PXQIHhZ4alfdw7Rdup6czHxUU6mx/SmCAwO27axN6jGHIYGZyYhQ==
+cozy-stack-client@^60.24.0:
+  version "60.24.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-60.24.0.tgz#3fa7d419b894565f82848db5a11a486f50ae7946"
+  integrity sha512-p+Vv59BJbtcBeXHc6JXm6mZzp2L7k97pFx6AsnOl8KmvnVE82dnYV6tmRHOHJe/bQn0nrrexhqNAyQ9BO92V4Q==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -9351,6 +9358,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^1.0.0:
   version "1.2.13"
@@ -13494,6 +13506,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
+  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+
+playwright@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
+  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+  dependencies:
+    playwright-core "1.58.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 popper.js@1.16.1-lts:
   version "1.16.1-lts"


### PR DESCRIPTION
## Why

The Drive web app has no end-to-end coverage. Lint and unit tests catch obvious breakage, but nothing exercises the actual UI against a real cozy-stack, which is exactly where sharing, multi-user flows, and cross-instance behaviour can regress unnoticed.

## What's covered

Folder CRUD (create / rename / move / duplicate / delete + restore), upload (single, multiple with the queue, file viewer), navigation (Recent, Favorites, Search, Trash), and the Shared Drives feature (Alice creates a drive, invites Bob, Bob browses content Alice puts inside). A second sharing flow exercises sharing a regular folder with another instance via the same auto-accept path.

## How sharing works without an SMTP server

cozy-stack normally delivers sharing invitations by email. Disabling SMTP in the test stack would leave invitations stuck at status=pending forever, so the suite drives the alternate path that bypasses email entirely:

- Both instances share the same OrgID and OrgDomain (set on instance creation via the admin REST API, the CLI doesn't accept those flags).
- The default context has auto_accept_trusted, auto_accept_trusted_contacts, and trusted_domains: cozy.localhost.
- Each instance is pre-populated with contacts for every other org member, with the peer's cozy URL filled in. With the URL on the contact, the share modal stamps the recipient's instance on the share, and cozy-stack takes the direct stack-to-stack path instead of falling through to SMTP.
- cozy-stack listens on port 80 inside the container so the receiving side's instance lookup (which doesn't strip the port from the Host header) finds the registered domain.

The sender PUTs the share, the recipient's stack matches the sender's domain against trusted_domains via the suffix rule, and the auto-accept job fires.

## When it runs

Three triggers: nightly cron at 03:00 UTC against the default branch, manual workflow_dispatch from the Actions tab, and a PR label \`e2e\` to opt a single PR in. The job is never required for merge or deploy.

## Why it ships with a dep alignment

\`cozy-sharing@31.2.0\` declares \`cozy-client >=60.24.0\` as a peer, but the lockfile kept 60.23.1 with a nested \`cozy-stack-client@60.23.0\`. The older \`createSharedDrive\` threw synchronously on a missing field, and an internal catch swallowed it, leaving the share modal open and the test waiting 15s for nothing. Bumping both packages to ^60.24.0 fixes the contract. The fixture now also attaches per-page console errors and uncaught page errors to failed tests so the next silent-catch breakage names itself instead of looking like a timeout.

## Local development

\`yarn build && npx playwright install chromium && yarn e2e\`. Set \`E2E_SKIP_TEARDOWN=1\` to keep the stack running between iterations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Full end-to-end suite added covering folder CRUD, uploads & viewer, navigation, favorites, trash, shared drives and sharing flows with authenticated cross-instance scenarios and reusable fixtures.
* **Chores**
  * CI workflow to run E2E, cache browsers, and upload reports on failure.
  * Local reproducible E2E environment via Docker composition plus global setup/teardown and persisted auth state.
  * .gitignore updated; npm scripts added to run, debug and view E2E reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->