### PR TITLE
feat: Move Download button in public page more menu

### DIFF
--- a/src/modules/public/PublicToolbarByLink.jsx
+++ b/src/modules/public/PublicToolbarByLink.jsx
@@ -14,7 +14,6 @@ import { addItems, download, hr, select } from '@/modules/actions'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import AddButton from '@/modules/drive/Toolbar/components/AddButton'
 import ViewSwitcher from '@/modules/drive/Toolbar/components/ViewSwitcher'
-import { DownloadFilesButton } from '@/modules/public/DownloadFilesButton'
 import PublicToolbarMoreMenu from '@/modules/public/PublicToolbarMoreMenu'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import UploadButton from '@/modules/upload/UploadButton'
@@ -37,7 +36,7 @@ const PublicToolbarByLink = ({
 
   const actions = makeActions(
     [
-      isMobile && download,
+      download,
       files.length > 1 && select,
       addItems,
       isMobile && (files.length > 1 || hasWriteAccess) && hr,
@@ -78,7 +77,6 @@ const PublicToolbarByLink = ({
                 />
               </>
             )}
-            {files.length > 0 && <DownloadFilesButton files={files} />}
             <ViewSwitcher className="u-ml-half" />
           </>
         )}


### PR DESCRIPTION
https://app.notion.com/p/linagora/Public-page-Move-Download-folder-button-to-context-menu-37c62718bad18001a180c8636c309b15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Download functionality has been reorganized and moved from a dedicated button to the actions menu, making it consistently accessible across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->