### PR TITLE
fix: skip permissions fetch on public route without redirectLink

### DIFF
--- a/src/hooks/useRedirectLink.jsx
+++ b/src/hooks/useRedirectLink.jsx
@@ -28,7 +28,17 @@ const useRedirectLink = ({ isPublic = false } = {}) => {
   const client = useClient()
   const navigate = useNavigate()
 
-  const isFromPublicFolder = searchParams.get('fromPublicFolder') === 'true'
+  /**
+   * We read query params from two sources because their position in the url
+   * changes how they are exposed :
+   * - for /#hash?searchParam, you need useSearchParams
+   * - for /?searchParam#hash, you need location.search
+   */
+  const getParam = key => searchParams.get(key) || params.get(key)
+
+  const isFromPublicFolder = getParam('fromPublicFolder') === 'true'
+
+  const redirectLink = getParam('redirectLink')
 
   const [currentMemberInstance, setCurrentMemberInstance] = useState(undefined)
 
@@ -49,19 +59,13 @@ const useRedirectLink = ({ isPublic = false } = {}) => {
       }
     }
 
-    if (isPublic && !isFromPublicFolder) {
+    // Only resolve the share owner's instance when we actually have a redirect
+    // target. Public-share tokens don't always have permission to read
+    // /permissions/self, so skipping unnecessary calls avoids 403 noise.
+    if (isPublic && !isFromPublicFolder && redirectLink) {
       fetch()
     }
-  }, [client, isPublic, isFromPublicFolder])
-
-  /**
-   * We search for redirectLink using two methods because
-   * the searchParam differs depending on the position in the url :
-   * - for /#hash?searchParam, you need useSearchParams
-   * - for /?searchParam#hash, you need location.search
-   */
-  const redirectLink =
-    searchParams.get('redirectLink') || params.get('redirectLink')
+  }, [client, isPublic, isFromPublicFolder, redirectLink])
 
   const redirectBack = () => {
     if (!redirectLink) {

--- a/src/hooks/useRedirectLink.spec.jsx
+++ b/src/hooks/useRedirectLink.spec.jsx
@@ -44,6 +44,7 @@ describe('useRedirectLink', () => {
 
   afterEach(() => {
     window.history = originalHistory
+    window.history.replaceState({}, '', '/')
     jest.clearAllMocks()
   })
 
@@ -164,5 +165,28 @@ describe('useRedirectLink', () => {
     expect(mockNavigate).toHaveBeenCalledTimes(0)
     expect(render.result.current.redirectLink).toBe('drive#/folder/id123')
     expect(render.result.current.canRedirect).toBe(false)
+  })
+
+  it('should not fetch permissions when no redirectLink is present', async () => {
+    useSearchParams.mockReturnValue([new URLSearchParams('')])
+    await act(async () => {
+      renderHook(() => useRedirectLink({ isPublic: true }))
+    })
+
+    expect(mockClient.collection().fetchOwnPermissions).not.toHaveBeenCalled()
+  })
+
+  it('should not fetch permissions on a public folder url shaped /?searchParam#hash', async () => {
+    useSearchParams.mockReturnValue([new URLSearchParams('')])
+    window.history.replaceState(
+      {},
+      '',
+      '/?redirectLink=drive%23%2Ffolder%2Fid123&fromPublicFolder=true'
+    )
+    await act(async () => {
+      renderHook(() => useRedirectLink({ isPublic: true }))
+    })
+
+    expect(mockClient.collection().fetchOwnPermissions).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- `useRedirectLink` was calling `fetchOwnPermissions` for every public viewer, but the result is only used when a `redirectLink` URL param is present.
- Public share tokens cannot always read `/permissions/self`, so the unnecessary call produced thousands of 403 errors with no user-facing impact.
- Gating the fetch on `redirectLink` removes the noise and skips wasted work in the common case.

Fixes DRIVE-ZH7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary permission checks during public-share redirects, improving performance and avoiding needless access queries when no redirect target is present.

* **Tests**
  * Added tests to ensure permission fetching is skipped when redirect parameters are absent and to prevent cross-test URL state leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->