### PR TITLE
fix(viewer): hide duplicate action for read-only recipients

### DIFF
--- a/src/hooks/useMoreMenuActions.jsx
+++ b/src/hooks/useMoreMenuActions.jsx
@@ -87,6 +87,7 @@ export const useMoreMenuActions = (
       hasWriteAccess: canWriteToCurrentFolder,
       shouldHideIfSharedDriveRecipient,
       canMove: canWriteToCurrentFolder,
+      canDuplicate: canWriteToCurrentFolder,
       isPublic: false,
       allLoaded,
       showAlert,

--- a/src/hooks/useMoreMenuActions.spec.jsx
+++ b/src/hooks/useMoreMenuActions.spec.jsx
@@ -1,0 +1,72 @@
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient } from 'cozy-client'
+
+import { useMoreMenuActions } from './useMoreMenuActions'
+import AppLike from 'test/components/AppLike'
+
+jest.mock('cozy-keys-lib', () => ({
+  useVaultClient: jest.fn()
+}))
+jest.mock('cozy-intent', () => ({
+  useWebviewIntent: jest.fn()
+}))
+
+const file = {
+  _id: 'file-1',
+  id: 'file-1',
+  _type: 'io.cozy.files',
+  type: 'file',
+  name: 'report.txt',
+  mime: 'text/plain',
+  dir_id: 'folder-1',
+  driveId: 'drive-1'
+}
+
+const setup = async ({ hasWriteAccess }) => {
+  const client = createMockClient({})
+  const hasWriteAccessMock = jest.fn().mockReturnValue(hasWriteAccess)
+  const sharingContextValue = {
+    refresh: jest.fn(),
+    hasWriteAccess: hasWriteAccessMock,
+    isOwner: jest.fn(),
+    allLoaded: true,
+    byDocId: {}
+  }
+
+  const wrapper = ({ children }) => (
+    <AppLike client={client} sharingContextValue={sharingContextValue}>
+      {children}
+    </AppLike>
+  )
+
+  const rendered = renderHook(() => useMoreMenuActions(file), { wrapper })
+  // Flush the print-availability effect so its state update stays inside act.
+  await act(async () => {})
+  return { ...rendered, hasWriteAccessMock }
+}
+
+const findAction = (actions, name) =>
+  actions.find(action => action[name])?.[name]
+
+describe('useMoreMenuActions', () => {
+  it('does not display duplicateTo without write access to the folder', async () => {
+    const { result, hasWriteAccessMock } = await setup({
+      hasWriteAccess: false
+    })
+
+    const duplicateTo = findAction(result.current, 'duplicateTo')
+    expect(duplicateTo.displayCondition([file])).toBe(false)
+    // Write access must be resolved with the file's driveId so proxied
+    // shared drive files are checked against the drive sharing.
+    expect(hasWriteAccessMock).toHaveBeenCalledWith(null, 'drive-1')
+  })
+
+  it('displays duplicateTo with write access to the folder', async () => {
+    const { result } = await setup({ hasWriteAccess: true })
+
+    const duplicateTo = findAction(result.current, 'duplicateTo')
+    expect(duplicateTo.displayCondition([file])).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem
A recipient with read-only access to a shared folder could see the "Duplicate to…" action in the file viewer's three-dot menu. Move and trash were correctly hidden there because they are gated on write access, but the duplicate action never received its canDuplicate option, so it fell back to its default and stayed visible for everyone.

## Change
Pass canDuplicate from the same write-access check the menu already uses for move and trash. The folder views already gate their list actions this way, so the viewer menu now behaves consistently with the file list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated menu to support permission-based duplicate actions. The duplicate option visibility now depends on user write access to the current folder.

* **Tests**
  * Added tests for menu action configuration, verifying that duplicate action visibility correctly reflects user folder write permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->