### PR TITLE
fix: Make migration progress banner background transparent

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "cozy-search": "^0.25.3",
     "cozy-sharing": "^31.2.0",
     "cozy-stack-client": "^60.23.0",
-    "cozy-ui": "^138.10.0",
+    "cozy-ui": "^138.12.0",
     "cozy-ui-plus": "^7.1.0",
     "cozy-viewer": "^28.0.7",
     "date-fns": "2.30.0",

--- a/src/components/Migration/MigrationProgressBanner.jsx
+++ b/src/components/Migration/MigrationProgressBanner.jsx
@@ -107,6 +107,7 @@ const DumbMigrationProgressBanner = ({ migrationDoc }) => {
   return (
     <ProgressionBanner
       icon={<Icon icon={Upload} size={16} />}
+      color="transparent"
       text={
         <>
           {t('MigrationProgressBanner.title')}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7201,10 +7201,10 @@ cozy-ui-plus@^7.1.0:
     react-international-phone "4.7.0"
     rooks "7.14.1"
 
-cozy-ui@^138.10.0:
-  version "138.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-138.10.0.tgz#808ec445223fe4e21cb502cd21273f8b6e201838"
-  integrity sha512-8+ufmosr66Ndc19G8Y4r5EVnnhTr4qFvhlsNAQOOnQyuAhBzLPhlZLVJzwlVkM8ZZD010EO0/AFwkm+6iBvpPw==
+cozy-ui@^138.12.0:
+  version "138.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-138.12.0.tgz#3e7650a6776be3dbaf0a5431508e53d976b3f0f7"
+  integrity sha512-QR3K2wEpjQgWZk4u9S0KHFg27j7Uip1apgwDD3vrIKXuoIFoQ7B1SZd+1wjQRZPLmjmNtf4exDl3ryvFy2V1CQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"


### PR DESCRIPTION
For a better integration with the design

<img width="1560" height="113" alt="image" src="https://github.com/user-attachments/assets/ecb592b3-f8d2-475e-bae5-69baa971d6be" />

<img width="1560" height="113" alt="image" src="https://github.com/user-attachments/assets/1e532c35-2ee1-4b8c-bac8-c8ac0bdb0d1c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `cozy-ui` dependency to the latest stable version.

* **Style**
  * Adjusted Migration Progress Banner styling for improved visual clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3841)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->