### PR TITLE
feat(sharings): open owned shares in drive

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -158,6 +158,8 @@ declare module 'cozy-sharing' {
     allLoaded: boolean
     refresh: () => void
     hasWriteAccess: (id: string, driveId?: string) => boolean
+    isOwner: (docId: string) => boolean
+    byDocId: Record<string, unknown>
   }
 
   export const useNativeFileSharing: () => {

--- a/src/modules/navigation/hooks/helpers.spec.js
+++ b/src/modules/navigation/hooks/helpers.spec.js
@@ -606,4 +606,109 @@ describe('computePath', () => {
       'file/file123'
     )
   })
+
+  it('should return /folder/:id for an owner folder opened from /sharings', () => {
+    // When the user is the owner of a sharing shown in /sharings, the
+    // folder is the real io.cozy.files document living in their Drive.
+    // The path must drop the /sharings prefix and use the normal Drive
+    // folder view.
+    const file = { _id: 'folder-1', dir_id: 'io.cozy.files.root-dir' }
+    expect(
+      computePath(file, {
+        type: 'directory',
+        pathname: '/sharings',
+        isPublic: false,
+        client: null,
+        isOwner: true
+      })
+    ).toBe('/folder/folder-1')
+  })
+
+  it('should return /folder/:id for an owner folder opened from a nested /sharings/folder', () => {
+    // The owner detection also covers nested sharings views (a folder
+    // browsed inside /sharings).
+    const file = { _id: 'folder-1', dir_id: 'io.cozy.files.root-dir' }
+    expect(
+      computePath(file, {
+        type: 'directory',
+        pathname: '/sharings/parent-folder',
+        isPublic: false,
+        client: null,
+        isOwner: true
+      })
+    ).toBe('/folder/folder-1')
+  })
+
+  it('should return /folder/:dirId/file/:id for an owner file opened from /sharings', () => {
+    // Symmetric case for files: owner files shown in /sharings open in
+    // the normal Drive viewer (`FilesViewerDrive`).
+    const file = { _id: 'file-1', dir_id: 'io.cozy.files.root-dir' }
+    expect(
+      computePath(file, {
+        type: 'file',
+        pathname: '/sharings',
+        isPublic: false,
+        client: null,
+        isOwner: true
+      })
+    ).toBe('/folder/io.cozy.files.root-dir/file/file-1')
+  })
+
+  it('should keep the sharings path for a recipient directory in /sharings', () => {
+    // Non-owner case must remain on the existing relative /sharings path
+    // so the recipient keeps browsing inside the sharings section.
+    const file = { _id: 'folder-1', dir_id: 'io.cozy.files.root-dir' }
+    expect(
+      computePath(file, {
+        type: 'directory',
+        pathname: '/sharings',
+        isPublic: false,
+        client: null,
+        isOwner: false
+      })
+    ).toBe('folder-1')
+  })
+
+  it('should keep the sharings path for a recipient file in /sharings', () => {
+    // Non-owner case for a file: stays on `file/:id` (resolves to
+    // /sharings/file/:id) so the recipient keeps using the sharings
+    // viewer.
+    const file = { _id: 'file-1', dir_id: 'io.cozy.files.root-dir' }
+    expect(
+      computePath(file, {
+        type: 'file',
+        pathname: '/sharings',
+        isPublic: false,
+        client: null,
+        isOwner: false
+      })
+    ).toBe('file/file-1')
+  })
+
+  it('should not redirect an owner file outside /sharings', () => {
+    // Outside /sharings the isOwner flag must not influence the path:
+    // the regular Drive behaviour (relative path) is preserved.
+    const file = { _id: 'file-1', dir_id: 'io.cozy.files.root-dir' }
+    expect(
+      computePath(file, {
+        type: 'file',
+        pathname: '/folder/parent',
+        isPublic: false,
+        client: null,
+        isOwner: true
+      })
+    ).toBe('file/file-1')
+  })
+
+  it('should default to non-owner behaviour when isOwner is undefined', () => {
+    // Backward compatibility: callers that don't pass isOwner keep the
+    // historical relative path.
+    const file = { _id: 'folder-1', dir_id: 'io.cozy.files.root-dir' }
+    expect(
+      computePath(file, {
+        type: 'directory',
+        pathname: '/sharings'
+      })
+    ).toBe('folder-1')
+  })
 })

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -43,6 +43,7 @@ interface ComputePathOptions {
   pathname: string
   isPublic: boolean
   client: CozyClient | null
+  isOwner?: boolean
 }
 
 export const computeFileType = (
@@ -162,7 +163,7 @@ const computeNextcloudPath = (
 
 export const computePath = (
   file: File,
-  { type, pathname, isPublic, client }: ComputePathOptions
+  { type, pathname, isPublic, client, isOwner = false }: ComputePathOptions
 ): string => {
   const paths = pathname.split('/').slice(1)
   const driveId = file.driveId as string | undefined
@@ -195,6 +196,13 @@ export const computePath = (
     case 'shortcut':
       return `/external/${file._id}`
     case 'directory':
+      // When the user is the owner of a sharing displayed in /sharings, the
+      // file/folder is the real io.cozy.files document living in their Drive,
+      // so we must drop the /sharings prefix and open it in the normal Drive
+      // folder view instead of the sharings folder view.
+      if (isOwner && pathname.startsWith('/sharings')) {
+        return `/folder/${file._id}`
+      }
       // On mobile, if we are in /favorites tab, we do not want it to appears in computed path
       // so we redirect to root route for folders
       if (pathname.startsWith('/favorites')) {
@@ -244,6 +252,14 @@ export const computePath = (
       }
       return `/shareddrive/${driveId}/${file.dir_id}/file/${file._id}`
     default:
+      // Owner of a file shown in /sharings owns the real io.cozy.files
+      // document on their instance, so the file should open in the normal
+      // Drive viewer (`/folder/:dirId/file/:fileId`) and leave the sharings
+      // section. Recipients (and the rest of the file cases) keep the
+      // existing relative /sharings/file/:fileId path.
+      if (isOwner && pathname.startsWith('/sharings')) {
+        return `/folder/${file.dir_id}/file/${file._id}`
+      }
       // On mobile, if we are in /favorites tab, we do not want it to appears in computed path
       // so we redirect to root route for files
       if (pathname.startsWith('/favorites')) {

--- a/src/modules/navigation/hooks/useFileLink.spec.tsx
+++ b/src/modules/navigation/hooks/useFileLink.spec.tsx
@@ -1,0 +1,88 @@
+import { computeIsSharingsOwner } from './useFileLink'
+
+describe('computeIsSharingsOwner', () => {
+  const ownerSharingContext = {
+    allLoaded: true,
+    byDocId: { 'file-1': {} },
+    isOwner: jest.fn((docId: string) => docId === 'file-1')
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns true for an owner shared document opened from sharings', () => {
+    expect(
+      computeIsSharingsOwner({
+        file: {
+          _id: 'file-1',
+          _type: 'io.cozy.files',
+          type: 'file',
+          name: 'file.pdf',
+          dir_id: 'io.cozy.files.root-dir'
+        },
+        pathname: '/sharings',
+        isPublic: false,
+        sharingContext: ownerSharingContext
+      })
+    ).toBe(true)
+  })
+
+  it('returns false when isOwner defaults to true for a document absent from byDocId', () => {
+    expect(
+      computeIsSharingsOwner({
+        file: {
+          _id: 'nested-file-1',
+          _type: 'io.cozy.files',
+          type: 'file',
+          name: 'nested-file.pdf',
+          dir_id: 'shared-folder-1'
+        },
+        pathname: '/sharings/shared-folder-1',
+        isPublic: false,
+        sharingContext: {
+          allLoaded: true,
+          byDocId: {},
+          isOwner: jest.fn(() => true)
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('returns false while sharings are not loaded', () => {
+    expect(
+      computeIsSharingsOwner({
+        file: {
+          _id: 'file-1',
+          _type: 'io.cozy.files',
+          type: 'file',
+          name: 'file.pdf',
+          dir_id: 'io.cozy.files.root-dir'
+        },
+        pathname: '/sharings',
+        isPublic: false,
+        sharingContext: {
+          ...ownerSharingContext,
+          allLoaded: false
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('returns false in public mode', () => {
+    expect(
+      computeIsSharingsOwner({
+        file: {
+          _id: 'file-1',
+          _type: 'io.cozy.files',
+          type: 'file',
+          name: 'file.pdf',
+          dir_id: 'io.cozy.files.root-dir'
+        },
+        pathname: '/sharings',
+        isPublic: true,
+        sharingContext: ownerSharingContext
+      })
+    ).toBe(false)
+  })
+})

--- a/src/modules/navigation/hooks/useFileLink.tsx
+++ b/src/modules/navigation/hooks/useFileLink.tsx
@@ -3,6 +3,7 @@ import { useLocation, useResolvedPath, useNavigate } from 'react-router-dom'
 import type { Path } from 'react-router-dom'
 
 import { useClient, generateWebLink } from 'cozy-client'
+import { useSharingContext } from 'cozy-sharing'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import type { File } from '@/components/FolderPicker/types'
@@ -28,6 +29,37 @@ export interface LinkResult {
 interface UseFileLinkResult {
   link: LinkResult
   openLink: (evt: React.MouseEvent<HTMLElement>) => void
+}
+
+interface SharingContextForFileLink {
+  isOwner?: (docId: string) => boolean
+  allLoaded?: boolean
+  byDocId?: Record<string, unknown>
+}
+
+const computeIsSharingsOwner = ({
+  file,
+  pathname,
+  isPublic,
+  sharingContext
+}: {
+  file: File
+  pathname: string
+  isPublic: boolean
+  sharingContext?: SharingContextForFileLink
+}): boolean => {
+  const isInSharings = pathname.startsWith('/sharings')
+  const isKnownSharedDoc = Boolean(
+    file._id && sharingContext?.byDocId?.[file._id]
+  )
+
+  return (
+    !isPublic &&
+    isInSharings &&
+    isKnownSharedDoc &&
+    Boolean(sharingContext?.allLoaded) &&
+    Boolean(sharingContext?.isOwner?.(file._id))
+  )
 }
 
 /**
@@ -57,6 +89,15 @@ const useFileLink = (
   const isOfficeEnabled = computeOfficeEnabled(isDesktop)
   const isExcalidrawEnabled = computeExcalidrawEnabled()
   const { isPublic } = usePublicContext()
+  const sharingContext = useSharingContext() as
+    | SharingContextForFileLink
+    | undefined
+  const isSharingsOwner = computeIsSharingsOwner({
+    file,
+    pathname,
+    isPublic,
+    sharingContext
+  })
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const cozyUrl = client?.getStackClient().uri as string
@@ -72,7 +113,8 @@ const useFileLink = (
     type,
     pathname,
     isPublic,
-    client
+    client,
+    isOwner: isSharingsOwner
   })
 
   const shouldBeOpenedInNewTab =
@@ -152,4 +194,4 @@ const useFileLink = (
   }
 }
 
-export { useFileLink }
+export { computeIsSharingsOwner, useFileLink }


### PR DESCRIPTION
## Why

Owned shares shown in `/sharings` should behave like regular Drive items:
folders should open their Drive folder view, and files should open the normal
Drive viewer instead of staying in the sharings section.

## How

- Detect owned shared documents in `useFileLink` through `useSharingContext`.
- Require the document to be present in `byDocId` before trusting `isOwner`.
- Pass the owner state to `computePath`.
- Route owned folders to `/folder/:folderId`.
- Route owned files to `/folder/:dirId/file/:fileId`.
- Keep recipient and non-owner paths unchanged.
- Extend `cozy-sharing` typings for `isOwner` and `byDocId`.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes

https://app.notion.com/p/linagora/Sharings-Own-folder-redirect-to-drive-38162718bad1803f83fce43c065b91d0