### PR TITLE
chore: upgrade cozy-sharing to 33.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
-    "cozy-sharing": "^33.3.3",
+    "cozy-sharing": "^33.3.4",
     "cozy-stack-client": "^60.27.0",
     "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8195,10 +8195,10 @@ cozy-search@^0.25.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^33.3.3:
-  version "33.3.3"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.3.3.tgz#ab1455a075373e949859b178d3f5dca84f986b2e"
-  integrity sha512-zJgm0J+i/4OqNcUYMclcz0O9dGamsymchYshuJUtFNM34BeWkfBkXAvIOKbUkqb1+xrin75YovghjRAAYx4psg==
+cozy-sharing@^33.3.4:
+  version "33.3.4"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.3.4.tgz#9789b76ccc7f860af10dcab96801d64cda949e68"
+  integrity sha512-PoOo24BSj1tj48B+4EGIuem0dm9S0ImxnSs1TuL/6MwTZcWal5ZlZ5RU1o9mAgqVrD152xck1XZ9VefnJNg/PQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
To get https://github.com/linagora/cozy-libs/pull/3031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies to include latest patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->