### PR TITLE
fix: Handle federated shared folders in the list of sharings

### DIFF
--- a/src/modules/filelist/cells/ShareContent.jsx
+++ b/src/modules/filelist/cells/ShareContent.jsx
@@ -8,6 +8,7 @@ import styles from '@/styles/filelist.styl'
 
 import { useViewSwitcherContext } from '@/lib/ViewSwitcherContext'
 import { joinPath } from '@/lib/path'
+import { isFromSharedDriveRecipient } from '@/modules/shareddrives/helpers'
 
 const ShareContent = ({ file, disabled, isInSyncFromSharing }) => {
   const navigate = useNavigate()
@@ -21,8 +22,11 @@ const ShareContent = ({ file, disabled, isInSyncFromSharing }) => {
     e.stopPropagation()
 
     if (!disabled) {
-      // should be only disabled
-      navigate(joinPath(pathname, `file/${file._id}/share`))
+      const sharePath = isFromSharedDriveRecipient(file)
+        ? `/shareddrive/${file.driveId}/${file._id}/file/${file.id}/share`
+        : joinPath(pathname, `file/${file.id}/share`)
+
+      navigate(sharePath)
     }
   }
 

--- a/src/modules/filelist/virtualized/cells/ShareContent.jsx
+++ b/src/modules/filelist/virtualized/cells/ShareContent.jsx
@@ -7,6 +7,7 @@ import { SharedStatus } from 'cozy-sharing'
 import styles from '@/styles/filelist.styl'
 
 import { joinPath } from '@/lib/path'
+import { isFromSharedDriveRecipient } from '@/modules/shareddrives/helpers'
 
 const ShareContent = ({ file, disabled }) => {
   const navigate = useNavigate()
@@ -18,8 +19,11 @@ const ShareContent = ({ file, disabled }) => {
     e.stopPropagation()
 
     if (!disabled) {
-      // should be only disabled
-      navigate(joinPath(pathname, `file/${file._id}/share`))
+      const sharePath = isFromSharedDriveRecipient(file)
+        ? `/shareddrive/${file.driveId}/${file._id}/file/${file.id}/share`
+        : joinPath(pathname, `file/${file.id}/share`)
+
+      navigate(sharePath)
     }
   }
 


### PR DESCRIPTION
When we click on the avatars in the list of sharing, we now handle federated shared folders when we are recipients

fixes https://github.com/linagora/twake-drive/issues/3832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file-sharing navigation for items from shared drives to use proper routing and ensure correct access when initiating shares

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->