### PR TITLE
fix: render share modal in shared-drive file viewer instead of blank page

### DIFF
--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -107,6 +107,11 @@ const sharedDriveRoutes = () => (
           element={<MoveSharedDriveFilesView isOpenInViewer />}
         />
         <Route path="v/duplicate" element={<DuplicateSharedDriveFilesView />} />
+        {/* The viewer's Share action navigates to a relative `v/share`; without
+            this child route the URL matches nothing and the page goes blank.
+            driveId is in the path so the modal resolves a proxied recipient
+            document. */}
+        <Route path="v/share" element={<ShareFileView />} />
       </Route>
       <Route path="file/:fileId/revision" element={<FileHistory />} />
       <Route path="file/:fileId/v/revision" element={<FileHistory />} />


### PR DESCRIPTION
## Problem
Opening a file from a shared drive in the viewer and using the Share action (three-dots menu) led to a blank page. The viewer's Share navigates to a relative `v/share`, but the folder-root shared-drive file viewer was the only viewer that never declared that child route, so the URL matched nothing and the whole route tree failed to render.

## Solution
Declare the `v/share` route under the shared-drive file viewer, the same way the regular drive folder viewer and the file-root shared-drive viewer already do. The driveId stays in the path, so the share modal resolves a proxied recipient document and layers over the viewer, and closing it returns to the viewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Share view for files in shared drives, enabling users to access file sharing options directly from the viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->