### PR TITLE
feat: pushBanner flags per platform

### DIFF
--- a/src/components/pushClient/Banner.jsx
+++ b/src/components/pushClient/Banner.jsx
@@ -6,6 +6,7 @@ import flow from 'lodash/flow'
 import React, { Component } from 'react'
 
 import { withClient } from 'cozy-client'
+import flag from 'cozy-flags'
 import Alert from 'cozy-ui/transpiled/react/Alert'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -53,12 +54,15 @@ class BannerClient extends Component {
   }
 
   render() {
-    if (Config.promoteDesktop.isActivated !== true || !this.state.mustShow)
+    if (Config.promoteApp.isActivated !== true || !this.state.mustShow)
       return null
 
     const { t } = this.props
 
     const isMobile = isIOS() || isAndroid()
+    if (isMobile && flag('drive.pushBanner-hide-mobile.enabled')) return null
+    if (!isMobile && flag('drive.pushBanner-hide-desktop.enabled')) return null
+
     const text = isMobile ? 'Nav.btn-client-mobile' : 'Nav.banner-txt-client'
     const link = isMobile
       ? getMobileAppDownloadLink({ t })

--- a/src/components/pushClient/Button.jsx
+++ b/src/components/pushClient/Button.jsx
@@ -26,7 +26,7 @@ const ButtonClient = ({ client, t }) => {
 
   useEffect(() => {
     const checkShouldShowButton = async () => {
-      if (Config.promoteDesktop.isActivated !== true || isFlagshipApp()) return
+      if (Config.promoteApp.isActivated !== true || isFlagshipApp()) return
 
       const hasBannerBeenClosed =
         (await localforage.getItem(DESKTOP_BANNER)) || false
@@ -54,11 +54,7 @@ const ButtonClient = ({ client, t }) => {
     localforage.setItem(DESKTOP_SMALL_BANNER, true)
   }
 
-  if (
-    Config.promoteDesktop.isActivated !== true ||
-    !mustShow ||
-    isFlagshipApp()
-  )
+  if (Config.promoteApp.isActivated !== true || !mustShow || isFlagshipApp())
     return null
 
   const link = getDesktopAppDownloadLink({ t })

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,5 +1,5 @@
 {
-  "promoteDesktop": {
-    "isActivated": false
+  "promoteApp": {
+    "isActivated": true
   }
 }

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -24,7 +24,7 @@ const flagsList = () => {
   flag('drive.onlyoffice.editorToolbarHeight') // flagName should use kebab case
   flag('drive.logger')
   flag('drive.dacc-files-size-by-slug')
-  flag('drive.pushBanner-hide-mobile.enabled')
+  flag('drive.pushBanner-hide-mobile.enabled', true)
   flag('drive.pushBanner-hide-desktop.enabled')
   flag('drive.breadcrumb.showCompleteBreadcrumbOnPublicPage') // flagName should use kebab case
   flag('drive.hide-nextcloud-dev')

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -24,6 +24,8 @@ const flagsList = () => {
   flag('drive.onlyoffice.editorToolbarHeight') // flagName should use kebab case
   flag('drive.logger')
   flag('drive.dacc-files-size-by-slug')
+  flag('drive.pushBanner-hide-mobile.enabled')
+  flag('drive.pushBanner-hide-desktop.enabled')
   flag('drive.breadcrumb.showCompleteBreadcrumbOnPublicPage') // flagName should use kebab case
   flag('drive.hide-nextcloud-dev')
   flag('drive.excalidraw.enabled')

--- a/src/modules/viewer/CallToAction.jsx
+++ b/src/modules/viewer/CallToAction.jsx
@@ -20,7 +20,7 @@ class CallToAction extends Component {
   }
 
   async componentDidMount() {
-    if (Config.promoteDesktop.isActivated !== true) return
+    if (Config.promoteApp.isActivated !== true) return
     const seen = (await localforage.getItem(NOVIEWER_DESKTOP_CTA)) || false
     if (!seen) {
       try {
@@ -40,7 +40,7 @@ class CallToAction extends Component {
   }
 
   render() {
-    if (!this.state.mustShow || Config.promoteDesktop.isActivated !== true)
+    if (!this.state.mustShow || Config.promoteApp.isActivated !== true)
       return null
 
     const { t } = this.props

--- a/src/modules/viewer/CallToAction.spec.jsx
+++ b/src/modules/viewer/CallToAction.spec.jsx
@@ -8,7 +8,7 @@ import { NOVIEWER_DESKTOP_CTA } from '@/components/pushClient'
 
 jest.mock('localforage')
 jest.mock('config/config.json', () => ({
-  promoteDesktop: { isActivated: true }
+  promoteApp: { isActivated: true }
 }))
 jest.mock('components/pushClient', () => ({
   getDesktopAppDownloadLink: jest.fn().mockReturnValue('https://twake.app'),


### PR DESCRIPTION
## What

Rename `promoteDesktop` config to `promoteApp` and add per-platform feature flags (`drive.pushBanner-hide-mobile.enabled` / `drive.pushBanner-hide-desktop.enabled`) to control which push-to-install banner is shown.
And hide mobile application push banner by defaut

## Why

The `promoteDesktop` config name was misleading — it actually controls both desktop and mobile app promotion banners in the push client. The rename makes the intent clearer.

Additionally, we wanted the ability to independently toggle the mobile vs desktop push banner in production without a deploy, hence the new `cozy-flags`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added independent feature flags to hide the push banner on mobile vs. desktop.
  * Push banner, promo button, and viewer CTA now use the same app-level promotion activation setting, with additional platform-specific visibility controlled by the new hide flags.

* **Chores**
  * Updated promotion configuration to use the new app activation flag.
  * Updated banner/button/CTA visibility logic and refreshed tests to match the new configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->