### PR TITLE
fix(filelist): make the row name link fill the cell height

### DIFF
--- a/src/modules/filelist/FileOpener.jsx
+++ b/src/modules/filelist/FileOpener.jsx
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import React, { useRef } from 'react'
 
 import styles from './fileopener.styl'
@@ -12,6 +13,7 @@ const FileOpener = ({
   disabled,
   isRenaming,
   onInteractWithFile,
+  fillHeight,
   children
 }) => {
   const rowRef = useRef()
@@ -33,7 +35,9 @@ const FileOpener = ({
     <FileLink
       ref={rowRef}
       link={link}
-      className={`${styles['file-opener']} ${styles['file-opener__a']}`}
+      className={cx(styles['file-opener'], styles['file-opener__a'], {
+        [styles['file-opener--fill-height']]: fillHeight
+      })}
       {...handlers}
     >
       {children}

--- a/src/modules/filelist/fileopener.styl
+++ b/src/modules/filelist/fileopener.styl
@@ -12,3 +12,11 @@
 .file-opener__a
     text-decoration none
     color var(--secondaryTextColor)
+
+// Make the link fill its cell so the whole row height (not just the
+// vertically-centered text) opens the file on double-click.
+.file-opener--fill-height
+    display flex
+    align-items center
+    width 100%
+    height 100%

--- a/src/modules/filelist/virtualized/cells/columns/NameCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/NameCell.jsx
@@ -50,6 +50,7 @@ const NameCell = ({
       toggle={toggle}
       isRenaming={isRenaming}
       onInteractWithFile={onInteractWithFile}
+      fillHeight
     >
       <FileName
         attributes={row}


### PR DESCRIPTION
## Problem

- In the list view the name link is vertically centered, leaving a bare strip above and below it.
- Double-clicking that top or bottom strip of a row did nothing: the file or folder would not open.

## Solution

Make the name link fill its cell height so the whole row, not just the centered text, opens the item on double-click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File links in lists now expand to fill the full row height for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->