### PR TITLE
chore: bump cozy-sharing to 33.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
-    "cozy-sharing": "^33.3.2",
+    "cozy-sharing": "^33.3.3",
     "cozy-stack-client": "^60.27.0",
     "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8195,10 +8195,10 @@ cozy-search@^0.25.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^33.3.2:
-  version "33.3.2"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.3.2.tgz#8624efe2d06d14736cc31d55643a307e3a06b809"
-  integrity sha512-cQC/QtoEDrVtXO82O41iDv3SISi+qsQRMPuIcSY12iqIAjUXWfmNgmXKu0LGSQjXvCgNoAlEMEPNiTIlb7VRHw==
+cozy-sharing@^33.3.3:
+  version "33.3.3"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.3.3.tgz#ab1455a075373e949859b178d3f5dca84f986b2e"
+  integrity sha512-zJgm0J+i/4OqNcUYMclcz0O9dGamsymchYshuJUtFNM34BeWkfBkXAvIOKbUkqb1+xrin75YovghjRAAYx4psg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
Bump cozy-sharing to 33.3.3 to pick up the latest patch release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->