### PR TITLE
fix: Remove unwanted border arount Grid items

### DIFF
--- a/src/modules/filelist/virtualized/GridFile.jsx
+++ b/src/modules/filelist/virtualized/GridFile.jsx
@@ -103,7 +103,6 @@ const GridFile = ({
   return (
     <Box
       display="block"
-      border={1}
       borderColor="var(--dividerColor)"
       borderRadius={8}
       padding={2}


### PR DESCRIPTION
Before:
<img width="171" height="243" alt="image" src="https://github.com/user-attachments/assets/9d56784c-97af-490f-a93d-ffcc3d3e3d49" />

After : 
<img width="163" height="245" alt="image" src="https://github.com/user-attachments/assets/77e04910-8480-4364-8dfa-f82201f2b55a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Removed border from file grid display for a cleaner visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->