### PR TITLE
fix: open office files directly in onlyoffice from file routes

### DIFF
--- a/src/modules/viewer/FileOpenerExternal.jsx
+++ b/src/modules/viewer/FileOpenerExternal.jsx
@@ -7,9 +7,9 @@
 
 import React, { useCallback, useEffect, useState } from 'react'
 import { RemoveScroll } from 'react-remove-scroll'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
 
-import { useClient } from 'cozy-client'
+import { useClient, models } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -76,6 +76,24 @@ const FileOpener = props => {
       loadFileInfo(requestedFileId)
     }
   }, [fileId, props.fileId, loadFileInfo])
+
+  // An Office document does not need the intermediate viewer with its
+  // "Open with Only Office" button: go straight to the editor, like the
+  // folder views and the public preview already do.
+  if (
+    !loading &&
+    !fileNotFound &&
+    file &&
+    models.file.shouldBeOpenedByOnlyOffice(file) &&
+    isOfficeEnabled(isDesktop)
+  ) {
+    return (
+      <Navigate
+        to={makeOnlyOfficeFileRoute(file.id, { driveId: file.driveId })}
+        replace
+      />
+    )
+  }
 
   return (
     <div className="u-pos-absolute u-w-100 u-h-100 u-bg-charcoalGrey">

--- a/src/modules/viewer/FileOpenerExternal.spec.jsx
+++ b/src/modules/viewer/FileOpenerExternal.spec.jsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { Route, Routes } from 'react-router-dom'
+
+import CozyClient from 'cozy-client'
+import flag from 'cozy-flags'
+
+import FileOpenerExternal from './FileOpenerExternal'
+import AppLike from 'test/components/AppLike'
+
+jest.mock('@/components/FilesRealTimeQueries', () => ({
+  ensureFileHasPath: jest.fn().mockImplementation(file => Promise.resolve(file))
+}))
+
+jest.mock('cozy-flags', () => {
+  const flags = {}
+  const flag = jest.fn((name, value) => {
+    if (value !== undefined) {
+      flags[name] = value
+    }
+    return flags[name] ?? null
+  })
+  return { __esModule: true, default: flag }
+})
+
+const mockViewer = jest.fn(() => <div>Viewer</div>)
+
+jest.mock('cozy-viewer', () => ({
+  ...jest.requireActual('cozy-viewer'),
+  __esModule: true,
+  default: props => mockViewer(props)
+}))
+
+const docxFile = {
+  _id: 'file-docx-id',
+  id: 'file-docx-id',
+  _type: 'io.cozy.files',
+  type: 'file',
+  name: 'Rapport.docx',
+  class: 'text',
+  mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  path: '/Rapport.docx'
+}
+
+const pdfFile = {
+  _id: 'file-pdf-id',
+  id: 'file-pdf-id',
+  _type: 'io.cozy.files',
+  type: 'file',
+  name: 'Rapport.pdf',
+  class: 'pdf',
+  mime: 'application/pdf',
+  path: '/Rapport.pdf'
+}
+
+describe('FileOpenerExternal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    flag('drive.office.enabled', true)
+    flag('drive.office.touchScreen.enabled', true)
+  })
+
+  afterEach(() => {
+    flag('drive.office.enabled', null)
+    flag('drive.office.touchScreen.enabled', null)
+  })
+
+  const setup = ({ file }) => {
+    const client = new CozyClient({})
+    client.query = jest.fn().mockResolvedValue({ data: file })
+    window.location.hash = `#/file/${file._id}`
+
+    return render(
+      <AppLike client={client}>
+        <Routes>
+          <Route path="/file/:fileId" element={<FileOpenerExternal />} />
+          <Route
+            path="/onlyoffice/:fileId"
+            element={<div>OnlyOffice editor</div>}
+          />
+        </Routes>
+      </AppLike>
+    )
+  }
+
+  it('redirects an Office file straight to the OnlyOffice editor', async () => {
+    setup({ file: docxFile })
+
+    expect(await screen.findByText('OnlyOffice editor')).toBeInTheDocument()
+    expect(mockViewer).not.toHaveBeenCalled()
+  })
+
+  it('renders the viewer for a non Office file', async () => {
+    setup({ file: pdfFile })
+
+    expect(await screen.findByText('Viewer')).toBeInTheDocument()
+  })
+
+  it('renders the viewer for an Office file when Office is disabled', async () => {
+    flag('drive.office.enabled', false)
+    flag('drive.office.touchScreen.enabled', false)
+
+    setup({ file: docxFile })
+
+    expect(await screen.findByText('Viewer')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Problem
Opening an Office document through the standalone file route, an app intent or a cozydrive:// link rendered the generic viewer with an 'Open with Only Office' button. The recipient of a shared Office file had to click that extra button to reach the content, while the folder views and the public preview already open the editor directly.

## Solution
FileOpenerExternal redirects to the OnlyOffice route as soon as the loaded file is an Office document and Office is enabled, the same destination the button navigated to. Non Office files, and Office files when the feature is disabled, keep the viewer.

## Why this cannot regress other views
FileOpenerExternal is only mounted on the standalone file/:fileId route and in the intent service. Folder, Recents and Sharings views build their links with useFileLink, which already routes Office files to /onlyoffice without going through this component, and the public share pages never mount it: their redirect lives in the public router and is untouched. The redirect target is built with the exact same makeOnlyOfficeFileRoute call the removed-from-the-path button used, so where the user ends up is unchanged, only the intermediate click is gone. The spec covers the three cases: Office file redirected, non Office file kept in the viewer, Office file kept in the viewer when the flag is off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Office documents now automatically redirect to the Only Office editor when the feature is enabled, bypassing the standard viewer interface for a dedicated editing experience.

* **Tests**
  * Added comprehensive test suite covering Office document routing behavior, validating redirects when Office is enabled, fallback to standard viewer when disabled, and proper handling of non-Office files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->