### PR TITLE
fix: open recipient shared-drive files from recents via the proxy

### DIFF
--- a/e2e/tests/z-shared-drive-open-file.spec.ts
+++ b/e2e/tests/z-shared-drive-open-file.spec.ts
@@ -1,0 +1,87 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import {
+  test,
+  expect,
+  stamp,
+  safeUnlink,
+  escapeRegExp
+} from '../helpers/fixtures'
+import {
+  createAndShareFolderWithBob,
+  openSharedDrive
+} from '../helpers/sharing'
+import { FileViewerPage } from '../pages/FileViewerPage'
+
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+
+// Shared across .serial tests — names lead with a stable, short token because
+// the breadcrumb truncates the tail.
+const DRIVE_PREFIX = 'OpenFileDrive'
+const DRIVE_NAME = `${DRIVE_PREFIX}-${stamp()}`
+const FILE_NAME = `open-file-${stamp()}.txt`
+
+// A recipient has no local copy of a shared-drive file: its document lives on
+// the owner's instance and is reached through the /sharings/drives proxy. The
+// regression this guards (DRIVE recents/search routing) made the recipient open
+// the file via the local /files/:id route, which 404s. Opening it here proves
+// the recipient path resolves to the proxied /shareddrive viewer and the
+// content is fetched through the drive proxy, not the local files API.
+test.describe.serial('Shared drive file open (recipient)', () => {
+  test('Alice shares a folder containing a file', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    const filePath = path.join(FIXTURE_DIR, FILE_NAME)
+    await copyFile(SAMPLE, filePath)
+    try {
+      await createAndShareFolderWithBob(alicePage, aliceDrive, DRIVE_NAME, {
+        seed: async () => {
+          await aliceDrive.uploadFiles(filePath)
+          await aliceDrive.row(FILE_NAME).waitVisible()
+        }
+      })
+    } finally {
+      await safeUnlink(filePath)
+    }
+  })
+
+  test('Bob opens the shared-drive file through the proxy', async ({
+    bobPage,
+    bobDrive
+  }) => {
+    await openSharedDrive(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
+    await bobDrive.row(FILE_NAME).waitVisible({ timeout: 10_000 })
+
+    // Open the file and capture the body request atomically: the viewer creates
+    // its download link via POST /sharings/drives/<driveId>/downloads. Awaiting
+    // both in one Promise.all means the response budget covers the action, not
+    // the slower viewer/route waits that follow.
+    const viewer = new FileViewerPage(bobPage)
+    const [proxiedDownload] = await Promise.all([
+      bobPage.waitForResponse(
+        res => /\/sharings\/drives\/[^/]+\/downloads/.test(res.url()),
+        { timeout: 20_000 }
+      ),
+      bobDrive.row(FILE_NAME).open()
+    ])
+    expect(proxiedDownload.ok()).toBeTruthy()
+
+    await viewer.waitForOpen()
+
+    // The route stays scoped to the shared drive — a local /folder or /recent
+    // file route here would mean the file resolved to the recipient's own
+    // (empty) files API and 404'd.
+    await bobPage.waitForURL(/\/shareddrive\/[^/]+\/[^/]+\/file\/[^/]+/)
+
+    // The viewer mounted the proxied file: its title is the filename, set once
+    // the proxied folder query loads (a second round-trip, so allow for proxy
+    // latency rather than the default expect timeout).
+    await expect(bobPage).toHaveTitle(new RegExp(escapeRegExp(FILE_NAME)), {
+      timeout: 15_000
+    })
+  })
+})

--- a/src/modules/navigation/hooks/helpers.spec.js
+++ b/src/modules/navigation/hooks/helpers.spec.js
@@ -353,9 +353,28 @@ describe('computeFileType', () => {
     expect(computeFileType(file)).toBe('directory')
   })
 
-  it('should return "file" for files with driveId but not in shared drives directory', () => {
+  it('should return "shared-drive-file" for a recipient shared-drive file nested in a folder', () => {
+    // A file a recipient sees inside a shared drive (e.g. from Recents or
+    // Search, fed by the dataproxy) carries a `driveId` but lives in a regular
+    // folder, so its `dir_id` is its real parent, not SHARED_DRIVES_DIR_ID. It
+    // must still route through the proxied /shareddrive viewer, otherwise it
+    // opens via the local /files/:id route which 404s (the file only exists on
+    // the owner's instance).
     const file = {
       dir_id: 'regular-folder',
+      _type: 'io.cozy.files',
+      type: 'file',
+      driveId: 'drive789'
+    }
+    expect(computeFileType(file)).toBe('shared-drive-file')
+  })
+
+  it('should return "file" for a driveId file missing dir_id (avoids a computePath throw)', () => {
+    // Without dir_id the /shareddrive route can't be built; degrade to the
+    // local file route instead of classifying it shared-drive-file and letting
+    // computePath throw during render.
+    const file = {
+      _id: 'file123',
       _type: 'io.cozy.files',
       type: 'file',
       driveId: 'drive789'
@@ -576,6 +595,20 @@ describe('computePath', () => {
     expect(
       computePath(file, { type: 'shared-drive-file', pathname: '/any' })
     ).toBe('/shareddrive/drive789/io.cozy.files.shared-drives-dir/file/file123')
+  })
+
+  it('should return a /shareddrive path for a recipient shared-drive file nested in a folder', () => {
+    // Recents/Search hand a shared-drive file with its real parent folder as
+    // dir_id; the path must scope it to the proxied shared drive.
+    const file = {
+      _id: 'file123',
+      dir_id: 'parent-folder',
+      driveId: 'drive789',
+      _type: 'io.cozy.files'
+    }
+    expect(
+      computePath(file, { type: 'shared-drive-file', pathname: '/recent' })
+    ).toBe('/shareddrive/drive789/parent-folder/file/file123')
   })
 
   it('should throw error for shared-drive-file without driveId', () => {

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -125,7 +125,14 @@ export const computeFileType = (
     file.dir_id === SHARED_DRIVES_DIR_ID
   ) {
     return 'shared-drive-root-file'
-  } else if (file.driveId && file.dir_id === SHARED_DRIVES_DIR_ID) {
+  } else if (file.driveId && file.dir_id && !isFileRootSharedDrive(file)) {
+    // Any file carrying a driveId is a proxied shared-drive file, except the
+    // owner's own file-root sharing root (which lives locally and is caught
+    // by isFileRootSharedDrive). Keying on dir_id === SHARED_DRIVES_DIR_ID
+    // here used to drop every recipient file nested in a shared-drive folder
+    // back to the local /files/:id route, which 404s. dir_id is required
+    // because the shared-drive route is built from it; without it, fall back
+    // to 'file' rather than letting computePath throw.
     return 'shared-drive-file'
   } else {
     return 'file'

--- a/src/modules/navigation/hooks/useFileLink.tsx
+++ b/src/modules/navigation/hooks/useFileLink.tsx
@@ -130,7 +130,11 @@ const useFileLink = (
   let to = useResolvedPath(path, {
     relative: forceFolderPath ? 'route' : 'path'
   })
-  if (forceFolderPath && !shouldBeOpenedInNewTab) {
+  // The folder prefix only makes sense for a relative in-folder path. Types
+  // that already resolve to an absolute route (e.g. shared-drive-file ->
+  // /shareddrive/...) must be left untouched, otherwise the prefix produces a
+  // malformed /folder/<dir_id>/shareddrive/... link.
+  if (forceFolderPath && !shouldBeOpenedInNewTab && !path.startsWith('/')) {
     to = {
       ...to,
       pathname:


### PR DESCRIPTION
## Problem
Opening a shared-drive file a recipient sees outside the drive view (Recents, Search) tried the local `/files/:id` route and 404'd, because the file lives on the owner's instance and is only reachable through the `/sharings/drives` proxy. `computeFileType` only treated a file as a shared-drive file when its parent was the shared-drives container, which never holds for a real file nested inside a drive.

## Solution
Classify any file carrying a `driveId` as a shared-drive file (excluding the owner's own file-root sharing root, which lives locally), so it routes to `/shareddrive/:driveId/:dir/file/:id`. `dir_id` is now required for that classification so a doc missing it falls back to the local route instead of throwing, and the folder-path prefix used by Favorites no longer mangles the already-absolute shared-drive path. Adds an e2e test covering a recipient opening a shared-drive file through the proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-drive file routing and loading for recipient accounts
  * Fixed path resolution for shared-drive files nested in folders

* **Tests**
  * Added end-to-end test validating shared-drive file opening for recipients
  * Enhanced test coverage for shared-drive file type computation and path resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->