### PR TITLE
fix: reserve breadcrumb space with a loading skeleton

### DIFF
--- a/src/hooks/useDisplayedFolder.spec.jsx
+++ b/src/hooks/useDisplayedFolder.spec.jsx
@@ -63,6 +63,24 @@ describe('useDisplayedFolder', () => {
     )
   })
 
+  it('reports isLoading while the folder query has not settled', () => {
+    useQuery.mockReturnValue({ data: null, fetchStatus: 'loading' })
+    useCurrentFolderId.mockReturnValue('folder-id')
+
+    expect(useDisplayedFolder().isLoading).toBe(true)
+  })
+
+  it('reports not loading once the folder query has settled', () => {
+    useQuery.mockReturnValue({
+      data: null,
+      fetchStatus: 'failed',
+      lastError: { status: 403 }
+    })
+    useCurrentFolderId.mockReturnValue('folder-id')
+
+    expect(useDisplayedFolder().isLoading).toBe(false)
+  })
+
   it('still queries the root directory on the authenticated route', () => {
     useQuery.mockReturnValue({ data: null, fetchStatus: 'pending' })
     useCurrentFolderId.mockReturnValue(null) // falls back to ROOT_DIR_ID

--- a/src/hooks/useDisplayedFolder.tsx
+++ b/src/hooks/useDisplayedFolder.tsx
@@ -10,7 +10,12 @@ interface DisplayedFolderResult {
   isNotFound: boolean
   displayedFolder: IOCozyFile | null
   initialDirId: string | null
+  isLoading: boolean
 }
+
+// The folder request is still resolving until it settles (loaded or failed).
+// Using a lookup instead of two comparisons keeps callers branch-free.
+const SETTLED_STATUSES = ['loaded', 'failed']
 
 const useDisplayedFolder = (): DisplayedFolderResult => {
   const { isPublic } = usePublicContext()
@@ -33,6 +38,7 @@ const useDisplayedFolder = (): DisplayedFolderResult => {
 
   const displayedFolder = folderResult.data ?? null
   const initialDirId = displayedFolder?.id ?? null
+  const isLoading = !SETTLED_STATUSES.includes(folderResult.fetchStatus)
 
   if (folderId) {
     const isNotFound =
@@ -42,14 +48,16 @@ const useDisplayedFolder = (): DisplayedFolderResult => {
     return {
       isNotFound,
       displayedFolder,
-      initialDirId
+      initialDirId,
+      isLoading
     }
   }
 
   return {
     isNotFound: true,
     displayedFolder: null,
-    initialDirId: null
+    initialDirId: null,
+    isLoading
   }
 }
 

--- a/src/modules/breadcrumb/components/BreadcrumbSkeleton.jsx
+++ b/src/modules/breadcrumb/components/BreadcrumbSkeleton.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import Skeleton from 'cozy-ui/transpiled/react/Skeleton'
+
+import styles from '@/modules/breadcrumb/styles/breadcrumb.styl'
+
+// Reuses the breadcrumb backdrop so the placeholder grows to fill the same
+// flex space as the real breadcrumb. Without it the topbar collapses while the
+// path loads and the view-toggle icons jump from left to right.
+const BreadcrumbSkeleton = () => (
+  <div
+    className={styles['fil-path-backdrop']}
+    data-testid="breadcrumb-skeleton"
+  >
+    <Skeleton variant="text" animation="wave" width={200} height={24} />
+  </div>
+)
+
+export default BreadcrumbSkeleton

--- a/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
+++ b/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
@@ -30,7 +30,10 @@ export const useBreadcrumbPath = ({
   const client = useClient()
   const [paths, setPaths] = useState([])
 
-  const folder = useFolder({ folderId: currentFolderId, driveId })
+  const { folder, fetchStatus } = useFolder({
+    folderId: currentFolderId,
+    driveId
+  })
   const folderAttributes = {
     id: folder?.id,
     name: folder?.name,
@@ -45,8 +48,12 @@ export const useBreadcrumbPath = ({
     }
 
     if (!folderAttributes.id || !folderAttributes.name) {
-      // Optionally set loading state or clear paths
-      setPaths([])
+      // While the folder query is in flight we keep the path empty so the
+      // breadcrumb can show its loading skeleton. Once the query has settled
+      // without a usable folder (inaccessible or deleted target), fall back to
+      // the root so the skeleton doesn't spin forever.
+      const isSettled = fetchStatus === 'loaded' || fetchStatus === 'failed'
+      setPaths(isSettled && rootBreadcrumbPath ? [rootBreadcrumbPath] : [])
       return
     }
 
@@ -121,6 +128,7 @@ export const useBreadcrumbPath = ({
     sharedDocumentIds,
     rootBreadcrumbPath,
     driveId,
+    fetchStatus,
     folderAttributes.id,
     folderAttributes.name,
     folderAttributes.dirId,

--- a/src/modules/breadcrumb/hooks/useBreadcrumbPath.spec.jsx
+++ b/src/modules/breadcrumb/hooks/useBreadcrumbPath.spec.jsx
@@ -25,7 +25,7 @@ describe('useBreadcrumbPath', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    useFolder.mockReturnValue(null)
+    useFolder.mockReturnValue({ folder: null, fetchStatus: 'loading' })
   })
 
   it('should get useClient from cozy-client', () => {
@@ -37,13 +37,14 @@ describe('useBreadcrumbPath', () => {
   })
 
   it('should return only Drive link when id undefined', async () => {
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: rootBreadcrumbPath.id,
         name: rootBreadcrumbPath.name,
         dirId: undefined
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
     // When
     const { result } = await renderHook(() =>
       useBreadcrumbPath({ rootBreadcrumbPath })
@@ -54,13 +55,14 @@ describe('useBreadcrumbPath', () => {
   })
 
   it('should return only Drive link when id is root_breadcrumb_path id', async () => {
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: rootBreadcrumbPath.id,
         name: rootBreadcrumbPath.name,
         dirId: undefined
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
     // When
     let render
     await act(async () => {
@@ -78,13 +80,14 @@ describe('useBreadcrumbPath', () => {
 
   it('should return only rootBreadcrumbPath when currentFolderId equals rootBreadcrumbPath.id (early return)', async () => {
     const someFolderId = 'some-folder-id'
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: someFolderId,
         name: 'Some Folder',
         dirId: rootBreadcrumbPath.id
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
 
     let render
     await act(async () => {
@@ -100,18 +103,70 @@ describe('useBreadcrumbPath', () => {
     expect(fetchFolder).not.toHaveBeenCalled()
   })
 
+  it('should fall back to rootBreadcrumbPath when the folder query fails (e.g. inaccessible target)', async () => {
+    // Given a folder query that settled in error (403 / forbidden share)
+    useClient.mockReturnValue('cozy-client')
+    useFolder.mockReturnValue({ folder: null, fetchStatus: 'failed' })
+
+    // When
+    let render
+    await act(async () => {
+      render = await renderHook(() =>
+        useBreadcrumbPath({ rootBreadcrumbPath, currentFolderId: '1234' })
+      )
+    })
+
+    // Then
+    expect(render.result.current).toEqual([rootBreadcrumbPath])
+  })
+
+  it('should fall back to rootBreadcrumbPath when the folder query loads without a folder (e.g. 404)', async () => {
+    // Given a folder query that settled as loaded but returned no document
+    useClient.mockReturnValue('cozy-client')
+    useFolder.mockReturnValue({ folder: null, fetchStatus: 'loaded' })
+
+    // When
+    let render
+    await act(async () => {
+      render = await renderHook(() =>
+        useBreadcrumbPath({ rootBreadcrumbPath, currentFolderId: '1234' })
+      )
+    })
+
+    // Then
+    expect(render.result.current).toEqual([rootBreadcrumbPath])
+  })
+
+  it('should keep the path empty while the folder query is loading', async () => {
+    // Given a folder query still in flight
+    useClient.mockReturnValue('cozy-client')
+    useFolder.mockReturnValue({ folder: null, fetchStatus: 'loading' })
+
+    // When
+    let render
+    await act(async () => {
+      render = await renderHook(() =>
+        useBreadcrumbPath({ rootBreadcrumbPath, currentFolderId: '1234' })
+      )
+    })
+
+    // Then: the empty path drives the loading skeleton, no premature fallback
+    expect(render.result.current).toEqual([])
+  })
+
   it('should call fetch folder', async () => {
     // Given
     const currentFolderId = '1234'
     useClient.mockReturnValue('cozy-client')
     const parentFolderId = 'parentFolderId'
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: parentFolderId
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
     fetchFolder.mockReturnValueOnce({ dir_id: rootBreadcrumbPath.id })
 
     // When
@@ -134,13 +189,14 @@ describe('useBreadcrumbPath', () => {
     useClient.mockReturnValue('cozy-client')
     fetchFolder.mockRejectedValue('error')
     const parentFolderId = 'parentFolderId'
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: parentFolderId
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
 
     // When
     let render
@@ -164,13 +220,14 @@ describe('useBreadcrumbPath', () => {
     useClient.mockReturnValue('cozy-client')
     fetchFolder.mockReturnValueOnce(undefined)
     const parentFolderId = 'parentFolderId'
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: parentFolderId
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
 
     // When
     await act(async () => {
@@ -189,13 +246,14 @@ describe('useBreadcrumbPath', () => {
     const parentFolderId = 'parentFolderId'
     const grandParentFolderId = 'grandParentFolderId'
     useClient.mockReturnValue('cozy-client')
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: parentFolderId
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
     fetchFolder.mockReturnValueOnce({
       id: parentFolderId,
       name: 'parent',
@@ -234,13 +292,14 @@ describe('useBreadcrumbPath', () => {
     useClient.mockReturnValue('cozy-client')
     fetchFolder.mockReturnValueOnce({ dir_id: rootBreadcrumbPath.id })
     const parentFolderId = 'parentFolderId'
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: parentFolderId
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
 
     // When
     let render
@@ -265,13 +324,14 @@ describe('useBreadcrumbPath', () => {
     }
     const currentFolderId = 'currentFolderId'
     useClient.mockReturnValue('cozy-client')
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: publicViewRootBreadcrumbPath.id
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
 
     // When
     let render
@@ -297,13 +357,14 @@ describe('useBreadcrumbPath', () => {
     const notSharedFolderId = 'notSharedFolderId'
     const sharedDocumentIds = [parentFolderId, 'another-id']
     useClient.mockReturnValue('cozy-client')
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: parentFolderId
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
     fetchFolder.mockReturnValueOnce({
       id: parentFolderId,
       name: 'parent',
@@ -346,13 +407,14 @@ describe('useBreadcrumbPath', () => {
     const notSharedFolderId = 'notSharedFolderId'
     const sharedDocumentIds = [parentFolderId, currentFolderId, 'another-id']
     useClient.mockReturnValue('cozy-client')
-    useFolder.mockReturnValue(
-      createFolder({
+    useFolder.mockReturnValue({
+      folder: createFolder({
         id: currentFolderId,
         name: 'current',
         dirId: parentFolderId
-      })
-    )
+      }),
+      fetchStatus: 'loaded'
+    })
     fetchFolder.mockReturnValueOnce({
       id: parentFolderId,
       name: 'parent',

--- a/src/modules/breadcrumb/utils/fetchFolder.js
+++ b/src/modules/breadcrumb/utils/fetchFolder.js
@@ -23,7 +23,7 @@ export const fetchFolder = async ({ client, folderId, driveId }) => {
  * @param {Object} params - The parameters for the function.
  * @param {string} params.folderId - The ID of the folder to fetch.
  * @param {string} [params.driveId] - The ID of the shared drive to fetch the folder from.
- * @returns {import('cozy-client/types/types').IOCozyFolder} The folder data.
+ * @returns {{ folder: import('cozy-client/types/types').IOCozyFolder, fetchStatus: string }} The folder data and the query fetch status.
  */
 export const useFolder = ({ folderId, driveId }) => {
   const folderQuery = driveId
@@ -31,5 +31,8 @@ export const useFolder = ({ folderId, driveId }) => {
     : buildFileOrFolderByIdQuery(folderId)
   const { options, definition } = folderQuery
   const folderQueryResults = useQuery(definition, options)
-  return folderQueryResults.data
+  return {
+    folder: folderQueryResults.data,
+    fetchStatus: folderQueryResults.fetchStatus
+  }
 }

--- a/src/modules/views/Folder/FolderViewBreadcrumb.jsx
+++ b/src/modules/views/Folder/FolderViewBreadcrumb.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import BreadcrumbSkeleton from '@/modules/breadcrumb/components/BreadcrumbSkeleton'
 import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
 import { useBreadcrumbPath } from '@/modules/breadcrumb/hooks/useBreadcrumbPath.jsx'
 
@@ -32,7 +33,9 @@ const FolderViewBreadcrumb = ({
       onBreadcrumbClick={onBreadcrumbClick}
       opening={false}
     />
-  ) : null
+  ) : (
+    <BreadcrumbSkeleton />
+  )
 }
 
 FolderViewBreadcrumb.propTypes = {

--- a/src/modules/views/Folder/FolderViewBreadcrumb.spec.jsx
+++ b/src/modules/views/Folder/FolderViewBreadcrumb.spec.jsx
@@ -70,12 +70,12 @@ describe('FolderViewBreadcrumb', () => {
     ).toEqual('false')
   })
 
-  it('should be null when path empty', () => {
+  it('should render skeleton when path empty', () => {
     // Given
     useBreadcrumbPath.mockReturnValue([])
 
     // When
-    const { container } = render(
+    const { getByTestId, queryByTestId } = render(
       <FolderViewBreadcrumb
         currentFolderId="1234"
         rootBreadcrumbPath={rootBreadcrumbPath}
@@ -83,15 +83,16 @@ describe('FolderViewBreadcrumb', () => {
     )
 
     // Then
-    expect(container).toMatchInlineSnapshot(`<div />`)
+    expect(getByTestId('breadcrumb-skeleton')).toBeTruthy()
+    expect(queryByTestId('MobileAwareBreadcrumb')).toBeNull()
   })
 
-  it('should be null when path undefined', () => {
+  it('should render skeleton when path undefined', () => {
     // Given
     useBreadcrumbPath.mockReturnValue()
 
     // When
-    const { container } = render(
+    const { getByTestId, queryByTestId } = render(
       <FolderViewBreadcrumb
         currentFolderId="1234"
         rootBreadcrumbPath={rootBreadcrumbPath}
@@ -99,6 +100,7 @@ describe('FolderViewBreadcrumb', () => {
     )
 
     // Then
-    expect(container).toMatchInlineSnapshot(`<div />`)
+    expect(getByTestId('breadcrumb-skeleton')).toBeTruthy()
+    expect(queryByTestId('MobileAwareBreadcrumb')).toBeNull()
   })
 })

--- a/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
+++ b/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
@@ -3,23 +3,26 @@ import { useNavigate } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
 
+import useDisplayedFolder from '@/hooks/useDisplayedFolder'
 import logger from '@/lib/logger'
+import BreadcrumbSkeleton from '@/modules/breadcrumb/components/BreadcrumbSkeleton'
 import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
 
-const FolderViewBreadcrumb = ({
-  displayedFolder,
-  sharedDocumentId,
-  getBreadcrumbPath
-}) => {
+const FolderViewBreadcrumb = ({ sharedDocumentId, getBreadcrumbPath }) => {
   const navigate = useNavigate()
   const client = useClient()
+  // Source the folder and its loading state here so the public view does not
+  // have to drill them in (it is already a complexity hotspot).
+  const { displayedFolder, isLoading: isFolderLoading } = useDisplayedFolder()
   const [path, setPath] = useState(null)
+  const [hasError, setHasError] = useState(false)
 
   useEffect(() => {
     let isMounted = true
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPath(null)
+    setHasError(false)
     if (!displayedFolder || !sharedDocumentId) return
 
     const asyncGetPaths = async () => {
@@ -35,7 +38,7 @@ const FolderViewBreadcrumb = ({
       } catch (error) {
         logger.error(`Error while fetching breadcrumb path: ${error}`)
         if (isMounted) {
-          setPath(null)
+          setHasError(true)
         }
       }
     }
@@ -56,13 +59,23 @@ const FolderViewBreadcrumb = ({
     [navigate]
   )
 
-  return path ? (
-    <Breadcrumb
-      path={path}
-      onBreadcrumbClick={onBreadcrumbClick}
-      opening={false}
-    />
-  ) : null
+  if (path) {
+    return (
+      <Breadcrumb
+        path={path}
+        onBreadcrumbClick={onBreadcrumbClick}
+        opening={false}
+      />
+    )
+  }
+
+  // No resolved path yet. Show the skeleton (to keep the topbar's shape) only
+  // while we're still resolving: the folder query is in flight, or it loaded
+  // and we're fetching its breadcrumb path. Once the folder request settles
+  // without a result (inaccessible / trashed / revoked) or the path fetch
+  // fails, render nothing instead of a skeleton that would animate forever.
+  const isResolving = isFolderLoading || (Boolean(displayedFolder) && !hasError)
+  return isResolving ? <BreadcrumbSkeleton /> : null
 }
 
 export default FolderViewBreadcrumb

--- a/src/modules/views/Folder/OldFolderViewBreadcrumb.spec.jsx
+++ b/src/modules/views/Folder/OldFolderViewBreadcrumb.spec.jsx
@@ -1,0 +1,104 @@
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import OldFolderViewBreadcrumb from './OldFolderViewBreadcrumb'
+
+import useDisplayedFolder from '@/hooks/useDisplayedFolder'
+
+jest.mock('modules/breadcrumb/components/MobileAwareBreadcrumb', () => ({
+  MobileAwareBreadcrumb: ({ path }) => (
+    <div data-testid="MobileAwareBreadcrumb" data-path={JSON.stringify(path)} />
+  )
+}))
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn()
+}))
+jest.mock('cozy-client', () => ({
+  useClient: jest.fn()
+}))
+jest.mock('@/lib/logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() }
+}))
+jest.mock('@/hooks/useDisplayedFolder', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+const mockDisplayedFolder = ({ displayedFolder = null, isLoading = false }) =>
+  useDisplayedFolder.mockReturnValue({ displayedFolder, isLoading })
+
+describe('OldFolderViewBreadcrumb', () => {
+  it('should render skeleton while the folder is loading', () => {
+    // Given the folder query is still in flight
+    mockDisplayedFolder({ displayedFolder: null, isLoading: true })
+
+    const { getByTestId, queryByTestId } = render(
+      <OldFolderViewBreadcrumb
+        sharedDocumentId={null}
+        getBreadcrumbPath={jest.fn()}
+      />
+    )
+
+    // Then the skeleton reserves the space instead of rendering nothing
+    expect(getByTestId('breadcrumb-skeleton')).toBeTruthy()
+    expect(queryByTestId('MobileAwareBreadcrumb')).toBeNull()
+  })
+
+  it('should render nothing when the folder cannot be loaded (settled, not loading)', () => {
+    // Given an inaccessible/trashed/revoked folder: the folder query has
+    // settled without a result, so it is no longer loading and there is no
+    // displayedFolder to build a breadcrumb from.
+    mockDisplayedFolder({ displayedFolder: null, isLoading: false })
+
+    const { container, queryByTestId } = render(
+      <OldFolderViewBreadcrumb
+        sharedDocumentId="shared"
+        getBreadcrumbPath={jest.fn()}
+      />
+    )
+
+    // Then we render nothing rather than a skeleton that spins forever
+    expect(queryByTestId('breadcrumb-skeleton')).toBeNull()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should render the breadcrumb once the path resolves', async () => {
+    // Given a resolved folder and a resolvable breadcrumb path
+    mockDisplayedFolder({ displayedFolder: { id: 'a' }, isLoading: false })
+    const path = [{ id: 'a', name: 'A' }]
+    const getBreadcrumbPath = jest.fn().mockResolvedValue(path)
+
+    // When
+    const { findByTestId, queryByTestId } = render(
+      <OldFolderViewBreadcrumb
+        sharedDocumentId="shared"
+        getBreadcrumbPath={getBreadcrumbPath}
+      />
+    )
+
+    // Then the real breadcrumb replaces the skeleton, with the resolved path
+    const breadcrumb = await findByTestId('MobileAwareBreadcrumb')
+    expect(breadcrumb.getAttribute('data-path')).toEqual(JSON.stringify(path))
+    expect(queryByTestId('breadcrumb-skeleton')).toBeNull()
+  })
+
+  it('should render nothing once a breadcrumb fetch error settles', async () => {
+    // Given a resolved folder but a path fetch that rejects
+    mockDisplayedFolder({ displayedFolder: { id: 'a' }, isLoading: false })
+    const getBreadcrumbPath = jest.fn().mockRejectedValue(new Error('boom'))
+
+    // When
+    const { container, queryByTestId } = render(
+      <OldFolderViewBreadcrumb
+        sharedDocumentId="shared"
+        getBreadcrumbPath={getBreadcrumbPath}
+      />
+    )
+
+    // Then the skeleton is dropped rather than left spinning forever
+    await waitFor(() => expect(queryByTestId('breadcrumb-skeleton')).toBeNull())
+    expect(queryByTestId('MobileAwareBreadcrumb')).toBeNull()
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/modules/views/Public/PublicFolderView.jsx
+++ b/src/modules/views/Public/PublicFolderView.jsx
@@ -197,7 +197,6 @@ const PublicFolderView = ({ sharedDocumentId }) => {
               <>
                 {isOldBreadcrumb ? (
                   <OldFolderViewBreadcrumb
-                    displayedFolder={displayedFolder}
                     sharedDocumentId={sharedDocumentId}
                     getBreadcrumbPath={getBreadcrumbPath}
                   />


### PR DESCRIPTION
Fixes #3863

## Summary

- The breadcrumb rendered nothing while its path loaded, so it reserved no space and the list/grid view toggle jumped from left to right once it resolved. This was most visible on public share pages, where the breadcrumb only appears after the folder and its ancestors load.
- A skeleton now holds the breadcrumb's space while loading, so the toggle stays put.
- The skeleton only shows while the folder is genuinely loading: it clears once the folder is known, so an inaccessible or revoked share no longer leaves a skeleton spinning forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook now exposes an isLoading flag for folder data.
  * Breadcrumb skeleton component added and shown while folder data is loading.

* **Bug Fixes**
  * Breadcrumb fallback refined: show placeholder while loading, hide after settled failures to avoid permanent skeletons.
  * Breadcrumb rendering now coordinates explicitly with folder loading state.

* **Tests**
  * Tests expanded for loading, settled-failure, and fallback breadcrumb behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-drive/pull/3865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->