### PR TITLE
fix: keep shared-drive action error and warning alerts on screen for 4 seconds

### DIFF
--- a/src/modules/actions/utils.js
+++ b/src/modules/actions/utils.js
@@ -31,7 +31,11 @@ export const downloadFiles = async (client, files, { showAlert, t } = {}) => {
         .collection(DOCTYPE_FILES, { driveId })
         .download(file, null, file.name)
     } catch (error) {
-      showAlert({ message: t(downloadFileError(error)), severity: 'error' })
+      showAlert({
+        message: t(downloadFileError(error)),
+        severity: 'error',
+        duration: 4000
+      })
     }
   } else {
     const ids = files.map(f => f.id)
@@ -78,7 +82,11 @@ export const trashFiles = async (client, files, { showAlert, t, driveId }) => {
     showAlert({ message: t('alert.trash_file_success'), severity: 'success' })
   } catch (err) {
     if (!isAlreadyInTrash(err)) {
-      showAlert({ message: t('alert.try_again'), severity: 'error' })
+      showAlert({
+        message: t('alert.try_again'),
+        severity: 'error',
+        duration: 4000
+      })
     }
   }
 }

--- a/src/modules/drive/RenameInput.jsx
+++ b/src/modules/drive/RenameInput.jsx
@@ -47,7 +47,11 @@ export const RenameInput = ({
         const newName = withoutExtension ? newValue + extension : newValue
         try {
           if (isOffline) {
-            showAlert({ message: t('alert.offline'), severity: 'error' })
+            showAlert({
+              message: t('alert.offline'),
+              severity: 'error',
+              duration: 4000
+            })
           } else {
             await updateFileNameQuery(client, file, newName)
             if (refreshFolderContent) refreshFolderContent()
@@ -58,7 +62,11 @@ export const RenameInput = ({
               'NetworkError when attempting to fetch resource.'
             )
           ) {
-            showAlert({ message: t('upload.alert.network'), severity: 'error' })
+            showAlert({
+              message: t('upload.alert.network'),
+              severity: 'error',
+              duration: 4000
+            })
           } else if (
             error.message.includes(
               'Invalid filename containing illegal character(s):'
@@ -72,22 +80,25 @@ export const RenameInput = ({
                 )[1]
               }),
               severity: 'error',
-              duration: 2000
+              duration: 4000
             })
           } else if (error.message.includes('Invalid filename:')) {
             showAlert({
               message: t('alert.file_name_illegal_name', { fileName: newName }),
-              severity: 'error'
+              severity: 'error',
+              duration: 4000
             })
           } else if (error.message.includes('Missing name argument')) {
             showAlert({
               message: t('alert.file_name_missing'),
-              severity: 'error'
+              severity: 'error',
+              duration: 4000
             })
           } else {
             showAlert({
               message: t('alert.file_name', { fileName: newName }),
-              severity: 'error'
+              severity: 'error',
+              duration: 4000
             })
           }
         } finally {

--- a/src/modules/drive/RenameInput.spec.jsx
+++ b/src/modules/drive/RenameInput.spec.jsx
@@ -164,7 +164,7 @@ describe('RenameInput', () => {
     await waitFor(() => {
       expect(showAlert).toHaveBeenCalledTimes(1)
       expect(showAlert).toHaveBeenCalledWith(
-        expect.objectContaining({ severity: 'error', duration: 2000 })
+        expect.objectContaining({ severity: 'error', duration: 4000 })
       )
     })
   })

--- a/src/modules/drive/Toolbar/components/AddFolderItem.jsx
+++ b/src/modules/drive/Toolbar/components/AddFolderItem.jsx
@@ -22,7 +22,8 @@ const AddFolderItem = ({ addFolder, onClick, isReadOnly }) => {
           'AddMenu.readOnlyFolder',
           'This is a read-only folder. You cannot perform this action.'
         ),
-        severity: 'warning'
+        severity: 'warning',
+        duration: 4000
       })
       onClick()
       return

--- a/src/modules/drive/Toolbar/components/CreateDocsItem.jsx
+++ b/src/modules/drive/Toolbar/components/CreateDocsItem.jsx
@@ -29,7 +29,8 @@ const CreateDocsItem = ({ displayedFolder, isReadOnly, onClick }) => {
           'AddMenu.readOnlyFolder',
           'This is a read-only folder. You cannot perform this action.'
         ),
-        severity: 'warning'
+        severity: 'warning',
+        duration: 4000
       })
       onClick()
       return

--- a/src/modules/drive/Toolbar/components/CreateExcalidrawItem.jsx
+++ b/src/modules/drive/Toolbar/components/CreateExcalidrawItem.jsx
@@ -26,7 +26,8 @@ const CreateExcalidrawItem = ({ isReadOnly, onClick }) => {
           'AddMenu.readOnlyFolder',
           'This is a read-only folder. You cannot perform this action.'
         ),
-        severity: 'warning'
+        severity: 'warning',
+        duration: 4000
       })
       onClick()
       return

--- a/src/modules/drive/Toolbar/components/CreateNoteItem.jsx
+++ b/src/modules/drive/Toolbar/components/CreateNoteItem.jsx
@@ -80,7 +80,8 @@ const CreateNoteItem = ({
           'AddMenu.readOnlyFolder',
           'This is a read-only folder. You cannot perform this action.'
         ),
-        severity: 'warning'
+        severity: 'warning',
+        duration: 4000
       })
       onClick()
       return

--- a/src/modules/drive/Toolbar/components/CreateOnlyOfficeItem.jsx
+++ b/src/modules/drive/Toolbar/components/CreateOnlyOfficeItem.jsx
@@ -29,7 +29,8 @@ const CreateOnlyOfficeItem = ({ fileClass, isReadOnly, onClick }) => {
           'AddMenu.readOnlyFolder',
           'This is a read-only folder. You cannot perform this action.'
         ),
-        severity: 'warning'
+        severity: 'warning',
+        duration: 4000
       })
       onClick()
       return

--- a/src/modules/drive/Toolbar/components/CreateShortcut.jsx
+++ b/src/modules/drive/Toolbar/components/CreateShortcut.jsx
@@ -24,7 +24,8 @@ const CreateShortcutWrapper = ({ openModal, onClick, isReadOnly }) => {
           'AddMenu.readOnlyFolder',
           'This is a read-only folder. You cannot perform this action.'
         ),
-        severity: 'warning'
+        severity: 'warning',
+        duration: 4000
       })
       onClick()
       return

--- a/src/modules/drive/Toolbar/components/ShortcutCreationModal.jsx
+++ b/src/modules/drive/Toolbar/components/ShortcutCreationModal.jsx
@@ -46,17 +46,29 @@ const ShortcutCreationModal = ({ onClose, onCreated }) => {
 
   const createShortcut = useCallback(async () => {
     if (!fileName || !url) {
-      showAlert({ message: t('Shortcut.needs_info'), severity: 'error' })
+      showAlert({
+        message: t('Shortcut.needs_info'),
+        severity: 'error',
+        duration: 4000
+      })
       return
     }
     const makedURL = makeURLValid(url)
     if (!makedURL) {
-      showAlert({ message: t('Shortcut.url_badformat'), severity: 'error' })
+      showAlert({
+        message: t('Shortcut.url_badformat'),
+        severity: 'error',
+        duration: 4000
+      })
       return
     }
     try {
       if (isOffline) {
-        showAlert({ message: t('alert.offline'), severity: 'error' })
+        showAlert({
+          message: t('alert.offline'),
+          severity: 'error',
+          duration: 4000
+        })
       } else {
         const response = await client.save({
           _type: DOCTYPE_FILES_SHORTCUT,
@@ -78,7 +90,11 @@ const ShortcutCreationModal = ({ onClose, onCreated }) => {
           'NetworkError when attempting to fetch resource.'
         )
       ) {
-        showAlert({ message: t('upload.alert.network'), severity: 'error' })
+        showAlert({
+          message: t('upload.alert.network'),
+          severity: 'error',
+          duration: 4000
+        })
       } else if (
         error.message.includes(
           'Invalid filename containing illegal character(s):'
@@ -92,17 +108,26 @@ const ShortcutCreationModal = ({ onClose, onCreated }) => {
             )[1]
           }),
           severity: 'error',
-          duration: 2000
+          duration: 4000
         })
       } else if (error.message.includes('Invalid filename:')) {
         showAlert({
           message: t('alert.file_name_illegal_name', { fileName }),
-          severity: 'error'
+          severity: 'error',
+          duration: 4000
         })
       } else if (error.message.includes('Missing name argument')) {
-        showAlert({ message: t('alert.file_name_missing'), severity: 'error' })
+        showAlert({
+          message: t('alert.file_name_missing'),
+          severity: 'error',
+          duration: 4000
+        })
       } else {
-        showAlert({ message: t('Shortcut.errored'), severity: 'error' })
+        showAlert({
+          message: t('Shortcut.errored'),
+          severity: 'error',
+          duration: 4000
+        })
       }
     }
   }, [

--- a/src/modules/drive/Toolbar/components/ShortcutCreationModal.spec.jsx
+++ b/src/modules/drive/Toolbar/components/ShortcutCreationModal.spec.jsx
@@ -167,7 +167,7 @@ describe('ShortcutCreationModal', () => {
     await waitFor(() => {
       expect(showAlert).toHaveBeenCalledTimes(1)
       expect(showAlert).toHaveBeenCalledWith(
-        expect.objectContaining({ severity: 'error', duration: 2000 })
+        expect.objectContaining({ severity: 'error', duration: 4000 })
       )
     })
   })

--- a/src/modules/drive/Toolbar/components/UploadItem.jsx
+++ b/src/modules/drive/Toolbar/components/UploadItem.jsx
@@ -61,7 +61,8 @@ const UploadItem = ({
           'AddMenu.readOnlyFolder',
           'This is a read-only folder. You cannot perform this action.'
         ),
-        severity: 'warning'
+        severity: 'warning',
+        duration: 4000
       })
       onClick()
       return

--- a/src/modules/duplicate/components/DuplicateModal.tsx
+++ b/src/modules/duplicate/components/DuplicateModal.tsx
@@ -72,7 +72,8 @@ const DuplicateModal: FC<DuplicateModalProps> = ({
     } catch (_e) {
       showAlert({
         message: t('DuplicateModal.error'),
-        severity: 'error'
+        severity: 'error',
+        duration: 4000
       })
     } finally {
       setBusy(false)

--- a/src/modules/move/MoveModal.jsx
+++ b/src/modules/move/MoveModal.jsx
@@ -145,7 +145,8 @@ const MoveModal = ({
       logger.warn(e)
       showAlert({
         message: t('Move.error', { smart_count: entries.length }),
-        severity: 'error'
+        severity: 'error',
+        duration: 4000
       })
     } finally {
       setMoveInProgress(false)


### PR DESCRIPTION
## Problem
Error and warning alerts for shared-drive actions (move, duplicate, trash, download, rename, shortcut creation, and the read-only warning on create/upload) auto-dismissed after a couple of seconds, so users often did not have time to read them. Two errors even hard-coded a 2 second timeout.

## Solution
Give these alerts a 4 second duration so users have time to read them. Upload error alerts are left as they are.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized alert and notification durations across the application. Error messages, warnings, and alerts now display consistently for 4 seconds, ensuring users have adequate time to read important information during file operations and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->