### PR TITLE
fix(filelist): constrain the parent-path link to its text

### DIFF
--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -368,6 +368,13 @@ column-width-thumbnail-bigger = 7rem
     &:focus
         text-decoration underline
 
+// Shrink the path link to its text. Its MidEllipsis child is a block-level
+// flex box that otherwise fills the whole name cell, turning the entire row
+// into a parent-folder link instead of the small path label.
+.fil-file-path
+    display inline-flex
+    max-width 100%
+
 .fil-file-infos
     display none
 


### PR DESCRIPTION
## Problem

- The parent-path label under each filename was clickable across the whole name cell.
- Clicking a row navigated to the parent folder instead of selecting or opening the item.
- When the parent was the Sharings view itself, that click was a no-op, so the row looked dead.

## Solution

The path link wraps a `MidEllipsis` block that stretched to fill the cell. Making it `inline-flex` shrinks it to its text, so the rest of the row selects/opens the item while the label still navigates to the parent.

## Demo

https://github.com/user-attachments/assets/7e444e1e-2657-453a-9319-4331f2e20c7c


