### PR TITLE
feat: upgrade cozy-sharing to 33.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
-    "cozy-sharing": "^33.1.1",
+    "cozy-sharing": "^33.2.2",
     "cozy-stack-client": "^60.24.0",
     "cozy-ui": "^139.1.0",
     "cozy-ui-plus": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7875,10 +7875,10 @@ cozy-search@^0.25.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^33.1.1:
-  version "33.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.1.1.tgz#6d5cc9d7fcb13d150ab35b22654c47b5931047b5"
-  integrity sha512-a+P5/3+c3/uzO+wwUHuQh3ywZXnLMG5RXtxo+1tDg01kwOhGyX5e7uZ3rPSs3dm6b5vhv71c9cfYFC765uYEcQ==
+cozy-sharing@^33.2.2:
+  version "33.2.2"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.2.2.tgz#dbed6bf4528a253452a129d2ab189bd1b4bcb2c0"
+  integrity sha512-pCpOV3uQ6xqcbcqlWeWMHloEnlomzAHivGN2T3Qcs7mpbL/withsXshnABRtCRlTLJiadOmaKkh7KwoGbpIsMQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
Bump `cozy-sharing` from `33.1.1` to `33.2.2`

- [linagora/cozy-libs#2994](https://github.com/linagora/cozy-libs/pull/2994) (`fix(cozy-sharing): Make matching diacritic-insensitive`)
- [linagora/cozy-libs#3021](https://github.com/linagora/cozy-libs/pull/3021) (`feat(cozy-sharing): Show progress icon on done button during share`)
- [linagora/cozy-libs#3022](https://github.com/linagora/cozy-libs/pull/3022) (`fix(cozy-sharing): Refresh link state in share modal`)
- [linagora/cozy-libs#3023](https://github.com/linagora/cozy-libs/pull/3023) (`fix(cozy-sharing): Allow sharing shared drive folder root by email`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `cozy-sharing` dependency to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->