### PR TITLE
feat: gate eu-dss verify behind its own flag

### DIFF
--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -32,4 +32,5 @@ const flagsList = () => {
   flag('sharing.auto-open-settings.enabled')
   flag('sharing.generate-link-button.enabled')
   flag('drive.sign.enabled')
+  flag('drive.verify.enabled')
 }

--- a/src/modules/actions/verifyWithEuDss.jsx
+++ b/src/modules/actions/verifyWithEuDss.jsx
@@ -42,7 +42,7 @@ export const verifyWithEuDss = ({
     allowMultiple: false,
     allowFolders: false,
     displayCondition: files =>
-      flag('drive.sign.enabled') &&
+      flag('drive.verify.enabled') &&
       files.length === 1 &&
       hasWriteAccess &&
       !isPublic,


### PR DESCRIPTION
## Summary

- Move the eu-dss verify action to its own `drive.verify.enabled` flag, leaving the sign action on `drive.sign.enabled`, so verification and signature can be toggled independently.
- Declare `drive.verify.enabled` in the flags switcher list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification functionality is now controlled via dedicated feature flag for improved control and rollout management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->