### PR TITLE
fix: dragging a file into a shared drive folder fails with 404

### DIFF
--- a/src/modules/paste/index.js
+++ b/src/modules/paste/index.js
@@ -20,7 +20,6 @@ import { computeNextcloudFolderQueryId } from '@/modules/nextcloud/helpers'
  *
  * @param {CozyClient} client - The cozy client instance
  * @param {import('@/components/FolderPicker/types').File} entry - The file or folder to move/copy
- * @param {import('@/components/FolderPicker/types').File} sourceDirectory - The source directory containing the entry
  * @param {import('@/components/FolderPicker/types').File} destDirectory - The destination directory
  * @param {string} operation - The operation type ('move' or 'copy')
  * @returns {Promise<Object>} The result of the shared drive operation
@@ -28,16 +27,16 @@ import { computeNextcloudFolderQueryId } from '@/modules/nextcloud/helpers'
 const executeSharedDriveMoveOrCopy = async (
   client,
   entry,
-  sourceDirectory,
   destDirectory,
   operation
 ) => {
   return await moveRelateToSharedDrive(
     client,
     {
-      instance: entry.driveId
-        ? sourceDirectory.attributes?.cozyMetadata?.createdOn
-        : '',
+      // The hosting instance is read from the entry itself: a shared-drive
+      // folder (e.g. the drive root used as source directory) does not always
+      // carry cozyMetadata.createdOn, while the moved file/folder always does.
+      instance: entry.driveId ? entry.cozyMetadata?.createdOn : '',
       file_id: isFile(entry) ? entry._id : '',
       dir_id: !isFile(entry) ? entry._id : '',
       sharing_id: entry.driveId
@@ -73,12 +72,7 @@ export const executeMove = async (
 ) => {
   const isSharedDriveOperation = entry.driveId || destDirectory.driveId
   if (isSharedDriveOperation) {
-    return await executeSharedDriveMoveOrCopy(
-      client,
-      entry,
-      sourceDirectory,
-      destDirectory
-    )
+    return await executeSharedDriveMoveOrCopy(client, entry, destDirectory)
   }
   return await move(client, entry, destDirectory, {
     force


### PR DESCRIPTION
## Problem

Dragging a file onto a folder inside a shared drive (as a recipient, and as the owner) failed with a "something went wrong" toast. The move request to `/sharings/drives/move` was sent with an empty `source.instance`, so the stack looked for the file in the user's personal drive and returned 404.

The source instance was read from the source directory's `cozyMetadata.createdOn`, but when the source directory is the shared drive root, that field is absent, so the instance came out undefined.

## Solution

Read the hosting instance from the moved entry's `cozyMetadata.createdOn` instead. The file or folder being moved always carries it, and it points at the same owner instance, so this works for drags from the drive root or any subfolder. It also makes the source and destination resolve the instance the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the internal process for identifying shared-drive instances during move or copy operations, improving reliability of these file operations on shared drives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->