### PR TITLE
fix(e2e): wait for a new link URL before reading the clipboard

### DIFF
--- a/e2e/pages/ShareByLinkPage.ts
+++ b/e2e/pages/ShareByLinkPage.ts
@@ -36,15 +36,25 @@ export class ShareByLinkPage {
    * waitForLinkRow) before opening restrictions. The caller's browser context
    * must have clipboard permissions granted. */
   async createLink(): Promise<string> {
-    await this.page.getByRole('button', { name: 'Copy link' }).click()
-    // The link is generated asynchronously and only then copied, so poll the
-    // clipboard until the URL lands rather than reading it immediately.
-    await this.page.waitForFunction(
-      async () => /^https?:\/\//.test(await navigator.clipboard.readText()),
-      null,
-      { timeout: 10_000 }
+    // The browser context is reused across tests, so the clipboard may
+    // already hold the previous test's link URL. Capture it so the poll
+    // below only resolves on a freshly generated URL — not just any URL.
+    const previousUrl = await this.page.evaluate(() =>
+      navigator.clipboard.readText().catch(() => '')
     )
-    return this.page.evaluate(() => navigator.clipboard.readText())
+    await this.page.getByRole('button', { name: 'Copy link' }).click()
+    // The link is generated asynchronously and only then copied, so poll
+    // until the clipboard holds a URL different from the previous one.
+    let text = ''
+    const start = Date.now()
+    while (Date.now() - start < 15_000) {
+      text = await this.page.evaluate(() =>
+        navigator.clipboard.readText().catch(() => '')
+      )
+      if (/^https?:\/\//.test(text) && text !== previousUrl) break
+      await this.page.waitForTimeout(100)
+    }
+    return text
   }
 
   /** Wait for the link recipient row to be present (after a modal reopen). */


### PR DESCRIPTION
The browser context is reused across tests, so the system clipboard still holds the previous test's link URL when createLink() runs. The old waitForFunction only checked that the clipboard started with http(s)://, so it resolved immediately with the stale URL and the test navigated to a previous test's link (e.g. the password-protected one) instead of its own.

Capture the previous URL before clicking and poll until the clipboard holds a different URL, so each test gets its own freshly generated link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved reliability of link-sharing test automation by enhancing clipboard detection polling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->