### PR TITLE
fix(selection): keep shift selection item visible

### DIFF
--- a/src/hooks/useShiftSelection/index.spec.tsx
+++ b/src/hooks/useShiftSelection/index.spec.tsx
@@ -53,15 +53,29 @@ describe('useShiftSelection', () => {
   let mockIsItemSelected: jest.Mock
   let mockRef: RefObject<HTMLElement>
   let mockElement: HTMLElement
+  let mockAddEventListener: jest.Mock
+  let mockQuerySelector: jest.Mock
+  let mockQuerySelectorAll: jest.Mock
+  let mockGetBoundingClientRect: jest.Mock
+  let mockScrollBy: jest.Mock
 
   beforeEach(() => {
     mockSetSelectedItems = jest.fn()
     mockIsItemSelected = jest.fn()
+    mockAddEventListener = jest.fn()
+    mockQuerySelector = jest.fn().mockReturnValue(null)
+    mockQuerySelectorAll = jest.fn().mockReturnValue([])
+    mockGetBoundingClientRect = jest.fn()
+    mockScrollBy = jest.fn()
 
     mockElement = {
       focus: jest.fn(),
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn()
+      addEventListener: mockAddEventListener,
+      removeEventListener: jest.fn(),
+      querySelector: mockQuerySelector,
+      querySelectorAll: mockQuerySelectorAll,
+      getBoundingClientRect: mockGetBoundingClientRect,
+      scrollBy: mockScrollBy
     } as unknown as HTMLElement
 
     mockRef = { current: mockElement }
@@ -227,6 +241,102 @@ describe('useShiftSelection', () => {
       })
 
       expect(mockHandleShiftClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('auto-scroll current item into view', () => {
+    const getKeydownHandler = (): ((event: KeyboardEvent) => void) => {
+      const calls = mockAddEventListener.mock.calls[0] as unknown[]
+      return calls[1] as (event: KeyboardEvent) => void
+    }
+
+    const makeFileElement = (fileId: string, rect: Partial<DOMRect>): Element =>
+      ({
+        getBoundingClientRect: jest.fn(() => rect)
+      }) as unknown as Element
+
+    it('scrolls down when the current item is below the scroll container', () => {
+      mockGetBoundingClientRect.mockReturnValue({
+        top: 0,
+        bottom: 100
+      })
+      mockQuerySelector.mockReturnValue(
+        makeFileElement('1', { top: 110, bottom: 140 })
+      )
+
+      renderHook(() =>
+        useShiftSelection({ items: mockFiles, viewType: 'list' }, mockRef)
+      )
+
+      const mockEvent = {
+        shiftKey: true,
+        key: 'ArrowDown',
+        preventDefault: jest.fn()
+      } as unknown as KeyboardEvent
+
+      act(() => {
+        getKeydownHandler()(mockEvent)
+      })
+
+      expect(mockScrollBy).toHaveBeenCalledWith({
+        top: 40,
+        behavior: 'auto'
+      })
+    })
+
+    it('scrolls up when the current item is above the scroll container', () => {
+      mockGetBoundingClientRect.mockReturnValue({
+        top: 50,
+        bottom: 150
+      })
+      mockQuerySelector.mockReturnValue(
+        makeFileElement('1', { top: 20, bottom: 40 })
+      )
+
+      renderHook(() =>
+        useShiftSelection({ items: mockFiles, viewType: 'list' }, mockRef)
+      )
+
+      const mockEvent = {
+        shiftKey: true,
+        key: 'ArrowUp',
+        preventDefault: jest.fn()
+      } as unknown as KeyboardEvent
+
+      act(() => {
+        getKeydownHandler()(mockEvent)
+      })
+
+      expect(mockScrollBy).toHaveBeenCalledWith({
+        top: -30,
+        behavior: 'auto'
+      })
+    })
+
+    it('does not scroll when the current item is already visible', () => {
+      mockGetBoundingClientRect.mockReturnValue({
+        top: 0,
+        bottom: 100
+      })
+      mockQuerySelector.mockReturnValue(
+        makeFileElement('1', { top: 20, bottom: 40 })
+      )
+
+      renderHook(() =>
+        useShiftSelection({ items: mockFiles, viewType: 'list' }, mockRef)
+      )
+
+      const mockEvent = {
+        shiftKey: true,
+        key: 'ArrowDown',
+        preventDefault: jest.fn()
+      } as unknown as KeyboardEvent
+
+      act(() => {
+        getKeydownHandler()(mockEvent)
+      })
+
+      expect(mockScrollBy).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/hooks/useShiftSelection/index.tsx
+++ b/src/hooks/useShiftSelection/index.tsx
@@ -20,6 +20,7 @@ import {
 
 import { isEditableTarget } from '@/hooks/helpers'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+import { scrollElementIntoViewInContainer } from '@/modules/selection/scrollHelpers'
 import { SelectedItems } from '@/modules/selection/types'
 
 type ViewType = 'list' | 'grid'
@@ -27,6 +28,7 @@ type ViewType = 'list' | 'grid'
 interface UseShiftSelectionParams {
   items: IOCozyFile[]
   viewType?: ViewType
+  scrollElement?: HTMLElement | null
 }
 
 interface UseShiftSelectionReturn {
@@ -41,21 +43,46 @@ interface UseShiftSelectionReturn {
  * - Select ranges of items using Shift+Click (from last interacted item to clicked item)
  * - Navigate and extend selection using Shift+Arrow keys (direction depends on viewType)
  *
+ * After each navigation the hook scrolls the rendered `[data-file-id]`
+ * element of the new lastInteractedItem into view. It uses the same kind
+ * of DOM scroll container as rectangular selection: compare item and
+ * scroll container bounds, then call `scrollBy` only for the missing
+ * distance.
+ *
  * @param {UseShiftSelectionParams} params - Configuration object containing items and view type
  * @param {IOCozyFile[]} params.items - Array of IOCozyFile objects to enable selection on
  * @param {ViewType} params.viewType - View type ('list' or 'grid') that determines keyboard navigation behavior
+ * @param {HTMLElement|null} params.scrollElement - Optional scrollable DOM container
  * @param ref - React ref to the container element that should receive keyboard events
  *
  * @returns {UseShiftSelectionReturn}
  */
 const useShiftSelection = (
-  { items, viewType = 'list' }: UseShiftSelectionParams,
+  { items, viewType = 'list', scrollElement = null }: UseShiftSelectionParams,
   ref: RefObject<HTMLElement>
 ): UseShiftSelectionReturn => {
   const { isMobile } = useBreakpoints()
 
   const itemsRef = useRef<IOCozyFile[]>([])
   itemsRef.current = useMemo(() => items, [items])
+
+  /**
+   * Scrolls the lastInteractedItem into view inside the scroll container.
+   * This mirrors rectangular selection: use the actual scrollable element
+   * and scroll only by the amount needed to reveal the current item.
+   */
+  const scrollToItem = useCallback(
+    (id: string) => {
+      const container = scrollElement || ref.current
+      if (!container) return
+
+      const element = container.querySelector(`[data-file-id="${id}"]`)
+      if (!element) return
+
+      scrollElementIntoViewInContainer(container, element)
+    },
+    [ref, scrollElement]
+  )
 
   const { selectedItems, setSelectedItems, isItemSelected, setIsSelectAll } =
     useSelectionContext()
@@ -71,13 +98,10 @@ const useShiftSelection = (
   }, [lastInteractedItem])
 
   const selectedItemMap: SelectedItems = useMemo(() => {
-    return selectedItems.reduce<SelectedItems>(
-      (prev: SelectedItems, cur: IOCozyFile) => ({
-        ...prev,
-        [cur._id]: cur
-      }),
-      {}
-    )
+    return selectedItems.reduce<SelectedItems>((acc, item) => {
+      acc[item._id] = item
+      return acc
+    }, {})
   }, [selectedItems])
 
   /**
@@ -108,6 +132,7 @@ const useShiftSelection = (
       setIsSelectAll(
         Object.keys(newSelectedItems).length === itemsRef.current.length
       )
+      scrollToItem(lastInteractedItemId)
     },
     [
       items,
@@ -115,7 +140,8 @@ const useShiftSelection = (
       selectedItemMap,
       setSelectedItems,
       setIsSelectAll,
-      setLastInteractedItem
+      setLastInteractedItem,
+      scrollToItem
     ]
   )
 
@@ -158,7 +184,10 @@ const useShiftSelection = (
 
       setSelectedItems(newSelectedItems)
       setLastInteractedItem(lastInteractedItemId)
-      setIsSelectAll(selectedItems.length === itemsRef.current.length)
+      setIsSelectAll(
+        Object.keys(newSelectedItems).length === itemsRef.current.length
+      )
+      scrollToItem(lastInteractedItemId)
     },
     [
       viewType,
@@ -168,7 +197,8 @@ const useShiftSelection = (
       setSelectedItems,
       isItemSelected,
       setIsSelectAll,
-      setLastInteractedItem
+      setLastInteractedItem,
+      scrollToItem
     ]
   )
 

--- a/src/modules/selection/RectangularSelection.jsx
+++ b/src/modules/selection/RectangularSelection.jsx
@@ -3,10 +3,10 @@ import Selecto from 'react-selecto'
 
 import styles from './RectangularSelection.styl'
 import { useSelectionContext } from './SelectionProvider'
+import { scrollContainerByDirection } from './scrollHelpers'
 
 const INTERACTIVE_ELEMENTS_SELECTOR =
   'button,a,input,select,textarea,label,[role="button"],[role="menuitem"],[role="option"]'
-const SCROLL_STEP_IN_PIXELS = 10
 /**
  * Hit rate for the Selecto library.
  * Controls how frequently the selection rectangle checks for elements to select.
@@ -334,10 +334,7 @@ const RectangularSelection = ({
     e => {
       if (!resolvedScrollContainer) return
 
-      resolvedScrollContainer.scrollBy(
-        e.direction[0] * SCROLL_STEP_IN_PIXELS,
-        e.direction[1] * SCROLL_STEP_IN_PIXELS
-      )
+      scrollContainerByDirection(resolvedScrollContainer, e.direction)
     },
     [resolvedScrollContainer]
   )

--- a/src/modules/selection/scrollHelpers.ts
+++ b/src/modules/selection/scrollHelpers.ts
@@ -5,6 +5,8 @@ const scrollContainerByDirection = (
   direction: number[],
   step = SCROLL_STEP_IN_PIXELS
 ): void => {
+  if (direction.length < 2) return
+
   container.scrollBy(direction[0] * step, direction[1] * step)
 }
 

--- a/src/modules/selection/scrollHelpers.ts
+++ b/src/modules/selection/scrollHelpers.ts
@@ -1,0 +1,31 @@
+const SCROLL_STEP_IN_PIXELS = 10
+
+const scrollContainerByDirection = (
+  container: HTMLElement,
+  direction: number[],
+  step = SCROLL_STEP_IN_PIXELS
+): void => {
+  container.scrollBy(direction[0] * step, direction[1] * step)
+}
+
+const scrollElementIntoViewInContainer = (
+  container: HTMLElement,
+  element: Element
+): void => {
+  const itemRect = element.getBoundingClientRect()
+  const containerRect = container.getBoundingClientRect()
+
+  if (itemRect.bottom > containerRect.bottom) {
+    container.scrollBy({
+      top: itemRect.bottom - containerRect.bottom,
+      behavior: 'auto'
+    })
+  } else if (itemRect.top < containerRect.top) {
+    container.scrollBy({
+      top: itemRect.top - containerRect.top,
+      behavior: 'auto'
+    })
+  }
+}
+
+export { scrollContainerByDirection, scrollElementIntoViewInContainer }

--- a/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
@@ -90,7 +90,8 @@ const FolderViewBodyContent = ({
   const { setLastInteractedItem, onShiftClick } = useShiftSelection(
     {
       items: sortedRows,
-      viewType
+      viewType,
+      scrollElement
     },
     folderViewRef
   )


### PR DESCRIPTION
Share DOM scroll helpers between rectangular selection and keyboard range selection. Use the actual scroll container to reveal the current item when extending a selection with Shift+Arrow.

[Capture vidéo du 2026-06-15 17-28-11.webm](https://github.com/user-attachments/assets/951dc7df-7d01-4d82-aa08-298fd26a1313)

https://app.notion.com/p/linagora/Add-scroll-when-use-Shift-arrow-to-select-37c62718bad18053823dec07e36bf911


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift selection now automatically scrolls the newly selected item into view when using Shift+Click or Shift+Arrow keyboard navigation (based on the active scroll container).
  * Rectangular selection auto-scrolls smoothly as you drag near the edges.

* **Tests**
  * Expanded shift-selection test coverage to verify proper event wiring and that auto-scrolling occurs only when the target item is outside the visible container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->