### PR TITLE
fix: Upgrade cozy-viewer to 28.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",
-    "cozy-viewer": "^28.1.6",
+    "cozy-viewer": "^28.1.18",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",
     "filesize": "10.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8290,10 +8290,10 @@ cozy-ui@^139.2.0:
     react-virtuoso "^4.13.0"
     rooks "7.14.1"
 
-cozy-viewer@^28.1.6:
-  version "28.1.6"
-  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-28.1.6.tgz#c144eb5efcb654cdd02ad8a7d477db5880f634f4"
-  integrity sha512-kTMxmymveGMAlxRxk6CwLMcIAZI4OrxiFxUUc+934J5+XQ6GvXxq0hyJh2lbDi7EM1cxiW/sxPZY0oRTh6WlOw==
+cozy-viewer@^28.1.18:
+  version "28.1.18"
+  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-28.1.18.tgz#801fae54616abb7f09f8ccd6a597412a9e2fab32"
+  integrity sha512-7mk8qSnQHY4FamsGMsAHNlwoagwAddtNYlxJnCGjL1EmWwuUQY/NWlzfyxgMXNDm03IKl3ZuknXm9C3WTbO1mw==
   dependencies:
     classnames "^2.5.1"
     hammerjs "^2.0.8"


### PR DESCRIPTION
 cozy-viewer 28.1.6 → 28.1.18
 - cozy/cozy-libs#3040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated a core dependency to a newer patch version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->