### PR TITLE
fix(shareddrives): hide edit actions for read-only recipients

### DIFF
--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -60,10 +60,9 @@ const EmptyCanvas = ({
       text={
         <>
           {text}
-          {showUploadLayout && (
+          {showUploadLayout && canUpload !== false && (
             <span className="u-db u-mt-1">
               <UploadButton
-                disabled={!canUpload}
                 componentsProps={{
                   button: { variant: 'secondary' }
                 }}

--- a/src/components/RightClick/RightClickAddMenu.jsx
+++ b/src/components/RightClick/RightClickAddMenu.jsx
@@ -1,16 +1,16 @@
 import React, { useContext } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { useSharingContext } from 'cozy-sharing'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { useRightClick } from '@/components/RightClick/RightClickProvider'
 import { useDisplayedFolder } from '@/hooks'
+import useCurrentFolderWriteAccess from '@/hooks/useCurrentFolderWriteAccess'
 import AddMenuProvider, {
   AddMenuContext
 } from '@/modules/drive/AddMenu/AddMenuProvider'
 
-const AddMenu = ({ children, ...props }) => {
+const AddMenu = ({ children, isFolderReadOnly, ...props }) => {
   const { isDesktop } = useBreakpoints()
   const { onOpen } = useRightClick()
   const { handleToggle, handleOfflineClick, isOffline } =
@@ -20,7 +20,7 @@ const AddMenu = ({ children, ...props }) => {
   const isInViewerMode = location.pathname.includes('/file/')
 
   if (!children) return null
-  if (!isDesktop || isInViewerMode)
+  if (!isDesktop || isInViewerMode || isFolderReadOnly)
     return React.Children.map(children, child =>
       React.isValidElement(child)
         ? React.cloneElement(child, {
@@ -49,12 +49,9 @@ const AddMenu = ({ children, ...props }) => {
 const RightClickAddMenu = ({ children, ...props }) => {
   const { isOpen, position } = useRightClick()
   const { displayedFolder } = useDisplayedFolder()
-  const { hasWriteAccess } = useSharingContext()
   const location = useLocation()
 
-  const isFolderReadOnly = displayedFolder
-    ? !hasWriteAccess(displayedFolder._id, displayedFolder.driveId)
-    : false
+  const isFolderReadOnly = !useCurrentFolderWriteAccess()
 
   const isInViewerMode = location.pathname.includes('/file/')
   const shouldShowAddMenu = isOpen('AddMenu') && !isInViewerMode
@@ -76,7 +73,9 @@ const RightClickAddMenu = ({ children, ...props }) => {
         }
       }}
     >
-      <AddMenu {...props}>{children}</AddMenu>
+      <AddMenu {...props} isFolderReadOnly={isFolderReadOnly}>
+        {children}
+      </AddMenu>
     </AddMenuProvider>
   )
 }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -157,6 +157,7 @@ declare module 'cozy-sharing' {
   export const useSharingContext: () => {
     allLoaded: boolean
     refresh: () => void
+    hasWriteAccess: (id: string, driveId?: string) => boolean
   }
 
   export const useNativeFileSharing: () => {

--- a/src/hooks/useCurrentFolderWriteAccess.spec.jsx
+++ b/src/hooks/useCurrentFolderWriteAccess.spec.jsx
@@ -1,0 +1,80 @@
+import ReactRouter from 'react-router-dom'
+
+import { useSharingContext } from 'cozy-sharing'
+
+import useCurrentFolderId from './useCurrentFolderId'
+import useCurrentFolderWriteAccess from './useCurrentFolderWriteAccess'
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn()
+}))
+jest.mock('cozy-sharing', () => ({
+  useSharingContext: jest.fn()
+}))
+jest.mock('./useCurrentFolderId')
+
+describe('useCurrentFolderWriteAccess', () => {
+  const setup = ({ driveId, folderId, hasWriteAccess, allLoaded = true }) => {
+    ReactRouter.useParams.mockReturnValue({ driveId })
+    useCurrentFolderId.mockReturnValue(folderId)
+    const hasWriteAccessMock = jest.fn().mockReturnValue(hasWriteAccess)
+    useSharingContext.mockReturnValue({
+      hasWriteAccess: hasWriteAccessMock,
+      allLoaded
+    })
+    return { hasWriteAccessMock }
+  }
+
+  it('is not writable for a viewer in a shared drive folder', () => {
+    const { hasWriteAccessMock } = setup({
+      driveId: 'drive-1',
+      folderId: 'folder-1',
+      hasWriteAccess: false
+    })
+
+    expect(useCurrentFolderWriteAccess()).toBe(false)
+    // The driveId from the route must be forwarded so write access resolves even
+    // though shared drive folders have no local io.cozy.files doc.
+    expect(hasWriteAccessMock).toHaveBeenCalledWith('folder-1', 'drive-1')
+  })
+
+  it('is writable for an editor in a shared drive folder', () => {
+    setup({ driveId: 'drive-1', folderId: 'folder-1', hasWriteAccess: true })
+
+    expect(useCurrentFolderWriteAccess()).toBe(true)
+  })
+
+  it('is writable in a regular owned folder without a driveId', () => {
+    const { hasWriteAccessMock } = setup({
+      driveId: undefined,
+      folderId: 'my-folder',
+      hasWriteAccess: true
+    })
+
+    expect(useCurrentFolderWriteAccess()).toBe(true)
+    expect(hasWriteAccessMock).toHaveBeenCalledWith('my-folder', undefined)
+  })
+
+  it.each([
+    { desc: 'there is no current folder', folderId: null, allLoaded: true },
+    {
+      desc: 'the sharing context is still loading',
+      folderId: 'folder-1',
+      allLoaded: false
+    }
+  ])(
+    'is writable, without checking access, when $desc',
+    ({ folderId, allLoaded }) => {
+      const { hasWriteAccessMock } = setup({
+        driveId: 'drive-1',
+        folderId,
+        hasWriteAccess: false,
+        allLoaded
+      })
+
+      expect(useCurrentFolderWriteAccess()).toBe(true)
+      expect(hasWriteAccessMock).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/hooks/useCurrentFolderWriteAccess.tsx
+++ b/src/hooks/useCurrentFolderWriteAccess.tsx
@@ -1,0 +1,28 @@
+import { useParams } from 'react-router-dom'
+
+import { useSharingContext } from 'cozy-sharing'
+
+import useCurrentFolderId from '@/hooks/useCurrentFolderId'
+
+/**
+ * Tells whether the user can write to the current folder.
+ *
+ * Shared drive folders are proxied from the owner, so the recipient has no local
+ * io.cozy.files doc for them. Resolving write access from the route driveId keeps
+ * the answer correct where a local folder doc is absent. The folder is treated as
+ * writable until the sharing context is loaded, to avoid hiding edit actions on
+ * owned folders during the initial load.
+ */
+const useCurrentFolderWriteAccess = (): boolean => {
+  const { driveId } = useParams()
+  const folderId = useCurrentFolderId()
+  const { hasWriteAccess, allLoaded } = useSharingContext()
+
+  if (!allLoaded || !folderId) {
+    return true
+  }
+
+  return hasWriteAccess(folderId, driveId)
+}
+
+export default useCurrentFolderWriteAccess

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -6,7 +6,6 @@ import { BarComponent } from 'cozy-bar'
 import CozyDevtools from 'cozy-devtools'
 import flag from 'cozy-flags'
 import FlagSwitcher from 'cozy-flags/dist/FlagSwitcher'
-import { useSharingContext } from 'cozy-sharing'
 import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import { Layout as LayoutUI } from 'cozy-ui/transpiled/react/Layout'
 import Sidebar from 'cozy-ui/transpiled/react/Sidebar'
@@ -20,6 +19,7 @@ import DriveText from '@/components/Icons/DriveText'
 import ButtonClient from '@/components/pushClient/Button'
 import { ROOT_DIR_ID } from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
+import useCurrentFolderWriteAccess from '@/hooks/useCurrentFolderWriteAccess'
 import { initFlags } from '@/lib/flags'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import AddButton from '@/modules/drive/Toolbar/components/AddButton'
@@ -41,7 +41,6 @@ const LayoutContent = () => {
   const dispatch = useDispatch()
   const { isMobile, isDesktop } = useBreakpoints()
   const { displayedFolder } = useDisplayedFolder()
-  const { hasWriteAccess } = useSharingContext()
   const { t } = useI18n()
 
   const shouldRedirect = useSelector(wasOperationRedirected)
@@ -56,9 +55,7 @@ const LayoutContent = () => {
     }
   }, [shouldRedirect, navigate, dispatch, setLastClicked])
 
-  const isFolderReadOnly = displayedFolder
-    ? !hasWriteAccess(displayedFolder._id, displayedFolder.driveId)
-    : false
+  const canWriteToCurrentFolder = useCurrentFolderWriteAccess()
 
   return (
     <LayoutUI onContextMenu={ev => ev.preventDefault()}>
@@ -72,15 +69,14 @@ const LayoutContent = () => {
         <FlagSwitcher />
         <Sidebar className="u-flex-justify-between">
           <div>
-            {isDesktop ? (
+            {isDesktop && canWriteToCurrentFolder ? (
               <div className="u-mh-1 u-mt-half">
                 <AddMenuProvider
                   canCreateFolder={true}
-                  canUpload={!isFolderReadOnly}
+                  canUpload={true}
                   disabled={false}
                   displayedFolder={displayedFolder}
                   isSelectionBarVisible={false}
-                  isReadOnly={isFolderReadOnly}
                   componentsProps={{ AddMenu: { isUploadDisabled: true } }}
                 >
                   <AddButton className="u-w-100 u-bdrs-6 u-mt-half u-mb-half u-fz-small" />
@@ -91,7 +87,6 @@ const LayoutContent = () => {
                   }}
                   label={t('upload.label')}
                   displayedFolder={displayedFolder}
-                  disabled={isFolderReadOnly}
                 />
               </div>
             ) : null}


### PR DESCRIPTION
## Context
On the recipient side of a shared drive or shared folder, a viewer with read-only access still saw the Create and Upload actions in the sidebar, the right-click add menu, and the empty-folder placeholder. Write access was inferred from the local folder document, but shared-drive folders are proxied from the owner and have no local document, so the check defaulted to writable and offered edit actions to users who cannot write.

## Solution
Resolve write access from the current route (folder id and drive id) through a new useCurrentFolderWriteAccess hook, and gate the sidebar, the right-click add menu, and the empty-folder upload button on it. The folder is treated as writable until the sharing context has loaded, so owned folders keep their actions during the initial load. The empty-folder placeholder now shows a read-only message instead of an upload prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upload and add options are no longer displayed in read-only folders.
  * Right-click context menu now respects folder permissions and won't show add operations when the folder is read-only.

* **Tests**
  * Added test coverage for folder write-access permissions checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->