### PR TITLE
feat: Add shared drive in nav

### DIFF
--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -16,6 +16,7 @@ import { ExternalNavItem } from '@/modules/navigation/ExternalNavItem'
 import { FavoriteList } from '@/modules/navigation/FavoriteList'
 import { useNavContext } from '@/modules/navigation/NavContext'
 import { NavItem } from '@/modules/navigation/NavItem'
+import { SharedDriveList } from '@/modules/navigation/SharedDriveList'
 import { SharingsNavItem } from '@/modules/navigation/SharingsNavItem'
 import { ExternalDrives } from '@/modules/navigation/components/ExternalDrivesList'
 
@@ -69,6 +70,9 @@ export const Nav = () => {
         </NavDesktopDropdown>
       )}
       {isDesktop ? <FavoriteList clickState={clickState} /> : null}
+      {isDesktop && flag('drive.shared-drive.enabled') ? (
+        <SharedDriveList clickState={clickState} />
+      ) : null}
       {isDesktop ? (
         <ExternalDrives clickState={clickState} className="u-mt-half" />
       ) : null}

--- a/src/modules/navigation/SharedDriveList.tsx
+++ b/src/modules/navigation/SharedDriveList.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react'
+
+import { NavDesktopDropdown } from 'cozy-ui/transpiled/react/Nav'
+import { useI18n } from 'twake-i18n'
+
+import { SharedDriveListItem } from './SharedDriveListItem'
+
+import type { SharedDrive } from '@/modules/shareddrives/helpers'
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
+
+interface SharedDriveListProps {
+  clickState: [string, (value: string | undefined) => void]
+}
+
+const SharedDriveList: FC<SharedDriveListProps> = ({ clickState }) => {
+  const { t } = useI18n()
+  const { sharedDrives } = useSharedDrives() as {
+    sharedDrives: SharedDrive[]
+  }
+
+  const orgDrives = sharedDrives.filter(
+    (sharing: SharedDrive) => sharing.org_drive
+  )
+
+  if (orgDrives.length > 0) {
+    return (
+      <NavDesktopDropdown label={t('Nav.item_shared_drives')}>
+        {orgDrives.map(sharing => (
+          <SharedDriveListItem
+            key={sharing._id}
+            sharing={sharing}
+            clickState={clickState}
+          />
+        ))}
+      </NavDesktopDropdown>
+    )
+  }
+
+  return null
+}
+
+export { SharedDriveList }

--- a/src/modules/navigation/SharedDriveListItem.tsx
+++ b/src/modules/navigation/SharedDriveListItem.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react'
+
+import FileTypeSharedDriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDrive'
+import { NavIcon, NavLink, NavItem } from 'cozy-ui/transpiled/react/Nav'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import { FileLink } from './components/FileLink'
+
+import { useSharedDriveLink } from '@/modules/navigation/hooks/useSharedDriveLink'
+import type { SharedDrive } from '@/modules/shareddrives/helpers'
+
+interface SharedDriveListItemProps {
+  sharing: SharedDrive
+  clickState: [string, (value: string | undefined) => void]
+}
+
+const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
+  sharing,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  clickState: [lastClicked, setLastClicked]
+}) => {
+  const { link } = useSharedDriveLink(sharing)
+
+  return (
+    <NavItem key={sharing._id}>
+      <FileLink
+        link={link}
+        className={NavLink.className}
+        onClick={(): void => setLastClicked(undefined)}
+      >
+        <NavIcon icon={FileTypeSharedDriveIcon} />
+        <Typography
+          className="u-fz-small"
+          variant="inherit"
+          color="inherit"
+          noWrap
+        >
+          {sharing.description}
+        </Typography>
+      </FileLink>
+    </NavItem>
+  )
+}
+
+export { SharedDriveListItem }

--- a/src/modules/shareddrives/helpers.ts
+++ b/src/modules/shareddrives/helpers.ts
@@ -7,6 +7,7 @@ export interface SharedDrive {
   description: string
   rules: Rule[]
   owner?: boolean
+  org_drive?: boolean
 }
 
 export interface Rule {


### PR DESCRIPTION
Behind flag('drive.shared-drive.enabled'). It is a considered as a first version to have access to shared drive. 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f0867dfd-cce4-416b-98e7-0ffd9a48a649" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Desktop navigation now includes shared drive support. Organization-shared drives are displayed in the sidebar navigation menu, allowing direct access to shared organizational resources. The shared drives section appears above the external drives list and is available when the feature is enabled. Clicking on a shared drive navigates directly to it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->