### PR TITLE
fix: Upgrade cozy-viewer to 28.1.18 + e2e tests

### DIFF
--- a/e2e/pages/FileViewerPage.ts
+++ b/e2e/pages/FileViewerPage.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test'
 
+import { expect } from '../helpers/fixtures'
+
 export class FileViewerPage {
   private readonly page: Page
 
@@ -10,6 +12,16 @@ export class FileViewerPage {
   /** The viewer route always contains `/file/<id>` in the URL fragment. */
   async waitForOpen(): Promise<void> {
     await this.page.waitForURL(/\/file\/[^/]+/, { timeout: 10_000 })
+  }
+
+  async expectWhoHasAccessWith(members: (string | RegExp)[]): Promise<void> {
+    await expect(
+      this.page.getByText('Who has access?', { exact: true })
+    ).toBeVisible()
+
+    for (const member of members) {
+      await expect(this.page.getByText(member).first()).toBeVisible()
+    }
   }
 
   /** Closes the viewer by navigating back, then waits for the file route to drop. */

--- a/e2e/tests/z-viewer-sharing-access.spec.ts
+++ b/e2e/tests/z-viewer-sharing-access.spec.ts
@@ -1,0 +1,54 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { test, stamp, safeUnlink } from '../helpers/fixtures'
+import {
+  createAndShareFolderWithBob,
+  openOwnerFolder,
+  waitForSharingRow
+} from '../helpers/sharing'
+import { FileViewerPage } from '../pages/FileViewerPage'
+
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+
+const DRIVE_NAME = `ViewerAccess-${stamp()}`
+const SUBFOLDER = `ViewerAccessSub-${stamp()}`
+const FILE_NAME = `viewer-access-${stamp()}.txt`
+
+test.describe('Viewer sharing access panel', () => {
+  test('shows shared folder members for a file inside a subfolder', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    const filePath = path.join(FIXTURE_DIR, FILE_NAME)
+    await copyFile(SAMPLE, filePath)
+
+    try {
+      await createAndShareFolderWithBob(alicePage, aliceDrive, DRIVE_NAME, {
+        seed: async () => {
+          await aliceDrive.createFolder(SUBFOLDER)
+          await aliceDrive.row(SUBFOLDER).open()
+          await alicePage.waitForURL(/\/folder\/[^/]+$/)
+          await aliceDrive.uploadFiles(filePath)
+          await aliceDrive.row(FILE_NAME).waitVisible()
+          await alicePage.goBack()
+          await aliceDrive.row(SUBFOLDER).waitVisible()
+        }
+      })
+    } finally {
+      await safeUnlink(filePath)
+    }
+
+    await waitForSharingRow(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+    await openOwnerFolder(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+    await aliceDrive.row(SUBFOLDER).open()
+    await aliceDrive.row(FILE_NAME).waitVisible({ timeout: 10_000 })
+    await aliceDrive.row(FILE_NAME).open()
+
+    const viewer = new FileViewerPage(alicePage)
+    await viewer.waitForOpen()
+    await viewer.expectWhoHasAccessWith(['You', /bob/i])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^139.2.0",
     "cozy-ui-plus": "^7.1.0",
-    "cozy-viewer": "^28.1.6",
+    "cozy-viewer": "^28.1.18",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",
     "filesize": "10.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8290,10 +8290,10 @@ cozy-ui@^139.2.0:
     react-virtuoso "^4.13.0"
     rooks "7.14.1"
 
-cozy-viewer@^28.1.6:
-  version "28.1.6"
-  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-28.1.6.tgz#c144eb5efcb654cdd02ad8a7d477db5880f634f4"
-  integrity sha512-kTMxmymveGMAlxRxk6CwLMcIAZI4OrxiFxUUc+934J5+XQ6GvXxq0hyJh2lbDi7EM1cxiW/sxPZY0oRTh6WlOw==
+cozy-viewer@^28.1.18:
+  version "28.1.18"
+  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-28.1.18.tgz#801fae54616abb7f09f8ccd6a597412a9e2fab32"
+  integrity sha512-7mk8qSnQHY4FamsGMsAHNlwoagwAddtNYlxJnCGjL1EmWwuUQY/NWlzfyxgMXNDm03IKl3ZuknXm9C3WTbO1mw==
   dependencies:
     classnames "^2.5.1"
     hammerjs "^2.0.8"


### PR DESCRIPTION
cozy-viewer 28.1.6 → 28.1.18
 - linagora/cozy-libs#3040

Add a e2e test that opens a file inside a federated
shared folder and checks that the viewer access panel lists the
inherited sharing members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for the file viewer's sharing access panel functionality, validating that team members are correctly displayed when accessing files within nested subfolders, with proper test cleanup procedures.

* **Chores**
  * Updated cozy-viewer dependency to the latest compatible version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->