### PR TITLE
fix: select a single file when clicking a row in list view

### DIFF
--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react'
 import { useSelector } from 'react-redux'
 
-import flag from 'cozy-flags'
 import VirtualizedTable from 'cozy-ui/transpiled/react/Table/Virtualized'
 import TableRowDnD from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd/TableRow'
 import virtuosoComponentsDnd from 'cozy-ui/transpiled/react/Table/Virtualized/Dnd/virtuosoComponents'
@@ -79,7 +78,7 @@ const Table = forwardRef(
     },
     ref
   ) => {
-    const { toggleSelectedItem, setSelectedItems } = useSelectionContext()
+    const { setSelectedItems } = useSelectionContext()
     const { isNew } = useNewItemHighlightContext()
     const isRenamingActive = useSelector(isRenamingSelector)
     const internalVirtuosoRef = useRef(null)
@@ -88,29 +87,17 @@ const Table = forwardRef(
 
     const { sortOrder, setOrder } = orderProps
 
-    const selectedItemsCount = Object.keys(selectedItems || {}).length
+    // cozy-ui invokes this with (row, column) and no DOM event, so modifier
+    // keys aren't available here: clicking the row body always selects just
+    // that row. Multi-select (ctrl/cmd-click, shift-range) goes through the
+    // name cell's FileOpener, which does receive the real event.
     const handleRowSelect = useCallback(
-      (row, event) => {
+      (row, column) => {
         if (isRenamingActive) return
-        event?.stopPropagation?.()
-        if (
-          flag('drive.dynamic-selection.enabled') &&
-          selectedItemsCount > 0 &&
-          !event?.shiftKey
-        ) {
-          setSelectedItems({ [row._id]: row })
-        } else {
-          toggleSelectedItem(row)
-        }
-        onInteractWithFile?.(row?._id, event)
+        setSelectedItems({ [row._id]: row })
+        onInteractWithFile?.(row?._id, column)
       },
-      [
-        toggleSelectedItem,
-        onInteractWithFile,
-        selectedItemsCount,
-        setSelectedItems,
-        isRenamingActive
-      ]
+      [onInteractWithFile, setSelectedItems, isRenamingActive]
     )
 
     const handleSort = ({ order, orderBy }) => {


### PR DESCRIPTION
## Problem

In the list view, clicking a file row added it to the current selection instead of replacing it, so clicking several files in a row selected all of them. Single click should select exactly one file. The grid view already behaves this way, so the two views were inconsistent.

## Solution

A click on a list row now selects only that row. The previous handler toggled the row into the selection (and the replace-on-click path was gated behind a flag that is off by default). Multi-select stays available through the name cell (ctrl/cmd-click and shift-range), which receives the real DOM event; the row-body handler only gets the column from cozy-ui, so it can't read modifier keys and simply selects the clicked file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified table row selection logic for improved performance and reliability.
  * Enhanced event handling for row interactions and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->