### PR TITLE
fix(sharings): show a shared single file as a file, not a folder

### DIFF
--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
@@ -114,6 +114,41 @@ describe('useTransformFolderListHasSharedDriveShortcuts', () => {
       })
     })
 
+    it('should treat a rule carrying a mime as file-root when the stack omits drive_root_type', () => {
+      const docxMime =
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      const mockSharedDrives = [
+        {
+          id: 'sharing-1',
+          // Stack predating the drive_root_type field: only the rule mime
+          // distinguishes a single shared file from a shared folder.
+          rules: [
+            {
+              values: ['file-1'],
+              title: 'New text document.docx',
+              mime: docxMime
+            }
+          ]
+        }
+      ]
+
+      mockUseSharedDrives.mockReturnValue({
+        sharedDrives: mockSharedDrives
+      })
+
+      const { result } = renderHook(() =>
+        useTransformFolderListHasSharedDriveShortcuts([])
+      )
+
+      expect(result.current.sharedDrives[0]).toMatchObject({
+        _id: 'file-1',
+        type: 'file',
+        name: 'New text document.docx',
+        mime: docxMime,
+        drive_root_type: DRIVE_ROOT_TYPE.FILE
+      })
+    })
+
     it('should derive OnlyOffice classes for file-root shared drives', () => {
       const mockSharedDrives = [
         {

--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
@@ -66,7 +66,13 @@ const useTransformFolderListHasSharedDriveShortcuts = (
         if (!rootId) return []
 
         const driveName = sharing.rules[0]?.title ?? ''
-        const isFileDriveRoot = sharing.drive_root_type === DRIVE_ROOT_TYPE.FILE
+        // The stack sets `drive_root_type` and the rule `mime` together for a
+        // single-file root. `drive_root_type` is a recent stack field, so fall
+        // back to the rule mime (only a file root carries one) to keep a shared
+        // file from rendering as a folder against stacks that don't send it.
+        const isFileDriveRoot =
+          sharing.drive_root_type === DRIVE_ROOT_TYPE.FILE ||
+          (!sharing.drive_root_type && Boolean(sharing.rules[0]?.mime))
         const fileMetadata = {
           name: driveName,
           ...(sharing.rules[0]?.mime ? { mime: sharing.rules[0].mime } : {})


### PR DESCRIPTION
## Context
In the Sharings section, a single shared file showed up as a broken folder for the recipient instead of a file. The recipient decided file vs folder solely from the sharing's `drive_root_type`, which is a recent stack field. Against a stack that does not send it, a shared single file fell through to a directory.

## Solution
Fall back to the sharing rule's `mime` when `drive_root_type` is absent. The stack only sets a `mime` on a single-file root, so a folder root (no mime) still renders as a folder, and current stacks that send `drive_root_type` are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shared drive classification to correctly identify file-root shared drives when certain metadata is unavailable, ensuring more accurate drive type detection.

* **Tests**
  * Added test coverage for shared drive classification edge cases to verify correct behavior across various metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->