### PR TITLE
fix: Display skeleton for public pages

### DIFF
--- a/src/modules/views/Public/usePublicFilesQuery.jsx
+++ b/src/modules/views/Public/usePublicFilesQuery.jsx
@@ -36,6 +36,10 @@ export const usePublicFilesQuery = currentFolderId => {
     const initialFetch = async () => {
       try {
         setFetchStatus('loading')
+        setData([])
+        setHasMore(false)
+        nextCursor.current = null
+
         const { included, cursor } = await statById(client, currentFolderId)
         nextCursor.current = cursor
         setData(included || [])


### PR DESCRIPTION
fixes https://github.com/linagora/twake-drive/issues/3851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pagination state not clearing when navigating between folders, preventing stale data from displaying alongside new folder contents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->