### PR TITLE
fix(shareddrives): stop the file list flashing the skeleton on upload

### DIFF
--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
@@ -83,6 +83,22 @@ describe('useSharedDriveFolder', () => {
     expect(result.current.hasMore).toBe(false)
   })
 
+  it('exposes a lastUpdate timestamp once data has loaded', async () => {
+    const statByIdMock = jest.fn().mockResolvedValue({
+      included: mockData,
+      links: {}
+    })
+    const mockClient = makeMockClient(statByIdMock)
+
+    const { result } = setup(mockClient)
+
+    expect(result.current.lastUpdate).toBeNull()
+
+    await waitFor(() => {
+      expect(result.current.lastUpdate).toEqual(expect.any(Number))
+    })
+  })
+
   it('should indicate when there is more data to fetch', async () => {
     const cursor = 'next-page-cursor'
     const statByIdMock = jest.fn().mockResolvedValue({

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
@@ -24,6 +24,10 @@ interface SharedDriveFolderReturn {
     included?: IOCozyFile[] | null
   }
   fetchStatus: 'loading' | 'loaded' | 'failed'
+  // Timestamp of the last successful load, kept across in-folder refreshes.
+  // The folder view uses it (like cozy-client's query lastUpdate) to avoid
+  // dropping an already-loaded folder back to the loading skeleton on refetch.
+  lastUpdate: number | null
   hasMore: boolean
   fetchMore: () => Promise<void>
 }
@@ -38,6 +42,7 @@ const useSharedDriveFolder = ({
   >({ data: undefined })
   const [fetchStatus, setFetchStatus] =
     useState<SharedDriveFolderReturn['fetchStatus']>('loading')
+  const [lastUpdate, setLastUpdate] = useState<number | null>(null)
   const [nextCursor, setNextCursor] = useState<string | null>(null)
   const nextCursorRef = useRef<string | null>(null)
   const isFetchingMore = useRef(false)
@@ -57,6 +62,14 @@ const useSharedDriveFolder = ({
     () => paginatedStatById(client, driveId),
     [client, driveId]
   )
+
+  // Forget the previous folder's load when navigating to a different folder so
+  // its first load shows the skeleton. Within the same folder lastUpdate is
+  // kept, so an in-folder refetch (realtime, or a re-run of the effect below)
+  // never drops the view back to the skeleton.
+  useEffect(() => {
+    setLastUpdate(null)
+  }, [driveId, folderId])
 
   useEffect(() => {
     const fetchSharedDriveFolder = async (
@@ -96,6 +109,7 @@ const useSharedDriveFolder = ({
         if (fetchGeneration.current === currentGeneration) {
           setSharedDriveResult({ included: allIncluded })
           setFetchStatus('loaded')
+          setLastUpdate(Date.now())
           nextCursorRef.current = cursor
           setNextCursor(cursor)
           loadedPagesCount.current = pagesToLoad
@@ -180,6 +194,7 @@ const useSharedDriveFolder = ({
     sharedDriveQuery,
     sharedDriveResult,
     fetchStatus,
+    lastUpdate,
     hasMore,
     fetchMore
   }

--- a/src/modules/views/Folder/hooks/getFolderViewState.spec.js
+++ b/src/modules/views/Folder/hooks/getFolderViewState.spec.js
@@ -1,0 +1,46 @@
+import { getFolderViewState } from './getFolderViewState'
+
+describe('getFolderViewState', () => {
+  it('reports loading for an empty folder that has never loaded', () => {
+    const { isLoading, isEmpty } = getFolderViewState({
+      queryResults: [{ fetchStatus: 'loading', data: [] }]
+    })
+
+    expect(isLoading).toBe(true)
+    expect(isEmpty).toBe(false)
+  })
+
+  it('keeps an already-loaded empty folder out of the loading skeleton when it refetches', () => {
+    // An in-folder refetch flips fetchStatus back to 'loading'. Because the
+    // folder has loaded once (lastUpdate set), it must stay on the empty state
+    // instead of flashing the skeleton on every uploaded file.
+    const { isLoading, isEmpty } = getFolderViewState({
+      queryResults: [
+        { fetchStatus: 'loading', data: [], lastUpdate: 1718000000000 }
+      ]
+    })
+
+    expect(isLoading).toBe(false)
+    expect(isEmpty).toBe(true)
+  })
+
+  it('shows data and never loading once a folder has rows', () => {
+    const { isLoading, hasDataToShow, isEmpty } = getFolderViewState({
+      queryResults: [
+        { fetchStatus: 'loading', data: [{ _id: '1' }], lastUpdate: 1 }
+      ]
+    })
+
+    expect(hasDataToShow).toBe(true)
+    expect(isLoading).toBe(false)
+    expect(isEmpty).toBe(false)
+  })
+
+  it('reports an error when a query fails', () => {
+    const { isInError } = getFolderViewState({
+      queryResults: [{ fetchStatus: 'failed', data: [] }]
+    })
+
+    expect(isInError).toBe(true)
+  })
+})

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -64,7 +64,7 @@ const SharedDriveFolderView = () => {
   const { isFabDisplayed, setIsFabDisplayed } = useContext(FabContext)
   const { isSelectionBarVisible } = useSelectionContext()
 
-  const { sharedDriveResult, fetchStatus, hasMore, fetchMore } =
+  const { sharedDriveResult, fetchStatus, lastUpdate, hasMore, fetchMore } =
     useSharedDriveFolder({
       driveId,
       folderId
@@ -73,6 +73,7 @@ const SharedDriveFolderView = () => {
   const queryResults = [
     {
       fetchStatus,
+      lastUpdate,
       data: sharedDriveResult.included ?? [],
       hasMore,
       fetchMore


### PR DESCRIPTION
## Problem
In an empty shared-drive folder, uploading files made the file list flash the loading skeleton once per uploaded file. The folder view derives the skeleton from the query's `fetchStatus`, but only when the query has no `lastUpdate`, the guard that keeps an already-loaded folder off the skeleton when it refetches. Regular folders get `lastUpdate` from cozy-client's query and so never flash. The shared-drive view builds its query result by hand and never set `lastUpdate`, so that guard was always defeated, and any in-folder refetch dropped the empty folder back to the skeleton.

## Solution
Expose a `lastUpdate` from `useSharedDriveFolder`, stamped on each successful load, kept across in-folder refetches, and reset only when the folder changes so a fresh folder still shows its initial skeleton. The shared-drive view passes it through, so an already-loaded folder stays put on refetch.

## Worth knowing
Opened as a draft: the fix is covered by unit tests on the hook and on `getFolderViewState`, but the trigger is real drag-and-drop into an empty folder, which can't be driven from a headless browser, so it still needs a manual visual check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared drive folder views now include a "last updated" timestamp so users can see when folder data was most recently refreshed.

* **Tests**
  * Added tests covering the last-update behavior and folder view state across loading, populated, refetching, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->