### PR TITLE
fix(e2e): follow latest cozy-stack image automatically

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -13,7 +13,8 @@ services:
       retries: 10
 
   cozystack:
-    image: cozy/cozy-stack
+    image: cozy/cozy-stack:latest
+    pull_policy: always
     depends_on:
       couchdb:
         condition: service_healthy


### PR DESCRIPTION
Switch the e2e compose stack from no tag to the upstream :latest tag and add pull_policy: always so the image is re-pulled
on every docker compose up, keeping the test stack in sync with upstream releases without manual bumps.
The time added is around 1s for pull when you already have the latest version but it avoids to have local failing tests because of the wrong cozy-stack version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing environment configuration to ensure the latest service version is used for e2e testing runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->