### PR TITLE
fix(sharings): keep the path label from clipping under a short name

### DIFF
--- a/src/modules/filelist/virtualized/cells/FileName.jsx
+++ b/src/modules/filelist/virtualized/cells/FileName.jsx
@@ -78,7 +78,10 @@ const FileName = ({
   }
 
   return (
-    <span title={infected ? t('antivirus.infectedFile') : title}>
+    <span
+      className={hidePath ? undefined : styles['fil-file-name-with-path']}
+      title={infected ? t('antivirus.infectedFile') : title}
+    >
       <Filename
         icon={
           <FileThumbnailComponent

--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -378,6 +378,10 @@ column-width-thumbnail-bigger = 7rem
 .fil-file-infos
     display none
 
+// Fill the name cell so the path label is not clipped under a short name.
+.fil-file-name-with-path
+    width 100%
+
 .fil-file-shared
     color var(--actionColorActive)
     font-size .75rem


### PR DESCRIPTION
## Problem
In the sharings list, the `/sharings` link shown under a shared drive's name gets clipped when the name is shorter than the link text (a one-letter share showed `/s` instead of `/sharings`). cozy-ui's `Filename` stacks the name and the path label in a column that shrinks to the name's width, so a path wider than a short name is cut off.

## Solution
Let that column fill the name cell when a path is shown, so the path label uses the available width instead of being capped to the name. Long paths still truncate at the cell edge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file list display to prevent path information from being clipped when displaying filenames alongside paths. The filename cell now properly utilizes available space to ensure all information remains visible without truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->