### PR TITLE
fix: hide Drives folder in move/copy destination picker

### DIFF
--- a/src/components/FolderPicker/FolderPickerContentCozy.tsx
+++ b/src/components/FolderPicker/FolderPickerContentCozy.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { useQuery } from 'cozy-client'
 import { isDirectory } from 'cozy-client/dist/models/file'
@@ -13,8 +13,7 @@ import { FolderPickerContentLoader } from '@/components/FolderPicker/FolderPicke
 import { isInvalidMoveTarget } from '@/components/FolderPicker/helpers'
 import { computeNextcloudRootFolder } from '@/components/FolderPicker/helpers'
 import type { File, FolderPickerEntry } from '@/components/FolderPicker/types'
-import { ROOT_DIR_ID } from '@/constants/config'
-import { buildMoveOrImportQuery, buildMagicFolderQuery } from '@/queries'
+import { buildMoveOrImportQuery } from '@/queries'
 
 interface FolderPickerContentCozyProps {
   folder: IOCozyFile
@@ -31,9 +30,7 @@ const FolderPickerContentCozy: React.FC<FolderPickerContentCozyProps> = ({
   isFolderCreationDisplayed,
   hideFolderCreation,
   entries,
-  navigateTo,
-  showNextcloudFolder,
-  showSharedDriveFolder
+  navigateTo
 }) => {
   const contentQuery = buildMoveOrImportQuery(folder._id)
   const {
@@ -48,39 +45,11 @@ const FolderPickerContentCozy: React.FC<FolderPickerContentCozyProps> = ({
     fetchMore: () => void
   }
 
-  const sharedFolderQuery = buildMagicFolderQuery({
-    id: 'io.cozy.files.shared-drives-dir',
-    enabled: folder._id === ROOT_DIR_ID
-  })
-  const sharedFolderResult = useQuery(
-    sharedFolderQuery.definition,
-    sharedFolderQuery.options
-  ) as unknown as {
-    fetchStatus: string
-    data?: IOCozyFile[]
-  }
-
-  const files: IOCozyFile[] = useMemo(() => {
-    if (
-      folder._id === ROOT_DIR_ID &&
-      (showNextcloudFolder || showSharedDriveFolder)
-    ) {
-      return [
-        ...(sharedFolderResult.fetchStatus === 'loaded'
-          ? (sharedFolderResult.data ?? [])
-          : []),
-        ...(filesData ?? [])
-      ]
-    }
-    return [...(filesData ?? [])]
-  }, [
-    folder._id,
-    showNextcloudFolder,
-    showSharedDriveFolder,
-    filesData,
-    sharedFolderResult.fetchStatus,
-    sharedFolderResult.data
-  ])
+  // The "Drives" folder (shared-drives-dir) is hidden from the normal file
+  // list, so it must not appear as a destination in the move/copy picker.
+  // buildMoveOrImportQuery already excludes it via partialIndex, so the list
+  // is used as-is with no manual injection.
+  const files: IOCozyFile[] = filesData ?? []
 
   const handleClick = (file: File): void => {
     if (isDirectory(file)) {


### PR DESCRIPTION
## Problem

The shared drives container (the "Drives" folder) is hidden from the normal file list, but it was being injected at the root of the move/copy destination picker. So when picking where to move or copy a file, users saw a "Drives" entry that has no business being a destination.

## Solution

Stop manually injecting the shared-drives-dir folder into the picker. The query that feeds the list (buildMoveOrImportQuery) already excludes it, so the list can be used as-is.

## Worth knowing

The injected "Drives" entry was also the only way to navigate into shared drives (and Nextcloud one level deeper) as a move/copy target from this modal. Removing it therefore also removes those destinations from the owner-at-root flow. This was a deliberate scope choice to keep the change small.

The showNextcloudFolder and showSharedDriveFolder props are still threaded down to this component and the shared-drive navigation branch is left in place, so they are currently inert here. That is intentional technical debt: it keeps the plumbing ready so re-enabling shared drives as a destination later is a small change rather than a rebuild.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
* Simplified the folder selection component's internal logic by consolidating data-fetching queries and removing redundant conditional operations. This improves code maintainability and performance while preserving all existing functionality and user-facing behavior. No changes to the component's interface or available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->