### PR TITLE
feat: Do not promote desktop application in drive

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,5 +1,5 @@
 {
   "promoteDesktop": {
-    "isActivated": true
+    "isActivated": false
   }
 }


### PR DESCRIPTION
This will hide different calls to action to download desktop application: Banner, button on sidebar

https://app.notion.com/p/linagora/Disable-banners-prompting-users-to-download-the-app-in-Drive-Twake_default-37c62718bad180afa410d361d540cb9e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Desktop promotion feature has been disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->