### PR TITLE
chore(build): share assets across the three web targets

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -8,10 +8,19 @@
       "path": "static/js/<chunkId>.<hash>.js"
     },
     {
+      "path": "static/js/async/<chunkId>.<hash>.js"
+    },
+    {
       "path": "static/js/cozy.<hash>.js"
     },
     {
       "path": "static/js/main.<hash>.js"
+    },
+    {
+      "path": "static/js/public.<hash>.js"
+    },
+    {
+      "path": "static/js/intents.<hash>.js"
     },
     {
       "path": "static/js/lib-react.<hash>.js"
@@ -20,34 +29,19 @@
       "path": "static/js/lib-router.<hash>.js"
     },
     {
+      "path": "static/js/lib-polyfill.<hash>.js"
+    },
+    {
       "path": "static/css/cozy.<hash>.css"
     },
     {
       "path": "static/css/main.<hash>.css"
     },
     {
-      "path": "public/<hash>.js"
+      "path": "static/css/public.<hash>.css"
     },
     {
-      "path": "public/static/js/<chunkId>.<hash>.js"
-    },
-    {
-      "path": "public/static/js/public.<hash>.js"
-    },
-    {
-      "path": "public/static/js/cozy.<hash>.js"
-    },
-    {
-      "path": "public/static/js/lib-react.<hash>.js"
-    },
-    {
-      "path": "public/static/js/lib-router.<hash>.js"
-    },
-    {
-      "path": "public/static/css/cozy.<hash>.css"
-    },
-    {
-      "path": "public/static/css/public.<hash>.css"
+      "path": "static/resource/<hash>.js"
     },
     {
       "path": "services/dacc.js"
@@ -56,10 +50,13 @@
       "path": "services/qualificationMigration.js"
     },
     {
-      "path": "<hash>.js"
+      "path": "main/index.html"
     },
     {
-      "path": "index.html"
+      "path": "public/index.html"
+    },
+    {
+      "path": "intents/index.html"
     },
     {
       "path": "assets/manifest.json"

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -44,7 +44,7 @@
   "langs": ["en", "fr"],
   "routes": {
     "/": {
-      "folder": "/",
+      "folder": "/main",
       "index": "index.html",
       "public": false
     },
@@ -65,6 +65,10 @@
     },
     "/assets": {
       "folder": "/assets",
+      "public": true
+    },
+    "/static": {
+      "folder": "/static",
       "public": true
     }
   },

--- a/rsbuild.config.mjs
+++ b/rsbuild.config.mjs
@@ -8,25 +8,89 @@ const config = getRsbuildConfig({
   hasIntents: true
 })
 
-// Self-host the Excalidraw fonts (the default unpkg CDN is blocked by our CSP).
-// Since 0.18 the library fetches them at runtime from `${EXCALIDRAW_ASSET_PATH}
-// fonts/...`, so we copy them to a top-level `fonts` directory. The asset path
-// is set in src/modules/views/Excalidraw/setupAssetPath.js. The prod and dev
-// font sets are byte-identical, so we copy only the prod one (both build modes
-// resolve the same `fonts/...` filenames at runtime). `info.minimized` stops
-// rspack from re-minifying the prebuilt assets.
+// rsbuild-config-cozy-app declares one environment (= one rspack compilation)
+// per web target, so the three targets each re-bundle React, cozy-* and the
+// editors into their own static/ tree and the registry tarball pays for every
+// module up to three times. We replace those three environments with a single
+// `web` environment holding the three entries: one chunk graph means shared
+// modules are emitted exactly once, under one static/ tree.
 //
-// Xiaolai is excluded: it is Excalidraw's CJK fallback font, ~12 MB of woff2
-// subsets (every other font set is <1 MB total), and we do not ship CJK glyph
-// rendering for drawings. Drop it to keep the build under the registry limit.
-const excalidrawAssets = [
-  {
-    from: 'node_modules/@excalidraw/excalidraw/dist/prod/fonts',
-    to: 'fonts',
-    globOptions: { ignore: ['**/Xiaolai/**'] },
-    info: { minimized: true }
-  }
-]
+// All hashed assets stay in build/static and are served by the `/static`
+// route, declared `public: true` in manifest.webapp so the public (shared
+// link) pages can load them without auth. Each entry keeps its own HTML file
+// ([name]/index.html); the `/` route points to the /main folder.
+const { main, public: publicEnv, intents, services } = config.environments
+
+const templates = {
+  main: main.html.template,
+  public: publicEnv.html.template,
+  intents: intents.html.template
+}
+
+config.environments = {
+  web: {
+    html: {
+      template: ({ entryName }) => templates[entryName]
+    },
+    source: {
+      entry: {
+        main: main.source.entry.main,
+        public: publicEnv.source.entry.public,
+        intents: intents.source.entry.intents
+      }
+    },
+    output: {
+      target: 'web',
+      filename: {
+        html: '[name]/index.html'
+      },
+      distPath: {
+        root: 'build'
+      },
+      copy: [
+        // manifest.webapp, README, LICENSE and public/ -> assets, as the
+        // generated main environment declared them.
+        ...main.output.copy,
+        {
+          from: 'src/assets/onlyOffice',
+          to: 'onlyOffice'
+        },
+        {
+          from: 'src/assets/favicons',
+          to: 'favicons'
+        },
+        // Self-host the Excalidraw fonts (the default unpkg CDN is blocked by
+        // our CSP). Since 0.18 the library fetches them at runtime from
+        // `${EXCALIDRAW_ASSET_PATH}fonts/...`; the asset path is set to
+        // /static/ in src/modules/views/Excalidraw/setupAssetPath.js. The prod
+        // and dev font sets are byte-identical, so we copy only the prod one.
+        // `info.minimized` stops rspack from re-minifying the prebuilt assets.
+        //
+        // Xiaolai is excluded: it is Excalidraw's CJK fallback font, ~12 MB of
+        // woff2 subsets (every other font set is <1 MB total), and we do not
+        // ship CJK glyph rendering for drawings.
+        {
+          from: 'node_modules/@excalidraw/excalidraw/dist/prod/fonts',
+          to: 'static/fonts',
+          globOptions: { ignore: ['**/Xiaolai/**'] },
+          info: { minimized: true }
+        }
+      ]
+    },
+    tools: {
+      rspack: {
+        output: {
+          // Asset modules without a dedicated rsbuild rule (e.g. the pdf.js
+          // worker react-pdf imports as a resource) default to `[hash][ext]`
+          // at the build root, which only the private `/` route serves. Keep
+          // them under static/ so the public route covers them too.
+          assetModuleFilename: 'static/resource/[hash][ext][query]'
+        }
+      }
+    }
+  },
+  services
+}
 
 const mergedConfig = mergeRsbuildConfig(config, {
   // Rsbuild enables dev.lazyCompilation by default, which defers compiling async
@@ -39,33 +103,13 @@ const mergedConfig = mergeRsbuildConfig(config, {
   dev: {
     lazyCompilation: false
   },
-  environments: {
-    main: {
-      output: {
-        copy: [
-          {
-            from: 'src/assets/onlyOffice',
-            to: 'onlyOffice'
-          },
-          {
-            from: 'src/assets/favicons',
-            to: 'favicons'
-          },
-          ...excalidrawAssets
-        ]
-      }
-    },
-    // The public (shared link) target is a separate build, so it needs its own
-    // copy of the Excalidraw assets to serve them under its /public prefix.
-    public: {
-      output: {
-        copy: [...excalidrawAssets]
-      }
-    }
-  },
   resolve: {
     alias: {
-      'react-pdf$': 'react-pdf/dist/esm/entry.webpack'
+      // The webpack5 entry wires the pdf.js worker through a `new URL(...)`
+      // asset module, so it honors assetModuleFilename and lands under
+      // static/ (the webpack4 entry inlines file-loader, which emits the
+      // worker at the build root where only the private `/` route serves it).
+      'react-pdf$': 'react-pdf/dist/esm/entry.webpack5'
     }
   }
 })

--- a/src/modules/public/LightFileViewer.jsx
+++ b/src/modules/public/LightFileViewer.jsx
@@ -25,6 +25,7 @@ import {
   isOfficeEnabled,
   makeOnlyOfficeFileRoute
 } from '@/modules/views/OnlyOffice/helpers'
+import { isPdfEditorEnabled, makePdfRoute } from '@/modules/views/Pdf/helpers'
 
 const LightFileViewer = ({ files, isPublic }) => {
   const sharingInfos = useSharingInfos()
@@ -40,6 +41,18 @@ const LightFileViewer = ({ files, isPublic }) => {
         fromPathname: pathname
       })
       navigate(route)
+    },
+    [navigate, pathname]
+  )
+
+  const pdfOpener = useCallback(
+    file => {
+      navigate(
+        makePdfRoute(file.id, {
+          fromPathname: pathname,
+          fromPublicFolder: true
+        })
+      )
     },
     [navigate, pathname]
   )
@@ -79,10 +92,9 @@ const LightFileViewer = ({ files, isPublic }) => {
               isEnabled: isOfficeEnabled(isDesktop),
               opener: onlyOfficeOpener
             },
-            // The PDF editor is not shipped in the public build (see
-            // targets/public AppRouter), so shared links only ever view PDFs.
             PdfViewer: {
-              isPdfEditorEnabled: false
+              isPdfEditorEnabled: isPdfEditorEnabled(),
+              opener: pdfOpener
             },
             toolbarProps: {
               showToolbar: isDesktop,

--- a/src/modules/views/Excalidraw/setupAssetPath.js
+++ b/src/modules/views/Excalidraw/setupAssetPath.js
@@ -1,33 +1,16 @@
 // Excalidraw loads its fonts and lazy chunks from the unpkg CDN by default,
-// which a strict production CSP blocks. We self-host the assets (copied to each
-// build by rsbuild, see rsbuild.config.mjs) and point Excalidraw at a
-// same-origin path so they resolve under the app's own origin.
-//
-// We derive the path from the target (main is served at "/", the public share
-// build at "/public/") rather than from the webpack public path, because in dev
-// the latter is the cross-origin rsbuild dev server (localhost:3000), which gets
-// fonts rejected by the browser's font sanitizer and the lazy chunks blocked.
+// which a strict production CSP blocks. We self-host the fonts (copied to
+// build/static/fonts by rsbuild, see rsbuild.config.mjs) and point Excalidraw
+// at a same-origin path so they resolve under the app's own origin. The
+// library fetches `${EXCALIDRAW_ASSET_PATH}fonts/...`, and the /static route
+// is public, so the same path works for both the logged-in app and the public
+// share pages.
 //
 // This file is imported before @excalidraw/excalidraw on purpose: the library
 // reads window.EXCALIDRAW_ASSET_PATH when it initializes its webpack publicPath,
 // so the value must be set first.
 if (typeof window !== 'undefined') {
-  const isPublic = window.location.pathname.startsWith('/public')
-  const assetPath = isPublic ? '/public/' : '/'
-
   if (!window.EXCALIDRAW_ASSET_PATH) {
-    window.EXCALIDRAW_ASSET_PATH = assetPath
-  }
-
-  // Excalidraw also code-splits browser-fs-access, its locale bundles and a few
-  // polyfills as webpack async chunks, which load from __webpack_public_path__
-  // rather than EXCALIDRAW_ASSET_PATH. In dev that path is the cross-origin main
-  // dev server (localhost:3000), unreachable from the public build served under
-  // /public, so the editor's locale and file actions fail to load there. Point
-  // it at the same-origin path for the public build (a no-op in production,
-  // where it already resolves to /public).
-  if (isPublic) {
-    // eslint-disable-next-line no-undef
-    __webpack_public_path__ = assetPath
+    window.EXCALIDRAW_ASSET_PATH = '/static/'
   }
 }

--- a/src/modules/views/Pdf/routes.jsx
+++ b/src/modules/views/Pdf/routes.jsx
@@ -1,7 +1,18 @@
-import React from 'react'
+import React, { Suspense, lazy } from 'react'
 import { Navigate, Route } from 'react-router-dom'
 
-import PdfView from '@/modules/views/Pdf'
+import Loader from '@/components/Loader'
+
+// The editor pulls in @embedpdf/react-pdf-viewer (several MB of JS plus the
+// Pdfium wasm), so it must stay out of the entry chunks: only visitors who
+// actually open a /pdf route should download it.
+const PdfView = lazy(() => import('@/modules/views/Pdf'))
+
+const LazyPdfView = props => (
+  <Suspense fallback={<Loader />}>
+    <PdfView {...props} />
+  </Suspense>
+)
 
 // The route fragments are returned from plain functions (not components) so that
 // React Router's createRoutesFromChildren still sees the <Route> elements
@@ -14,8 +25,8 @@ import PdfView from '@/modules/views/Pdf'
  */
 export const getPdfRoutes = () => (
   <>
-    <Route path="pdf/:fileId" element={<PdfView />} />
-    <Route path="pdf/:driveId/:fileId" element={<PdfView />} />
+    <Route path="pdf/:fileId" element={<LazyPdfView />} />
+    <Route path="pdf/:driveId/:fileId" element={<LazyPdfView />} />
   </>
 )
 
@@ -33,7 +44,7 @@ export const getPublicPdfRoutes = ({ isReadOnly = false } = {}) => (
       // The editor is for editing only: a read-only share must not reach it,
       // even by typing the URL. Send those visitors back to the public viewer.
       element={
-        isReadOnly ? <Navigate to="/" replace /> : <PdfView isPublic={true} />
+        isReadOnly ? <Navigate to="/" replace /> : <LazyPdfView isPublic />
       }
     />
   </>

--- a/src/modules/views/Public/PublicFileViewer.jsx
+++ b/src/modules/views/Public/PublicFileViewer.jsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useEffect, useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import React, { useMemo, useEffect, useState, useCallback } from 'react'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 
 import Viewer, {
   FooterActionButtons,
@@ -9,12 +9,26 @@ import Viewer, {
 import { FilesViewerLoading } from '@/components/FilesViewerLoading'
 import useHead from '@/components/useHead'
 import { useCurrentFolderId } from '@/hooks'
+import { isPdfEditorEnabled, makePdfRoute } from '@/modules/views/Pdf/helpers'
 import usePublicFilesQuery from '@/modules/views/Public/usePublicFilesQuery'
 
 const PublicFileViewer = () => {
   const { fileId } = useParams()
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   useHead()
+
+  const pdfOpener = useCallback(
+    file => {
+      navigate(
+        makePdfRoute(file.id, {
+          fromPathname: pathname,
+          fromPublicFolder: true
+        })
+      )
+    },
+    [navigate, pathname]
+  )
 
   const [fetchingMore, setFetchingMore] = useState(false)
 
@@ -89,10 +103,9 @@ const PublicFileViewer = () => {
       onChangeRequest={handleChange}
       onCloseRequest={handleClose}
       componentsProps={{
-        // The PDF editor is not shipped in the public build (see
-        // targets/public AppRouter), so shared links only ever view PDFs.
         PdfViewer: {
-          isPdfEditorEnabled: false
+          isPdfEditorEnabled: isPdfEditorEnabled(),
+          opener: pdfOpener
         },
         toolbarProps: {
           hideSummarizeBtn: true

--- a/src/targets/public/components/AppRouter.jsx
+++ b/src/targets/public/components/AppRouter.jsx
@@ -21,14 +21,12 @@ import OnlyOfficeView from '@/modules/views/OnlyOffice'
 import OnlyOfficeCreateView from '@/modules/views/OnlyOffice/Create'
 import OnlyOfficePaywallView from '@/modules/views/OnlyOffice/OnlyOfficePaywallView'
 import { isOfficeEnabled } from '@/modules/views/OnlyOffice/helpers'
+import { isPdfEditorEnabled } from '@/modules/views/Pdf/helpers'
+import { getPublicPdfRoutes } from '@/modules/views/Pdf/routes'
 import { PublicFileViewer } from '@/modules/views/Public/PublicFileViewer'
 import { PublicFolderView } from '@/modules/views/Public/PublicFolderView'
 
 // Group the flag-gated editor routes so the AppRouter switch stays small.
-// The PDF editor (EmbedPDF + its Pdfium wasm) is intentionally left out of the
-// public build: shared links only need to view PDFs, which cozy-viewer already
-// does, and bundling the editor pushed the public target over the registry's
-// 20 MB limit. PDF editing stays available in the logged-in app.
 const getPublicEditorRoutes = ({ isReadOnly, isExcalidrawShared, data }) => (
   <>
     {isExcalidrawEnabled() &&
@@ -37,6 +35,7 @@ const getPublicEditorRoutes = ({ isReadOnly, isExcalidrawShared, data }) => (
         isShared: isExcalidrawShared,
         data
       })}
+    {isPdfEditorEnabled() && getPublicPdfRoutes({ isReadOnly })}
   </>
 )
 


### PR DESCRIPTION
## Problem
The main, public and intents targets are three separate rspack compilations, so React, the cozy libraries and the editors are re-bundled into each target's own static tree. The registry tarball pays for every shared module up to three times: it sits at 18MB against the 20MB limit, and every new editor or heavy dependency multiplies its cost by the number of targets that use it. That pressure is what previously forced the PDF editor out of the public build.

## Solution
The three targets become entries of a single compilation. Shared modules are emitted once under build/static, exposed through a new public /static route so share pages can load them without auth, and each target keeps its own index.html (the / route now points at /main). The react-pdf alias moves to the webpack5 entry so the pdf.js worker lands under static/ instead of the build root, where only the private route could serve it. The tarball drops from 18MB to 10.8MB and stays flat when a dependency is added to more targets.

Since the editor chunks are now shipped once regardless, the PDF editor is restored on shared links. It is also loaded lazily, keeping it out of the initial payload of both the public page and the logged-in app (about 1MB less each).

## Worth knowing
All JS becomes publicly fetchable through /static, including chunks only used by the logged-in app. The code is AGPL and already published, so nothing sensitive changes hands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF editing capability is now available in shared and public file views.

* **Performance**
  * PDF viewer components now load on-demand, improving initial application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->