### PR TITLE
fix: show shared onlyoffice document in the recipient's language

### DIFF
--- a/src/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/modules/views/OnlyOffice/useConfig.jsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom'
 import { useClient, isQueryLoading, generateWebLink } from 'cozy-client'
 import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'twake-i18n'
 
 import { useOnlyOfficeContext } from '@/modules/views/OnlyOffice/OnlyOfficeProvider'
 import {
@@ -27,6 +28,11 @@ const useConfig = () => {
   const client = useClient()
   const instanceUri = client.getStackClient().uri
   const [currentSearchParams] = useSearchParams()
+  // The viewer's own locale. For a shared document opened by a recipient, the
+  // editor is rendered on the owner's instance, so we carry this through the
+  // redirect (see the `lang` search param below) to keep the editor in the
+  // recipient's language instead of the owner's.
+  const { lang } = useI18n()
 
   const [config, setConfig] = useState()
   const [status, setStatus] = useState('loading')
@@ -70,6 +76,7 @@ const useConfig = () => {
           ])
         }
         if (public_name) searchParams.push(['username', public_name])
+        if (lang) searchParams.push(['lang', lang])
 
         const link = generateWebLink({
           cozyUrl: `${protocol}://${instance}`,
@@ -99,6 +106,9 @@ const useConfig = () => {
           document: onlyoffice.document,
           editorConfig: {
             ...(onlyoffice.editorConfig ?? onlyoffice.editor),
+            // Show the editor in the viewer's language. The backend fills this
+            // with the owner's instance locale, which is wrong for a recipient.
+            lang,
             mode:
               (onlyoffice.editorConfig?.mode ?? onlyoffice.editor?.mode) ===
               'edit'
@@ -135,7 +145,8 @@ const useConfig = () => {
     instanceUri,
     isDesktop,
     currentSearchParams,
-    setOfficeKey
+    setOfficeKey,
+    lang
   ])
 
   return { config, status }

--- a/src/targets/public/localeHelper.js
+++ b/src/targets/public/localeHelper.js
@@ -1,3 +1,4 @@
+import { getQueryParameter } from '@/lib/react-cozy-helpers'
 import { locales } from '@/locales'
 
 const supportedLocales = new Set(Object.keys(locales))
@@ -32,9 +33,13 @@ export const getBrowserLocale = () => {
 /**
  * Determines the locale for the public sharing page.
  *
- * When `isLoggedIn` is `false`, the visitor is anonymous so the browser locale
- * is used. When `isLoggedIn` is `true` or absent (cozy-stack < PR#4719), the
- * instance locale from the dataset is used for backward compatibility.
+ * A `lang` query param takes precedence when it names a supported locale: a
+ * recipient opening a shared document is redirected here from their own
+ * instance, which forwards their locale so the page is shown in their language
+ * rather than the owner's. Otherwise, when `isLoggedIn` is `false` the visitor
+ * is anonymous so the browser locale is used, and when `isLoggedIn` is `true`
+ * or absent (cozy-stack < PR#4719) the instance locale from the dataset is used
+ * for backward compatibility.
  *
  * @param {object} dataset - The parsed `data-cozy` dataset from the DOM root.
  * @param {boolean} [dataset.isLoggedIn] - Whether the current user is
@@ -42,7 +47,13 @@ export const getBrowserLocale = () => {
  * @param {string} [dataset.locale] - The Cozy instance locale (e.g. `'fr'`).
  * @returns {string} The resolved locale key to use for translations.
  */
-export const getPublicPageLocale = dataset =>
-  'isLoggedIn' in dataset && !dataset.isLoggedIn
+export const getPublicPageLocale = dataset => {
+  const { lang } = getQueryParameter()
+  if (lang && supportedLocales.has(lang)) {
+    return lang
+  }
+
+  return 'isLoggedIn' in dataset && !dataset.isLoggedIn
     ? getBrowserLocale()
     : dataset.locale || 'en'
+}

--- a/src/targets/public/localeHelper.spec.js
+++ b/src/targets/public/localeHelper.spec.js
@@ -1,5 +1,15 @@
 import { getBrowserLocale, getPublicPageLocale } from './localeHelper'
 
+import { getQueryParameter } from '@/lib/react-cozy-helpers'
+
+jest.mock('@/lib/react-cozy-helpers', () => ({
+  getQueryParameter: jest.fn(() => ({}))
+}))
+
+beforeEach(() => {
+  getQueryParameter.mockReturnValue({})
+})
+
 describe('getBrowserLocale', () => {
   const originalNavigator = { ...navigator }
 
@@ -93,5 +103,21 @@ describe('getPublicPageLocale', () => {
 
   it('falls back to en when isLoggedIn is absent and locale is missing', () => {
     expect(getPublicPageLocale({})).toBe('en')
+  })
+
+  it('prefers a supported lang query param over the instance locale', () => {
+    getQueryParameter.mockReturnValue({ lang: 'en' })
+    expect(getPublicPageLocale({ isLoggedIn: true, locale: 'fr' })).toBe('en')
+  })
+
+  it('prefers a supported lang query param over the browser locale', () => {
+    mockLanguages(['es'])
+    getQueryParameter.mockReturnValue({ lang: 'de' })
+    expect(getPublicPageLocale({ isLoggedIn: false, locale: 'fr' })).toBe('de')
+  })
+
+  it('ignores an unsupported lang query param', () => {
+    getQueryParameter.mockReturnValue({ lang: 'xx' })
+    expect(getPublicPageLocale({ isLoggedIn: true, locale: 'fr' })).toBe('fr')
   })
 })


### PR DESCRIPTION
## Problem

A recipient opening a shared OnlyOffice document (shared drive or cozy-to-cozy folder) saw the editor in the owner's language instead of their own. Opening a shared document redirects the viewer to the owner's public route, so the editor config is built on the owner's instance and the editor language (and the surrounding public page) come from the owner's instance locale. The recipient's own locale, known on their instance before the redirect, was never carried across.

## Solution

Forward the viewer's locale through the redirect as a `lang` query param, then use it to set the OnlyOffice editor language and to resolve the public page locale (when it names a supported language). The editor language is not part of the signed editor token, so overriding it client side is safe. A reader now opens the document in their own language, while opening your own document keeps using your locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language preference support via query parameter on public shared documents, enabling recipients to view shared content in their preferred language.
  * Improved locale consistency in the OnlyOffice viewer for shared document access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->