### PR TITLE
fix(sharings): align the new-sharing badge with its row

### DIFF
--- a/src/modules/filelist/virtualized/cells/Share.jsx
+++ b/src/modules/filelist/virtualized/cells/Share.jsx
@@ -3,12 +3,14 @@ import React from 'react'
 import ShareContent from './ShareContent'
 import SharingShortcutBadge from './SharingShortcutBadge'
 
+import styles from '@/styles/filelist.styl'
+
 const Share = ({ row, isRowDisabledOrInSyncFromSharing }) => {
   return (
-    <>
-      <ShareContent file={row} disabled={isRowDisabledOrInSyncFromSharing} />
+    <div className={styles['fil-content-share']}>
       <SharingShortcutBadge file={row} />
-    </>
+      <ShareContent file={row} disabled={isRowDisabledOrInSyncFromSharing} />
+    </div>
   )
 }
 

--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -431,7 +431,18 @@ column-width-thumbnail-bigger = 7rem
 .fil-content-status .fil-content-file-placeholder
     animation-delay 1.1s
 
+.fil-content-share
+    display flex
+    align-items center
+    justify-content flex-end
+    gap 0.25rem
+
 .fil-content-sharestatus
+    // Center the share-status avatar in its box: as a plain block its inline
+    // avatar baseline-aligns to the top of a tall line box, which leaves it
+    // sitting a few pixels above center.
+    display inline-flex
+    align-items center
     cursor pointer
     &--disabled
         cursor default


### PR DESCRIPTION
## Context
In the virtualized Sharings list, the new-sharing notification badge looked misaligned with its row. The real culprit is the share-status avatar next to it: its wrapper is a plain block, so the inline avatar baseline-aligns to the top of a tall line box and sits a few pixels above the row center. The badge, being correctly centered, then read as misaligned against the high avatar. The badge was also wrapping onto its own line below the status.

## Solution
Center the share-status avatar in its own box so it sits on the row center, and lay the badge and the status out on one inline, vertically centered line (badge before the avatar) instead of stacking them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and alignment of sharing UI elements in the file list with enhanced spacing and visual centering of share status indicators, ensuring consistent presentation across the sharing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->