### PR TITLE
fix(shared-drive): show skeleton for shared drive recipients

### DIFF
--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -70,10 +70,14 @@ const SharedDriveFolderView = () => {
       folderId
     })
 
-  const queryResults =
-    sharedDriveResult.included !== undefined
-      ? [{ fetchStatus, data: sharedDriveResult.included, hasMore, fetchMore }]
-      : []
+  const queryResults = [
+    {
+      fetchStatus,
+      data: sharedDriveResult.included ?? [],
+      hasMore,
+      fetchMore
+    }
+  ]
 
   const canWriteToCurrentFolder = hasWriteAccess(folderId, driveId)
 


### PR DESCRIPTION
fixes https://github.com/linagora/twake-drive/issues/3780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data handling in the shared drive folder view to ensure more consistent and reliable behavior when processing folder contents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->