### PR TITLE
fix(pdf): serve embedpdf runtime assets from same origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,12 @@
     "worker-loader": "2.0.0"
   },
   "dependencies": {
+    "@embedpdf/default-stamps": "0.0.1",
+    "@embedpdf/fonts-arabic": "1.0.0",
+    "@embedpdf/fonts-hebrew": "1.0.0",
+    "@embedpdf/fonts-latin": "1.0.0",
+    "@embedpdf/models": "2.14.3",
+    "@embedpdf/pdfium": "2.14.3",
     "@embedpdf/react-pdf-viewer": "2.14.3",
     "@excalidraw/excalidraw": "0.18.1",
     "@sentry/react": "7.119.0",

--- a/rsbuild.config.mjs
+++ b/rsbuild.config.mjs
@@ -76,6 +76,53 @@ config.environments = {
           to: 'static/fonts',
           globOptions: { ignore: ['**/Xiaolai/**'] },
           info: { minimized: true }
+        },
+        // Self-host the EmbedPDF (PDF editor) runtime assets. The library
+        // otherwise fetches them from jsDelivr, which our CSP blocks. Everything
+        // lands under static/ (the public route) and is wired up in
+        // src/modules/views/Pdf/pdfAssets.js. `info.minimized` stops rspack from
+        // re-processing these prebuilt binaries.
+        //
+        // 1. The Pdfium wasm engine.
+        {
+          from: 'node_modules/@embedpdf/pdfium/dist/pdfium.wasm',
+          to: 'static/pdfium.wasm',
+          info: { minimized: true }
+        },
+        // 2. The default stamp library (manifest.json + stamps.pdf per locale).
+        {
+          from: 'node_modules/@embedpdf/default-stamps',
+          to: 'static/embedpdf-stamps',
+          globOptions: { ignore: ['**/package.json', '**/LICENSE'] },
+          info: { minimized: true }
+        },
+        // 3. Glyph-fallback fonts. Only Latin (covers Cyrillic/Greek/Vietnamese),
+        // Arabic and Hebrew are shipped; the ~140 MB CJK packages are omitted
+        // (see pdfAssets.js). Fonts are fetched lazily, only when a PDF needs them.
+        //
+        // For Latin we ship only Regular (400) and Bold (700): the full Noto Sans
+        // family is 18 files / ~5 MB gzipped, which would blow the 20 MB registry
+        // budget, and fallback rendering does not need the extra weights/italics.
+        // pdfAssets.js maps exactly these two files.
+        {
+          from: 'node_modules/@embedpdf/fonts-latin/fonts/NotoSans-Regular.ttf',
+          to: 'static/embedpdf-fonts/latin/NotoSans-Regular.ttf',
+          info: { minimized: true }
+        },
+        {
+          from: 'node_modules/@embedpdf/fonts-latin/fonts/NotoSans-Bold.ttf',
+          to: 'static/embedpdf-fonts/latin/NotoSans-Bold.ttf',
+          info: { minimized: true }
+        },
+        {
+          from: 'node_modules/@embedpdf/fonts-arabic/fonts',
+          to: 'static/embedpdf-fonts/arabic',
+          info: { minimized: true }
+        },
+        {
+          from: 'node_modules/@embedpdf/fonts-hebrew/fonts',
+          to: 'static/embedpdf-fonts/hebrew',
+          info: { minimized: true }
         }
       ]
     },
@@ -95,7 +142,31 @@ config.environments = {
           // at the build root, which only the private `/` route serves. Keep
           // them under static/ so the public route covers them too.
           assetModuleFilename: 'static/resource/[hash][ext][query]'
-        }
+        },
+        plugins: [
+          {
+            // @embedpdf/pdfium references its wasm with
+            // `new URL('pdfium.wasm', import.meta.url)`, which rspack bundles as
+            // a second ~4.6 MB (2 MB gzipped) copy under static/wasm/*.module.wasm
+            // (an asyncWebAssembly asset a module rule can't override). We serve
+            // the wasm ourselves (config.wasmUrl -> /static/pdfium.wasm, see
+            // pdfAssets.js) and the engine never falls back to the bundled copy,
+            // so it is dead weight. Drop it before emit to stay under the 20 MB
+            // registry size limit.
+            apply(compiler) {
+              compiler.hooks.emit.tap(
+                'drop-bundled-pdfium-wasm',
+                compilation => {
+                  for (const name of Object.keys(compilation.assets)) {
+                    if (/static[\\/]wasm[\\/].*\.module\.wasm$/.test(name)) {
+                      delete compilation.assets[name]
+                    }
+                  }
+                }
+              )
+            }
+          }
+        ]
       }
     }
   },

--- a/src/modules/views/Pdf/PdfEditor.jsx
+++ b/src/modules/views/Pdf/PdfEditor.jsx
@@ -3,6 +3,12 @@ import React, { useEffect } from 'react'
 
 import Oops from '@/components/Error/Oops'
 import Loader from '@/components/Loader'
+import {
+  PDFIUM_WASM_URL,
+  STAMP_MANIFESTS,
+  FONT_FALLBACK,
+  SNIPPET_FONTS
+} from '@/modules/views/Pdf/pdfAssets'
 import { usePdfDocument } from '@/modules/views/Pdf/usePdfDocument'
 
 const PdfEditor = ({ file, flushRef, isReadOnly = false, author }) => {
@@ -35,6 +41,12 @@ const PdfEditor = ({ file, flushRef, isReadOnly = false, author }) => {
       <PDFViewer
         config={{
           src: url,
+          // Serve every EmbedPDF runtime asset from our own origin instead of
+          // jsDelivr (blocked by the production CSP). See pdfAssets.js.
+          wasmUrl: PDFIUM_WASM_URL,
+          stamp: { manifests: STAMP_MANIFESTS },
+          fontFallback: FONT_FALLBACK,
+          fonts: SNIPPET_FONTS,
           // The file lifecycle is owned by Twake Drive (the Save button and back
           // navigation), so opening or closing another document from inside the
           // editor makes no sense. Disable only those two entries of EmbedPDF's

--- a/src/modules/views/Pdf/pdfAssets.js
+++ b/src/modules/views/Pdf/pdfAssets.js
@@ -1,0 +1,68 @@
+// EmbedPDF fetches several assets from the jsDelivr CDN at runtime (the Pdfium
+// wasm, the default stamp library, glyph-fallback fonts and the UI/signature
+// webfonts). Our production CSP forbids connecting to external origins, so we
+// self-host everything and point EmbedPDF at same-origin paths.
+//
+// The files are copied into build/static by rsbuild (see rsbuild.config.mjs),
+// exactly like the Excalidraw fonts. The /static route is declared public in
+// manifest.webapp, so these resolve for both the logged-in app and the public
+// (shared link) pages.
+import { fonts as arabicFonts } from '@embedpdf/fonts-arabic'
+import { fonts as hebrewFonts } from '@embedpdf/fonts-hebrew'
+import { fonts as latinFonts } from '@embedpdf/fonts-latin'
+import { FontCharset } from '@embedpdf/models'
+
+const STATIC_BASE = '/static'
+
+// Custom URL for the Pdfium wasm (default: jsDelivr). Passed as config.wasmUrl.
+export const PDFIUM_WASM_URL = `${STATIC_BASE}/pdfium.wasm`
+
+// Self-hosted default stamp library. `{locale}` is resolved by the stamp plugin
+// against the current i18n locale and falls back to `en`, matching the upstream
+// CDN behavior. Passed as config.stamp.manifests.
+export const STAMP_MANIFESTS = [
+  {
+    url: `${STATIC_BASE}/embedpdf-stamps/{locale}/manifest.json`,
+    fallbackLocale: 'en'
+  }
+]
+
+const toVariants = (fonts, dir) =>
+  fonts.map(f => ({
+    url: `${STATIC_BASE}/embedpdf-fonts/${dir}/${f.file}`,
+    weight: f.weight,
+    italic: f.italic
+  }))
+
+// We only ship Regular (400) and Bold (700) of the Latin family to stay within
+// the registry size budget (the full Noto Sans family is ~5 MB gzipped). rsbuild
+// copies exactly these two files, so the fallback map must reference only them.
+const latinFallbackFonts = latinFonts.filter(
+  f => !f.italic && (f.weight === 400 || f.weight === 700)
+)
+
+// Glyph fallback used by Pdfium when a PDF embeds no font for a given script.
+// We ship Latin (which also covers Cyrillic/Greek/Vietnamese), Arabic and
+// Hebrew (~11 MB total, fetched lazily and only when actually needed). The CJK
+// packages (~140 MB) are intentionally omitted: those charsets simply have no
+// fallback entry, so Pdfium never requests them and no external call is made.
+// To add CJK later, ship @embedpdf/fonts-{jp,kr,sc,tc} the same way and map the
+// SHIFTJIS / HANGEUL / GB2312 / CHINESEBIG5 charsets here.
+export const FONT_FALLBACK = {
+  fonts: {
+    [FontCharset.CYRILLIC]: toVariants(latinFallbackFonts, 'latin'),
+    [FontCharset.GREEK]: toVariants(latinFallbackFonts, 'latin'),
+    [FontCharset.VIETNAMESE]: toVariants(latinFallbackFonts, 'latin'),
+    [FontCharset.ARABIC]: toVariants(arabicFonts, 'arabic'),
+    [FontCharset.HEBREW]: toVariants(hebrewFonts, 'hebrew')
+  }
+}
+
+// The snippet UI font (Open Sans) and the signature modal's cursive fonts load
+// from Google Fonts by default. `null` skips the <link> entirely and falls back
+// to the system font stack, keeping every request same-origin. Passed as
+// config.fonts.
+export const SNIPPET_FONTS = {
+  ui: null,
+  signature: null
+}

--- a/src/modules/views/Pdf/pdfAssets.js
+++ b/src/modules/views/Pdf/pdfAssets.js
@@ -12,7 +12,14 @@ import { fonts as hebrewFonts } from '@embedpdf/fonts-hebrew'
 import { fonts as latinFonts } from '@embedpdf/fonts-latin'
 import { FontCharset } from '@embedpdf/models'
 
-const STATIC_BASE = '/static'
+// Absolute base URL for the self-hosted assets. The Pdfium engine and the glyph
+// fallback run inside a `blob:` Web Worker whose base URL is the blob itself, so
+// a root-relative path like `/static/...` cannot be resolved there ("Failed to
+// parse URL"). Anchoring to `window.location.origin` keeps the URLs valid in the
+// worker as well as on the main thread. The /static route lives on the app's own
+// origin in both the logged-in and public (shared link) cases.
+const ORIGIN = typeof window !== 'undefined' ? window.location.origin : ''
+const STATIC_BASE = `${ORIGIN}/static`
 
 // Custom URL for the Pdfium wasm (default: jsDelivr). Passed as config.wasmUrl.
 export const PDFIUM_WASM_URL = `${STATIC_BASE}/pdfium.wasm`

--- a/src/modules/views/Pdf/pdfAssets.spec.js
+++ b/src/modules/views/Pdf/pdfAssets.spec.js
@@ -1,0 +1,56 @@
+// The @embedpdf font/model packages ship as ESM and are excluded from the jest
+// transform (see transformIgnorePatterns), so we mock them with the minimal
+// shape pdfAssets.js needs.
+jest.mock('@embedpdf/fonts-latin', () => ({
+  fonts: [
+    { file: 'NotoSans-Regular.ttf', weight: 400 },
+    { file: 'NotoSans-Bold.ttf', weight: 700 },
+    { file: 'NotoSans-Italic.ttf', weight: 400, italic: true }
+  ]
+}))
+jest.mock('@embedpdf/fonts-arabic', () => ({
+  fonts: [{ file: 'NotoNaskhArabic-Regular.ttf', weight: 400 }]
+}))
+jest.mock('@embedpdf/fonts-hebrew', () => ({
+  fonts: [{ file: 'NotoSansHebrew-Regular.ttf', weight: 400 }]
+}))
+jest.mock('@embedpdf/models', () => ({
+  FontCharset: {
+    CYRILLIC: 204,
+    GREEK: 161,
+    VIETNAMESE: 163,
+    ARABIC: 178,
+    HEBREW: 177
+  }
+}))
+
+const {
+  PDFIUM_WASM_URL,
+  STAMP_MANIFESTS,
+  FONT_FALLBACK
+} = require('@/modules/views/Pdf/pdfAssets')
+
+// The Pdfium engine and glyph fallback fetch these URLs from inside a blob: Web
+// Worker, where root-relative paths cannot be resolved. Every asset URL must be
+// absolute (anchored to the page origin), otherwise the editor hangs forever on
+// "Initializing plugins". jsdom serves the test page from http://cozy.localhost:8080.
+const isAbsolute = url => /^https?:\/\//.test(url)
+
+describe('pdfAssets', () => {
+  it('exposes an absolute Pdfium wasm URL', () => {
+    expect(isAbsolute(PDFIUM_WASM_URL)).toBe(true)
+    expect(PDFIUM_WASM_URL).toBe(`${window.location.origin}/static/pdfium.wasm`)
+  })
+
+  it('exposes an absolute stamp manifest URL', () => {
+    expect(isAbsolute(STAMP_MANIFESTS[0].url)).toBe(true)
+  })
+
+  it('exposes absolute glyph-fallback font URLs', () => {
+    const urls = Object.values(FONT_FALLBACK.fonts)
+      .flat()
+      .map(variant => variant.url)
+    expect(urls.length).toBeGreaterThan(0)
+    urls.forEach(url => expect(isAbsolute(url)).toBe(true))
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,6 +2000,11 @@
     "@embedpdf/engines" "2.14.3"
     "@embedpdf/models" "2.14.3"
 
+"@embedpdf/default-stamps@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/default-stamps/-/default-stamps-0.0.1.tgz#bb9309e49a134bfa39091126e4fe90bdb6762f0a"
+  integrity sha512-qNIhYQlbWRZ0W9XMNYaRWGTTTlO/HtrcHvNJDyoPp4Gxf6qVSHTMY9JCdHCyoW6aUP2tp2/wteh5wgJoO4t+nw==
+
 "@embedpdf/engines@2.14.3":
   version "2.14.3"
   resolved "https://registry.yarnpkg.com/@embedpdf/engines/-/engines-2.14.3.tgz#1d9e93fd0065fe16f11a52cb8925f1dcad50716d"
@@ -17479,7 +17484,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17505,15 +17510,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -17673,7 +17669,7 @@ stringify-clone@^1.0.0:
   resolved "https://registry.yarnpkg.com/stringify-clone/-/stringify-clone-1.1.1.tgz#309a235fb4ecfccd7d388dbe18ba904facaf433b"
   integrity sha512-LIFpvBnQJF3ZGoV770s3feH+wRVCMRSisI8fl1E57WfgKOZKUMaC1r4eJXybwGgXZ/iTTJoK/tsOku1GLPyyxQ==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -17693,13 +17689,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -19184,7 +19173,7 @@ worker-loader@2.0.0:
     loader-utils "^1.0.0"
     schema-utils "^0.4.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19200,15 +19189,6 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
## Summary

- Copy the Pdfium wasm, the default stamp library and the glyph-fallback fonts into `build/static` and point the PDF editor at those same-origin paths, so they no longer load from jsDelivr (blocked by the CSP).
- Disable the EmbedPDF Google Fonts UI and signature webfonts, falling back to the system font stack.
- Ship only Latin Regular/Bold fallback fonts and drop the duplicate Pdfium wasm rspack emits, keeping the build tarball under the 20 MB registry limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the PDF editor to self-host PDF runtime assets (including PDFium WASM and stamp manifests) from the app origin for smoother, more reliable loading.
  * Added configurable font fallback/snippet font behavior and improved multilingual font support (notably Arabic and Hebrew).
* **Tests**
  * Added automated Jest coverage to verify generated asset URLs and runtime configuration.
* **Chores**
  * Updated project dependencies to include required EmbedPDF runtime packages and assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->