### PR TITLE
fix(onlyoffice): disable Edit button for all editing modes

### DIFF
--- a/src/modules/views/OnlyOffice/Toolbar/EditButton.jsx
+++ b/src/modules/views/OnlyOffice/Toolbar/EditButton.jsx
@@ -99,7 +99,7 @@ const EditButton = ({ openTooltip }) => {
       <Buttons
         className="u-ml-half"
         onClick={handleClick}
-        disabled={editorMode === 'edit'}
+        disabled={editorMode !== 'view'}
         startIcon={<Icon icon={RenameIcon} />}
         label={t('OnlyOffice.actions.edit')}
       />


### PR DESCRIPTION
Previously the button was only disabled when editorMode was exactly 'edit',
but it could also be 'write' (from drive.office.defaultMode flag). The condition now checks editorMode !== 'view' to cover all editing modes.

fixes https://github.com/linagora/twake-drive/issues/3657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the edit button's enabled/disabled state to correctly reflect the current editor mode, ensuring the button is only clickable when appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->