### PR TITLE
feat(sort): add flag for default updated_at sort on folders

### DIFF
--- a/src/hooks/useFolderSort/index.ts
+++ b/src/hooks/useFolderSort/index.ts
@@ -28,7 +28,9 @@ const useFolderSort = (
   folderId: string
 ): [Sort, (props: Sort) => void, boolean] => {
   const defaultSort: Sort =
-    folderId === TRASH_DIR_ID || folderId === RECENT_FOLDER_ID
+    folderId === TRASH_DIR_ID ||
+    folderId === RECENT_FOLDER_ID ||
+    flag('drive.default-updated-at-sort.enabled')
       ? SORT_BY_UPDATE_DATE
       : DEFAULT_SORT
 


### PR DESCRIPTION
When drive.default-updated-at-sort.enabled is active, regular folders default to sorting by updated_at descending instead of name ascending.

The flag was already documented but not implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded default folder sorting behavior to use update date as the default sort option in additional scenarios when a feature flag is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->