### PR TITLE
feat(grist): open and create grist documents as drive files

### DIFF
--- a/src/assets/icons/icon-grist.svg
+++ b/src/assets/icons/icon-grist.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="6" fill="#fff" />
+  <rect x="6" y="6" width="20" height="20" rx="2" fill="#16B378" />
+  <path
+    fill="#fff"
+    d="M9 12h14v2H9zM9 16h14v2H9zM9 20h14v2H9zM13 9h2v14h-2z"
+    opacity="0.9"
+  />
+</svg>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,6 +58,7 @@
     "menu_create_note": "Note",
     "menu_create_docs": "Docs",
     "menu_create_excalidraw": "Excalidraw",
+    "menu_create_grist": "Grist",
     "menu_create_shortcut": "Shortcut",
     "share": "Share",
     "trash": "Remove",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -58,6 +58,7 @@
     "menu_create_note": "Note",
     "menu_create_docs": "Docs",
     "menu_create_excalidraw": "Excalidraw",
+    "menu_create_grist": "Grist",
     "menu_create_shortcut": "Raccourci",
     "share": "Partager",
     "trash": "Supprimer",

--- a/src/modules/drive/Toolbar/components/CreateDocumentItems.jsx
+++ b/src/modules/drive/Toolbar/components/CreateDocumentItems.jsx
@@ -5,6 +5,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import CreateDocsItem from '@/modules/drive/Toolbar/components/CreateDocsItem'
 import CreateExcalidrawItem from '@/modules/drive/Toolbar/components/CreateExcalidrawItem'
+import CreateGristItem from '@/modules/drive/Toolbar/components/CreateGristItem'
 import CreateNoteItem from '@/modules/drive/Toolbar/components/CreateNoteItem'
 import CreateOnlyOfficeItem from '@/modules/drive/Toolbar/components/CreateOnlyOfficeItem'
 import { isOfficeEditingEnabled } from '@/modules/views/OnlyOffice/helpers'
@@ -38,6 +39,13 @@ const CreateDocumentItems = ({
       )}
       {flag('drive.excalidraw.enabled') && (!isPublic || canUpload) && (
         <CreateExcalidrawItem isReadOnly={isReadOnly} onClick={onClick} />
+      )}
+      {!isPublic && flag('drive.grist.enabled') && (
+        <CreateGristItem
+          displayedFolder={displayedFolder}
+          isReadOnly={isReadOnly}
+          onClick={onClick}
+        />
       )}
       {canUpload && isOfficeEditingEnabled(isDesktop) && (
         <>

--- a/src/modules/drive/Toolbar/components/CreateGristItem.jsx
+++ b/src/modules/drive/Toolbar/components/CreateGristItem.jsx
@@ -1,0 +1,60 @@
+import get from 'lodash/get'
+import React from 'react'
+
+import { useClient, generateWebLink, useCapabilities } from 'cozy-client'
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+import { useI18n } from 'twake-i18n'
+
+import IconGrist from '@/assets/icons/icon-grist.svg'
+import { displayedFolderOrRootFolder } from '@/hooks/helpers'
+
+const CreateGristItem = ({ displayedFolder, isReadOnly, onClick }) => {
+  const client = useClient()
+  const { t } = useI18n()
+
+  const { capabilities } = useCapabilities(client)
+  const isFlatDomain = get(capabilities, 'flat_subdomains')
+  const { showAlert } = useAlert()
+
+  const _displayedFolder = displayedFolderOrRootFolder(displayedFolder)
+
+  const handleClick = async () => {
+    if (isReadOnly) {
+      showAlert({
+        message: t(
+          'AddMenu.readOnlyFolder',
+          'This is a read-only folder. You cannot perform this action.'
+        ),
+        severity: 'warning',
+        duration: 4000
+      })
+      onClick()
+      return
+    }
+
+    const url = generateWebLink({
+      slug: 'grist',
+      cozyUrl: client.getStackClient().uri,
+      subDomainType: isFlatDomain ? 'flat' : 'nested',
+      pathname: '',
+      hash: `/bridge/grist/new/${_displayedFolder._id}`
+    })
+
+    window.location.href = url
+  }
+
+  return (
+    <ActionsMenuItem onClick={handleClick}>
+      <ListItemIcon>
+        <Icon icon={IconGrist} />
+      </ListItemIcon>
+      <ListItemText primary={t('toolbar.menu_create_grist')} />
+    </ActionsMenuItem>
+  )
+}
+
+export default CreateGristItem

--- a/src/modules/grist/helpers.js
+++ b/src/modules/grist/helpers.js
@@ -1,0 +1,13 @@
+export const GRIST_EXTENSION = 'grist'
+
+/**
+ * Checks whether a file is a Grist document handle, based on its extension and
+ * the Grist doc id kept in its metadata.
+ *
+ * @param {object} file - An io.cozy.files document
+ * @returns {boolean}
+ */
+export const isGrist = file =>
+  Boolean(
+    file?.name?.endsWith(`.${GRIST_EXTENSION}`) && file?.metadata?.externalId
+  )

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -11,6 +11,7 @@ import { IOCozyFile } from 'cozy-client/types/types'
 import type { File } from '@/components/FolderPicker/types'
 import { TRASH_DIR_ID, SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { joinPath } from '@/lib/path'
+import { isGrist } from '@/modules/grist/helpers'
 import {
   isNextcloudShortcut,
   isNextcloudFile
@@ -82,6 +83,8 @@ export const computeFileType = (
     }
   } else if (isDocs(file)) {
     return 'docs'
+  } else if (isGrist(file)) {
+    return 'grist'
   } else if (isExcalidraw(file) && isExcalidrawEnabled) {
     return 'excalidraw'
   } else if (isResolvableFileRootSharedDriveShortcut(file)) {
@@ -138,6 +141,8 @@ export const computeApp = (type: string): string => {
       return 'notes'
     case 'docs':
       return 'docs'
+    case 'grist':
+      return 'grist'
     default:
       return 'drive'
   }
@@ -193,6 +198,8 @@ export const computePath = (
       }
     case 'docs':
       return `/bridge/docs/${(file as IOCozyFile).metadata.externalId}`
+    case 'grist':
+      return `/bridge/grist/${(file as IOCozyFile).metadata.externalId}`
     case 'shortcut':
       return `/external/${file._id}`
     case 'directory':


### PR DESCRIPTION
## Summary

- Dispatch `.grist` files (real `io.cozy.files` with the Grist doc id in `metadata.externalId`) to the `grist` coquille, mirroring the Docs integration: `computeFileType` returns `grist`, `computeApp` maps it to the `grist` slug, `computePath` builds `/bridge/grist/<externalId>`.
- Add a `drive.grist.enabled` flag-gated "Grist" entry to the create menu, pointing to the coquille's `/bridge/grist/new/<folderId>` route.
- Add `isGrist` helper, the `icon-grist.svg` asset and the `menu_create_grist` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now create new Grist documents directly from the toolbar create menu when the feature is enabled, with controls preventing creation in read-only folders
  * Added comprehensive recognition and routing support for Grist document types throughout the application
  * Extended localization support with English and French translations for all Grist-related menu items and UI elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->