### PR TITLE
fix: guard MoveModal against entries without a path

### DIFF
--- a/src/modules/move/MoveModal.jsx
+++ b/src/modules/move/MoveModal.jsx
@@ -63,13 +63,16 @@ const MoveModal = ({
   const handleConfirm = async folder => {
     setFolderSelected(folder)
 
-    const sharedParentPath = getSharedParentPath(entries[0].path)
+    const sharedParentPath = entries[0].path
+      ? getSharedParentPath(entries[0].path)
+      : ''
     const targetPath = joinPath(folder.path, entries[0].name)
 
     const areMovedFilesShared = hasOneOfEntriesShared(entries, byDocId)
-    const isOriginParentShared = hasSharedParent(entries[0].path) || !!driveId
+    const isOriginParentShared =
+      hasSharedParent(entries[0].path || '') || !!driveId
     const isTargetShared =
-      hasSharedParent(targetPath) ||
+      hasSharedParent(targetPath || '') ||
       (!!folder.driveId && folder.driveId !== driveId)
     const isInsideSameSharedFolder =
       (sharedParentPath && targetPath.startsWith(sharedParentPath)) ||

--- a/src/modules/move/MoveModal.spec.jsx
+++ b/src/modules/move/MoveModal.spec.jsx
@@ -195,6 +195,26 @@ describe('MoveModal component', () => {
       expect(moveButton).toBeDisabled()
     })
 
+    it('should not crash when entries have no path attribute', async () => {
+      const entriesWithoutPath = [
+        {
+          _id: 'no_path_file',
+          dir_id: 'bills',
+          name: 'no_path_file.pdf'
+        }
+      ]
+
+      setup({ entries: entriesWithoutPath })
+
+      const moveButton = await screen.findByText('Move')
+      fireEvent.click(moveButton)
+
+      await waitFor(() => {
+        expect(move).toHaveBeenCalled()
+        expect(onCloseSpy).toHaveBeenCalled()
+      })
+    })
+
     it('should move entries to destination', async () => {
       CozyFile.getFullpath.mockImplementation((destinationFolder, name) =>
         Promise.resolve(


### PR DESCRIPTION
## Summary

- Calling `hasSharedParent` / `getSharedParentPath` with an undefined path crashed the move flow inside `cozy-sharing` on `documentPath.indexOf`.
- Apply the same defensive guards already used in `paste/index.js` so the modal handles entries without a `path` attribute.
- Add a regression test that exercises the no-path case.

Fixes DRIVE-10WK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the move operation to more safely handle items with missing or incomplete data attributes, preventing crashes in edge cases. This improvement ensures greater stability and reliability when moving items in the application, providing a smoother experience even with atypical data configurations. Full backward compatibility is maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->