### PR TITLE
fix: Include driveId when opening OnlyOffice files from sharing

### DIFF
--- a/src/modules/public/LightFileViewer.jsx
+++ b/src/modules/public/LightFileViewer.jsx
@@ -36,6 +36,7 @@ const LightFileViewer = ({ files, isPublic }) => {
   const onlyOfficeOpener = useCallback(
     file => {
       const route = makeOnlyOfficeFileRoute(file.id, {
+        driveId: file.driveId,
         fromPathname: pathname
       })
       navigate(route)

--- a/src/modules/search/components/helpers.js
+++ b/src/modules/search/components/helpers.js
@@ -46,7 +46,10 @@ export const makeNormalizedFile = (client, folders, file) => {
       url = `/n/${file.id}`
       openOn = 'notes'
     } else if (models.file.shouldBeOpenedByOnlyOffice(file)) {
-      url = makeOnlyOfficeFileRoute(file.id, { fromPathname: urlToFolder })
+      url = makeOnlyOfficeFileRoute(file.id, {
+        driveId: file.driveId,
+        fromPathname: urlToFolder
+      })
     } else {
       url = `${urlToFolder}/file/${file._id}`
     }
@@ -83,7 +86,7 @@ export const indexFiles = async client => {
     .getStackClient()
     .fetchJSON(
       'GET',
-      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,class,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
+      '/data/io.cozy.files/_all_docs?Fields=_id,trashed,dir_id,name,path,type,mime,class,driveId,metadata.title,metadata.version&DesignDocs=false&include_docs=true'
     )
   const files = resp.rows.map(row => ({ id: row.id, ...row.doc }))
   const folders = files.filter(file => file.type === TYPE_DIRECTORY)

--- a/src/modules/search/components/helpers.spec.jsx
+++ b/src/modules/search/components/helpers.spec.jsx
@@ -3,6 +3,7 @@ import { createMockClient, models } from 'cozy-client'
 import { makeNormalizedFile, TYPE_DIRECTORY } from './helpers'
 
 models.note.fetchURL = jest.fn(() => 'noteUrl')
+models.file.shouldBeOpenedByOnlyOffice = jest.fn(() => false)
 
 const client = createMockClient({})
 
@@ -110,5 +111,24 @@ describe('makeNormalizedFile', () => {
       mime: undefined,
       type: 'file'
     })
+  })
+
+  it('should include driveId when file is OnlyOffice document', () => {
+    models.file.shouldBeOpenedByOnlyOffice = jest.fn(() => true)
+    const folders = [{ _id: 'folderId', path: 'folderPath' }]
+    const file = {
+      _id: 'fileId',
+      id: 'onlyofficeId',
+      dir_id: 'folderId',
+      type: 'file',
+      name: 'document.docx',
+      mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      class: 'document',
+      driveId: 'drive123'
+    }
+
+    const normalizedFile = makeNormalizedFile(client, folders, file)
+
+    expect(normalizedFile.url).toContain('/onlyoffice/drive123/')
   })
 })

--- a/src/modules/viewer/FileOpenerExternal.jsx
+++ b/src/modules/viewer/FileOpenerExternal.jsx
@@ -92,7 +92,10 @@ const FileOpener = props => {
             componentsProps={{
               OnlyOfficeViewer: {
                 isEnabled: isOfficeEnabled(isDesktop),
-                opener: file => navigate(makeOnlyOfficeFileRoute(file.id))
+                opener: file =>
+                  navigate(
+                    makeOnlyOfficeFileRoute(file.id, { driveId: file.driveId })
+                  )
               }
             }}
           >

--- a/src/modules/viewer/FilesViewer.jsx
+++ b/src/modules/viewer/FilesViewer.jsx
@@ -171,7 +171,10 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange, viewerProps }) => {
           componentsProps={{
             OnlyOfficeViewer: {
               isEnabled: isOfficeEnabled(isDesktop),
-              opener: file => navigate(makeOnlyOfficeFileRoute(file.id))
+              opener: file =>
+                navigate(
+                  makeOnlyOfficeFileRoute(file.id, { driveId: file.driveId })
+                )
             },
             toolbarProps: {
               showFilePath: true,


### PR DESCRIPTION
As a shared folder recipient, the wrong route was used to display a onlyoffice file. Now we pass the driveId to it

https://www.notion.so/linagora/Shared-Drive-file-error-page-with-details-and-qualifications-32562718bad180e1b3c9c5bc5167b672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Office file opening now consistently includes drive context so files open with the correct drive-specific route in the OnlyOffice viewer across the app.

* **Tests**
  * Added a unit test verifying OnlyOffice file URLs include the expected drive segment when applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->