### PR TITLE
feat: Hide "Leave sharing" for shared drives

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
-    "cozy-sharing": "^33.4.2",
+    "cozy-sharing": "^33.5.0",
     "cozy-stack-client": "^60.27.0",
     "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",

--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -46,7 +46,7 @@ const MoreMenu = ({
   const [menuIsVisible, setMenuVisible] = useState(false)
   const anchorRef = useRef()
   const { isMobile } = useBreakpoints()
-  const { allLoaded } = useSharingContext() // We need to wait for the sharing context to be completely loaded to avoid race conditions
+  const { allLoaded, canLeave } = useSharingContext() // We need to wait for the sharing context to be completely loaded to avoid race conditions
 
   const handleToggle = useCallback(
     () => toggleMenu(menuIsVisible, setMenuVisible),
@@ -127,9 +127,11 @@ const MoreMenu = ({
                 />
               </InsideRegularFolder>
             )}
-            {isSharedDriveRecipient && isSharedWithMe && (
-              <LeaveSharedDriveButtonItem files={[displayedFolder]} />
-            )}
+            {isSharedDriveRecipient &&
+              isSharedWithMe &&
+              canLeave(displayedFolder._id) && (
+                <LeaveSharedDriveButtonItem files={[displayedFolder]} />
+              )}
           </ActionsMenu>
         )}
       </AddMenuProvider>

--- a/src/modules/shareddrives/components/actions/leaveSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/leaveSharedDrive.js
@@ -9,7 +9,7 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { isSharedDriveDoc } from '@/modules/shareddrives/helpers'
 
 // Only for sharing tabs
-export const leaveSharedDrive = ({ client, showAlert, t }) => {
+export const leaveSharedDrive = ({ client, showAlert, t, canLeave }) => {
   const label = t('toolbar.menu_leave_shared_drive')
   const icon = LogoutIcon
 
@@ -18,7 +18,9 @@ export const leaveSharedDrive = ({ client, showAlert, t }) => {
     label: label,
     icon,
     displayCondition: docs => {
-      return docs.length === 1 && isSharedDriveDoc(docs[0])
+      return (
+        docs.length === 1 && isSharedDriveDoc(docs[0]) && canLeave(docs[0]._id)
+      )
     },
     action: async docs => {
       const sharedDriveId = docs[0].driveId

--- a/src/modules/views/Sharings/helpers.js
+++ b/src/modules/views/Sharings/helpers.js
@@ -4,13 +4,14 @@ export const buildSharingsActionsOptions = ({
   sharingContext,
   filteredResult
 }) => {
-  const { allLoaded, refresh, isOwner } = sharingContext
+  const { allLoaded, refresh, isOwner, canLeave } = sharingContext
 
   return {
     ...base,
     ...nativeSharing,
     refresh,
     isOwner,
+    canLeave,
     hasWriteAccess: true,
     canMove: true,
     isPublic: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8195,10 +8195,10 @@ cozy-search@^0.25.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^33.4.2:
-  version "33.4.2"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.4.2.tgz#3a68018e9481821bfb6d5af57fc0fd5e59d20a2e"
-  integrity sha512-U2qvrfZcdQz36e5h/87I7pGzI4YIV2y23OyvP/6LRmDxfgrm30ScrMcynOoDZ6FrIFqa2Ji0ewzb5mI/0jwWgw==
+cozy-sharing@^33.5.0:
+  version "33.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.5.0.tgz#11acd58b78fb5b5e019982bca1dc1add7b77ff36"
+  integrity sha512-pVhCaeDogAMWSudaOZj2DlHhjANcayXvlxTXl/nWqkEOoUaGwSewIjZWyEbMw9O5KouT3LGsdvjqi1ZwJvyzkQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
For B2B shared drives, we want to hide "Leave sharing" as it is not wished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Leave shared drive” action to respect additional permission checks, preventing unauthorized departures from shared drives.
* **Chores**
  * Updated the `cozy-sharing` dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->