### PR TITLE
fix(sharings): show only received shares in the sharings section

### DIFF
--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
@@ -253,6 +253,32 @@ describe('useTransformFolderListHasSharedDriveShortcuts', () => {
       })
     })
 
+    it('should expose the drive owner flag on transformed entries', () => {
+      mockUseSharedDrives.mockReturnValue({
+        sharedDrives: [
+          {
+            id: 'sharing-owned',
+            owner: true,
+            rules: [{ values: ['folder-owned'], title: 'Owned Drive' }]
+          },
+          {
+            id: 'sharing-received',
+            owner: false,
+            rules: [{ values: ['folder-received'], title: 'Received Drive' }]
+          }
+        ]
+      })
+
+      const { result } = renderHook(() =>
+        useTransformFolderListHasSharedDriveShortcuts([])
+      )
+
+      expect(result.current.sharedDrives).toEqual([
+        expect.objectContaining({ driveId: 'sharing-owned', owner: true }),
+        expect.objectContaining({ driveId: 'sharing-received', owner: false })
+      ])
+    })
+
     it('should filter out nextcloud shortcuts', () => {
       const mockSharedDrives = [
         {

--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
@@ -16,11 +16,13 @@ import type {
 interface SharedDrive {
   id: string
   drive_root_type?: DriveRootType
+  owner?: boolean
   rules: SharingRule[]
 }
 
 interface TransformedSharedDrive extends SharedDriveFile {
   driveId: string
+  owner?: boolean
 }
 
 interface UseTransformFolderListReturn {
@@ -99,6 +101,7 @@ const useTransformFolderListHasSharedDriveShortcuts = (
             {
               ...fileInSharingSection,
               driveId: sharing.id,
+              owner: sharing.owner,
               ...(isFileDriveRoot
                 ? {
                     ...fileMetadata,
@@ -114,6 +117,7 @@ const useTransformFolderListHasSharedDriveShortcuts = (
             _id: rootId,
             id: rootId,
             _type: 'io.cozy.files' as const,
+            owner: sharing.owner,
             path: `/Drives/${driveName}`,
             ...sharedDriveData,
             attributes: sharedDriveData

--- a/src/modules/views/Sharings/index.spec.jsx
+++ b/src/modules/views/Sharings/index.spec.jsx
@@ -98,7 +98,11 @@ describe('Sharings View', () => {
   })
 
   it('should display placeholder when all files are not loaded', async () => {
-    mockSharingContext.mockReturnValue({ byDocId: [], allLoaded: false })
+    mockSharingContext.mockReturnValue({
+      byDocId: [],
+      allLoaded: false,
+      isOwner: jest.fn(() => false)
+    })
     const { container } = setup()
 
     await waitFor(() => {
@@ -109,7 +113,11 @@ describe('Sharings View', () => {
   })
 
   it('should not display placeholder when all files are loaded', async () => {
-    mockSharingContext.mockReturnValue({ byDocId: [], allLoaded: true })
+    mockSharingContext.mockReturnValue({
+      byDocId: [],
+      allLoaded: true,
+      isOwner: jest.fn(() => false)
+    })
     useQuery.mockReturnValue(filesFixtureWithPath)
 
     const { container } = setup()

--- a/src/modules/views/Sharings/useFilteredSharings.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.jsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import flag from 'cozy-flags'
+import { useSharingContext } from 'cozy-sharing'
 
 import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { useTransformFolderListHasSharedDriveShortcuts } from '@/hooks/useTransformFolderListHasSharedDriveShortcuts'
@@ -11,18 +12,35 @@ const buildBaseShape = (result, hasIds) => ({
   lastFetch: hasIds ? result.lastFetch : Date.now()
 })
 
+// The Sharings section is an inbox: it lists only what was shared with the
+// current user. Anything the user owns (files, folders, shared drives) is
+// already reachable from My Drive and the shared-drive views, so it is dropped
+// here. The view gates rendering on the sharing context being loaded, and the
+// filtered ids are byDocId keys, so isOwner is authoritative when this runs;
+// the `?.` is purely defensive. A drive without an owner flag is kept, so a
+// recipient never loses a drive link to a missing signal.
+const isReceivedFile = isOwner => item => !isOwner?.(item._id ?? item.id ?? '')
+const isReceivedDrive = drive => drive.owner !== true
+
 const computeData = ({
   result,
+  isOwner,
   withoutSharedDrives,
   transformedSharedDrives,
   nonSharedDriveList
 }) => {
   if (withoutSharedDrives) {
     return (
-      result.data?.filter(item => item.dir_id !== SHARED_DRIVES_DIR_ID) || []
+      result.data?.filter(
+        item =>
+          item.dir_id !== SHARED_DRIVES_DIR_ID && isReceivedFile(isOwner)(item)
+      ) || []
     )
   }
-  return [...transformedSharedDrives, ...nonSharedDriveList]
+  return [
+    ...transformedSharedDrives.filter(isReceivedDrive),
+    ...nonSharedDriveList.filter(isReceivedFile(isOwner))
+  ]
 }
 
 /**
@@ -41,6 +59,8 @@ export const useFilteredSharings = ({ result, sharedDocumentIds }) => {
   const withoutSharedDrives =
     !isEnabledSharedDrive && !isEnabledFederatedSharedFolder
 
+  const { isOwner } = useSharingContext()
+
   const {
     sharedDrives: transformedSharedDrives,
     nonSharedDriveList,
@@ -51,12 +71,14 @@ export const useFilteredSharings = ({ result, sharedDocumentIds }) => {
     const hasIds = sharedDocumentIds?.length > 0
     const data = computeData({
       result,
+      isOwner,
       withoutSharedDrives,
       transformedSharedDrives,
       nonSharedDriveList
     })
     return { ...buildBaseShape(result, hasIds), data, count: data.length }
   }, [
+    isOwner,
     withoutSharedDrives,
     transformedSharedDrives,
     nonSharedDriveList,

--- a/src/modules/views/Sharings/useFilteredSharings.spec.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.spec.jsx
@@ -1,0 +1,103 @@
+import { renderHook } from '@testing-library/react'
+
+import flag from 'cozy-flags'
+import { useSharingContext } from 'cozy-sharing'
+
+import { useFilteredSharings } from './useFilteredSharings'
+
+import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
+import { useTransformFolderListHasSharedDriveShortcuts } from '@/hooks/useTransformFolderListHasSharedDriveShortcuts'
+
+jest.mock('cozy-flags')
+jest.mock('cozy-sharing', () => ({
+  useSharingContext: jest.fn()
+}))
+jest.mock('@/hooks/useTransformFolderListHasSharedDriveShortcuts', () => ({
+  useTransformFolderListHasSharedDriveShortcuts: jest.fn()
+}))
+
+const ownedFile = { _id: 'owned-file', name: 'Owned file', dir_id: 'dir' }
+const receivedFile = {
+  _id: 'received-file',
+  name: 'Received file',
+  dir_id: 'dir'
+}
+const ownedDrive = { driveId: 'owned-drive', name: 'My drive', owner: true }
+const receivedDrive = {
+  driveId: 'received-drive',
+  name: 'Their drive',
+  owner: false
+}
+
+const names = result => result.current.filteredResult.data.map(d => d.name)
+
+const setup = ({
+  flags = {},
+  ownedIds = ['owned-file'],
+  resultData = [ownedFile, receivedFile],
+  transformedSharedDrives = [ownedDrive, receivedDrive],
+  nonSharedDriveList = [ownedFile, receivedFile]
+} = {}) => {
+  flag.mockImplementation(name => flags[name] ?? false)
+  useSharingContext.mockReturnValue({
+    isOwner: id => ownedIds.includes(id)
+  })
+  useTransformFolderListHasSharedDriveShortcuts.mockReturnValue({
+    sharedDrives: transformedSharedDrives,
+    nonSharedDriveList,
+    sharedDrivesLoaded: true
+  })
+
+  return renderHook(() =>
+    useFilteredSharings({
+      result: { data: resultData, fetchStatus: 'loaded', lastFetch: 1 },
+      sharedDocumentIds: ['x']
+    })
+  )
+}
+
+describe('useFilteredSharings', () => {
+  beforeEach(() => jest.resetAllMocks())
+
+  describe('with shared drives enabled', () => {
+    const flags = { 'drive.shared-drive.enabled': true }
+
+    it('drops files the user owns and keeps received ones', () => {
+      const { result } = setup({ flags })
+
+      expect(names(result)).toContain('Received file')
+      expect(names(result)).not.toContain('Owned file')
+    })
+
+    it('drops drives the user owns and keeps received drive links', () => {
+      const { result } = setup({ flags })
+
+      expect(names(result)).toContain('Their drive')
+      expect(names(result)).not.toContain('My drive')
+    })
+
+    it('keeps a drive whose ownership is unknown', () => {
+      const { result } = setup({
+        flags,
+        transformedSharedDrives: [{ driveId: 'd', name: 'Unknown drive' }]
+      })
+
+      expect(names(result)).toContain('Unknown drive')
+    })
+  })
+
+  describe('with shared drives disabled', () => {
+    it('drops owned files from the raw result and hides the drives dir', () => {
+      const { result } = setup({
+        flags: {},
+        resultData: [
+          ownedFile,
+          receivedFile,
+          { _id: 'drives', name: 'Drives', dir_id: SHARED_DRIVES_DIR_ID }
+        ]
+      })
+
+      expect(names(result)).toEqual(['Received file'])
+    })
+  })
+})


### PR DESCRIPTION
## Context

The Sharings section listed everything the user was part of, including the files, folders, and drives the user created and shared out to others. Those items are already reachable from My Drive and the shared-drive views, so the section duplicated them instead of acting as an inbox of what was shared with the user.

## Solution

Filter the Sharings list down to shares the user received (where the user is not the owner). Owned files, folders, and shared drives are dropped; received shared-drive links stay, since they are the only way a recipient reaches the drive. The folder picker, which also reuses the shared-drive transform, is untouched and still shows owned drives so the user can move and copy into them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ownership tracking for shared drives and items in the Sharings view; items are now correctly filtered based on ownership status.

* **Tests**
  * Added comprehensive test coverage for shared-drive ownership handling and sharing filter logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->