### PR TITLE
test(e2e): Cover viewer inherited sharing access

### DIFF
--- a/e2e/pages/FileViewerPage.ts
+++ b/e2e/pages/FileViewerPage.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test'
 
+import { expect } from '../helpers/fixtures'
+
 export class FileViewerPage {
   private readonly page: Page
 
@@ -10,6 +12,16 @@ export class FileViewerPage {
   /** The viewer route always contains `/file/<id>` in the URL fragment. */
   async waitForOpen(): Promise<void> {
     await this.page.waitForURL(/\/file\/[^/]+/, { timeout: 10_000 })
+  }
+
+  async expectWhoHasAccessWith(members: (string | RegExp)[]): Promise<void> {
+    await expect(
+      this.page.getByText('Who has access?', { exact: true })
+    ).toBeVisible()
+
+    for (const member of members) {
+      await expect(this.page.getByText(member).first()).toBeVisible()
+    }
   }
 
   /** Closes the viewer by navigating back, then waits for the file route to drop. */

--- a/e2e/tests/z-viewer-sharing-access.spec.ts
+++ b/e2e/tests/z-viewer-sharing-access.spec.ts
@@ -1,0 +1,54 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { test, stamp, safeUnlink } from '../helpers/fixtures'
+import {
+  createAndShareFolderWithBob,
+  openOwnerFolder,
+  waitForSharingRow
+} from '../helpers/sharing'
+import { FileViewerPage } from '../pages/FileViewerPage'
+
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+
+const DRIVE_NAME = `ViewerAccess-${stamp()}`
+const SUBFOLDER = `ViewerAccessSub-${stamp()}`
+const FILE_NAME = `viewer-access-${stamp()}.txt`
+
+test.describe('Viewer sharing access panel', () => {
+  test('shows shared folder members for a file inside a subfolder', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    const filePath = path.join(FIXTURE_DIR, FILE_NAME)
+    await copyFile(SAMPLE, filePath)
+
+    try {
+      await createAndShareFolderWithBob(alicePage, aliceDrive, DRIVE_NAME, {
+        seed: async () => {
+          await aliceDrive.createFolder(SUBFOLDER)
+          await aliceDrive.row(SUBFOLDER).open()
+          await alicePage.waitForURL(/\/folder\/[^/]+$/)
+          await aliceDrive.uploadFiles(filePath)
+          await aliceDrive.row(FILE_NAME).waitVisible()
+          await alicePage.goBack()
+          await aliceDrive.row(SUBFOLDER).waitVisible()
+        }
+      })
+    } finally {
+      await safeUnlink(filePath)
+    }
+
+    await waitForSharingRow(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+    await openOwnerFolder(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+    await aliceDrive.row(SUBFOLDER).open()
+    await aliceDrive.row(FILE_NAME).waitVisible({ timeout: 10_000 })
+    await aliceDrive.row(FILE_NAME).open()
+
+    const viewer = new FileViewerPage(alicePage)
+    await viewer.waitForOpen()
+    await viewer.expectWhoHasAccessWith(['You', /bob/i])
+  })
+})


### PR DESCRIPTION
Add a Playwright e2e test that opens a file inside a federated shared folder and checks that the viewer access panel lists the inherited sharing members.

Needs next cozy-viewer with https://github.com/linagora/cozy-libs/pull/3040 to work 

https://app.notion.com/p/linagora/Who-has-access-seciton-in-viewer-is-wrong-36862718bad1807b9145c6714ab3f0ba?source=copy_link