### PR TITLE
fix(build): keep main entry html at the bundle root

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -50,7 +50,7 @@
       "path": "services/qualificationMigration.js"
     },
     {
-      "path": "main/index.html"
+      "path": "index.html"
     },
     {
       "path": "public/index.html"

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -44,7 +44,7 @@
   "langs": ["en", "fr"],
   "routes": {
     "/": {
-      "folder": "/main",
+      "folder": "/",
       "index": "index.html",
       "public": false
     },

--- a/rsbuild.config.mjs
+++ b/rsbuild.config.mjs
@@ -17,8 +17,10 @@ const config = getRsbuildConfig({
 //
 // All hashed assets stay in build/static and are served by the `/static`
 // route, declared `public: true` in manifest.webapp so the public (shared
-// link) pages can load them without auth. Each entry keeps its own HTML file
-// ([name]/index.html); the `/` route points to the /main folder.
+// link) pages can load them without auth. The main entry's HTML stays at the
+// bundle root (build/index.html, see tools.htmlPlugin) so the `/` route serves
+// it and the native app can load it directly; public/intents keep their own
+// [name]/index.html.
 const { main, public: publicEnv, intents, services } = config.environments
 
 const templates = {
@@ -78,6 +80,14 @@ config.environments = {
       ]
     },
     tools: {
+      // One environment emits every entry's HTML as `[name]/index.html`, which
+      // would put the main app at /main/index.html. The native (flagship) app
+      // loads the bundle's root index.html directly, so the main entry must stay
+      // at build/index.html; the other entries keep their per-name folder.
+      htmlPlugin(htmlConfig, { entryName }) {
+        htmlConfig.filename =
+          entryName === 'main' ? 'index.html' : `${entryName}/index.html`
+      },
       rspack: {
         output: {
           // Asset modules without a dedicated rsbuild rule (e.g. the pdf.js


### PR DESCRIPTION
## Context
The single-compilation build (shared assets across targets) emits every entry as `[name]/index.html`, so the main app landed at `/main/index.html` and the `/` route pointed there. The native app loads the bundle's root `index.html` directly, so it 404s on the entry page.

## Solution
Emit the main entry at `build/index.html` (public and intents keep their per-name folder) and point the `/` route back to the root. The shared `/static` assets and the rest of the single-compilation build are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment configuration to serve the application from the root path instead of a subdirectory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->