### PR TITLE
fix: bump cozy-sharing to 33.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
-    "cozy-sharing": "^33.4.0",
+    "cozy-sharing": "^33.4.1",
     "cozy-stack-client": "^60.27.0",
     "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8195,10 +8195,10 @@ cozy-search@^0.25.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^33.4.0:
-  version "33.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.4.0.tgz#79d2808915d5c9fc79217f08853e34890706faad"
-  integrity sha512-vSXJZQag2Wz9SpDNcDsUSxktz0ZBr8YR6UT7GRGAbeS0XSX0hTQvw15/DOmWVIWaQWRDeDcmXbWc5jzYgVhuXA==
+cozy-sharing@^33.4.1:
+  version "33.4.1"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.4.1.tgz#2ad6b10fcc785a6931e89908e385ec711e17b42e"
+  integrity sha512-JaO3FIzMc5fQbeQBNID6lsHkwpi/dG6tfgmqfkdRVKtenSgt9qS1FB2qHrlWPyi0yNjli1qaDrJj+5peIVwUsQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
Bump cozy-sharing to 33.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to the latest patch version for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->