### PR TITLE
chore(excalidraw): drop the bundled xiaolai cjk font

### DIFF
--- a/rsbuild.config.mjs
+++ b/rsbuild.config.mjs
@@ -15,10 +15,15 @@ const config = getRsbuildConfig({
 // font sets are byte-identical, so we copy only the prod one (both build modes
 // resolve the same `fonts/...` filenames at runtime). `info.minimized` stops
 // rspack from re-minifying the prebuilt assets.
+//
+// Xiaolai is excluded: it is Excalidraw's CJK fallback font, ~12 MB of woff2
+// subsets (every other font set is <1 MB total), and we do not ship CJK glyph
+// rendering for drawings. Drop it to keep the build under the registry limit.
 const excalidrawAssets = [
   {
     from: 'node_modules/@excalidraw/excalidraw/dist/prod/fonts',
     to: 'fonts',
+    globOptions: { ignore: ['**/Xiaolai/**'] },
     info: { minimized: true }
   }
 ]


### PR DESCRIPTION
## Summary

- Exclude Excalidraw's Xiaolai CJK font from the rsbuild font copy.
- It is ~12 MB of incompressible woff2 per build (two copies) and only renders CJK glyphs, so it pushes the published tarball over the registry size limit for no benefit here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated font asset configuration to exclude the Xiaolai font set from the build while preserving existing font directory structure and pre-minified assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->