### PR TITLE
chore: upgrade cozy-ui to 139.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "cozy-search": "^0.25.3",
     "cozy-sharing": "^33.2.2",
     "cozy-stack-client": "^60.24.0",
-    "cozy-ui": "^139.1.0",
+    "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",
     "cozy-viewer": "^28.0.7",
     "date-fns": "2.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7937,10 +7937,10 @@ cozy-ui-plus@^7.1.0:
     react-international-phone "4.7.0"
     rooks "7.14.1"
 
-cozy-ui@^139.1.0:
-  version "139.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-139.1.0.tgz#daf7e00eb8b96c69990149d9f747504c43a71bd1"
-  integrity sha512-FrVddEYQKsieh2keW0oChR22GStlmqBykHr2FgUTj8YOQUhhdQTa2QA9eC1Z5byJJPkqvru45GCkuyiVGgD+Ig==
+cozy-ui@^139.2.0:
+  version "139.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-139.2.0.tgz#3899337ae71a48dc65a838feff9cf1c9e3793513"
+  integrity sha512-x6TMxtYtBO5qA8R+T901o43cKboTWvEDPrusocZySgGqZakt8ASQzOcbN8Gx7wkK40ErWJspEaX7WUCA2RlyqQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"
@@ -13760,9 +13760,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
## Change
Bumps cozy-ui from 139.1.0 to 139.2.0

reverts the table column changes that caused a bug in firefox