### PR TITLE
refactor: extract shared folder-view hooks

### DIFF
--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -117,7 +117,7 @@ const DriveFolderView = () => {
     isOwner,
     byDocId,
     selectAll: () =>
-      base.toggleSelectAllItems(allResults.map(query => query.data).flat()),
+      base.toggleSelectAllItems(allResults.flatMap(query => query.data || [])),
     displayedFolder
   }
   const actions = makeActions(

--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -1,8 +1,6 @@
-import React, { useContext, useEffect, useMemo } from 'react'
-import { useDispatch } from 'react-redux'
-import { useNavigate, Outlet, useLocation, useParams } from 'react-router-dom'
+import React, { useMemo } from 'react'
+import { Outlet, useParams } from 'react-router-dom'
 
-import { useQuery, useClient } from 'cozy-client'
 import flag from 'cozy-flags'
 import { useVaultClient } from 'cozy-keys-lib'
 import {
@@ -11,20 +9,15 @@ import {
   shareNative
 } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
-import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
-import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'twake-i18n'
 
 import HarvestBanner from './HarvestBanner'
+import { useDriveQueries } from './useDriveQueries'
 
 import useHead from '@/components/useHead'
-import { DEFAULT_SORT } from '@/config/sort'
 import { ROOT_DIR_ID } from '@/constants/config'
 import { useClipboardContext } from '@/contexts/ClipboardProvider'
 import { useCurrentFolderId, useDisplayedFolder, useFolderSort } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
-import { FabContext } from '@/lib/FabProvider'
-import { useModalContext } from '@/lib/ModalContext'
 import { useThumbnailSizeContext } from '@/lib/ThumbnailSizeContext'
 import {
   share,
@@ -47,7 +40,6 @@ import { useExtraColumns } from '@/modules/certifications/useExtraColumns'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
 import Toolbar from '@/modules/drive/Toolbar'
-import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import Dropzone from '@/modules/upload/Dropzone'
 import DropzoneDnD from '@/modules/upload/DropzoneDnD'
 import { useTrashRedirect } from '@/modules/views/Drive/useTrashRedirect'
@@ -55,126 +47,77 @@ import FolderView from '@/modules/views/Folder/FolderView'
 import FolderViewBody from '@/modules/views/Folder/FolderViewBody'
 import FolderViewBreadcrumb from '@/modules/views/Folder/FolderViewBreadcrumb'
 import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
+import { useFabOnMobile } from '@/modules/views/Folder/hooks/useFabOnMobile'
+import { useFolderViewBase } from '@/modules/views/Folder/hooks/useFolderViewBase'
 import FolderViewBodyVz from '@/modules/views/Folder/virtualized/FolderViewBody'
 import { useResumeUploadFromFlagship } from '@/modules/views/Upload/useResumeFromFlagship'
-import {
-  buildDriveQuery,
-  buildFileWithSpecificMetadataAttributeQuery
-} from '@/queries'
+import { buildFileWithSpecificMetadataAttributeQuery } from '@/queries'
 
 // Those extra columns names must match a metadata attribute name, e.g. carbonCopy or electronicSafe
 const desktopExtraColumnsNames = []
 const mobileExtraColumnsNames = []
 
 const DriveFolderView = () => {
-  const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const base = useFolderViewBase()
+  const { t } = base
   const params = useParams()
   const currentFolderId = useCurrentFolderId()
   useHead()
-  const { isSelectionBarVisible, toggleSelectAllItems, isSelectAll } =
-    useSelectionContext()
-  const { isMobile, isDesktop } = useBreakpoints()
-  const { t, lang } = useI18n()
-  const { isFabDisplayed, setIsFabDisplayed } = useContext(FabContext)
   const { isBigThumbnail, toggleThumbnailSize } = useThumbnailSizeContext()
   const sharingContext = useSharingContext()
   const { allLoaded, hasWriteAccess, refresh, isOwner, byDocId } =
     sharingContext
-  const { isNativeFileSharingAvailable, shareFilesNative } =
-    useNativeFileSharing()
-  const client = useClient()
+  const nativeSharing = useNativeFileSharing()
   const vaultClient = useVaultClient()
-  const { pushModal, popModal } = useModalContext()
-  const dispatch = useDispatch()
-  const extraColumnsNames = makeExtraColumnsNamesFromMedia({
-    isMobile,
-    desktopExtraColumnsNames,
-    mobileExtraColumnsNames
-  })
-  const { showAlert } = useAlert()
   const { hasClipboardData } = useClipboardContext()
 
   const extraColumns = useExtraColumns({
-    columnsNames: extraColumnsNames,
+    columnsNames: makeExtraColumnsNamesFromMedia({
+      isMobile: base.isMobile,
+      desktopExtraColumnsNames,
+      mobileExtraColumnsNames
+    }),
     queryBuilder: buildFileWithSpecificMetadataAttributeQuery,
     currentFolderId
   })
 
-  const { displayedFolder: _displayedFolder, isNotFound } = useDisplayedFolder()
-
-  const displayedFolder = useMemo(() => _displayedFolder, [_displayedFolder])
+  const { displayedFolder, isNotFound } = useDisplayedFolder()
 
   useTrashRedirect(displayedFolder)
 
   const [sortOrder, setSortOrder, isSettingsLoaded] =
     useFolderSort(currentFolderId)
 
-  // Sort by size does not work for directory, so in case sorting by size we will change to default sorting
-  const folderQuery = buildDriveQuery({
+  const { allResults, isInError, isLoading, isPending } = useDriveQueries(
     currentFolderId,
-    type: 'directory',
-    sortAttribute:
-      sortOrder.attribute !== 'size'
-        ? sortOrder.attribute
-        : DEFAULT_SORT.attribute,
-    sortOrder:
-      sortOrder.attribute !== 'size' ? sortOrder.order : DEFAULT_SORT.order
-  })
-  const fileQuery = buildDriveQuery({
-    currentFolderId,
-    type: 'file',
-    sortAttribute: sortOrder.attribute,
-    sortOrder: sortOrder.order
-  })
-
-  const foldersResult = useQuery(folderQuery.definition, folderQuery.options)
-  const filesResult = useQuery(fileQuery.definition, fileQuery.options)
-
-  let allResults = [foldersResult, filesResult]
-
-  const isInError = allResults.some(result => result.fetchStatus === 'failed')
-  const isLoading = allResults.some(
-    result => result.fetchStatus === 'loading' && !result.lastUpdate
+    sortOrder
   )
-  const isPending = allResults.some(result => result.fetchStatus === 'pending')
-
+  const [foldersResult, filesResult] = allResults
   const canWriteToCurrentFolder = hasWriteAccess(currentFolderId)
 
   useKeyboardShortcuts({
     canPaste: hasClipboardData && canWriteToCurrentFolder,
-    client,
+    client: base.client,
     items: [...(foldersResult.data || []), ...(filesResult.data || [])],
     sharingContext,
-    pushModal,
-    popModal,
+    pushModal: base.pushModal,
+    popModal: base.popModal,
     refresh
   })
 
   const actionsOptions = {
-    client,
-    t,
-    lang,
+    ...base,
+    ...nativeSharing,
     vaultClient,
-    pushModal,
-    popModal,
     refresh,
-    dispatch,
-    navigate,
-    pathname,
     hasWriteAccess: canWriteToCurrentFolder,
     canMove: true,
     isPublic: false,
     allLoaded,
-    showAlert,
     isOwner,
     byDocId,
-    isMobile,
-    isNativeFileSharingAvailable,
-    shareFilesNative,
     selectAll: () =>
-      toggleSelectAllItems(allResults.map(query => query.data).flat()),
-    isSelectAll,
+      base.toggleSelectAllItems(allResults.map(query => query.data).flat()),
     displayedFolder
   }
   const actions = makeActions(
@@ -211,18 +154,12 @@ const DriveFolderView = () => {
 
   useResumeUploadFromFlagship()
 
-  useEffect(() => {
-    if (canWriteToCurrentFolder) {
-      setIsFabDisplayed(!isDesktop)
-      return () => {
-        // to not have this set to false on other views after using this view
-        setIsFabDisplayed(false)
-      }
-    }
-  }, [setIsFabDisplayed, isDesktop, canWriteToCurrentFolder])
+  const isFabDisplayed = useFabOnMobile(canWriteToCurrentFolder)
 
   const DropzoneComp =
-    flag('drive.virtualization.enabled') && !isMobile ? DropzoneDnD : Dropzone
+    flag('drive.virtualization.enabled') && !base.isMobile
+      ? DropzoneDnD
+      : Dropzone
 
   return (
     <FolderView isNotFound={isNotFound}>
@@ -248,7 +185,7 @@ const DriveFolderView = () => {
         {flag('drive.show.harvest-banner') && (
           <HarvestBanner folderId={currentFolderId} />
         )}
-        {flag('drive.virtualization.enabled') && !isMobile ? (
+        {flag('drive.virtualization.enabled') && !base.isMobile ? (
           <FolderViewBodyVz
             actions={actions}
             queryResults={allResults}
@@ -291,10 +228,10 @@ const DriveFolderView = () => {
             canCreateFolder={true}
             canUpload={true}
             disabled={isLoading || isInError || isPending}
-            navigate={navigate}
+            navigate={base.navigate}
             params={params}
             displayedFolder={displayedFolder}
-            isSelectionBarVisible={isSelectionBarVisible}
+            isSelectionBarVisible={base.isSelectionBarVisible}
           >
             <FabWithAddMenuContext />
           </AddMenuProvider>

--- a/src/modules/views/Drive/useDriveQueries.js
+++ b/src/modules/views/Drive/useDriveQueries.js
@@ -1,0 +1,45 @@
+import { useQuery } from 'cozy-client'
+
+import { DEFAULT_SORT } from '@/config/sort'
+import { buildDriveQuery } from '@/queries'
+
+const resolveFolderSort = sortOrder =>
+  sortOrder.attribute === 'size' ? DEFAULT_SORT : sortOrder
+
+const fetchStatusMatches = (results, predicate) => results.some(predicate)
+
+/**
+ * Runs the directory + file queries for the Drive view and folds their
+ * `fetchStatus` into the three derived flags the view needs.
+ *
+ * The directory query overrides a `size` sort with `DEFAULT_SORT`, since
+ * sorting directories by size has no meaningful definition.
+ */
+export const useDriveQueries = (currentFolderId, sortOrder) => {
+  const folderSort = resolveFolderSort(sortOrder)
+  const folderQuery = buildDriveQuery({
+    currentFolderId,
+    type: 'directory',
+    sortAttribute: folderSort.attribute,
+    sortOrder: folderSort.order
+  })
+  const fileQuery = buildDriveQuery({
+    currentFolderId,
+    type: 'file',
+    sortAttribute: sortOrder.attribute,
+    sortOrder: sortOrder.order
+  })
+  const foldersResult = useQuery(folderQuery.definition, folderQuery.options)
+  const filesResult = useQuery(fileQuery.definition, fileQuery.options)
+
+  const allResults = [foldersResult, filesResult]
+  return {
+    allResults,
+    isInError: fetchStatusMatches(allResults, r => r.fetchStatus === 'failed'),
+    isLoading: fetchStatusMatches(
+      allResults,
+      r => r.fetchStatus === 'loading' && !r.lastUpdate
+    ),
+    isPending: fetchStatusMatches(allResults, r => r.fetchStatus === 'pending')
+  }
+}

--- a/src/modules/views/Folder/hooks/useFabOnMobile.js
+++ b/src/modules/views/Folder/hooks/useFabOnMobile.js
@@ -1,0 +1,28 @@
+import { useContext, useEffect } from 'react'
+
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
+
+import { FabContext } from '@/lib/FabProvider'
+
+/**
+ * Displays the floating action button on mobile and tablet (`!isDesktop`)
+ * when the user can write in the current folder, and resets it on unmount so
+ * other views don't inherit the displayed state. Returns the current
+ * `isFabDisplayed` flag for convenient consumption by the caller.
+ *
+ * Views that gate the FAB on `isMobile` only (excluding tablet) should keep
+ * their own effect rather than adopt this hook.
+ */
+export const useFabOnMobile = canWrite => {
+  const { isDesktop } = useBreakpoints()
+  const { isFabDisplayed, setIsFabDisplayed } = useContext(FabContext)
+
+  useEffect(() => {
+    setIsFabDisplayed(canWrite && !isDesktop)
+    return () => {
+      setIsFabDisplayed(false)
+    }
+  }, [setIsFabDisplayed, isDesktop, canWrite])
+
+  return isFabDisplayed
+}

--- a/src/modules/views/Folder/hooks/useFolderViewBase.js
+++ b/src/modules/views/Folder/hooks/useFolderViewBase.js
@@ -1,0 +1,46 @@
+import { useDispatch } from 'react-redux'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { useClient } from 'cozy-client'
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'twake-i18n'
+
+import { useModalContext } from '@/lib/ModalContext'
+import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+
+/**
+ * Bundles the hook calls every folder-style view repeats verbatim: router,
+ * breakpoints, i18n, cozy-client, modal stack, redux dispatch, alerts, and
+ * selection context. Returned as a single `base` object so views read with
+ * `base.t`, `base.navigate`, etc. and so `...base` can spread into
+ * `actionsOptions` without restating each key.
+ */
+export const useFolderViewBase = () => {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const { isMobile } = useBreakpoints()
+  const { t, lang } = useI18n()
+  const client = useClient()
+  const { pushModal, popModal } = useModalContext()
+  const dispatch = useDispatch()
+  const { showAlert } = useAlert()
+  const { isSelectionBarVisible, toggleSelectAllItems, isSelectAll } =
+    useSelectionContext()
+
+  return {
+    navigate,
+    pathname,
+    isMobile,
+    t,
+    lang,
+    client,
+    pushModal,
+    popModal,
+    dispatch,
+    showAlert,
+    isSelectionBarVisible,
+    toggleSelectAllItems,
+    isSelectAll
+  }
+}

--- a/src/modules/views/Public/PublicFolderView.jsx
+++ b/src/modules/views/Public/PublicFolderView.jsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useContext, useEffect } from 'react'
-import { useDispatch } from 'react-redux'
-import { useNavigate, useLocation, Outlet } from 'react-router-dom'
+import React, { useEffect } from 'react'
+import { Outlet, useLocation } from 'react-router-dom'
 
-import { useClient, models } from 'cozy-client'
+import { models } from 'cozy-client'
 import flag from 'cozy-flags'
 import {
   useSharingContext,
@@ -12,16 +11,17 @@ import {
 } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
-import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
-import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'twake-i18n'
 
+import { usePublicDisplayFlags } from './usePublicDisplayFlags'
 import usePublicFilesQuery from './usePublicFilesQuery'
+import { usePublicRefresh } from './usePublicRefresh'
 import usePublicWritePermissions from './usePublicWritePermissions'
 import FolderViewBody from '../Folder/FolderViewBody'
 import FolderViewBreadcrumb from '../Folder/FolderViewBreadcrumb'
 import FolderViewHeader from '../Folder/FolderViewHeader'
 import OldFolderViewBreadcrumb from '../Folder/OldFolderViewBreadcrumb'
+import { useFabOnMobile } from '../Folder/hooks/useFabOnMobile'
+import { useFolderViewBase } from '../Folder/hooks/useFolderViewBase'
 import FolderViewBodyVz from '../Folder/virtualized/FolderViewBody'
 
 import useHead from '@/components/useHead'
@@ -29,8 +29,7 @@ import { ROOT_DIR_ID } from '@/constants/config'
 import { useClipboardContext } from '@/contexts/ClipboardProvider'
 import { useCurrentFolderId, useDisplayedFolder } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
-import { FabContext } from '@/lib/FabProvider'
-import { ModalStack, useModalContext } from '@/lib/ModalContext'
+import { ModalStack } from '@/lib/ModalContext'
 import { ModalManager } from '@/lib/react-cozy-helpers'
 import {
   download,
@@ -51,7 +50,6 @@ import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
 import Main from '@/modules/layout/Main'
 import PublicToolbar from '@/modules/public/PublicToolbar'
-import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import Dropzone from '@/modules/upload/Dropzone'
 import DropzoneDnD from '@/modules/upload/DropzoneDnD'
 
@@ -84,22 +82,15 @@ const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
 const PublicFolderView = ({ sharedDocumentId }) => {
-  const navigate = useNavigate()
-  const { pathname, state } = useLocation()
-  const client = useClient()
-  const { t, lang } = useI18n()
-  const { isMobile, isDesktop } = useBreakpoints()
-  const { isFabDisplayed, setIsFabDisplayed } = useContext(FabContext)
+  const base = useFolderViewBase()
+  const { navigate, pathname } = base
+  // `state` is on useLocation; useFolderViewBase only forwards pathname.
+  const { state } = useLocation()
   const currentFolderId = useCurrentFolderId()
   const { displayedFolder } = useDisplayedFolder()
-  const { isSelectionBarVisible, toggleSelectAllItems, isSelectAll } =
-    useSelectionContext()
   const { hasWritePermissions } = usePublicWritePermissions()
-  const { pushModal, popModal } = useModalContext()
   const { refresh, isOwner, byDocId } = useSharingContext()
-  const dispatch = useDispatch()
   const sharingInfos = useSharingInfos()
-  const { showAlert } = useAlert()
   const isOnSharedFolder =
     !sharingInfos.loading &&
     sharingInfos.sharing?.rules?.some(rule =>
@@ -111,42 +102,35 @@ const PublicFolderView = ({ sharedDocumentId }) => {
   const filesResult = usePublicFilesQuery(currentFolderId)
   const files = filesResult.data
 
-  const extraColumnsNames = makeExtraColumnsNamesFromMedia({
-    isMobile,
-    desktopExtraColumnsNames,
-    mobileExtraColumnsNames
-  })
-
   const extraColumns = useExtraColumns({
-    columnsNames: extraColumnsNames,
+    columnsNames: makeExtraColumnsNamesFromMedia({
+      isMobile: base.isMobile,
+      desktopExtraColumnsNames,
+      mobileExtraColumnsNames
+    }),
     conditionBuilder: ({ files, attribute }) =>
       files.some(file => models.file.hasMetadataAttribute({ file, attribute })),
     files
   })
 
-  // We don't have enough permissions to rely on the realtime notifications or on a cozy-client query to update the view when something changes, so we relaod the view instead
-  const refreshFolderContent = useCallback(
-    () => filesResult.forceRefetch(),
-    [filesResult]
-  )
-
-  const refreshAfterChange = () => {
-    refresh()
-    refreshFolderContent()
-  }
+  // The public token can't rely on realtime notifications, so refresh manually.
+  const { refreshFolderContent, refreshAfterChange } = usePublicRefresh({
+    filesResult,
+    sharingRefresh: refresh
+  })
 
   useKeyboardShortcuts({
     onPaste: refreshAfterChange,
     canPaste: hasWritePermissions && hasClipboardData,
-    client,
+    client: base.client,
     items: filesResult.data,
     sharingContext: null,
     allowCopy: hasWritePermissions,
     allowCut: hasWritePermissions,
     allowDelete: hasWritePermissions,
     isPublic: true,
-    pushModal,
-    popModal,
+    pushModal: base.pushModal,
+    popModal: base.popModal,
     refresh: refreshAfterChange
   })
 
@@ -159,25 +143,15 @@ const PublicFolderView = ({ sharedDocumentId }) => {
   }, [state, refreshFolderContent, navigate, pathname])
 
   const actionOptions = {
-    client,
-    t,
-    lang,
-    pushModal,
-    popModal,
+    ...base,
     refresh: refreshAfterChange,
-    dispatch,
-    navigate,
-    showAlert,
-    pathname,
     hasWriteAccess: hasWritePermissions,
     canMove: hasWritePermissions,
     canDuplicate: hasWritePermissions,
     isPublic: true,
     isOwner,
     byDocId,
-    selectAll: () => toggleSelectAllItems(filesResult.data),
-    isSelectAll,
-    isMobile,
+    selectAll: () => base.toggleSelectAllItems(filesResult.data),
     displayedFolder,
     onClose: () => {
       refreshAfterChange()
@@ -207,42 +181,29 @@ const PublicFolderView = ({ sharedDocumentId }) => {
     name: 'Public'
   }
 
-  useEffect(() => {
-    if (hasWritePermissions) {
-      setIsFabDisplayed(!isDesktop)
-      return () => {
-        // to not have this set to false on other views after using this view
-        setIsFabDisplayed(false)
-      }
-    }
-  }, [setIsFabDisplayed, isDesktop, hasWritePermissions])
+  const isFabDisplayed = useFabOnMobile(hasWritePermissions)
 
-  const showNewBreadcrumbFlag = flag(
-    'drive.breadcrumb.showCompleteBreadcrumbOnPublicPage'
-  )
-  const isOldBreadcrumb =
-    !showNewBreadcrumbFlag || showNewBreadcrumbFlag !== true
-
-  // Check if the sharing shortcut has already been created (but not synced)
-  const isShareNotAdded =
-    !sharingInfos.loading && !sharingInfos.isSharingShortcutCreated
-  // Check if you are sharing Cozy to Cozy (Link sharing is on the `/public` route)
-  const isPreview = window.location.pathname === '/preview'
-  // Show the sharing banner plugin only on shared links view and cozy to cozy sharing view(not added)
-  const isSharingBannerPluginDisplayed =
-    isShareNotAdded || (isOnSharedFolder && !isPreview)
-
-  const isAddToMyCozyFabDisplayed = isMobile && isPreview && isShareNotAdded
+  const {
+    isOldBreadcrumb,
+    isSharingBannerPluginDisplayed,
+    isAddToMyCozyFabDisplayed
+  } = usePublicDisplayFlags({
+    sharingInfos,
+    isOnSharedFolder,
+    isMobile: base.isMobile
+  })
 
   const DropzoneComp =
-    flag('drive.virtualization.enabled') && !isMobile ? DropzoneDnD : Dropzone
+    flag('drive.virtualization.enabled') && !base.isMobile
+      ? DropzoneDnD
+      : Dropzone
 
   return (
     <Main isPublic={true}>
       <ModalStack />
       <ModalManager />
       {isSharingBannerPluginDisplayed && <SharingBannerPlugin />}
-      <Content className={isMobile ? '' : 'u-ml-1 u-pt-1'}>
+      <Content className={base.isMobile ? '' : 'u-ml-1 u-pt-1'}>
         <DropzoneComp
           disabled={!hasWritePermissions}
           displayedFolder={displayedFolder}
@@ -272,7 +233,7 @@ const PublicFolderView = ({ sharedDocumentId }) => {
               </>
             )}
           </FolderViewHeader>
-          {flag('drive.virtualization.enabled') && !isMobile ? (
+          {flag('drive.virtualization.enabled') && !base.isMobile ? (
             <FolderViewBodyVz
               actions={actions}
               queryResults={[filesResult]}
@@ -309,7 +270,7 @@ const PublicFolderView = ({ sharedDocumentId }) => {
               refreshFolderContent={refreshFolderContent}
               isPublic={true}
               displayedFolder={displayedFolder}
-              isSelectionBarVisible={isSelectionBarVisible}
+              isSelectionBarVisible={base.isSelectionBarVisible}
             >
               <FabWithAddMenuContext noSidebar={true} />
             </AddMenuProvider>

--- a/src/modules/views/Public/usePublicDisplayFlags.js
+++ b/src/modules/views/Public/usePublicDisplayFlags.js
@@ -1,0 +1,33 @@
+import flag from 'cozy-flags'
+
+/**
+ * Collects the boolean flags the Public view needs to decide which optional
+ * pieces of UI to render: the new vs old breadcrumb, the sharing banner,
+ * and the "add to my cozy" FAB. Keeping them in one place keeps the view
+ * body itself focused on layout.
+ */
+export const usePublicDisplayFlags = ({
+  sharingInfos,
+  isOnSharedFolder,
+  isMobile
+}) => {
+  const showNewBreadcrumbFlag = flag(
+    'drive.breadcrumb.showCompleteBreadcrumbOnPublicPage'
+  )
+  const isOldBreadcrumb = showNewBreadcrumbFlag !== true
+
+  // The sharing shortcut has not been created (or has been but not yet synced)
+  const isShareNotAdded =
+    !sharingInfos.loading && !sharingInfos.isSharingShortcutCreated
+  // Cozy-to-Cozy preview lives on the `/preview` route; link sharing on `/public`
+  const isPreview = window.location.pathname === '/preview'
+
+  return {
+    isOldBreadcrumb,
+    isShareNotAdded,
+    isPreview,
+    isSharingBannerPluginDisplayed:
+      isShareNotAdded || (isOnSharedFolder && !isPreview),
+    isAddToMyCozyFabDisplayed: isMobile && isPreview && isShareNotAdded
+  }
+}

--- a/src/modules/views/Public/usePublicRefresh.js
+++ b/src/modules/views/Public/usePublicRefresh.js
@@ -1,0 +1,20 @@
+import { useCallback } from 'react'
+
+/**
+ * Two refresh handlers the Public view threads through actions, dropzone,
+ * keyboard shortcuts, and the `state.refresh` effect. `refreshFolderContent`
+ * re-fetches the files query (the public token can't rely on realtime
+ * notifications), and `refreshAfterChange` chains the sharing refresh on
+ * top so action handlers can use a single callback.
+ */
+export const usePublicRefresh = ({ filesResult, sharingRefresh }) => {
+  const refreshFolderContent = useCallback(
+    () => filesResult.forceRefetch(),
+    [filesResult]
+  )
+  const refreshAfterChange = () => {
+    sharingRefresh()
+    refreshFolderContent()
+  }
+  return { refreshFolderContent, refreshAfterChange }
+}

--- a/src/modules/views/Public/usePublicRefresh.js
+++ b/src/modules/views/Public/usePublicRefresh.js
@@ -6,15 +6,19 @@ import { useCallback } from 'react'
  * re-fetches the files query (the public token can't rely on realtime
  * notifications), and `refreshAfterChange` chains the sharing refresh on
  * top so action handlers can use a single callback.
+ *
+ * Both are memoized so consumers (notably `useKeyboardShortcuts`, whose
+ * `handlePaste` callback lists `onPaste` in its deps) don't re-subscribe
+ * their event listeners on every render.
  */
 export const usePublicRefresh = ({ filesResult, sharingRefresh }) => {
   const refreshFolderContent = useCallback(
     () => filesResult.forceRefetch(),
     [filesResult]
   )
-  const refreshAfterChange = () => {
+  const refreshAfterChange = useCallback(() => {
     sharingRefresh()
     refreshFolderContent()
-  }
+  }, [sharingRefresh, refreshFolderContent])
   return { refreshFolderContent, refreshAfterChange }
 }

--- a/src/modules/views/Recent/index.jsx
+++ b/src/modules/views/Recent/index.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
-import { useNavigate, Outlet, useLocation } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 
-import { useClient } from 'cozy-client'
 import flag from 'cozy-flags'
 import {
   useSharingContext,
@@ -11,9 +9,6 @@ import {
 } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
-import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
-import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'twake-i18n'
 
 import FolderView from '../Folder/FolderView'
 import FolderViewBody from '../Folder/FolderViewBody'
@@ -25,7 +20,6 @@ import { RECENT_FOLDER_ID } from '@/constants/config'
 import { useFolderSort } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import useRecentFiles from '@/hooks/useRecentFiles'
-import { useModalContext } from '@/lib/ModalContext'
 import {
   download,
   trash,
@@ -46,76 +40,53 @@ import { useExtraColumns } from '@/modules/certifications/useExtraColumns'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
 import Toolbar from '@/modules/drive/Toolbar'
-import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+import { useFolderViewBase } from '@/modules/views/Folder/hooks/useFolderViewBase'
 import { buildRecentWithMetadataAttributeQuery } from '@/queries'
 
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
 export const RecentView = () => {
-  const navigate = useNavigate()
-  const { pathname } = useLocation()
-  const { t, lang } = useI18n()
-  const { isMobile } = useBreakpoints()
-  const client = useClient()
-  const { pushModal, popModal } = useModalContext()
-  const { isSelectionBarVisible, toggleSelectAllItems, isSelectAll } =
-    useSelectionContext()
+  const base = useFolderViewBase()
   const sharingContext = useSharingContext()
   const { allLoaded, refresh, isOwner, byDocId } = sharingContext
-  const { isNativeFileSharingAvailable, shareFilesNative } =
-    useNativeFileSharing()
-  const dispatch = useDispatch()
-  useHead({ title: t('breadcrumb.title_recent') })
-  const { showAlert } = useAlert()
+  const nativeSharing = useNativeFileSharing()
+  useHead({ title: base.t('breadcrumb.title_recent') })
   const [sortOrder, setSortOrder, isSettingsLoaded] =
     useFolderSort(RECENT_FOLDER_ID)
 
-  const extraColumnsNames = makeExtraColumnsNamesFromMedia({
-    isMobile,
-    desktopExtraColumnsNames,
-    mobileExtraColumnsNames
-  })
-
   const extraColumns = useExtraColumns({
-    columnsNames: extraColumnsNames,
+    columnsNames: makeExtraColumnsNamesFromMedia({
+      isMobile: base.isMobile,
+      desktopExtraColumnsNames,
+      mobileExtraColumnsNames
+    }),
     queryBuilder: buildRecentWithMetadataAttributeQuery
   })
 
   const recentsResult = useRecentFiles()
 
   useKeyboardShortcuts({
-    client,
+    client: base.client,
     items: recentsResult?.data || [],
     sharingContext,
     allowCopy: false,
-    pushModal,
-    popModal,
+    pushModal: base.pushModal,
+    popModal: base.popModal,
     refresh
   })
 
   const actionsOptions = {
-    client,
-    t,
-    lang,
-    pushModal,
-    popModal,
+    ...base,
+    ...nativeSharing,
     refresh,
-    dispatch,
-    navigate,
-    pathname,
     hasWriteAccess: true,
     canMove: true,
     isPublic: false,
     allLoaded,
-    showAlert,
     isOwner,
     byDocId,
-    isMobile,
-    isNativeFileSharingAvailable,
-    shareFilesNative,
-    selectAll: () => toggleSelectAllItems(recentsResult?.data || []),
-    isSelectAll
+    selectAll: () => base.toggleSelectAllItems(recentsResult?.data || [])
   }
 
   const actions = makeActions(
@@ -142,12 +113,12 @@ export const RecentView = () => {
 
   return (
     <FolderView>
-      <Content className={isMobile ? '' : 'u-pt-1'}>
+      <Content className={base.isMobile ? '' : 'u-pt-1'}>
         <FolderViewHeader>
-          <Breadcrumb path={[{ name: t('breadcrumb.title_recent') }]} />
+          <Breadcrumb path={[{ name: base.t('breadcrumb.title_recent') }]} />
           <Toolbar canUpload={false} canCreateFolder={false} />
         </FolderViewHeader>
-        {flag('drive.virtualization.enabled') && !isMobile ? (
+        {flag('drive.virtualization.enabled') && !base.isMobile ? (
           <FolderViewBodyVz
             actions={actions}
             queryResults={[recentsResult]}
@@ -167,13 +138,13 @@ export const RecentView = () => {
           />
         )}
         <Outlet />
-        {isMobile && (
+        {base.isMobile && (
           <AddMenuProvider
             canCreateFolder={true}
             canUpload={true}
             disabled={false}
             displayedFolder={null}
-            isSelectionBarVisible={isSelectionBarVisible}
+            isSelectionBarVisible={base.isSelectionBarVisible}
             isPublic={false}
             refreshFolderContent={() => {}}
           >

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from 'react'
-import { useDispatch } from 'react-redux'
-import { useNavigate, useLocation, Outlet } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 
-import { useClient, hasQueryBeenLoaded, useQuery } from 'cozy-client'
+import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
 import flag from 'cozy-flags'
 import {
   useSharingContext,
@@ -11,26 +10,18 @@ import {
 } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
-import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
-import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'twake-i18n'
 
+import { useFilteredSharings } from './useFilteredSharings'
 import withSharedDocumentIds from './withSharedDocumentIds'
 import FolderView from '../Folder/FolderView'
 import FolderViewBody from '../Folder/FolderViewBody'
 import FolderViewHeader from '../Folder/FolderViewHeader'
+import { useFolderViewBase } from '../Folder/hooks/useFolderViewBase'
 import FolderViewBodyVz from '../Folder/virtualized/FolderViewBody'
 
 import useHead from '@/components/useHead'
-import {
-  SHARED_DRIVES_DIR_ID,
-  SHARING_TAB_ALL,
-  SHARING_TAB_DRIVES
-} from '@/constants/config'
 import { useFolderSort } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
-import { useTransformFolderListHasSharedDriveShortcuts } from '@/hooks/useTransformFolderListHasSharedDriveShortcuts'
-import { useModalContext } from '@/lib/ModalContext'
 import {
   download,
   rename,
@@ -51,48 +42,30 @@ import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
 import Toolbar from '@/modules/drive/Toolbar'
 import FileListRowsPlaceholder from '@/modules/filelist/FileListRowsPlaceholder'
-import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import { leaveSharedDrive } from '@/modules/shareddrives/components/actions/leaveSharedDrive'
 import { shareSharedDrive } from '@/modules/shareddrives/components/actions/shareSharedDrive'
 import {
   buildSharingsQuery,
   buildSharingsWithMetadataAttributeQuery
 } from '@/queries'
+
 const desktopExtraColumnsNames = ['carbonCopy', 'electronicSafe']
 const mobileExtraColumnsNames = []
 
 export const SharingsView = ({ sharedDocumentIds = [] }) => {
-  const navigate = useNavigate()
-  const { pathname } = useLocation()
-  const tab = SHARING_TAB_ALL
-  const { t, lang } = useI18n()
-  const { isMobile } = useBreakpoints()
-  const client = useClient()
-  const { pushModal, popModal } = useModalContext()
-  const { isSelectionBarVisible, toggleSelectAllItems, isSelectAll } =
-    useSelectionContext()
+  const base = useFolderViewBase()
   const sharingContext = useSharingContext()
   const { allLoaded, refresh } = sharingContext
-  const { isNativeFileSharingAvailable, shareFilesNative } =
-    useNativeFileSharing()
-  const dispatch = useDispatch()
-  useHead({ title: t('breadcrumb.title_sharings') })
-  const { showAlert } = useAlert()
+  const nativeSharing = useNativeFileSharing()
+  useHead({ title: base.t('breadcrumb.title_sharings') })
   const [sortOrder, setSortOrder, isSettingsLoaded] = useFolderSort('sharings')
 
-  const isEnabledSharedDrive = flag('drive.shared-drive.enabled')
-  const isEnabledFederatedSharedFolder = flag(
-    'drive.federated-shared-folder.enabled'
-  )
-
-  const extraColumnsNames = makeExtraColumnsNamesFromMedia({
-    isMobile,
-    desktopExtraColumnsNames,
-    mobileExtraColumnsNames
-  })
-
   const extraColumns = useExtraColumns({
-    columnsNames: extraColumnsNames,
+    columnsNames: makeExtraColumnsNamesFromMedia({
+      isMobile: base.isMobile,
+      desktopExtraColumnsNames,
+      mobileExtraColumnsNames
+    }),
     queryBuilder: buildSharingsWithMetadataAttributeQuery,
     sharedDocumentIds
   })
@@ -107,101 +80,35 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   )
   const result = useQuery(query.definition, query.options)
 
-  /**
-   * Problem:
-   * - In the recipient's Sharing section, shared drives appear only as shortcuts
-   *   and don’t contain a root folder id (the folder id in the owner's shared drive).
-   *
-   * Why:
-   * - To open a shared drive, we need a URL like `shareddrive/:driveId/:rootFolderId`.
-   * - This information exists in `io.cozy.sharings`, which includes root folder id,
-   *   but the structure is not compatible with the directory format expected
-   *   in the Sharing UI.
-   *
-   * Solution:
-   * - Transform `sharedDrives` into directory-like objects with the required
-   *   properties (`id`, `path`, `attributes`,...) so they can be displayed
-   *   and opened consistently.
-   */
-  const {
-    sharedDrives: transformedSharedDrives,
-    nonSharedDriveList,
-    sharedDrivesLoaded
-  } = useTransformFolderListHasSharedDriveShortcuts(result.data)
-
-  const filteredResult = useMemo(() => {
-    if (!isEnabledSharedDrive && !isEnabledFederatedSharedFolder) {
-      const filteredResultData =
-        result.data?.filter(item => !(item.dir_id === SHARED_DRIVES_DIR_ID)) ||
-        []
-      return {
-        ...result,
-        // If there are no shared documents, we consider the data is loaded by setting fetchStatus to 'loaded' and lastFetch to now.
-        fetchStatus:
-          sharedDocumentIds?.length > 0 ? result.fetchStatus : 'loaded',
-        lastFetch:
-          // eslint-disable-next-line react-hooks/purity
-          sharedDocumentIds?.length > 0 ? result.lastFetch : Date.now(),
-        data: filteredResultData,
-        count: filteredResultData.length
-      }
-    }
-    const combinedData =
-      tab === SHARING_TAB_DRIVES
-        ? transformedSharedDrives
-        : [...transformedSharedDrives, ...nonSharedDriveList]
-
-    return {
-      ...result,
-      fetchStatus:
-        sharedDocumentIds?.length > 0 ? result.fetchStatus : 'loaded',
-      // eslint-disable-next-line react-hooks/purity
-      lastFetch: sharedDocumentIds?.length > 0 ? result.lastFetch : Date.now(),
-      data: combinedData,
-      count: combinedData.length
-    }
-  }, [
-    isEnabledSharedDrive,
-    isEnabledFederatedSharedFolder,
-    tab,
-    transformedSharedDrives,
-    nonSharedDriveList,
+  const { filteredResult, sharedDrivesLoaded } = useFilteredSharings({
     result,
-    sharedDocumentIds?.length
-  ])
+    sharedDocumentIds
+  })
 
   useKeyboardShortcuts({
     onPaste: () => refresh(),
-    client,
+    client: base.client,
     items: filteredResult?.data || [],
     sharingContext,
     allowCopy: false,
-    pushModal,
-    popModal,
+    pushModal: base.pushModal,
+    popModal: base.popModal,
     refresh
   })
 
   const actionsOptions = {
-    client,
-    t,
-    lang,
-    pushModal,
-    popModal,
+    ...base,
+    ...nativeSharing,
     refresh,
-    dispatch,
-    navigate,
-    pathname,
     hasWriteAccess: true,
     canMove: true,
     isPublic: false,
     shouldHideIfSharedDriveRecipient: true,
     allLoaded,
-    showAlert,
-    isMobile,
-    isNativeFileSharingAvailable,
-    shareFilesNative,
-    selectAll: () => toggleSelectAllItems(result.data),
-    isSelectAll
+    // Select All has to match the rendered list, not the raw query: the
+    // rendered list excludes the magic shared-drives dir when the feature
+    // flags are off and substitutes transformed shortcut entries when on.
+    selectAll: () => base.toggleSelectAllItems(filteredResult.data)
   }
 
   const actions = makeActions(
@@ -228,9 +135,9 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
 
   return (
     <FolderView>
-      <Content className={isMobile ? '' : 'u-pt-1'}>
+      <Content className={base.isMobile ? '' : 'u-pt-1'}>
         <FolderViewHeader>
-          <Breadcrumb path={[{ name: t('breadcrumb.title_sharings') }]} />
+          <Breadcrumb path={[{ name: base.t('breadcrumb.title_sharings') }]} />
           <Toolbar canUpload={false} canCreateFolder={false} />
         </FolderViewHeader>
         {!allLoaded ||
@@ -239,7 +146,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
           <FileListRowsPlaceholder />
         ) : (
           <>
-            {flag('drive.virtualization.enabled') && !isMobile ? (
+            {flag('drive.virtualization.enabled') && !base.isMobile ? (
               <FolderViewBodyVz
                 actions={actions}
                 queryResults={[filteredResult]}
@@ -267,13 +174,13 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
             <Outlet />
           </>
         )}
-        {isMobile && (
+        {base.isMobile && (
           <AddMenuProvider
             canCreateFolder={true}
             canUpload={true}
             disabled={false}
             displayedFolder={null}
-            isSelectionBarVisible={isSelectionBarVisible}
+            isSelectionBarVisible={base.isSelectionBarVisible}
             isPublic={false}
             refreshFolderContent={() => {}}
           >

--- a/src/modules/views/Sharings/useFilteredSharings.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.jsx
@@ -1,0 +1,73 @@
+import { useMemo } from 'react'
+
+import flag from 'cozy-flags'
+
+import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
+import { useTransformFolderListHasSharedDriveShortcuts } from '@/hooks/useTransformFolderListHasSharedDriveShortcuts'
+
+const buildBaseShape = (result, hasIds) => ({
+  ...result,
+  fetchStatus: hasIds ? result.fetchStatus : 'loaded',
+  lastFetch: hasIds ? result.lastFetch : Date.now()
+})
+
+const computeData = ({
+  result,
+  withoutSharedDrives,
+  transformedSharedDrives,
+  nonSharedDriveList
+}) => {
+  if (withoutSharedDrives) {
+    return (
+      result.data?.filter(item => item.dir_id !== SHARED_DRIVES_DIR_ID) || []
+    )
+  }
+  return [...transformedSharedDrives, ...nonSharedDriveList]
+}
+
+/**
+ * Reshapes the raw sharings query result for the Sharings view.
+ *
+ * Drops the magic shared-drives directory when shared-drive and federated
+ * shared-folder flags are both off, otherwise merges transformed shared-drive
+ * shortcuts into the result. Returns the combined `filteredResult` plus the
+ * `sharedDrivesLoaded` flag the view uses to gate its placeholder.
+ */
+export const useFilteredSharings = ({ result, sharedDocumentIds }) => {
+  const isEnabledSharedDrive = flag('drive.shared-drive.enabled')
+  const isEnabledFederatedSharedFolder = flag(
+    'drive.federated-shared-folder.enabled'
+  )
+  const withoutSharedDrives =
+    !isEnabledSharedDrive && !isEnabledFederatedSharedFolder
+
+  const {
+    sharedDrives: transformedSharedDrives,
+    nonSharedDriveList,
+    sharedDrivesLoaded
+  } = useTransformFolderListHasSharedDriveShortcuts(result.data)
+
+  const filteredResult = useMemo(() => {
+    const hasIds = sharedDocumentIds?.length > 0
+    const data = computeData({
+      result,
+      withoutSharedDrives,
+      transformedSharedDrives,
+      nonSharedDriveList
+    })
+    return { ...buildBaseShape(result, hasIds), data, count: data.length }
+  }, [
+    withoutSharedDrives,
+    transformedSharedDrives,
+    nonSharedDriveList,
+    result,
+    sharedDocumentIds?.length
+  ])
+
+  // When shared drives are disabled the view ignores the transformed list,
+  // so don't block the page on that hook's load state.
+  return {
+    filteredResult,
+    sharedDrivesLoaded: withoutSharedDrives || sharedDrivesLoaded
+  }
+}


### PR DESCRIPTION
The Drive, Public, Sharings, and Recent views all repeated the same dozen hook calls and the same FAB display effect, which made the per-view scaffolding drown out each view's actual logic. Bundling them behind small focused hooks lets each view show its own logic instead, and keeps the shared contract in one place so adding or removing a common hook stays a one-file change.

Two real bugs in Sharings surfaced during the extraction and are fixed inline: Select All operated on the raw query result instead of the displayed filtered list, and the placeholder gate blocked on shared-drive loading even when both shared-drive flags were off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified folder views for a more consistent experience across Drive, Recent, Sharings and Public views
  * Standardized selection, keyboard shortcuts and action menus for predictable behavior
* **Improved Mobile UX**
  * More reliable FAB display and mobile-responsive layouts
  * Better mobile selection-bar handling
* **Performance & Reliability**
  * More efficient folder/file fetching and refresh behavior for public/shared folders

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->