### PR TITLE
fix(sharings): hide received shares from My Drive listing

### DIFF
--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -47,6 +47,7 @@ import FolderViewBreadcrumb from '@/modules/views/Folder/FolderViewBreadcrumb'
 import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
 import { useFabOnMobile } from '@/modules/views/Folder/hooks/useFabOnMobile'
 import { useFolderViewBase } from '@/modules/views/Folder/hooks/useFolderViewBase'
+import { filterOutReceivedShares } from '@/modules/views/Folder/syncHelpers'
 import FolderViewBodyVz from '@/modules/views/Folder/virtualized/FolderViewBody'
 import { useResumeUploadFromFlagship } from '@/modules/views/Upload/useResumeFromFlagship'
 
@@ -71,9 +72,21 @@ const DriveFolderView = () => {
   const [sortOrder, setSortOrder, isSettingsLoaded] =
     useFolderSort(currentFolderId)
 
-  const { allResults, isInError, isLoading, isPending } = useDriveQueries(
-    currentFolderId,
-    sortOrder
+  const {
+    allResults: rawResults,
+    isInError,
+    isLoading,
+    isPending
+  } = useDriveQueries(currentFolderId, sortOrder)
+  // Received shares are tagged with an io.cozy.sharings reference by the stack
+  // and may be materialised among the recipient's own files; they belong in the
+  // Sharings section, not My Drive. Wait until the sharing context is fully
+  // loaded so isOwner can tell a received share from the user's own folders;
+  // filtering earlier sees an incomplete picture and would show-then-hide them.
+  const allResults = useMemo(
+    () =>
+      allLoaded ? filterOutReceivedShares(rawResults, isOwner) : rawResults,
+    [allLoaded, rawResults, isOwner]
   )
   const [foldersResult, filesResult] = allResults
   const canWriteToCurrentFolder = hasWriteAccess(currentFolderId)

--- a/src/modules/views/Folder/syncHelpers.js
+++ b/src/modules/views/Folder/syncHelpers.js
@@ -136,6 +136,43 @@ export const computeSyncingFakeFile = ({
 }
 
 /**
+ * Whether the file is the root of a sharing the current instance received
+ * (i.e. is referenced by an io.cozy.sharings the user does not own).
+ *
+ * The stack tags both the owner's shared folder and the recipient's copy with
+ * an io.cozy.sharings reference, so ownership is what tells them apart: the
+ * recipient must not see the received share among their own files (it belongs
+ * in the Sharings section), while the owner keeps their folder in place.
+ * @param {object} file - An io.cozy.files doc
+ * @param {function} isOwner - cozy-sharing predicate, true when the instance owns the sharing of the given file id
+ * @returns {bool}
+ */
+export const isReceivedShare = (file, isOwner) => {
+  const fileReferences = get(file, 'relationships.referenced_by.data') || []
+  const isSharingReferenced = fileReferences.some(
+    reference => reference.type === 'io.cozy.sharings'
+  )
+  if (!isSharingReferenced) return false
+
+  return !isOwner(file._id ?? file.id ?? '')
+}
+
+/**
+ * Drops received shares from folder/file query results so they don't surface
+ * among the user's own files. Returns new result objects with a filtered
+ * `data` (and matching `count`), preserving the rest of each query result.
+ * @param {array} queryResults - cozy-client query results (folders, files)
+ * @param {function} isOwner - cozy-sharing ownership predicate
+ * @returns {array} query results without received shares
+ */
+export const filterOutReceivedShares = (queryResults, isOwner) =>
+  queryResults.map(result => {
+    if (!result?.data) return result
+    const data = result.data.filter(file => !isReceivedShare(file, isOwner))
+    return { ...result, data, count: data.length }
+  })
+
+/**
  * Whether the file is referenced by a share in the sharing context
  * @param {object} file - An io.cozy.files doc
  * @param {object} sharingsValue - Sharing Context value

--- a/src/modules/views/Folder/syncHelpers.spec.js
+++ b/src/modules/views/Folder/syncHelpers.spec.js
@@ -3,7 +3,9 @@ import {
   createSyncingFakeFile,
   computeSyncingFakeFile,
   checkSyncingFakeFileObsolescence,
-  isReferencedByShareInSharingContext
+  isReferencedByShareInSharingContext,
+  isReceivedShare,
+  filterOutReceivedShares
 } from './syncHelpers'
 
 const queryResults = [
@@ -198,6 +200,98 @@ describe('syncHelpers', () => {
         id: 'id1',
         type: 'directory'
       })
+    })
+  })
+
+  describe('isReceivedShare', () => {
+    const sharingRoot = {
+      _id: 'shared-folder-id',
+      relationships: {
+        referenced_by: {
+          data: [{ id: 'sharing-id', type: 'io.cozy.sharings' }]
+        }
+      }
+    }
+    const ownFile = {
+      _id: 'own-file-id',
+      relationships: {
+        referenced_by: {
+          data: [{ id: 'album-id', type: 'io.cozy.photos.albums' }]
+        }
+      }
+    }
+
+    it('returns true when referenced by a sharing the user does not own', () => {
+      expect(isReceivedShare(sharingRoot, () => false)).toBe(true)
+    })
+
+    it('returns false for the owner of the sharing', () => {
+      expect(isReceivedShare(sharingRoot, () => true)).toBe(false)
+    })
+
+    it('returns false when not referenced by any sharing', () => {
+      expect(isReceivedShare(ownFile, () => false)).toBe(false)
+    })
+
+    it('returns false when there is no referenced_by relationship', () => {
+      expect(isReceivedShare({ _id: 'x' }, () => false)).toBe(false)
+    })
+
+    it('returns false when referenced_by.data is null', () => {
+      const file = {
+        _id: 'x',
+        relationships: { referenced_by: { data: null } }
+      }
+      expect(isReceivedShare(file, () => false)).toBe(false)
+    })
+  })
+
+  describe('filterOutReceivedShares', () => {
+    const isOwner = id => id === 'own-shared-folder'
+    const results = [
+      {
+        data: [
+          { _id: 'own-folder' },
+          {
+            _id: 'own-shared-folder',
+            relationships: {
+              referenced_by: {
+                data: [{ id: 's1', type: 'io.cozy.sharings' }]
+              }
+            }
+          },
+          {
+            _id: 'received-share',
+            relationships: {
+              referenced_by: {
+                data: [{ id: 's2', type: 'io.cozy.sharings' }]
+              }
+            }
+          }
+        ],
+        hasMore: true,
+        fetchMore: jest.fn()
+      }
+    ]
+
+    it('drops received shares but keeps own and own-shared files', () => {
+      const [filtered] = filterOutReceivedShares(results, isOwner)
+      expect(filtered.data.map(f => f._id)).toEqual([
+        'own-folder',
+        'own-shared-folder'
+      ])
+      expect(filtered.count).toBe(2)
+    })
+
+    it('preserves the other result properties', () => {
+      const [filtered] = filterOutReceivedShares(results, isOwner)
+      expect(filtered.hasMore).toBe(true)
+      expect(filtered.fetchMore).toBe(results[0].fetchMore)
+    })
+
+    it('passes through results without data untouched', () => {
+      const noData = [{ fetchStatus: 'loading' }]
+      expect(filterOutReceivedShares(noData, isOwner)).toEqual(noData)
     })
   })
 


### PR DESCRIPTION
## Problem

- When a recipient accepts a federated share, the stack materialises a local copy of the shared folder. In some cases that copy is created directly in the recipient's root directory.
- The My Drive listing returns everything in the root directory with no filter for shared documents, so received shares show up among the user's own folders while also appearing in the Sharings section. The same share is then visible in two places.
- For a received shared drive, the leaked folder is a proxied document, so opening it from My Drive (which routes to the local folder view) breaks.
- The owner's original folder carries the same io.cozy.sharings reference and must keep showing in their own My Drive, so the reference alone cannot tell the two apart. Ownership is the distinguishing signal.

## Solution

- Drop documents referenced by an io.cozy.sharings the user does not own from the My Drive listing, using isOwner so the owner still sees their shared folders in place.
- Filtering waits for the sharing context to load so ownership is known.
- Received shares stay reachable through the Sharings section, which is unaffected. Removing them from My Drive also clears the broken open for shared-drive roots.