### PR TITLE
fix: stop unhandled 403 rejections on public sharing pages

### DIFF
--- a/src/components/PushBanner/PushBanner.spec.jsx
+++ b/src/components/PushBanner/PushBanner.spec.jsx
@@ -76,11 +76,6 @@ describe('PushBanner', () => {
     })
   })
 
-  it('should hide banner when is public', () => {
-    const { container } = render(<PushBanner isPublic={true} />)
-    expect(container).toBeEmptyDOMElement()
-  })
-
   it('should hide banner when the instance information is not loaded', () => {
     useInstanceInfo.mockReturnValue({
       isLoaded: false

--- a/src/components/PushBanner/index.jsx
+++ b/src/components/PushBanner/index.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import React from 'react'
 
 import { useInstanceInfo } from 'cozy-client'
@@ -12,11 +11,11 @@ import BannerClient from '../../components/pushClient/Banner'
 /**
  * Component to manage all banner display logic
  */
-const PushBanner = ({ isPublic }) => {
+const PushBanner = () => {
   const { bannerDismissed } = usePushBannerContext()
   const { isLoaded, diskUsage } = useInstanceInfo()
 
-  if (isPublic || !isLoaded) return null
+  if (!isLoaded) return null
 
   const diskInfos = makeDiskInfos(
     diskUsage?.data?.attributes?.used,
@@ -32,15 +31,6 @@ const PushBanner = ({ isPublic }) => {
   }
 
   return null
-}
-
-PushBanner.defaultProps = {
-  isPublic: false
-}
-
-PushBanner.propTypes = {
-  /** Whether public context */
-  isPublic: PropTypes.bool
 }
 
 export default PushBanner

--- a/src/components/useHead.jsx
+++ b/src/components/useHead.jsx
@@ -3,7 +3,9 @@ import { useParams } from 'react-router-dom'
 
 import { useQuery } from 'cozy-client'
 
+import { ROOT_DIR_ID } from '@/constants/config'
 import useUpdateFavicon from '@/hooks/useUpdateFavicon'
+import { usePublicContext } from '@/modules/public/PublicProvider'
 import useUpdateDocumentTitle from '@/modules/views/useUpdateDocumentTitle'
 import {
   buildFileOrFolderByIdQuery,
@@ -12,19 +14,23 @@ import {
 
 const useHead = ({ title } = {}) => {
   const { driveId, folderId, fileId } = useParams()
+  const { isPublic } = usePublicContext()
 
   const isFileOpen = useMemo(() => fileId !== undefined, [fileId])
 
+  const id = isFileOpen ? fileId : folderId
+
+  // Public-share tokens cannot read the instance root directory; the query
+  // would 403 and leak as an unhandled rejection through useQuery.
+  const isForbiddenRootOnPublic = isPublic && id === ROOT_DIR_ID
+
   const fileQuery = driveId
-    ? buildSharedDriveFolderQuery({
-        driveId,
-        folderId: isFileOpen ? fileId : folderId
-      })
-    : buildFileOrFolderByIdQuery(isFileOpen ? fileId : folderId)
-  const { data: file, fetchStatus } = useQuery(
-    fileQuery.definition,
-    fileQuery.options
-  )
+    ? buildSharedDriveFolderQuery({ driveId, folderId: id })
+    : buildFileOrFolderByIdQuery(id)
+  const { data: file, fetchStatus } = useQuery(fileQuery.definition, {
+    ...fileQuery.options,
+    enabled: fileQuery.options.enabled !== false && !isForbiddenRootOnPublic
+  })
 
   useUpdateDocumentTitle(file, fetchStatus, title)
   useUpdateFavicon(file, fetchStatus)

--- a/src/components/useHead.spec.jsx
+++ b/src/components/useHead.spec.jsx
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react'
+import { useParams } from 'react-router-dom'
+
+import { useQuery } from 'cozy-client'
+
+import useHead from './useHead'
+
+import { ROOT_DIR_ID } from '@/constants/config'
+import { usePublicContext } from '@/modules/public/PublicProvider'
+
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  useQuery: jest.fn()
+}))
+
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn()
+}))
+
+jest.mock('@/modules/public/PublicProvider')
+jest.mock('@/hooks/useUpdateFavicon')
+jest.mock('@/modules/views/useUpdateDocumentTitle')
+
+describe('useHead', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    usePublicContext.mockReturnValue({ isPublic: false })
+    useQuery.mockReturnValue({ data: null, fetchStatus: 'pending' })
+  })
+
+  it('does not query the instance root directory on the public route', () => {
+    // The instance root is forbidden for public-share tokens; querying it 403s
+    // and leaks as an unhandled rejection through useQuery.
+    useParams.mockReturnValue({ folderId: ROOT_DIR_ID })
+    usePublicContext.mockReturnValue({ isPublic: true })
+
+    renderHook(() => useHead())
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ enabled: false })
+    )
+  })
+
+  it('queries the folder on the authenticated route', () => {
+    useParams.mockReturnValue({ folderId: ROOT_DIR_ID })
+    usePublicContext.mockReturnValue({ isPublic: false })
+
+    renderHook(() => useHead())
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ enabled: true })
+    )
+  })
+})

--- a/src/hooks/useDisplayedFolder.spec.jsx
+++ b/src/hooks/useDisplayedFolder.spec.jsx
@@ -4,6 +4,7 @@ import useCurrentFolderId from './useCurrentFolderId'
 import useDisplayedFolder from './useDisplayedFolder'
 
 import { ROOT_DIR_ID } from '@/constants/config'
+import { usePublicContext } from '@/modules/public/PublicProvider'
 
 jest.mock('cozy-client', () => ({
   ...jest.requireActual('cozy-client'),
@@ -11,8 +12,14 @@ jest.mock('cozy-client', () => ({
 }))
 
 jest.mock('./useCurrentFolderId')
+jest.mock('@/modules/public/PublicProvider')
 
 describe('useDisplayedFolder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    usePublicContext.mockReturnValue({ isPublic: false })
+  })
+
   it('should return file folder if current folder exists', () => {
     const FOLDER = {
       id: 'folder-id',
@@ -38,5 +45,34 @@ describe('useDisplayedFolder', () => {
     const { displayedFolder } = useDisplayedFolder()
 
     expect(displayedFolder).toBe(FOLDER)
+  })
+
+  it('does not query the instance root directory on the public route', () => {
+    // Public-share tokens cannot read the instance root directory, so the query
+    // would 403. cozy-client's useQuery does not catch that rejection, so it
+    // surfaces as an unhandled promise rejection.
+    useQuery.mockReturnValue({ data: null, fetchStatus: 'pending' })
+    useCurrentFolderId.mockReturnValue(null) // falls back to ROOT_DIR_ID
+    usePublicContext.mockReturnValue({ isPublic: true })
+
+    useDisplayedFolder()
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ enabled: false })
+    )
+  })
+
+  it('still queries the root directory on the authenticated route', () => {
+    useQuery.mockReturnValue({ data: null, fetchStatus: 'pending' })
+    useCurrentFolderId.mockReturnValue(null) // falls back to ROOT_DIR_ID
+    usePublicContext.mockReturnValue({ isPublic: false })
+
+    useDisplayedFolder()
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ enabled: true })
+    )
   })
 })

--- a/src/hooks/useDisplayedFolder.tsx
+++ b/src/hooks/useDisplayedFolder.tsx
@@ -3,6 +3,7 @@ import { IOCozyFile } from 'cozy-client/types/types'
 
 import { ROOT_DIR_ID } from '@/constants/config'
 import useCurrentFolderId from '@/hooks/useCurrentFolderId'
+import { usePublicContext } from '@/modules/public/PublicProvider'
 import { buildFileOrFolderByIdQuery } from '@/queries'
 
 interface DisplayedFolderResult {
@@ -12,13 +13,19 @@ interface DisplayedFolderResult {
 }
 
 const useDisplayedFolder = (): DisplayedFolderResult => {
+  const { isPublic } = usePublicContext()
   const folderId = useCurrentFolderId() ?? ROOT_DIR_ID
 
+  // Public-share tokens cannot read the instance root directory, so the query
+  // would 403. cozy-client's useQuery does not catch that rejection, so it
+  // surfaces as an unhandled promise rejection. Skip it.
+  const isForbiddenRootOnPublic = isPublic && folderId === ROOT_DIR_ID
+
   const folderQuery = buildFileOrFolderByIdQuery(folderId)
-  const folderResult = useQuery(
-    folderQuery.definition,
-    folderQuery.options
-  ) as unknown as {
+  const folderResult = useQuery(folderQuery.definition, {
+    ...folderQuery.options,
+    enabled: folderQuery.options.enabled !== false && !isForbiddenRootOnPublic
+  }) as unknown as {
     data?: IOCozyFile | null
     fetchStatus: string
     lastError: { status: number }

--- a/src/modules/layout/Main.jsx
+++ b/src/modules/layout/Main.jsx
@@ -10,9 +10,9 @@ import { NEXTCLOUD_MIGRATIONS_DOCTYPE } from '@/lib/doctypes'
 
 const Main = ({ children, isPublic = false }) => (
   <MainUI>
-    <PushBanner isPublic={isPublic} />
     {!isPublic && (
       <>
+        <PushBanner />
         <RealTimeQueries doctype={NEXTCLOUD_MIGRATIONS_DOCTYPE} />
         <MigrationProgressBanner />
       </>

--- a/src/modules/layout/Main.spec.jsx
+++ b/src/modules/layout/Main.spec.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import Main from './Main'
+
+jest.mock('cozy-ui/transpiled/react/Layout', () => ({
+  Main: ({ children }) => <div>{children}</div>
+}))
+jest.mock('cozy-client', () => ({ RealTimeQueries: () => null }))
+jest.mock('@/components/PushBanner', () => () => (
+  <div data-testid="push-banner" />
+))
+jest.mock('@/components/Migration/MigrationProgressBanner', () => ({
+  MigrationProgressBanner: () => null
+}))
+
+describe('Main', () => {
+  it('does not mount PushBanner on the public route', () => {
+    // PushBanner calls useInstanceInfo, which queries /settings/disk-usage. A
+    // public-share token cannot read it (403), and cozy-client's useQuery does
+    // not catch that rejection. PushBanner renders null on
+    // public anyway, so it must not be mounted there at all.
+    render(<Main isPublic>{[]}</Main>)
+
+    expect(screen.queryByTestId('push-banner')).toBeNull()
+  })
+
+  it('mounts PushBanner on the authenticated route', () => {
+    render(<Main isPublic={false}>{[]}</Main>)
+
+    expect(screen.queryByTestId('push-banner')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Public sharing pages run on a read-only sharecode token that cannot read instance-level resources such as the root directory or disk usage. The app issued those queries anyway, and because cozy-client's useQuery does not catch a failed query's promise, every 403 became an unhandled rejection hitting thousands of public visitors.
- useDisplayedFolder and useHead now skip the root directory query when on a public route.
- PushBanner is no longer mounted on public pages, where it rendered nothing but still fetched disk usage through useInstanceInfo.

Fixes DRIVE-111P
Fixes DRIVE-112T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented 403 errors when viewing public shares by disabling problematic root queries.
  * Push banner behavior refined: it no longer appears in public shares and is hidden while instance info is still loading.

* **Tests**
  * Added tests covering public-share behavior and conditional query enabling/disabling across hooks and layout components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->