### PR TITLE
fix(excalidraw): load public async chunks from the same origin

### DIFF
--- a/src/modules/views/Excalidraw/setupAssetPath.js
+++ b/src/modules/views/Excalidraw/setupAssetPath.js
@@ -11,8 +11,23 @@
 // This file is imported before @excalidraw/excalidraw on purpose: the library
 // reads window.EXCALIDRAW_ASSET_PATH when it initializes its webpack publicPath,
 // so the value must be set first.
-if (typeof window !== 'undefined' && !window.EXCALIDRAW_ASSET_PATH) {
-  window.EXCALIDRAW_ASSET_PATH = window.location.pathname.startsWith('/public')
-    ? '/public/'
-    : '/'
+if (typeof window !== 'undefined') {
+  const isPublic = window.location.pathname.startsWith('/public')
+  const assetPath = isPublic ? '/public/' : '/'
+
+  if (!window.EXCALIDRAW_ASSET_PATH) {
+    window.EXCALIDRAW_ASSET_PATH = assetPath
+  }
+
+  // Excalidraw also code-splits browser-fs-access, its locale bundles and a few
+  // polyfills as webpack async chunks, which load from __webpack_public_path__
+  // rather than EXCALIDRAW_ASSET_PATH. In dev that path is the cross-origin main
+  // dev server (localhost:3000), unreachable from the public build served under
+  // /public, so the editor's locale and file actions fail to load there. Point
+  // it at the same-origin path for the public build (a no-op in production,
+  // where it already resolves to /public).
+  if (isPublic) {
+    // eslint-disable-next-line no-undef
+    __webpack_public_path__ = assetPath
+  }
 }


### PR DESCRIPTION
## Summary

- Set `__webpack_public_path__` to the public build path in `setupAssetPath.js` so Excalidraw's webpack async chunks (browser-fs-access, locales, canvas polyfill) load same-origin.
- They previously loaded from the cross-origin dev server in the public build and failed, which broke the editor's locale and file open/save in dev.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved asset and webpack chunk loading from incorrect origins in the `/public` share build to ensure proper same-origin resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->