### PR TITLE
fix(sharings): show share action for received shared folders

### DIFF
--- a/src/modules/shareddrives/components/actions/shareSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/shareSharedDrive.js
@@ -14,7 +14,7 @@ import { isFileRootSharedDrive } from '@/modules/shareddrives/rootFileNavigation
 // drives are handled by `shareFileRootSharedDrive`. The two are mutually
 // exclusive: this one hides itself when the doc is a file-root, and the
 // file-root one only shows for file-roots.
-export const shareSharedDrive = ({ navigate, t, isOwner, pathname }) => {
+export const shareSharedDrive = ({ navigate, t, pathname }) => {
   const label = t('Files.share.cta')
   const icon = ShareIcon
 
@@ -28,8 +28,7 @@ export const shareSharedDrive = ({ navigate, t, isOwner, pathname }) => {
       return (
         docs.length === 1 &&
         isSharedDriveDoc(doc) &&
-        !isFileRootSharedDrive(doc) &&
-        isOwner?.(doc._id)
+        !isFileRootSharedDrive(doc)
       )
     },
     // Same route the avatars build, so the share button layers the modal over

--- a/src/modules/shareddrives/components/actions/shareSharedDrive.spec.js
+++ b/src/modules/shareddrives/components/actions/shareSharedDrive.spec.js
@@ -6,7 +6,7 @@ describe('shareSharedDrive', () => {
   const t = key => key
   const navigate = jest.fn()
 
-  const makeAction = ({ isOwner = () => true, pathname = '/sharings' } = {}) =>
+  const makeAction = ({ isOwner, pathname = '/sharings' } = {}) =>
     shareSharedDrive({ navigate, t, isOwner, pathname })
 
   beforeEach(() => {
@@ -14,13 +14,32 @@ describe('shareSharedDrive', () => {
   })
 
   it.each`
-    label                                       | doc                                                                               | isOwner                     | expected
-    ${'folder-root shared drive owned by user'} | ${{ _id: 'folder-id', driveId: 'drive-id' }}                                      | ${id => id === 'folder-id'} | ${true}
-    ${'folder-root shared drive not owned'}     | ${{ _id: 'folder-id', driveId: 'drive-id' }}                                      | ${() => false}              | ${false}
-    ${'file-root shared drive'}                 | ${{ _id: 'file-id', driveId: 'drive-id', drive_root_type: DRIVE_ROOT_TYPE.FILE }} | ${() => true}               | ${false}
-    ${'document outside shared drive'}          | ${{ _id: 'file-id' }}                                                             | ${() => true}               | ${false}
-  `('returns $expected for $label', ({ doc, isOwner, expected }) => {
-    expect(makeAction({ isOwner }).displayCondition([doc])).toBe(expected)
+    label                                             | doc                                                                               | expected
+    ${'folder-root shared drive owned by user'}       | ${{ _id: 'folder-id', driveId: 'drive-id' }}                                      | ${true}
+    ${'folder-root shared drive received from owner'} | ${{ _id: 'folder-id', driveId: 'drive-id' }}                                      | ${true}
+    ${'file-root shared drive'}                       | ${{ _id: 'file-id', driveId: 'drive-id', drive_root_type: DRIVE_ROOT_TYPE.FILE }} | ${false}
+    ${'document outside shared drive'}                | ${{ _id: 'file-id' }}                                                             | ${false}
+  `('returns $expected for $label', ({ doc, expected }) => {
+    expect(makeAction().displayCondition([doc])).toBe(expected)
+  })
+
+  it('shows the action for received folder-root shared drives', () => {
+    const action = makeAction({ isOwner: () => false })
+
+    expect(
+      action.displayCondition([{ _id: 'folder-id', driveId: 'drive-id' }])
+    ).toBe(true)
+  })
+
+  it('hides the action when multiple documents are selected', () => {
+    const action = makeAction()
+
+    expect(
+      action.displayCondition([
+        { _id: 'folder-id', driveId: 'drive-id' },
+        { _id: 'other-folder-id', driveId: 'drive-id' }
+      ])
+    ).toBe(false)
   })
 
   it('layers the share modal over the sharings list', () => {


### PR DESCRIPTION
https://app.notion.com/p/linagora/missing-share-action-38062718bad180a5b59ffe9469ec7d2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated visibility conditions for the "Share" action on shared drives. The action now appears for additional shared drive scenarios, including received shared drives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->