### PR TITLE
fix: Forget owner-only shared drive sharings

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
-    "cozy-sharing": "^33.6.0",
+    "cozy-sharing": "^33.6.1",
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,10 +8200,10 @@ cozy-search@^0.25.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^33.6.0:
-  version "33.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.6.0.tgz#691b98c8f504c8f4b8b580cc87a2a2a222bd03d1"
-  integrity sha512-r4maSQfaZb7G99QalWJ5GC1jd0wkw5WWKn/vyhCije2fhu8MEBDEB3kDdHs0YtoD9Z2DMRCW/ToO4h1Uj978dw==
+cozy-sharing@^33.6.1:
+  version "33.6.1"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-33.6.1.tgz#75bd43b63afc57a05bb6930918d86ebefb60ccae"
+  integrity sha512-dzXx5WAvnsx+nqwkcdTILQm2OYu9O0DCCTGipWjfRXluQmX55gTi/WjmdIemTUOT9HLCT9U8cE8Y81GDoNhSyA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
## Summary

  Fix stale shared-drive sharing state after the last recipient/group is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest patch version for stability and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->