### PR TITLE
fix(pdf): drop the PDF editor from the public build

### DIFF
--- a/src/modules/public/LightFileViewer.jsx
+++ b/src/modules/public/LightFileViewer.jsx
@@ -25,7 +25,6 @@ import {
   isOfficeEnabled,
   makeOnlyOfficeFileRoute
 } from '@/modules/views/OnlyOffice/helpers'
-import { isPdfEditorEnabled, makePdfRoute } from '@/modules/views/Pdf/helpers'
 
 const LightFileViewer = ({ files, isPublic }) => {
   const sharingInfos = useSharingInfos()
@@ -41,18 +40,6 @@ const LightFileViewer = ({ files, isPublic }) => {
         fromPathname: pathname
       })
       navigate(route)
-    },
-    [navigate, pathname]
-  )
-
-  const pdfOpener = useCallback(
-    file => {
-      navigate(
-        makePdfRoute(file.id, {
-          fromPathname: pathname,
-          fromPublicFolder: true
-        })
-      )
     },
     [navigate, pathname]
   )
@@ -92,9 +79,10 @@ const LightFileViewer = ({ files, isPublic }) => {
               isEnabled: isOfficeEnabled(isDesktop),
               opener: onlyOfficeOpener
             },
+            // The PDF editor is not shipped in the public build (see
+            // targets/public AppRouter), so shared links only ever view PDFs.
             PdfViewer: {
-              isPdfEditorEnabled: isPdfEditorEnabled(),
-              opener: pdfOpener
+              isPdfEditorEnabled: false
             },
             toolbarProps: {
               showToolbar: isDesktop,

--- a/src/modules/views/Public/PublicFileViewer.jsx
+++ b/src/modules/views/Public/PublicFileViewer.jsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useEffect, useState, useCallback } from 'react'
-import { useParams, useNavigate, useLocation } from 'react-router-dom'
+import React, { useMemo, useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
 
 import Viewer, {
   FooterActionButtons,
@@ -9,26 +9,12 @@ import Viewer, {
 import { FilesViewerLoading } from '@/components/FilesViewerLoading'
 import useHead from '@/components/useHead'
 import { useCurrentFolderId } from '@/hooks'
-import { isPdfEditorEnabled, makePdfRoute } from '@/modules/views/Pdf/helpers'
 import usePublicFilesQuery from '@/modules/views/Public/usePublicFilesQuery'
 
 const PublicFileViewer = () => {
   const { fileId } = useParams()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
   useHead()
-
-  const pdfOpener = useCallback(
-    file => {
-      navigate(
-        makePdfRoute(file.id, {
-          fromPathname: pathname,
-          fromPublicFolder: true
-        })
-      )
-    },
-    [navigate, pathname]
-  )
 
   const [fetchingMore, setFetchingMore] = useState(false)
 
@@ -103,9 +89,10 @@ const PublicFileViewer = () => {
       onChangeRequest={handleChange}
       onCloseRequest={handleClose}
       componentsProps={{
+        // The PDF editor is not shipped in the public build (see
+        // targets/public AppRouter), so shared links only ever view PDFs.
         PdfViewer: {
-          isPdfEditorEnabled: isPdfEditorEnabled(),
-          opener: pdfOpener
+          isPdfEditorEnabled: false
         },
         toolbarProps: {
           hideSummarizeBtn: true

--- a/src/targets/public/components/AppRouter.jsx
+++ b/src/targets/public/components/AppRouter.jsx
@@ -21,12 +21,14 @@ import OnlyOfficeView from '@/modules/views/OnlyOffice'
 import OnlyOfficeCreateView from '@/modules/views/OnlyOffice/Create'
 import OnlyOfficePaywallView from '@/modules/views/OnlyOffice/OnlyOfficePaywallView'
 import { isOfficeEnabled } from '@/modules/views/OnlyOffice/helpers'
-import { isPdfEditorEnabled } from '@/modules/views/Pdf/helpers'
-import { getPublicPdfRoutes } from '@/modules/views/Pdf/routes'
 import { PublicFileViewer } from '@/modules/views/Public/PublicFileViewer'
 import { PublicFolderView } from '@/modules/views/Public/PublicFolderView'
 
 // Group the flag-gated editor routes so the AppRouter switch stays small.
+// The PDF editor (EmbedPDF + its Pdfium wasm) is intentionally left out of the
+// public build: shared links only need to view PDFs, which cozy-viewer already
+// does, and bundling the editor pushed the public target over the registry's
+// 20 MB limit. PDF editing stays available in the logged-in app.
 const getPublicEditorRoutes = ({ isReadOnly, isExcalidrawShared, data }) => (
   <>
     {isExcalidrawEnabled() &&
@@ -35,7 +37,6 @@ const getPublicEditorRoutes = ({ isReadOnly, isExcalidrawShared, data }) => (
         isShared: isExcalidrawShared,
         data
       })}
-    {isPdfEditorEnabled() && getPublicPdfRoutes({ isReadOnly })}
   </>
 )
 


### PR DESCRIPTION
## Problem
The EmbedPDF editor added recently pulls in a Pdfium wasm engine (~4.5MB) plus its own JS chunks. The public (shared-link) target is a separate build, so it got its own full copy of all of that, pushing the published app archive past the registry's 20MB limit and breaking the publish CI.

## Solution
Shared links only ever need to view PDFs, which cozy-viewer already does without the editor. So the PDF editor is no longer wired into the public build: the public router drops the editor route, and the two public viewers no longer offer the "Edit" affordance. That severs the only import path that dragged EmbedPDF and the wasm into the public bundle, bringing the archive back under the limit. PDF editing is unchanged in the logged-in app.

## Worth knowing
Editable public PDF shares no longer open the in-browser annotation editor; recipients view the PDF instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Viewer Updates**
  * PDF files in shared links and public builds are now view-only, with editing capabilities disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->