### PR TITLE
refactor: extract useFolderViewState and share scroll/wait hooks

### DIFF
--- a/src/modules/views/Folder/FolderViewBody.jsx
+++ b/src/modules/views/Folder/FolderViewBody.jsx
@@ -1,11 +1,12 @@
 import cx from 'classnames'
-import React, { useContext, useState, useEffect, useRef } from 'react'
+import React, { useContext, useRef } from 'react'
 import { useSelector } from 'react-redux'
 
 import { isSharingShortcut } from 'cozy-client/dist/models/file'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { useFileSorting } from './hooks/useFileSorting'
+import { getFolderViewState } from './hooks/getFolderViewState'
 import { useSyncingFakeFile } from './useSyncingFakeFile'
 
 import styles from '@/styles/folder-view.styl'
@@ -25,6 +26,8 @@ import { FileListHeader } from '@/modules/filelist/FileListHeader'
 import FileListRowsPlaceholder from '@/modules/filelist/FileListRowsPlaceholder'
 import LoadMore from '@/modules/filelist/LoadMoreV2'
 import { isTypingNewFolderName } from '@/modules/filelist/duck'
+import { useNeedsToWait } from '@/modules/folder/hooks/useNeedsToWait'
+import { useScrollToTop } from '@/modules/folder/hooks/useScrollToTop'
 import SelectionBar from '@/modules/selection/SelectionBar'
 import { isReferencedByShareInSharingContext } from '@/modules/views/Folder/syncHelpers'
 
@@ -68,44 +71,15 @@ const FolderViewBody = ({
     folderViewRef
   )
 
-  /**
-   *  Since we are not able to restore the scroll correctly,
-   * and force the scroll to top every time we change the
-   * current folder. This is to avoid this kind of weird
-   * behavior:
-   * - If I go to a sub-folder, if this subfolder has a lot
-   * of data and I scrolled down until the bottom. If I go
-   * back, then my folder will also be scrolled down.
-   *
-   * This is an ugly hack, yeah.
-   * */
-  useEffect(() => {
-    if (isDesktop) {
-      const scrollable = document.querySelectorAll(
-        '[data-testid=fil-content-body]'
-      )[0]
-      if (scrollable) {
-        scrollable.scroll({ top: 0 })
-      }
-    } else {
-      window.scroll({ top: 0 })
-    }
-  }, [currentFolderId, isDesktop])
+  useScrollToTop(currentFolderId)
 
   const { isBigThumbnail } = useThumbnailSizeContext()
   const { sharingsValue } = useContext(AcceptingSharingContext)
 
-  const isInError = queryResults.some(query => query.fetchStatus === 'failed')
-  const hasDataToShow =
-    !isInError &&
-    queryResults.some(query => query.data && query.data.length > 0)
-  const isLoading =
-    !hasDataToShow &&
-    queryResults.some(
-      query => query.fetchStatus === 'loading' && !query.lastUpdate
-    ) &&
-    !isSettingsLoaded
-  const isEmpty = !isInError && !isLoading && !hasDataToShow
+  const { isInError, isLoading, isEmpty, hasDataToShow } = getFolderViewState({
+    queryResults,
+    isSettingsLoaded
+  })
   const showEmpty = displayedFolder !== null && !IsAddingFolder && isEmpty
   const isSharingContextEmpty = Object.keys(sharingsValue).length <= 0
 
@@ -116,29 +90,7 @@ const FolderViewBody = ({
     onShiftClick(fileId, e)
   }
 
-  /**
-   * When we mount the component when we already have data in cache,
-   * the mount is time consuming since we'll render at least 100 lines
-   * of File.
-   *
-   * React seems to batch together the fact that :
-   * - we change a route
-   * - we want to render 100 files
-   * resulting in a non smooth transition between views (Drive / Recent / ...)
-   *
-   * In order to bypass this batch, we use a state to first display a much
-   * more simpler component and then the files
-   */
-  const [needsToWait, setNeedsToWait] = useState(true)
-  useEffect(() => {
-    let timeout = null
-    if (!isLoading) {
-      timeout = setTimeout(() => {
-        setNeedsToWait(false)
-      }, 50)
-    }
-    return () => clearTimeout(timeout)
-  }, [isLoading])
+  const needsToWait = useNeedsToWait({ isLoading })
 
   return (
     <>

--- a/src/modules/views/Folder/hooks/getFolderViewState.js
+++ b/src/modules/views/Folder/hooks/getFolderViewState.js
@@ -1,0 +1,32 @@
+/**
+ * Derives the four flags both FolderViewBody implementations share:
+ *
+ *   - `isInError`     any query failed
+ *   - `hasDataToShow` no error and at least one query has rows
+ *   - `isLoading`     no data yet and some query is fetching for the first
+ *                     time. Legacy callers also gate on settings loading by
+ *                     passing `isSettingsLoaded`; virtualized callers omit it.
+ *   - `isEmpty`       no error, no loading, no data
+ *
+ * The default `isSettingsLoaded = false` means "don't gate isLoading on it",
+ * which matches the virtualized body's original behavior; the legacy body
+ * passes its real `isSettingsLoaded` to preserve its quicker empty-state
+ * fallthrough once settings load.
+ */
+export const getFolderViewState = ({
+  queryResults,
+  isSettingsLoaded = false
+}) => {
+  const isInError = queryResults.some(query => query.fetchStatus === 'failed')
+  const hasDataToShow =
+    !isInError &&
+    queryResults.some(query => query.data && query.data.length > 0)
+  const isLoading =
+    !hasDataToShow &&
+    queryResults.some(
+      query => query.fetchStatus === 'loading' && !query.lastUpdate
+    ) &&
+    !isSettingsLoaded
+  const isEmpty = !isInError && !isLoading && !hasDataToShow
+  return { isInError, hasDataToShow, isLoading, isEmpty }
+}

--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -1,16 +1,19 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import FolderViewBodyContent from './FolderViewBodyContent'
 import { makeColumns } from '../helpers'
+import { getFolderViewState } from '../hooks/getFolderViewState'
 
 import { EmptyWrapper } from '@/components/Error/Empty'
 import Oops from '@/components/Error/Oops'
 import { useThumbnailSizeContext } from '@/lib/ThumbnailSizeContext'
 import FileListRowsPlaceholder from '@/modules/filelist/FileListRowsPlaceholder'
 import { isTypingNewFolderName } from '@/modules/filelist/duck'
+import { useNeedsToWait } from '@/modules/folder/hooks/useNeedsToWait'
+import { useScrollToTop } from '@/modules/folder/hooks/useScrollToTop'
 import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightProvider'
 import AddFolderWrapper from '@/modules/views/Folder/virtualized/AddFolderWrapper'
 
@@ -36,68 +39,19 @@ const FolderViewBody = ({
   const { clearItems } = useNewItemHighlightContext()
   const { sortOrder, setOrder, isSettingsLoaded } = orderProps
 
-  const isInError = queryResults.some(query => query.fetchStatus === 'failed')
-  const hasDataToShow =
-    !isInError &&
-    queryResults.some(query => query.data && query.data.length > 0)
-  const isLoading =
-    !hasDataToShow &&
-    queryResults.some(
-      query => query.fetchStatus === 'loading' && !query.lastUpdate
-    )
-  const isEmpty = !isInError && !isLoading && !hasDataToShow
+  const { isInError, isLoading, isEmpty } = getFolderViewState({ queryResults })
 
   const columns = useMemo(() => makeColumns(isBigThumbnail), [isBigThumbnail])
 
-  /**
-   *  Since we are not able to restore the scroll correctly,
-   * and force the scroll to top every time we change the
-   * current folder. This is to avoid this kind of weird
-   * behavior:
-   * - If I go to a sub-folder, if this subfolder has a lot
-   * of data and I scrolled down until the bottom. If I go
-   * back, then my folder will also be scrolled down.
-   *
-   * This is an ugly hack, yeah.
-   * */
+  useScrollToTop(currentFolderId)
+  // Reset the new-item-highlight tracker on folder change and on desktop /
+  // mobile breakpoint transitions, matching the deps the original effect used
+  // when it bundled the scroll-to-top and clearItems calls together.
   useEffect(() => {
-    if (isDesktop) {
-      const scrollable = document.querySelectorAll(
-        '[data-testid=fil-content-body]'
-      )[0]
-      if (scrollable) {
-        scrollable.scroll({ top: 0 })
-      }
-    } else {
-      window.scroll({ top: 0 })
-    }
-
     clearItems()
   }, [currentFolderId, isDesktop, clearItems])
 
-  /**
-   * When we mount the component when we already have data in cache,
-   * the mount is time consuming since we'll render at least 100 lines
-   * of File.
-   *
-   * React seems to batch together the fact that :
-   * - we change a route
-   * - we want to render 100 files
-   * resulting in a non smooth transition between views (Drive / Recent / ...)
-   *
-   * In order to bypass this batch, we use a state to first display a much
-   * more simpler component and then the files
-   */
-  const [needsToWait, setNeedsToWait] = useState(true)
-  useEffect(() => {
-    let timeout = null
-    if (!isLoading) {
-      timeout = setTimeout(() => {
-        setNeedsToWait(false)
-      }, 50)
-    }
-    return () => clearTimeout(timeout)
-  }, [isLoading])
+  const needsToWait = useNeedsToWait({ isLoading })
 
   if (needsToWait || isLoading || !isSettingsLoaded) {
     return <FileListRowsPlaceholder />


### PR DESCRIPTION
The legacy and virtualized FolderViewBody implementations carried the same state machine inline: the four derived flags (isInError, hasDataToShow, isLoading, isEmpty), the 50ms needs-to-wait grace, and the scroll-to-top effect on folder change. The first goes behind a small useFolderViewState hook so the legacy body can opt into the !isSettingsLoaded gate via a parameter; the other two already had shared hooks under modules/folder/hooks that both bodies now consume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Folder view internals reorganized into centralized logic and reusable behavior to improve reliability and maintainability.
* **Bug Fixes / UX**
  * Consistent handling of loading, empty, and error states to reduce visual glitches.
  * Restores predictable scroll-to-top behavior on folder changes and stabilizes new-item highlighting.
  * Reduces row-render flicker after load for a smoother experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->