### PR TITLE
fix: use correct size prop for AvatarList in Share toolbar

### DIFF
--- a/src/modules/drive/Toolbar/share/ShareItem.jsx
+++ b/src/modules/drive/Toolbar/share/ShareItem.jsx
@@ -35,7 +35,7 @@ const ShareItem = ({ displayedFolder }) => {
                 : 'toolbar.menu_share_folder'
             )}
           />
-          <AvatarList recipients={recipients} link={link} size="small" />
+          <AvatarList recipients={recipients} link={link} size="s" />
         </ActionsMenuItem>
       )}
     </SharedDocument>


### PR DESCRIPTION
<img width="329" height="129" alt="image" src="https://github.com/user-attachments/assets/8f1ea927-418f-412a-9789-a892ee5566d2" />

https://app.notion.com/p/linagora/make-avatars-smaller-Context-menu-38162718bad1806d9b65f7bb26223ec6?source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted avatar sizing in the share recipients display to use a smaller size variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->