### PR TITLE
fix: stop public breadcrumb infinite loop on shared subfolders

### DIFF
--- a/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
+++ b/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
@@ -17,19 +17,30 @@ const FolderViewBreadcrumb = ({ sharedDocumentId, getBreadcrumbPath }) => {
   const [path, setPath] = useState(null)
   const [hasError, setHasError] = useState(false)
 
+  // Depend on the folder identity, not the object: getBreadcrumbPath writes to
+  // the cozy-client store, which churns the displayedFolder reference and would
+  // re-run this effect forever.
+  const folderId = displayedFolder?.id
+  const folderName = displayedFolder?.name
+  const folderDirId = displayedFolder?.dir_id
+
   useEffect(() => {
     let isMounted = true
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPath(null)
     setHasError(false)
-    if (!displayedFolder || !sharedDocumentId) return
+    if (!folderId || !sharedDocumentId) return
 
     const asyncGetPaths = async () => {
       try {
         const paths = await getBreadcrumbPath({
           client,
-          displayedFolder,
+          displayedFolder: {
+            id: folderId,
+            name: folderName,
+            dir_id: folderDirId
+          },
           sharedDocumentId
         })
         if (isMounted) {
@@ -48,7 +59,14 @@ const FolderViewBreadcrumb = ({ sharedDocumentId, getBreadcrumbPath }) => {
     return () => {
       isMounted = false
     }
-  }, [displayedFolder, sharedDocumentId, client, getBreadcrumbPath])
+  }, [
+    folderId,
+    folderName,
+    folderDirId,
+    sharedDocumentId,
+    client,
+    getBreadcrumbPath
+  ])
 
   const onBreadcrumbClick = useCallback(
     ({ id }) => {
@@ -74,7 +92,7 @@ const FolderViewBreadcrumb = ({ sharedDocumentId, getBreadcrumbPath }) => {
   // and we're fetching its breadcrumb path. Once the folder request settles
   // without a result (inaccessible / trashed / revoked) or the path fetch
   // fails, render nothing instead of a skeleton that would animate forever.
-  const isResolving = isFolderLoading || (Boolean(displayedFolder) && !hasError)
+  const isResolving = isFolderLoading || (Boolean(folderId) && !hasError)
   return isResolving ? <BreadcrumbSkeleton /> : null
 }
 

--- a/src/modules/views/Folder/OldFolderViewBreadcrumb.spec.jsx
+++ b/src/modules/views/Folder/OldFolderViewBreadcrumb.spec.jsx
@@ -83,6 +83,40 @@ describe('OldFolderViewBreadcrumb', () => {
     expect(queryByTestId('breadcrumb-skeleton')).toBeNull()
   })
 
+  it('does not refetch the breadcrumb path when only the folder object reference changes', async () => {
+    // A store write gives a fresh displayedFolder object with the same identity;
+    // the path must still be fetched only once.
+    mockDisplayedFolder({
+      displayedFolder: { id: 'a', name: 'A', dir_id: 'root' },
+      isLoading: false
+    })
+    const getBreadcrumbPath = jest
+      .fn()
+      .mockResolvedValue([{ id: 'a', name: 'A' }])
+
+    const { rerender, findByTestId } = render(
+      <OldFolderViewBreadcrumb
+        sharedDocumentId="shared"
+        getBreadcrumbPath={getBreadcrumbPath}
+      />
+    )
+    await findByTestId('MobileAwareBreadcrumb')
+    expect(getBreadcrumbPath).toHaveBeenCalledTimes(1)
+
+    mockDisplayedFolder({
+      displayedFolder: { id: 'a', name: 'A', dir_id: 'root' },
+      isLoading: false
+    })
+    rerender(
+      <OldFolderViewBreadcrumb
+        sharedDocumentId="shared"
+        getBreadcrumbPath={getBreadcrumbPath}
+      />
+    )
+    await Promise.resolve()
+    expect(getBreadcrumbPath).toHaveBeenCalledTimes(1)
+  })
+
   it('should render nothing once a breadcrumb fetch error settles', async () => {
     // Given a resolved folder but a path fetch that rejects
     mockDisplayedFolder({ displayedFolder: { id: 'a' }, isLoading: false })


### PR DESCRIPTION
## Summary

Fixes #3866. Opening a subfolder of a public link froze the tab.

- The breadcrumb effect depended on the whole `displayedFolder` object. `getBreadcrumbPath` writes parent folders into the cozy-client store, so `useDisplayedFolder` returns a new reference, re-triggering the effect in a fetch loop that starves the event loop.
- Now it depends on the folder identity (`id`, `name`, `dir_id`) instead, matching `useBreadcrumbPath`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs no longer trigger unnecessary path refetches when the same folder is re-displayed with a different internal object, improving performance and stability; loading indicator behavior updated to rely on stable folder identity.

* **Tests**
  * Added test coverage to confirm breadcrumb path is fetched once and not retriggered on object-reference changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->