### PR TITLE
fix(shareddrives): stop file list blinking on realtime refresh

### DIFF
--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
@@ -214,6 +214,81 @@ describe('useSharedDriveFolder', () => {
       }))
     })
 
+    it('should keep the current list visible while a realtime re-fetch is in flight', async () => {
+      const page1 = [{ _id: '1', name: 'file-1.txt', type: 'file' }]
+      const refreshedPage1 = [
+        { _id: '1', name: 'file-1.txt', type: 'file' },
+        { _id: '2', name: 'file-2.txt', type: 'file' }
+      ]
+
+      let resolveRefetch
+      const refetchPromise = new Promise(resolve => {
+        resolveRefetch = resolve
+      })
+
+      const statByIdMock = jest
+        .fn()
+        .mockResolvedValueOnce({ included: page1, links: {} })
+        .mockReturnValueOnce(refetchPromise)
+      const mockClient = makeMockClient(statByIdMock)
+      const { result } = setup(mockClient)
+
+      await waitFor(() =>
+        expect(result.current.sharedDriveResult.included).toEqual(page1)
+      )
+      expect(result.current.fetchStatus).toBe('loaded')
+
+      // A realtime event triggers a background re-fetch.
+      await act(async () => {
+        triggerRealtimeEvent()
+      })
+
+      // While the re-fetch is in flight the existing list must stay on screen:
+      // no data wipe and no flip back to 'loading' (otherwise the file list is
+      // replaced by the loading skeleton and the screen blinks).
+      expect(result.current.sharedDriveResult.included).toEqual(page1)
+      expect(result.current.fetchStatus).toBe('loaded')
+
+      await act(async () => {
+        resolveRefetch({ included: refreshedPage1, links: {} })
+      })
+
+      await waitFor(() =>
+        expect(result.current.sharedDriveResult.included).toEqual(
+          refreshedPage1
+        )
+      )
+      expect(result.current.fetchStatus).toBe('loaded')
+    })
+
+    it('should keep the current list when a realtime re-fetch fails', async () => {
+      const page1 = [{ _id: '1', name: 'file-1.txt', type: 'file' }]
+
+      const statByIdMock = jest
+        .fn()
+        .mockResolvedValueOnce({ included: page1, links: {} })
+        .mockRejectedValueOnce(new Error('Network error'))
+      const mockClient = makeMockClient(statByIdMock)
+      const { result } = setup(mockClient)
+
+      await waitFor(() =>
+        expect(result.current.sharedDriveResult.included).toEqual(page1)
+      )
+
+      await act(async () => {
+        triggerRealtimeEvent()
+      })
+
+      // A failed background refresh must not wipe the list or flip to an error
+      // state once data is already on screen.
+      expect(result.current.sharedDriveResult.included).toEqual(page1)
+      expect(result.current.fetchStatus).toBe('loaded')
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error fetching shared drive folder:',
+        expect.any(Error)
+      )
+    })
+
     it('should re-fetch only page 1 when realtime fires before any fetchMore', async () => {
       const cursor = 'cursor-page-2'
       const page1 = [{ _id: '1', name: 'file-1.txt', type: 'file' }]

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
@@ -59,15 +59,25 @@ const useSharedDriveFolder = ({
   )
 
   useEffect(() => {
-    const fetchSharedDriveFolder = async (pagesToLoad = 1): Promise<void> => {
+    const fetchSharedDriveFolder = async (
+      pagesToLoad = 1,
+      { isRefresh = false }: { isRefresh?: boolean } = {}
+    ): Promise<void> => {
       fetchGeneration.current += 1
       const currentGeneration = fetchGeneration.current
 
-      setSharedDriveResult({ data: undefined, included: undefined })
-      setFetchStatus('loading')
-      nextCursorRef.current = null
-      setNextCursor(null)
-      loadedPagesCount.current = 0
+      // On a realtime-triggered refresh, keep the current list and cursor on
+      // screen and refetch in the background; only swap once the new data
+      // arrives. Wiping to a loading state here would replace the list with the
+      // loading skeleton on every realtime event and make the view blink while
+      // files are being added.
+      if (!isRefresh) {
+        setSharedDriveResult({ data: undefined, included: undefined })
+        setFetchStatus('loading')
+        nextCursorRef.current = null
+        setNextCursor(null)
+        loadedPagesCount.current = 0
+      }
 
       try {
         let allIncluded: IOCozyFile[] = []
@@ -92,7 +102,15 @@ const useSharedDriveFolder = ({
         }
       } catch (error) {
         logger.error('Error fetching shared drive folder:', error)
-        if (fetchGeneration.current === currentGeneration) {
+        // A failed background refresh keeps the data already on screen rather
+        // than dropping the user into an error state. But if nothing has loaded
+        // yet (a refresh racing the very first load), surface the error instead
+        // of leaving the view stuck on the loading skeleton.
+        const hasLoadedData = loadedPagesCount.current > 0
+        if (
+          fetchGeneration.current === currentGeneration &&
+          (!isRefresh || !hasLoadedData)
+        ) {
           setSharedDriveResult({ data: undefined, included: undefined })
           setFetchStatus('failed')
           nextCursorRef.current = null
@@ -106,7 +124,9 @@ const useSharedDriveFolder = ({
     }
 
     const debouncedFetch = debounce(() => {
-      void fetchSharedDriveFolder(Math.max(1, loadedPagesCount.current))
+      void fetchSharedDriveFolder(Math.max(1, loadedPagesCount.current), {
+        isRefresh: true
+      })
     }, 500)
 
     let realtime: CozyRealtime | undefined


### PR DESCRIPTION
## Problem

- In a shared drive, a member with write access who uploads files sees the list blink.
- The recipient view refetches the folder on every realtime file event.
- Each refetch cleared the data and showed a loading state first, so the list was replaced by the skeleton and then redrawn.
- Uploads fire these events in bursts, so the list blanks out repeatedly.

## Solution

Refresh in the background and keep the current list on screen, only swapping once the new data arrives. The initial load still shows the skeleton, and a failed refresh keeps the existing list (unless nothing has loaded yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime synchronization to preserve currently displayed folder contents when background refreshes are in progress
  * Fixed issue where failed realtime updates would overwrite existing data; existing content now remains on-screen until successful refresh

<!-- end of auto-generated comment: release notes by coderabbit.ai -->