### PR TITLE
test(e2e): cover context menu, drag-drop, rename, and link sharing

### DIFF
--- a/e2e/helpers/stack.ts
+++ b/e2e/helpers/stack.ts
@@ -1,0 +1,86 @@
+import { stackExec } from './config'
+
+/**
+ * Stack-side helpers for tests that need to manipulate state the UI can't
+ * reach. The expiration DatePicker has `minDate = today`, so a share link can
+ * never be made expired through the UI; to test enforcement we create the
+ * link with a future date and then backdate the permission's `expires_at`
+ * directly on the stack.
+ *
+ * A share-by-link is an `io.cozy.permissions` doc. The stack lists them per
+ * doctype at `/permissions/doctype/:doctype/shared-by-link` and updates them at
+ * `/permissions/:id`. The update is restricted to the permission's parent, so
+ * we use the drive app token (which created the link) rather than a plain
+ * doctype token.
+ */
+
+interface PermissionDoc {
+  id: string
+  attributes: {
+    expires_at?: string
+    permissions?: Record<string, { values?: string[] }>
+  }
+}
+
+/** Mint an app token for the drive app, the parent of the link permission. */
+function driveAppToken(instance: string): string {
+  return stackExec(`instances token-app ${instance} drive`)
+}
+
+/** Find the share-by-link permission whose rule targets `fileId`. */
+export async function findLinkPermission(
+  instance: string,
+  fileId: string
+): Promise<PermissionDoc> {
+  const token = driveAppToken(instance)
+  const res = await fetch(
+    `http://${instance}/permissions/doctype/io.cozy.files/shared-by-link`,
+    { headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' } }
+  )
+  if (!res.ok) {
+    throw new Error(
+      `List sharedByLink permissions on ${instance} failed (${res.status}): ${await res.text()}`
+    )
+  }
+  const body = (await res.json()) as { data: PermissionDoc[] }
+  const match = body.data.find(doc =>
+    Object.values(doc.attributes.permissions ?? {}).some(rule =>
+      (rule.values ?? []).includes(fileId)
+    )
+  )
+  if (!match) {
+    throw new Error(
+      `No share-by-link permission found for ${fileId} on ${instance}`
+    )
+  }
+  return match
+}
+
+/** PATCH a permission's `expires_at` to an arbitrary instant (past = expired). */
+export async function setLinkExpiry(
+  instance: string,
+  permissionId: string,
+  expiresAt: Date
+): Promise<void> {
+  const token = driveAppToken(instance)
+  const res = await fetch(`http://${instance}/permissions/${permissionId}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    },
+    body: JSON.stringify({
+      data: {
+        type: 'io.cozy.permissions',
+        id: permissionId,
+        attributes: { expires_at: expiresAt.toISOString() }
+      }
+    })
+  })
+  if (!res.ok) {
+    throw new Error(
+      `PATCH permission ${permissionId} on ${instance} failed (${res.status}): ${await res.text()}`
+    )
+  }
+}

--- a/e2e/pages/DrivePage.ts
+++ b/e2e/pages/DrivePage.ts
@@ -48,4 +48,67 @@ export class DrivePage {
       .first()
       .setInputFiles(filePaths)
   }
+
+  /** Right-click the empty file-list area to open RightClickAddMenu (menu id
+   * `AddMenu`). Both the toolbar and the context menu render the same
+   * `add-folder-link` testid, so the click is scoped to the open menu. */
+  async createFolderViaContextMenu(name: string): Promise<void> {
+    await this.openAddContextMenu()
+    await this.page
+      .getByRole('menu')
+      .locator('[data-testid="add-folder-link"]')
+      .click()
+    const input = this.page.getByTestId('name-input').locator('input')
+    await input.waitFor({ state: 'visible' })
+    await input.fill(name)
+    await input.press('Enter')
+    await this.row(name).waitVisible()
+  }
+
+  /** Same context menu as createFolderViaContextMenu, driving the upload
+   * input the menu renders. setInputFiles works on the hidden input, so this
+   * asserts the menu path opens and feeds the same upload pipeline. */
+  async uploadFilesViaContextMenu(filePaths: string | string[]): Promise<void> {
+    await this.openAddContextMenu()
+    await this.page
+      .getByRole('menu')
+      .locator('input[data-testid="upload-btn"]')
+      .setInputFiles(filePaths)
+  }
+
+  /** Synthesise an OS drag-and-drop: Playwright can't drag real files, so we
+   * build a DataTransfer in-page and dispatch the drop on the file list, which
+   * bubbles to the react-dropzone root wrapping it.
+   *
+   * react-dropzone's file-selector defaults a dropped file's path to
+   * `./<name>` when `webkitGetAsEntry` is null (always, for a scripted
+   * DataTransfer). Drive reads that `./` as a folder structure and tries to
+   * create a "." folder, which fails. Pinning `webkitRelativePath` to the bare
+   * name yields a slash-free path so Drive treats it as a loose top-level file. */
+  async dropFiles(
+    files: { name: string; mime: string; content: string }[]
+  ): Promise<void> {
+    const dataTransfer = await this.page.evaluateHandle(items => {
+      const dt = new DataTransfer()
+      for (const item of items) {
+        const file = new File([item.content], item.name, { type: item.mime })
+        Object.defineProperty(file, 'webkitRelativePath', {
+          value: item.name,
+          configurable: true
+        })
+        dt.items.add(file)
+      }
+      return dt
+    }, files)
+
+    await this.fileList.dispatchEvent('drop', { dataTransfer })
+  }
+
+  /** Right-click the empty content area; the dropzone wrapper's onContextMenu
+   * opens the AddMenu. Callers must be in an empty folder so the click lands
+   * on blank space and not on a file row (which opens the file menu instead). */
+  private async openAddContextMenu(): Promise<void> {
+    await this.fileList.click({ button: 'right' })
+    await this.page.getByRole('menu').waitFor({ state: 'visible' })
+  }
 }

--- a/e2e/pages/PublicLinkPage.ts
+++ b/e2e/pages/PublicLinkPage.ts
@@ -1,0 +1,40 @@
+import type { Page, Locator } from '@playwright/test'
+
+/**
+ * A public share link opened in a fresh, unauthenticated browser context.
+ *
+ * A password-protected link is gated by a stack-served password page before
+ * the Drive public route loads; an expired link is rejected outright. The
+ * exact markup of those stack pages is not in the app source, so the selectors
+ * here are intentionally broad (input type, role) and are pinned by the live
+ * suite rather than by a testid we control.
+ */
+export class PublicLinkPage {
+  private readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /** The password prompt's input — stack-rendered, no testid we own. */
+  get passwordInput(): Locator {
+    return this.page.locator('input[type="password"]').first()
+  }
+
+  /** The Drive public folder view's file list once access is granted. */
+  get fileList(): Locator {
+    return this.page.getByTestId('fil-content-body')
+  }
+
+  /** Shown when the link is expired or revoked (Error.public_unshared_title). */
+  get unavailableMessage(): Locator {
+    return this.page.getByRole('heading', { name: /no longer available/i })
+  }
+
+  /** Fill the stack-served password prompt and submit it. */
+  async enterPassword(password: string): Promise<void> {
+    await this.passwordInput.waitFor({ state: 'visible' })
+    await this.passwordInput.fill(password)
+    await this.passwordInput.press('Enter')
+  }
+}

--- a/e2e/pages/ShareByLinkPage.ts
+++ b/e2e/pages/ShareByLinkPage.ts
@@ -1,0 +1,86 @@
+import type { Page, Locator } from '@playwright/test'
+
+/**
+ * Drives the "share by link" flow inside the share modal.
+ *
+ * The public link is not created up front: clicking "Copy link" generates it
+ * (and copies it to the clipboard), after which a "link recipient" row appears
+ * with a cog. Clicking that row opens the ShareRestrictionModal where password
+ * and expiration are configured.
+ *
+ * Assumes the share modal is already open. Label matching assumes English.
+ */
+export class ShareByLinkPage {
+  private readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /** The link recipient row, present only once a link exists. Its text flips
+   * to "Anyone with a password" after a password is set. */
+  private get linkRow(): Locator {
+    return this.page.getByText(/Anyone with (the link|a password)/)
+  }
+
+  /** The ShareRestrictionModal is a second dialog stacked over the share
+   * modal; scope to it by its "Sharing link" title so its toggles and Confirm
+   * button don't collide with the share modal underneath. */
+  private get restrictionModal(): Locator {
+    return this.page.getByRole('dialog').filter({ hasText: 'Sharing link' })
+  }
+
+  /** Generate the public link via "Copy link" and return the copied URL. The
+   * link is created server-side here, but the link recipient row only renders
+   * after the modal re-fetches permissions, so callers reopen the modal (see
+   * waitForLinkRow) before opening restrictions. The caller's browser context
+   * must have clipboard permissions granted. */
+  async createLink(): Promise<string> {
+    await this.page.getByRole('button', { name: 'Copy link' }).click()
+    // The link is generated asynchronously and only then copied, so poll the
+    // clipboard until the URL lands rather than reading it immediately.
+    await this.page.waitForFunction(
+      async () => /^https?:\/\//.test(await navigator.clipboard.readText()),
+      null,
+      { timeout: 10_000 }
+    )
+    return this.page.evaluate(() => navigator.clipboard.readText())
+  }
+
+  /** Wait for the link recipient row to be present (after a modal reopen). */
+  async waitForLinkRow(): Promise<void> {
+    await this.linkRow.waitFor({ state: 'visible' })
+  }
+
+  /** Open the restriction modal by clicking the link recipient row (its cog). */
+  async openRestrictions(): Promise<void> {
+    await this.linkRow.click()
+    await this.restrictionModal.waitFor({ state: 'visible' })
+  }
+
+  /** Toggle password protection on and fill the password field. */
+  async enablePassword(password: string): Promise<void> {
+    const modal = this.restrictionModal
+    await modal.getByText('Limit access with a password').click()
+    await modal.getByLabel('Password').fill(password)
+  }
+
+  /** `date` must already be formatted for the current locale (MM/dd/yyyy in
+   * English); the cozy-ui DatePicker has `enableKeyboard`, so we type it
+   * rather than navigating the calendar popup. */
+  async enableExpiration(date: string): Promise<void> {
+    const modal = this.restrictionModal
+    await modal.getByText('Remove access after a deadline').click()
+    // The DatePicker's label "Deadline" is also the icon button's aria-label,
+    // so match the date input by its numeric inputmode (the only one here).
+    await modal.locator('input[inputmode="numeric"]').fill(date)
+  }
+
+  /** Confirm the restriction modal and wait for it to close. */
+  async confirm(): Promise<void> {
+    await this.restrictionModal
+      .getByRole('button', { name: 'Confirm' })
+      .click()
+    await this.restrictionModal.waitFor({ state: 'hidden', timeout: 15_000 })
+  }
+}

--- a/e2e/tests/folder-crud.spec.ts
+++ b/e2e/tests/folder-crud.spec.ts
@@ -20,6 +20,24 @@ test.describe('Folder CRUD', () => {
     await expect(aliceDrive.row(name).cell).toBeVisible()
   })
 
+  test('creates a folder via the right-click context menu', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    // Enter a fresh, empty folder so the right-click opens the AddMenu on blank
+    // space instead of a file row's context menu.
+    const parent = `CtxParent ${stamp()}`
+    await aliceDrive.createFolder(parent)
+    await aliceDrive.row(parent).open()
+    await alicePage.waitForURL(/\/folder\/[^/]+$/)
+
+    const child = `CtxFolder ${stamp()}`
+    await aliceDrive.createFolderViaContextMenu(child)
+    await expect(aliceDrive.row(child).cell).toBeVisible()
+  })
+
   test('renames a folder via the row action menu', async ({
     alicePage,
     aliceDrive
@@ -31,6 +49,26 @@ test.describe('Folder CRUD', () => {
     await aliceDrive.createFolder(original)
     await aliceDrive.row(original).rename(renamed)
     await expect(aliceDrive.row(renamed).cell).toBeVisible()
+  })
+
+  test('renames a file via the row action menu', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const original = `file-${stamp()}.txt`
+    const renamed = `renamed-${stamp()}.txt`
+    const filePath = path.join(path.dirname(FIXTURE), original)
+    await copyFile(FIXTURE, filePath)
+    try {
+      await aliceDrive.uploadFiles(filePath)
+      await aliceDrive.row(original).waitVisible()
+      await aliceDrive.row(original).rename(renamed)
+      await expect(aliceDrive.row(renamed).cell).toBeVisible()
+    } finally {
+      await safeUnlink(filePath)
+    }
   })
 
   test('moves a folder into a sibling folder', async ({

--- a/e2e/tests/upload-and-viewer.spec.ts
+++ b/e2e/tests/upload-and-viewer.spec.ts
@@ -52,6 +52,48 @@ test.describe('Upload & file viewer', () => {
     }
   })
 
+  test('uploads a file via the right-click context menu', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    // Operate inside a fresh, empty folder so the right-click lands on blank
+    // space (the AddMenu) rather than a file row (the file menu).
+    const folder = `CtxUpload ${stamp()}`
+    await aliceDrive.createFolder(folder)
+    await aliceDrive.row(folder).open()
+    await alicePage.waitForURL(/\/folder\/[^/]+$/)
+
+    const uniqueName = `ctx-${stamp()}.txt`
+    const fixturePath = path.join(FIXTURE_DIR, uniqueName)
+    await copyFile(SAMPLE, fixturePath)
+    try {
+      await aliceDrive.uploadFilesViaContextMenu(fixturePath)
+      await aliceDrive.row(uniqueName).waitVisible()
+    } finally {
+      await safeUnlink(fixturePath)
+    }
+  })
+
+  test('uploads a file by dragging it onto the dropzone', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+
+    const folder = `DragDrop ${stamp()}`
+    await aliceDrive.createFolder(folder)
+    await aliceDrive.row(folder).open()
+    await alicePage.waitForURL(/\/folder\/[^/]+$/)
+
+    const fileName = `dropped-${stamp()}.txt`
+    await aliceDrive.dropFiles([
+      { name: fileName, mime: 'text/plain', content: 'dropped via DnD' }
+    ])
+    await aliceDrive.row(fileName).waitVisible()
+  })
+
   test('opens an uploaded file in the viewer and closes it', async ({
     alicePage,
     aliceDrive

--- a/e2e/tests/z-link-sharing.spec.ts
+++ b/e2e/tests/z-link-sharing.spec.ts
@@ -1,0 +1,136 @@
+import type { Browser, Page } from '@playwright/test'
+
+import { USERS } from '../helpers/config'
+import { findLinkPermission, setLinkExpiry } from '../helpers/stack'
+import { test, expect, stamp } from '../helpers/fixtures'
+import type { DrivePage } from '../pages/DrivePage'
+import { ShareByLinkPage } from '../pages/ShareByLinkPage'
+import { PublicLinkPage } from '../pages/PublicLinkPage'
+
+const ALICE_ROOT = `${USERS.alice.appUrl}/#/folder`
+
+/** MM/dd/yyyy for the English DatePicker, `offsetDays` from today. */
+function localeDate(offsetDays: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + offsetDays)
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${mm}/${dd}/${d.getFullYear()}`
+}
+
+/** Open the share modal from the folder toolbar and wait for the dialog. */
+async function openShareModal(page: Page): Promise<void> {
+  await page.getByRole('button', { name: /share/i }).click()
+  await page.getByRole('dialog').waitFor({ state: 'visible' })
+}
+
+/** Close and reopen the share modal so it remounts and re-reads the sharing
+ * context; the link recipient row only renders from freshly read permissions. */
+async function reopenShareModal(page: Page): Promise<void> {
+  const dialog = page.getByRole('dialog')
+  await dialog
+    .getByRole('button', { name: /^(done|close)$/i })
+    .first()
+    .click()
+  await dialog.waitFor({ state: 'hidden' })
+  await openShareModal(page)
+}
+
+/** Create an empty folder, enter it, open the share modal. Returns the folder
+ * id (from the URL) and a ShareByLinkPage to drive the link flow. */
+async function openShareForNewFolder(
+  page: Page,
+  drive: DrivePage
+): Promise<{ folderId: string; link: ShareByLinkPage }> {
+  await page.goto(ALICE_ROOT)
+  const folder = `Linked ${stamp()}`
+  await drive.createFolder(folder)
+  await drive.row(folder).open()
+  await page.waitForURL(/\/folder\/[^/]+$/)
+  const folderId = page.url().match(/\/folder\/([^/?]+)/)?.[1] ?? ''
+  expect(folderId).not.toBe('')
+
+  await openShareModal(page)
+  return { folderId, link: new ShareByLinkPage(page) }
+}
+
+/** Run `fn` against a fresh, unauthenticated context (an anonymous visitor). */
+async function withAnonymousPage(
+  browser: Browser,
+  fn: (page: Page) => Promise<void>
+): Promise<void> {
+  const ctx = await browser.newContext()
+  try {
+    await fn(await ctx.newPage())
+  } finally {
+    await ctx.close()
+  }
+}
+
+test.describe('Share by link', () => {
+  test('a password-protected link challenges before granting access', async ({
+    alicePage,
+    aliceDrive,
+    browser
+  }) => {
+    await alicePage
+      .context()
+      .grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    const { link } = await openShareForNewFolder(alicePage, aliceDrive)
+    const password = `pw-${stamp()}`
+    const url = await link.createLink()
+    expect(url).toMatch(/^https?:\/\//)
+
+    await reopenShareModal(alicePage)
+    await link.waitForLinkRow()
+    await link.openRestrictions()
+    await link.enablePassword(password)
+    await link.confirm()
+
+    await withAnonymousPage(browser, async pub => {
+      await pub.goto(url)
+      const publicPage = new PublicLinkPage(pub)
+      await publicPage.enterPassword(password)
+      await expect(publicPage.fileList).toBeVisible({ timeout: 15_000 })
+    })
+  })
+
+  test('an expired link is rejected', async ({
+    alicePage,
+    aliceDrive,
+    browser
+  }) => {
+    await alicePage
+      .context()
+      .grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    const { folderId, link } = await openShareForNewFolder(alicePage, aliceDrive)
+    const url = await link.createLink()
+
+    await reopenShareModal(alicePage)
+    await link.waitForLinkRow()
+    await link.openRestrictions()
+    // The picker rejects past dates, so set a future deadline to exercise the
+    // happy path, then backdate the permission on the stack to force expiry.
+    await link.enableExpiration(localeDate(1))
+    await link.confirm()
+
+    const permission = await findLinkPermission(USERS.alice.instance, folderId)
+    await setLinkExpiry(
+      USERS.alice.instance,
+      permission.id,
+      new Date('2000-01-01T00:00:00Z')
+    )
+
+    await withAnonymousPage(browser, async pub => {
+      await pub.goto(url)
+      const publicPage = new PublicLinkPage(pub)
+      // Assert the rejection positively (the "link no longer available" page)
+      // rather than only the absence of content, which the SPA would satisfy
+      // momentarily before mounting regardless of expiry.
+      await expect(publicPage.unavailableMessage).toBeVisible({ timeout: 15_000 })
+      await expect(publicPage.fileList).toHaveCount(0)
+    })
+  })
+})


### PR DESCRIPTION
## Context

The E2E suite covered the toolbar Create and Upload buttons and cozy-to-cozy sharing, but not the right-click menu, drag-and-drop, file rename, or public link sharing. The link flows matter most: they exercise the anonymous public route, which has regressed before.

## Tests added

- Create a folder via the right-click context menu
- Upload a file via the right-click context menu
- Upload a file by drag-and-drop
- Rename a file
- Share a folder by a password-protected link, verified by hitting the password challenge in a fresh anonymous browser
- Reject an expired link, verified by backdating the permission on the stack and asserting the "link no longer available" page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for folder creation, renaming, and deletion via context-menu flows.
  * Added upload tests for context-menu uploads and simulated drag‑and‑drop uploads.
  * Added end-to-end share-by-link scenarios: creating links, copying links, password protection, expiration, and public (anonymous) access checks.
  * Added test helpers and page objects to drive link permission manipulation, password gating, and public-link interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->