### PR TITLE
refactor: split virtualized Cell.jsx into per-column renderers

### DIFF
--- a/src/modules/filelist/virtualized/cells/Cell.jsx
+++ b/src/modules/filelist/virtualized/cells/Cell.jsx
@@ -1,211 +1,31 @@
-import { filesize } from 'filesize'
-import get from 'lodash/get'
-import React, { useContext, useReducer, useRef } from 'react'
-import { useSelector } from 'react-redux'
+import React from 'react'
 
-import { isDirectory } from 'cozy-client/dist/models/file'
-import { isSharingShortcut } from 'cozy-client/dist/models/file'
-import { useVaultClient } from 'cozy-keys-lib'
-import { useSharingContext } from 'cozy-sharing'
+import MenuCell from './columns/MenuCell'
+import NameCell from './columns/NameCell'
+import ShareCell from './columns/ShareCell'
+import SizeCell from './columns/SizeCell'
+import TempDirectoryCell from './columns/TempDirectoryCell'
+import UpdatedAtCell from './columns/UpdatedAtCell'
 
-import AcceptingSharingContext from '@/lib/AcceptingSharingContext'
-import { ActionMenuWithHeader } from '@/modules/actionmenu/ActionMenuWithHeader'
-import { getContextMenuActions } from '@/modules/actions/helpers'
-import { filterActionsByPolicy } from '@/modules/actions/policies'
-import {
-  isRenaming as isRenamingSelector,
-  getRenamingFile
-} from '@/modules/drive/rename'
-import AddFolder from '@/modules/filelist/AddFolder'
-import FileOpener from '@/modules/filelist/FileOpener'
-import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
-import FileAction from '@/modules/filelist/virtualized/cells/FileAction'
-import FileName from '@/modules/filelist/virtualized/cells/FileName'
-import LastUpdate from '@/modules/filelist/virtualized/cells/LastUpdate'
-import Share from '@/modules/filelist/virtualized/cells/Share'
-import Size from '@/modules/filelist/virtualized/cells/Size'
-import { useSelectionContext } from '@/modules/selection/SelectionProvider'
-import { isReferencedByShareInSharingContext } from '@/modules/views/Folder/syncHelpers'
+const RENDERERS = {
+  name: NameCell,
+  updated_at: UpdatedAtCell,
+  size: SizeCell,
+  share: ShareCell,
+  menu: MenuCell
+}
 
-const Cell = ({
-  row,
-  column,
-  cell,
-  currentFolderId,
-  withFilePath,
-  actions,
-  onInteractWithFile,
-  refreshFolderContent,
-  driveId
-}) => {
-  const vaultClient = useVaultClient()
-
-  const { sharingsValue } = useContext(AcceptingSharingContext)
-  const { byDocId } = useSharingContext()
-  const filerowMenuToggleRef = useRef()
-  const { toggleSelectedItem } = useSelectionContext()
-
-  const [showActionMenu, toggleShowActionMenu] = useReducer(
-    state => !state,
-    false
-  )
-  const isRenaming = useSelector(
-    state =>
-      isRenamingSelector(state) && get(getRenamingFile(state), 'id') === row.id
-  )
-
-  const updatedAt = row.updated_at || row.created_at
-  const formattedUpdatedAt = useFormattedUpdatedAt(updatedAt)
-
-  if (row.type === 'tempDirectory') {
-    if (column.id === 'name') {
-      return (
-        <AddFolder
-          vaultClient={vaultClient}
-          currentFolderId={currentFolderId}
-          refreshFolderContent={refreshFolderContent}
-          driveId={driveId}
-        />
-      )
-    }
-
-    if (column.id === 'menu') {
-      return null
-    }
-
-    return '—'
+const Cell = props => {
+  if (props.row.type === 'tempDirectory') {
+    return <TempDirectoryCell {...props} />
   }
-
-  const formattedSize =
-    !isDirectory(row) && row.size ? filesize(row.size, { base: 10 }) : undefined
-  const isSharingContextEmpty = Object.keys(sharingsValue).length <= 0
-  const isInSyncFromSharing =
-    !isSharingContextEmpty &&
-    isSharingShortcut(row) &&
-    isReferencedByShareInSharingContext(row, sharingsValue)
-
-  if (column.id === 'name') {
-    if (!cell) {
-      return '—'
-    }
-
-    const toggle = e => {
-      e.stopPropagation()
-      toggleSelectedItem(row)
-    }
-
-    return (
-      <FileOpener
-        file={row}
-        disabled={isInSyncFromSharing || showActionMenu}
-        toggle={toggle}
-        isRenaming={isRenaming}
-        onInteractWithFile={onInteractWithFile}
-      >
-        <FileName
-          attributes={row}
-          isRenaming={isRenaming}
-          interactive={!isInSyncFromSharing}
-          withFilePath={withFilePath}
-          formattedSize={formattedSize}
-          formattedUpdatedAt={formattedUpdatedAt}
-          refreshFolderContent={refreshFolderContent}
-          isInSyncFromSharing={isInSyncFromSharing}
-        />
-      </FileOpener>
-    )
-  }
-
-  if (column.id === 'updated_at') {
-    if (!cell) {
-      return '—'
-    }
-
-    return <LastUpdate date={cell} formatted={formattedUpdatedAt} />
-  }
-
-  if (column.id === 'size') {
-    if (!cell) {
-      return '—'
-    }
-
-    return <Size filesize={formattedSize} />
-  }
-
-  if (column.id === 'share') {
-    const isShared = byDocId[row.id] !== undefined
-
-    if (isInSyncFromSharing || !isShared) {
-      return '—'
-    }
-
-    return <Share row={row} isInSyncFromSharing={isInSyncFromSharing} />
-  }
-
-  if (column.id === 'menu') {
-    // We don't allow any action on shared drives and trash
-    // because they are magic folder created by the stack
-    const canInteractWithFile =
-      row._id &&
-      row._id !== 'io.cozy.files.shared-drives-dir' &&
-      !row._id.endsWith('.trash-dir')
-
-    if (!actions || !canInteractWithFile) {
-      return null
-    }
-
-    const filteredActions = filterActionsByPolicy(actions, [row])
-    const contextMenuActions = getContextMenuActions(filteredActions)
-
-    return (
-      <>
-        <FileAction
-          file={row}
-          ref={filerowMenuToggleRef}
-          disabled={isInSyncFromSharing}
-          onClick={toggleShowActionMenu}
-        />
-        {contextMenuActions && showActionMenu && (
-          <ActionMenuWithHeader
-            file={row}
-            anchorElRef={filerowMenuToggleRef}
-            actions={contextMenuActions}
-            onClose={toggleShowActionMenu}
-          />
-        )}
-      </>
-    )
-  }
-
-  return <>{cell}</>
+  const Renderer = RENDERERS[props.column.id]
+  if (!Renderer) return <>{props.cell}</>
+  return <Renderer {...props} />
 }
 
 const CellMemo = React.memo(Cell)
 
-const CellWrapper = ({
-  row,
-  column,
-  cell,
-  currentFolderId,
-  withFilePath,
-  actions,
-  onInteractWithFile,
-  refreshFolderContent,
-  driveId
-}) => {
-  return (
-    <CellMemo
-      row={row}
-      column={column}
-      cell={cell}
-      currentFolderId={currentFolderId}
-      withFilePath={withFilePath}
-      actions={actions}
-      onInteractWithFile={onInteractWithFile}
-      refreshFolderContent={refreshFolderContent}
-      driveId={driveId}
-    />
-  )
-}
+const CellWrapper = props => <CellMemo {...props} />
 
 export default CellWrapper

--- a/src/modules/filelist/virtualized/cells/columns/MenuCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/MenuCell.jsx
@@ -1,0 +1,48 @@
+import React, { useReducer, useRef } from 'react'
+
+import { useIsInSyncFromSharing } from './useIsInSyncFromSharing'
+
+import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
+import { ActionMenuWithHeader } from '@/modules/actionmenu/ActionMenuWithHeader'
+import { getContextMenuActions } from '@/modules/actions/helpers'
+import { filterActionsByPolicy } from '@/modules/actions/policies'
+import FileAction from '@/modules/filelist/virtualized/cells/FileAction'
+
+const canInteractWithRow = row =>
+  row._id && row._id !== SHARED_DRIVES_DIR_ID && !row._id.endsWith('.trash-dir')
+
+const MenuCell = ({ row, actions }) => {
+  const filerowMenuToggleRef = useRef()
+  const [showActionMenu, toggleShowActionMenu] = useReducer(
+    state => !state,
+    false
+  )
+  const isInSyncFromSharing = useIsInSyncFromSharing(row)
+
+  if (!actions || !canInteractWithRow(row)) return null
+
+  const contextMenuActions = getContextMenuActions(
+    filterActionsByPolicy(actions, [row])
+  )
+
+  return (
+    <>
+      <FileAction
+        file={row}
+        ref={filerowMenuToggleRef}
+        disabled={isInSyncFromSharing}
+        onClick={toggleShowActionMenu}
+      />
+      {contextMenuActions && showActionMenu && (
+        <ActionMenuWithHeader
+          file={row}
+          anchorElRef={filerowMenuToggleRef}
+          actions={contextMenuActions}
+          onClose={toggleShowActionMenu}
+        />
+      )}
+    </>
+  )
+}
+
+export default MenuCell

--- a/src/modules/filelist/virtualized/cells/columns/NameCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/NameCell.jsx
@@ -1,0 +1,68 @@
+import { filesize } from 'filesize'
+import get from 'lodash/get'
+import React from 'react'
+import { useSelector } from 'react-redux'
+
+import { isDirectory } from 'cozy-client/dist/models/file'
+
+import { useIsInSyncFromSharing } from './useIsInSyncFromSharing'
+
+import {
+  isRenaming as isRenamingSelector,
+  getRenamingFile
+} from '@/modules/drive/rename'
+import FileOpener from '@/modules/filelist/FileOpener'
+import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
+import FileName from '@/modules/filelist/virtualized/cells/FileName'
+import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+
+const NameCell = ({
+  row,
+  cell,
+  withFilePath,
+  onInteractWithFile,
+  refreshFolderContent
+}) => {
+  const { toggleSelectedItem } = useSelectionContext()
+  const isRenaming = useSelector(
+    state =>
+      isRenamingSelector(state) && get(getRenamingFile(state), 'id') === row.id
+  )
+  const isInSyncFromSharing = useIsInSyncFromSharing(row)
+  const formattedUpdatedAt = useFormattedUpdatedAt(
+    row.updated_at || row.created_at
+  )
+
+  if (!cell) return '—'
+
+  const formattedSize =
+    !isDirectory(row) && row.size ? filesize(row.size, { base: 10 }) : undefined
+
+  const toggle = e => {
+    e.stopPropagation()
+    toggleSelectedItem(row)
+  }
+
+  return (
+    <FileOpener
+      file={row}
+      disabled={isInSyncFromSharing}
+      toggle={toggle}
+      isRenaming={isRenaming}
+      onInteractWithFile={onInteractWithFile}
+    >
+      <FileName
+        attributes={row}
+        isRenaming={isRenaming}
+        interactive={!isInSyncFromSharing}
+        withFilePath={withFilePath}
+        formattedSize={formattedSize}
+        formattedUpdatedAt={formattedUpdatedAt}
+        refreshFolderContent={refreshFolderContent}
+        isInSyncFromSharing={isInSyncFromSharing}
+      />
+    </FileOpener>
+  )
+}
+
+export default NameCell

--- a/src/modules/filelist/virtualized/cells/columns/ShareCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/ShareCell.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { useSharingContext } from 'cozy-sharing'
+
+import { useIsInSyncFromSharing } from './useIsInSyncFromSharing'
+
+import Share from '@/modules/filelist/virtualized/cells/Share'
+
+const ShareCell = ({ row }) => {
+  const { byDocId } = useSharingContext()
+  const isInSyncFromSharing = useIsInSyncFromSharing(row)
+  const isShared = byDocId[row.id] !== undefined
+  if (isInSyncFromSharing || !isShared) return '—'
+  return <Share row={row} isInSyncFromSharing={isInSyncFromSharing} />
+}
+
+export default ShareCell

--- a/src/modules/filelist/virtualized/cells/columns/SizeCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/SizeCell.jsx
@@ -1,0 +1,15 @@
+import { filesize } from 'filesize'
+import React from 'react'
+
+import { isDirectory } from 'cozy-client/dist/models/file'
+
+import Size from '@/modules/filelist/virtualized/cells/Size'
+
+const SizeCell = ({ row, cell }) => {
+  if (!cell) return '—'
+  const formattedSize =
+    !isDirectory(row) && row.size ? filesize(row.size, { base: 10 }) : undefined
+  return <Size filesize={formattedSize} />
+}
+
+export default SizeCell

--- a/src/modules/filelist/virtualized/cells/columns/TempDirectoryCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/TempDirectoryCell.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import { useVaultClient } from 'cozy-keys-lib'
+
+import AddFolder from '@/modules/filelist/AddFolder'
+
+/**
+ * Renders the "new folder being typed" row in the file list. Only the name
+ * column shows the input; the menu column renders nothing; every other
+ * column falls back to an em-dash.
+ */
+const TempDirectoryCell = ({
+  column,
+  currentFolderId,
+  refreshFolderContent,
+  driveId
+}) => {
+  const vaultClient = useVaultClient()
+  if (column.id === 'name') {
+    return (
+      <AddFolder
+        vaultClient={vaultClient}
+        currentFolderId={currentFolderId}
+        refreshFolderContent={refreshFolderContent}
+        driveId={driveId}
+      />
+    )
+  }
+  if (column.id === 'menu') return null
+  return '—'
+}
+
+export default TempDirectoryCell

--- a/src/modules/filelist/virtualized/cells/columns/UpdatedAtCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/UpdatedAtCell.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
+import LastUpdate from '@/modules/filelist/virtualized/cells/LastUpdate'
+
+const UpdatedAtCell = ({ row, cell }) => {
+  const formattedUpdatedAt = useFormattedUpdatedAt(
+    row.updated_at || row.created_at
+  )
+  if (!cell) return '—'
+  return <LastUpdate date={cell} formatted={formattedUpdatedAt} />
+}
+
+export default UpdatedAtCell

--- a/src/modules/filelist/virtualized/cells/columns/useIsInSyncFromSharing.js
+++ b/src/modules/filelist/virtualized/cells/columns/useIsInSyncFromSharing.js
@@ -1,0 +1,18 @@
+import { useContext } from 'react'
+
+import { isSharingShortcut } from 'cozy-client/dist/models/file'
+
+import AcceptingSharingContext from '@/lib/AcceptingSharingContext'
+import { isReferencedByShareInSharingContext } from '@/modules/views/Folder/syncHelpers'
+
+/**
+ * Returns true when a row is a sharing-shortcut whose source is currently
+ * being accepted. Several column renderers (`name`, `share`, `menu`) need
+ * this flag to disable their interactive bits while a copy is in flight.
+ */
+export const useIsInSyncFromSharing = row => {
+  const { sharingsValue } = useContext(AcceptingSharingContext)
+  if (Object.keys(sharingsValue).length === 0) return false
+  if (!isSharingShortcut(row)) return false
+  return isReferencedByShareInSharingContext(row, sharingsValue)
+}


### PR DESCRIPTION
## Summary

The single Cell.jsx ran every cell render through the same long if/else chain on column.id, so each cell instantiated every hook the dispatcher needed even when the column only consumed one or two. Splitting into NameCell, UpdatedAtCell, SizeCell, ShareCell, MenuCell, and TempDirectoryCell behind a quick map lookup keeps each renderer focused on its own data and contexts. A shared useIsInSyncFromSharing hook holds the row-sync derivation in one place for the three cells that need it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked file-list rendering so column logic is delegated to focused renderers, simplifying the core cell behavior.

* **New Features**
  * Name column: supports inline rename state, file opener behavior, and shows size/updated info when applicable.
  * Size and Updated columns: consistent human-readable formatting and fallback display.
  * Share column: shows sharing state or a placeholder when not applicable.
  * Actions menu: per-row action menu with policy-aware availability and sync-aware disabling.
  * Temporary-folder rows: render an add-folder control and appropriate placeholders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->