### PR TITLE
feat: Handle 2 versions of OO

### DIFF
--- a/src/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/modules/views/OnlyOffice/useConfig.jsx
@@ -98,8 +98,13 @@ const useConfig = () => {
           // complete config doc : https://api.onlyoffice.com/editors/advanced
           document: onlyoffice.document,
           editorConfig: {
-            ...onlyoffice.editor,
-            mode: onlyoffice.editor.mode === 'edit' ? editorMode : 'view',
+            ...(onlyoffice.editorConfig
+              ? onlyoffice.editorConfig
+              : onlyoffice.editor),
+            mode:
+              onlyoffice.editorConfig?.mode || onlyoffice.editor.mode === 'edit'
+                ? editorMode
+                : 'view',
             user: { name },
             customization: {
               reviewDisplay: 'markup'


### PR DESCRIPTION
It seems that the upgrade to OnlyOffice 9.3 on the server requires this stuff. (from 8.0) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OnlyOffice document editor configuration handling to prioritize explicit editor configuration when present and correctly determine edit mode with a safer fallback, ensuring more reliable and flexible editor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->