### PR TITLE
fix(sharings): deduplicate transient shared-drive entries

### DIFF
--- a/src/modules/views/Sharings/useFilteredSharings.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.jsx
@@ -11,18 +11,65 @@ const buildBaseShape = (result, hasIds) => ({
   lastFetch: hasIds ? result.lastFetch : Date.now()
 })
 
+const getDocId = item => item._id ?? item.id
+const isSharedDrivesDirItem = item => item.dir_id === SHARED_DRIVES_DIR_ID
+const shouldReplaceItem = (current, candidate) =>
+  isSharedDrivesDirItem(current) && !isSharedDrivesDirItem(candidate)
+
+/**
+ * Drops duplicate representations of the same file/folder.
+ *
+ * During transient sharing updates, the Sharings view can receive the same
+ * document twice: once as the real Drive entry and once as a transformed
+ * shared-drive entry. The transformed entry has `dir_id` set to the
+ * shared-drives magic directory, which renders as `/sharings` in the list.
+ * Keep the real Drive entry whenever it is available so the row path matches
+ * the stable state after a page reload.
+ */
+export const deduplicateSharingShortcuts = data => {
+  if (!data?.length) return data
+
+  const indexByDocId = new Map()
+  const deduplicatedData = []
+  let hasDuplicates = false
+
+  for (const item of data) {
+    const docId = getDocId(item)
+    if (!docId) {
+      deduplicatedData.push(item)
+      continue
+    }
+
+    const existingIndex = indexByDocId.get(docId)
+    if (existingIndex === undefined) {
+      indexByDocId.set(docId, deduplicatedData.length)
+      deduplicatedData.push(item)
+      continue
+    }
+
+    hasDuplicates = true
+    if (shouldReplaceItem(deduplicatedData[existingIndex], item)) {
+      deduplicatedData[existingIndex] = item
+    }
+  }
+
+  return hasDuplicates ? deduplicatedData : data
+}
+
 const computeData = ({
   result,
   withoutSharedDrives,
   transformedSharedDrives,
   nonSharedDriveList
 }) => {
+  let data
   if (withoutSharedDrives) {
-    return (
+    data =
       result.data?.filter(item => item.dir_id !== SHARED_DRIVES_DIR_ID) || []
-    )
+  } else {
+    data = [...transformedSharedDrives, ...nonSharedDriveList]
   }
-  return [...transformedSharedDrives, ...nonSharedDriveList]
+  return deduplicateSharingShortcuts(data)
 }
 
 /**
@@ -30,8 +77,9 @@ const computeData = ({
  *
  * Drops the magic shared-drives directory when shared-drive and federated
  * shared-folder flags are both off, otherwise merges transformed shared-drive
- * shortcuts into the result. Returns the combined `filteredResult` plus the
- * `sharedDrivesLoaded` flag the view uses to gate its placeholder.
+ * shortcuts into the result. Then drops transient duplicate representations of
+ * the same document, preferring the real Drive entry over the shared-drives
+ * synthetic entry.
  */
 export const useFilteredSharings = ({ result, sharedDocumentIds }) => {
   const isEnabledSharedDrive = flag('drive.shared-drive.enabled')

--- a/src/modules/views/Sharings/useFilteredSharings.spec.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.spec.jsx
@@ -1,0 +1,136 @@
+import { renderHook } from '@testing-library/react'
+
+import {
+  deduplicateSharingShortcuts,
+  useFilteredSharings
+} from './useFilteredSharings'
+
+jest.mock('cozy-sharing', () => ({
+  useSharingContext: jest.fn()
+}))
+
+jest.mock('cozy-flags', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+jest.mock('@/hooks/useTransformFolderListHasSharedDriveShortcuts', () => ({
+  useTransformFolderListHasSharedDriveShortcuts: jest.fn()
+}))
+
+const mockFlag = require('cozy-flags').default
+
+const mockUseTransform =
+  require('@/hooks/useTransformFolderListHasSharedDriveShortcuts').useTransformFolderListHasSharedDriveShortcuts
+
+const rootFolder = {
+  _id: 'folder-photos',
+  id: 'folder-photos',
+  name: 'Photos',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.root-dir',
+  path: '/Photos'
+}
+
+const sharedDrivesFolder = {
+  _id: 'folder-photos',
+  id: 'folder-photos',
+  name: 'Photos',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.shared-drives-dir',
+  path: '/Drives/Photos'
+}
+
+const anotherFolder = {
+  _id: 'folder-other',
+  id: 'folder-other',
+  name: 'Photos',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.root-dir',
+  path: '/Archives/Photos'
+}
+
+describe('deduplicateSharingShortcuts', () => {
+  it('returns the same list when data is empty', () => {
+    expect(deduplicateSharingShortcuts([])).toEqual([])
+  })
+
+  it('keeps regular entries when there is no duplicate document id', () => {
+    const data = [rootFolder, anotherFolder]
+
+    expect(deduplicateSharingShortcuts(data)).toBe(data)
+  })
+
+  it('deduplicates same-id transient entries by keeping the regular Drive entry', () => {
+    const result = deduplicateSharingShortcuts([sharedDrivesFolder, rootFolder])
+
+    expect(result).toEqual([rootFolder])
+  })
+
+  it('keeps the shared-drives entry when it is the only representation', () => {
+    expect(deduplicateSharingShortcuts([sharedDrivesFolder])).toEqual([
+      sharedDrivesFolder
+    ])
+  })
+})
+
+describe('useFilteredSharings', () => {
+  const setupMocks = ({ flags = {} } = {}) => {
+    mockFlag.mockImplementation(name => Boolean(flags[name]))
+    mockUseTransform.mockReturnValue({
+      sharedDrives: [],
+      nonSharedDriveList: [],
+      sharedDrivesLoaded: true
+    })
+  }
+
+  it('drops the transient shared-drives duplicate from the rendered list', () => {
+    setupMocks()
+
+    const data = [sharedDrivesFolder, rootFolder]
+    const result = { data, fetchStatus: 'loaded', lastFetch: Date.now() }
+
+    const { result: hook } = renderHook(() =>
+      useFilteredSharings({
+        result,
+        sharedDocumentIds: [rootFolder._id]
+      })
+    )
+
+    expect(hook.current.filteredResult.data).toEqual([rootFolder])
+    expect(hook.current.filteredResult.count).toBe(1)
+  })
+
+  it('deduplicates after merging transformed shared drives and non-shared-drive files', () => {
+    mockFlag.mockImplementation(name =>
+      [
+        'drive.shared-drive.enabled',
+        'drive.federated-shared-folder.enabled'
+      ].includes(name)
+    )
+    mockUseTransform.mockReturnValue({
+      sharedDrives: [sharedDrivesFolder],
+      nonSharedDriveList: [rootFolder],
+      sharedDrivesLoaded: true
+    })
+
+    const result = {
+      data: [rootFolder],
+      fetchStatus: 'loaded',
+      lastFetch: Date.now()
+    }
+
+    const { result: hook } = renderHook(() =>
+      useFilteredSharings({
+        result,
+        sharedDocumentIds: [rootFolder._id]
+      })
+    )
+
+    expect(hook.current.filteredResult.data).toEqual([rootFolder])
+    expect(hook.current.filteredResult.count).toBe(1)
+  })
+})


### PR DESCRIPTION
When a folder is shared from Sharings, the view can briefly receive that same file twice: the real Drive entry and a transformed shared-drive entry. The transformed entry uses the shared-drives magic directory, which is rendered as /sharings in the file path column.

Deduplicate by document id after merging the query result with transformed shared-drive entries, and prefer the real Drive entry when both representations are present.

https://app.notion.com/p/linagora/Folders-doubling-in-sherings-38262718bad180a4ac3de913943d4707?source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate sharing entries that appeared during sharing updates. The system now automatically removes redundant entries and prioritizes the primary Drive representation when duplicates occur.

* **Tests**
  * Added comprehensive test coverage for sharing deduplication functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->