### PR TITLE
fix: report a failed dataproxy recents query instead of hiding it

### DIFF
--- a/src/hooks/useRecentFiles.jsx
+++ b/src/hooks/useRecentFiles.jsx
@@ -27,7 +27,7 @@ const useDataProxyRecents = () => {
           setFetchStatus('loaded')
           return
         } catch (err) {
-          logger.warn('Error fetching recents from dataproxy', err)
+          logger.error('Error fetching recents from dataproxy', err)
         }
       }
 

--- a/src/hooks/useRecentFiles.spec.jsx
+++ b/src/hooks/useRecentFiles.spec.jsx
@@ -17,7 +17,8 @@ jest.mock('cozy-dataproxy-lib', () => ({
 }))
 
 jest.mock('@/lib/logger', () => ({
-  warn: jest.fn()
+  warn: jest.fn(),
+  error: jest.fn()
 }))
 
 jest.mock('@/queries', () => ({
@@ -66,7 +67,7 @@ describe('useDataProxyRecents', () => {
       expect(result.current.error).toBe(null)
       expect(mockDataProxy.recents).toHaveBeenCalledTimes(1)
       expect(mockClient.fetchQueryAndGetFromState).not.toHaveBeenCalled()
-      expect(logger.warn).not.toHaveBeenCalled()
+      expect(logger.error).not.toHaveBeenCalled()
     })
   })
 
@@ -96,7 +97,7 @@ describe('useDataProxyRecents', () => {
       await waitFor(() => expect(result.current.fetchStatus).toBe('loaded'))
       expect(result.current.data).toEqual(fallbackData)
       expect(result.current.error).toBe(null)
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         'Error fetching recents from dataproxy',
         mockError
       )
@@ -123,7 +124,7 @@ describe('useDataProxyRecents', () => {
       // Wait for fallback query error to be processed
       await waitFor(() => expect(result.current.fetchStatus).toBe('error'))
       expect(result.current.error).toEqual(fallbackError)
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         'Error fetching recents from dataproxy',
         mockError
       )


### PR DESCRIPTION
## Problem

When the dataproxy recents query fails, the error was logged at `warn` and swallowed, so it never reached Sentry and we had no visibility into it (the view silently falls back to the local query).

## Solution

Log the failure with `logger.error`, which the app's Sentry config records, while keeping the local-query fallback. Matches how the rest of the app reports errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging severity for recents synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->