### PR TITLE
feat(layout): disable sidebar add/upload on readonly folders, redirect on no-folder sections

### DIFF
--- a/src/modules/drive/AddMenu/AddMenuProvider.jsx
+++ b/src/modules/drive/AddMenu/AddMenuProvider.jsx
@@ -30,7 +30,8 @@ const AddMenuProvider = ({
   displayedFolder,
   isSelectionBarVisible,
   componentsProps,
-  isReadOnly
+  isReadOnly,
+  onAddFolder
 }) => {
   const [menuIsVisible, setMenuVisible] = useState(false)
   const isOffline = useBrowserOffline()
@@ -73,6 +74,7 @@ const AddMenuProvider = ({
         isOffline,
         handleOfflineClick,
         isPublic,
+        onAddFolder,
         a11y: {
           'aria-controls': menuIsVisible ? 'add-menu' : undefined,
           'aria-haspopup': true,

--- a/src/modules/drive/Toolbar/components/AddFolderItem.jsx
+++ b/src/modules/drive/Toolbar/components/AddFolderItem.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { connect } from 'react-redux'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
@@ -9,11 +9,13 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useI18n } from 'twake-i18n'
 
+import { AddMenuContext } from '@/modules/drive/AddMenu/AddMenuProvider'
 import { showNewFolderInput } from '@/modules/filelist/duck'
 
 const AddFolderItem = ({ addFolder, onClick, isReadOnly }) => {
   const { t } = useI18n()
   const { showAlert } = useAlert()
+  const { onAddFolder } = useContext(AddMenuContext)
 
   const handleClick = () => {
     if (isReadOnly) {
@@ -28,7 +30,11 @@ const AddFolderItem = ({ addFolder, onClick, isReadOnly }) => {
       onClick()
       return
     }
-    addFolder()
+    if (onAddFolder) {
+      onAddFolder()
+    } else {
+      addFolder()
+    }
     onClick()
   }
 

--- a/src/modules/filelist/AddFolder.jsx
+++ b/src/modules/filelist/AddFolder.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useClient } from 'cozy-client'
@@ -12,9 +12,11 @@ import { AddFolderCard } from '@/modules/filelist/AddFolderCard'
 import { AddFolderRow } from '@/modules/filelist/AddFolderRow'
 import {
   isTypingNewFolderName,
-  hideNewFolderInput
+  hideNewFolderInput,
+  showNewFolderInput
 } from '@/modules/filelist/duck'
 import AddFolderRowVz from '@/modules/filelist/virtualized/AddFolderRow'
+import { consumeCreateOnRoot } from '@/modules/layout/Layout'
 import { createFolder } from '@/modules/navigation/duck'
 import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightProvider'
 
@@ -53,6 +55,13 @@ const AddFolderWithState = ({
   const client = useClient()
   const dispatch = useDispatch()
   const visible = useSelector(isTypingNewFolderName)
+
+  // When arriving at root from a no-folder section, auto-open the folder input.
+  useEffect(() => {
+    if (consumeCreateOnRoot()) {
+      dispatch(showNewFolderInput())
+    }
+  }, [dispatch])
 
   const onSubmit = (name, showAlert, t) =>
     dispatch(async dispatch =>

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -37,6 +37,17 @@ import UploadQueue from '@/modules/upload/UploadQueue'
 
 initFlags()
 
+// Flag consumed by AddFolder when it mounts on root after a no-folder navigation.
+let pendingCreateOnRoot = false
+
+export const consumeCreateOnRoot = () => {
+  if (pendingCreateOnRoot) {
+    pendingCreateOnRoot = false
+    return true
+  }
+  return false
+}
+
 const LayoutContent = () => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
@@ -50,7 +61,6 @@ const LayoutContent = () => {
 
   useEffect(() => {
     if (shouldRedirect) {
-      // Update lastClicked state to ensure sidebar shows the correct active item
       setLastClicked(`/folder/${ROOT_DIR_ID}`)
       navigate(`/folder/${ROOT_DIR_ID}`)
       dispatch({ type: RESET_OPERATION_REDIRECTED })
@@ -61,6 +71,12 @@ const LayoutContent = () => {
 
   const isNoFolderSection = rawFolderId === null || rawFolderId === TRASH_DIR_ID
   const isReadOnly = !isNoFolderSection && !canWriteToCurrentFolder
+
+  const goToRoot = ({ create } = {}) => {
+    if (create) pendingCreateOnRoot = true
+    setLastClicked(`/folder/${ROOT_DIR_ID}`)
+    navigate(`/folder/${ROOT_DIR_ID}`)
+  }
 
   return (
     <LayoutUI onContextMenu={ev => ev.preventDefault()}>
@@ -74,7 +90,32 @@ const LayoutContent = () => {
         <FlagSwitcher />
         <Sidebar className="u-flex-justify-between">
           <div>
-            {isDesktop ? (
+            {isDesktop && isNoFolderSection ? (
+              <div className="u-mh-1 u-mt-half">
+                <AddMenuProvider
+                  canCreateFolder={true}
+                  canUpload={true}
+                  disabled={false}
+                  displayedFolder={displayedFolder}
+                  isSelectionBarVisible={false}
+                  componentsProps={{ AddMenu: { isUploadDisabled: true } }}
+                  onAddFolder={() => goToRoot({ create: true })}
+                >
+                  <AddButton className="u-w-100 u-bdrs-6 u-mt-half u-mb-half u-fz-small" />
+                </AddMenuProvider>
+                <UploadButton
+                  folderId={null}
+                  onUploadStart={() => goToRoot()}
+                  componentsProps={{
+                    button: {
+                      className: 'u-w-100 u-bdrs-6 u-fz-small'
+                    }
+                  }}
+                  label={t('upload.label')}
+                  displayedFolder={displayedFolder}
+                />
+              </div>
+            ) : isDesktop ? (
               <div className="u-mh-1 u-mt-half">
                 <AddMenuProvider
                   canCreateFolder={true}
@@ -111,8 +152,6 @@ const LayoutContent = () => {
           )}
         </Sidebar>
         <UploadQueue />
-        {/* Mounted once here so every route (folders and editors) keeps the
-            io.cozy.files store in sync with server-side changes. */}
         <FilesRealTimeQueries />
         <SelectionProvider>
           <Outlet />

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -17,8 +17,9 @@ import FilesRealTimeQueries from '@/components/FilesRealTimeQueries'
 import Drive from '@/components/Icons/Drive'
 import DriveText from '@/components/Icons/DriveText'
 import ButtonClient from '@/components/pushClient/Button'
-import { ROOT_DIR_ID } from '@/constants/config'
+import { ROOT_DIR_ID, TRASH_DIR_ID } from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
+import useCurrentFolderId from '@/hooks/useCurrentFolderId'
 import useCurrentFolderWriteAccess from '@/hooks/useCurrentFolderWriteAccess'
 import { initFlags } from '@/lib/flags'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
@@ -42,6 +43,7 @@ const LayoutContent = () => {
   const { isMobile, isDesktop } = useBreakpoints()
   const { displayedFolder } = useDisplayedFolder()
   const { t } = useI18n()
+  const rawFolderId = useCurrentFolderId()
 
   const shouldRedirect = useSelector(wasOperationRedirected)
   const [, setLastClicked] = useNavContext()
@@ -57,6 +59,9 @@ const LayoutContent = () => {
 
   const canWriteToCurrentFolder = useCurrentFolderWriteAccess()
 
+  const isNoFolderSection = rawFolderId === null || rawFolderId === TRASH_DIR_ID
+  const isReadOnly = !isNoFolderSection && !canWriteToCurrentFolder
+
   return (
     <LayoutUI onContextMenu={ev => ev.preventDefault()}>
       <NewItemHighlightProvider>
@@ -69,12 +74,12 @@ const LayoutContent = () => {
         <FlagSwitcher />
         <Sidebar className="u-flex-justify-between">
           <div>
-            {isDesktop && canWriteToCurrentFolder ? (
+            {isDesktop ? (
               <div className="u-mh-1 u-mt-half">
                 <AddMenuProvider
                   canCreateFolder={true}
                   canUpload={true}
-                  disabled={false}
+                  disabled={isReadOnly}
                   displayedFolder={displayedFolder}
                   isSelectionBarVisible={false}
                   componentsProps={{ AddMenu: { isUploadDisabled: true } }}
@@ -82,8 +87,12 @@ const LayoutContent = () => {
                   <AddButton className="u-w-100 u-bdrs-6 u-mt-half u-mb-half u-fz-small" />
                 </AddMenuProvider>
                 <UploadButton
+                  disabled={isReadOnly}
                   componentsProps={{
-                    button: { className: 'u-w-100 u-bdrs-6 u-fz-small' }
+                    button: {
+                      className: 'u-w-100 u-bdrs-6 u-fz-small',
+                      disabled: isReadOnly
+                    }
                   }}
                   label={t('upload.label')}
                   displayedFolder={displayedFolder}

--- a/src/modules/upload/UploadButton.jsx
+++ b/src/modules/upload/UploadButton.jsx
@@ -20,9 +20,11 @@ const UploadButton = ({
   disabled,
   className,
   displayedFolder,
+  folderId,
   sharingState,
   componentsProps,
-  onUploaded
+  onUploaded,
+  onUploadStart
 }) => {
   const { showAlert } = useAlert()
   const { addItems } = useNewItemHighlightContext()
@@ -30,15 +32,19 @@ const UploadButton = ({
   const dispatch = useDispatch()
   const client = useClient()
 
+  // Explicit folderId (e.g. null on no-folder sections) overrides displayedFolder.id.
+  const dirId = folderId !== undefined ? folderId : displayedFolder?.id
+
   const onUpload = files => {
+    onUploadStart?.()
     dispatch(
       uploadFiles(
         files,
-        displayedFolder.id,
+        dirId,
         sharingState,
         onUploaded,
         { client, showAlert, t },
-        displayedFolder.driveId,
+        displayedFolder?.driveId,
         addItems
       )
     )
@@ -91,6 +97,8 @@ UploadButton.propTypes = {
   componentsProps: PropTypes.object,
   onUploaded: PropTypes.func,
   displayedFolder: PropTypes.object, // io.cozy.files
+  folderId: PropTypes.string,
+  onUploadStart: PropTypes.func,
   // in case of upload conflicts, shared files are not overridden
   sharingState: PropTypes.object.isRequired
 }

--- a/src/modules/upload/UploadButton.jsx
+++ b/src/modules/upload/UploadButton.jsx
@@ -46,6 +46,29 @@ const UploadButton = ({
 
   const { isPublic } = usePublicContext()
 
+  const button = (
+    <Button
+      {...componentsProps?.button}
+      variant={isPublic ? 'secondary' : 'primary'}
+      disabled={disabled}
+      style={
+        isPublic
+          ? undefined
+          : {
+              color: 'var(--primaryTextColor)',
+              backgroundColor: 'var(--paperBackgroundColor)'
+            }
+      }
+      component="span"
+      startIcon={<Icon icon={UploadIcon} size={12} />}
+      label={label}
+    />
+  )
+
+  if (disabled) {
+    return <div className={className}>{button}</div>
+  }
+
   return (
     <FileInput
       className={className}
@@ -56,21 +79,7 @@ const UploadButton = ({
       data-testid="upload-btn"
       value={[]} // always erase the value to be able to re-upload the same file
     >
-      <Button
-        {...componentsProps?.button}
-        variant={isPublic ? 'secondary' : 'primary'}
-        style={
-          isPublic
-            ? undefined
-            : {
-                color: 'var(--primaryTextColor)',
-                backgroundColor: 'var(--paperBackgroundColor)'
-              }
-        }
-        component="span"
-        startIcon={<Icon icon={UploadIcon} size={12} />}
-        label={label}
-      />
+      {button}
     </FileInput>
   )
 }


### PR DESCRIPTION
- Disable AddButton and UploadButton when current folder is readonly                                   
- On /recents, /sharings, /trash: navigate to root then execute the action                             
- AddFolder auto-opens the name input after navigating from no-folder sections                         
- UploadButton navigates to root immediately on file selection from no-folder sections                                            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined “add folder” flow from root/no-folder: after navigating to the root, the app automatically opens the new-folder input.
  * Upload now accepts an explicit target folder (including root/no-folder scenarios) and provides an upload-start callback.

* **Improvements**
  * Refined toolbar actions by section and permissions: “Add”/“Upload” are correctly enabled/disabled for read-only contexts.
  * Improved add-folder integration so menu actions can trigger the right folder-creation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->