### PR TITLE
fix(shareddrives): hide leave sharing for owned shared drives

### DIFF
--- a/src/modules/shareddrives/components/actions/leaveSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/leaveSharedDrive.js
@@ -9,7 +9,13 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { isSharedDriveDoc } from '@/modules/shareddrives/helpers'
 
 // Only for sharing tabs
-export const leaveSharedDrive = ({ client, showAlert, t, canLeave }) => {
+export const leaveSharedDrive = ({
+  client,
+  showAlert,
+  t,
+  canLeave,
+  isOwner
+}) => {
   const label = t('toolbar.menu_leave_shared_drive')
   const icon = LogoutIcon
 
@@ -19,7 +25,10 @@ export const leaveSharedDrive = ({ client, showAlert, t, canLeave }) => {
     icon,
     displayCondition: docs => {
       return (
-        docs.length === 1 && isSharedDriveDoc(docs[0]) && canLeave(docs[0]._id)
+        docs.length === 1 &&
+        isSharedDriveDoc(docs[0]) &&
+        canLeave(docs[0]._id) &&
+        !isOwner(docs[0]._id)
       )
     },
     action: async docs => {

--- a/src/modules/shareddrives/components/actions/leaveSharedDrive.spec.js
+++ b/src/modules/shareddrives/components/actions/leaveSharedDrive.spec.js
@@ -1,0 +1,59 @@
+import { leaveSharedDrive } from './leaveSharedDrive'
+
+describe('leaveSharedDrive', () => {
+  const t = key => key
+  const client = {
+    collection: jest.fn(() => ({
+      revokeSelf: jest.fn().mockResolvedValue()
+    }))
+  }
+  const showAlert = jest.fn()
+
+  const makeAction = ({ canLeave = () => true, isOwner = () => false } = {}) =>
+    leaveSharedDrive({ client, showAlert, t, canLeave, isOwner })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('displayCondition', () => {
+    it.each`
+      label                                      | docs                                                          | canLeave       | isOwner        | expected
+      ${'recipient of folder-root shared drive'} | ${[{ _id: 'folder-id', driveId: 'drive-id' }]}                | ${() => true}  | ${() => false} | ${true}
+      ${'owner of folder-root shared drive'}     | ${[{ _id: 'folder-id', driveId: 'drive-id' }]}                | ${() => true}  | ${() => true}  | ${false}
+      ${'org shared drive (B2B) recipient'}      | ${[{ _id: 'folder-id', driveId: 'drive-id' }]}                | ${() => false} | ${() => false} | ${false}
+      ${'document outside shared drive'}         | ${[{ _id: 'file-id' }]}                                       | ${() => true}  | ${() => false} | ${false}
+      ${'multiple documents selected'}           | ${[{ _id: 'a', driveId: 'd1' }, { _id: 'b', driveId: 'd2' }]} | ${() => true}  | ${() => false} | ${false}
+    `(
+      'returns $expected for $label',
+      ({ docs, canLeave, isOwner, expected }) => {
+        const action = makeAction({ canLeave, isOwner })
+        expect(action.displayCondition(docs)).toBe(expected)
+      }
+    )
+
+    it('hides the action for the owner even when canLeave returns true', () => {
+      const action = makeAction({ canLeave: () => true, isOwner: () => true })
+      expect(
+        action.displayCondition([{ _id: 'folder-id', driveId: 'drive-id' }])
+      ).toBe(false)
+    })
+  })
+
+  describe('action', () => {
+    it('revokes self on the sharing matching the driveId and shows a success alert', async () => {
+      const revokeSelf = jest.fn().mockResolvedValue()
+      client.collection.mockReturnValueOnce({ revokeSelf })
+
+      const action = makeAction()
+      await action.action([{ _id: 'folder-id', driveId: 'drive-id' }])
+
+      expect(client.collection).toHaveBeenCalledWith('io.cozy.sharings')
+      expect(revokeSelf).toHaveBeenCalledWith({ _id: 'drive-id' })
+      expect(showAlert).toHaveBeenCalledWith({
+        message: 'Files.share.revokeSelf.success',
+        severity: 'success'
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What

- Hide the "Leave sharing" action in the sharings list when the current user owns the federated shared drive.

## Why

- `displayCondition` only filtered org shared drives (B2B) via `canLeave`. Owners of federated shared drives still saw the action, which does not apply to them.

## How

- Add `isOwner` to the `leaveSharedDrive` action factory options. It is already exposed by the sharing context and propagated through `buildSharingsActionsOptions`, so no wiring change is needed upstream.
- Extend `displayCondition` with `!isOwner(docs[0]._id)` alongside the existing `isSharedDriveDoc` and `canLeave` guards.
- Add a colocated `leaveSharedDrive.spec.js` covering owner, recipient, org drive, non-shared-drive, and multi-selection cases.

https://app.notion.com/p/linagora/Owner-Sharings-hide-action-38262718bad180fcb671dbc1b04cc014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Owners can no longer leave their own shared drives; the "leave shared drive" action is now hidden for drive owners.

* **Tests**
  * Added comprehensive test coverage for the "leave shared drive" functionality and visibility conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->