### PR TITLE
fix(shareddrives): open move/duplicate over shared-drive viewer

### DIFF
--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -100,7 +100,13 @@ const sharedDriveRoutes = () => (
       <Route
         path="file/:fileId"
         element={<OutletWrapper Component={FilesViewerSharedDrive} />}
-      />
+      >
+        <Route
+          path="v/move"
+          element={<MoveSharedDriveFilesView isOpenInViewer />}
+        />
+        <Route path="v/duplicate" element={<DuplicateSharedDriveFilesView />} />
+      </Route>
       <Route path="file/:fileId/revision" element={<FileHistory />} />
       <Route path="file/:fileId/v/revision" element={<FileHistory />} />
       <Route path="file/:fileId/share" element={<ShareFileView />} />

--- a/src/modules/views/Modal/MoveSharedDriveFilesView.jsx
+++ b/src/modules/views/Modal/MoveSharedDriveFilesView.jsx
@@ -6,7 +6,7 @@ import useDisplayedFolder from '@/hooks/useDisplayedFolder'
 import MoveModal from '@/modules/move/MoveModal'
 import { useQueryMultipleSharedDriveFolders } from '@/modules/shareddrives/hooks/useQueryMultipleSharedDriveFolders'
 
-const MoveSharedDriveFilesView = () => {
+const MoveSharedDriveFilesView = ({ isOpenInViewer }) => {
   const navigate = useNavigate()
   const { state } = useLocation()
   const { displayedFolder } = useDisplayedFolder()
@@ -17,8 +17,10 @@ const MoveSharedDriveFilesView = () => {
   })
 
   if (sharedDriveResults && displayedFolder) {
+    // Moved files leave the current folder, so closing from the viewer returns
+    // to the folder rather than the now-stale file viewer.
     const onClose = () => {
-      navigate('..', { replace: true })
+      navigate(isOpenInViewer ? '../..' : '..', { replace: true })
     }
 
     const showNextcloudFolder = !sharedDriveResults.some(


### PR DESCRIPTION
## Problem

In a shared drive, opening a file in the viewer and triggering Move or Duplicate from the three-dot menu navigated to a URL with no matching route, so nothing opened. The viewer was a dead end for these two actions.

## Solution

Nest the `v/move` and `v/duplicate` picker routes under the shared-drive file viewer route so the picker renders on top of the viewer, the same way the regular folder viewer already works.

Closing behaves per action: duplicate returns to the viewer (the original file stays), while move returns to the folder (the moved file is no longer there to view).

Closes #3888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now move shared drive files directly from the file viewer.
  * Users can now duplicate shared drive files directly from the file viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->