### PR TITLE
fix: force view mode when onlyoffice grants read-only access

### DIFF
--- a/src/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/modules/views/OnlyOffice/useConfig.jsx
@@ -98,11 +98,10 @@ const useConfig = () => {
           // complete config doc : https://api.onlyoffice.com/editors/advanced
           document: onlyoffice.document,
           editorConfig: {
-            ...(onlyoffice.editorConfig
-              ? onlyoffice.editorConfig
-              : onlyoffice.editor),
+            ...(onlyoffice.editorConfig ?? onlyoffice.editor),
             mode:
-              onlyoffice.editorConfig?.mode || onlyoffice.editor.mode === 'edit'
+              (onlyoffice.editorConfig?.mode ?? onlyoffice.editor?.mode) ===
+              'edit'
                 ? editorMode
                 : 'view',
             user: { name },


### PR DESCRIPTION
## Summary

- Compare the backend-provided mode against `edit` instead of using `editorConfig?.mode` as a truthy test.
- The OO 9.4 backend returns `mode: 'view'` for read-only access, which is a truthy string, so the previous condition always opened the editor in editable mode.
- Normalize the mode from `editorConfig.mode` (OO 9.4) with a fallback to `editor.mode` (older OO) using optional chaining.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OnlyOffice editor configuration handling with improved mode defaults and configuration merging logic. The editor now defaults to 'view' mode unless explicitly configured for 'edit' mode, ensuring more reliable and predictable behavior when opening documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->