### PR TITLE
fix: e2e tests for readonly shared drive

### DIFF
--- a/e2e/tests/z-shared-drive-members.spec.ts
+++ b/e2e/tests/z-shared-drive-members.spec.ts
@@ -52,11 +52,11 @@ test.describe.serial('Shared drive members & permissions', () => {
     await openSharedDrive(bobPage, USERS.bob, bobDrive, VIEWER_DRIVE)
     await bobDrive.row(VIEWER_FILE).waitVisible({ timeout: 10_000 })
 
-    // Read-only recipients must not be offered write entry points — the
-    // buttons are hidden outright (cozy-ui's FileInput ignores `disabled`,
-    // so a disabled Upload would still open the file picker).
-    await expect(createButton).not.toBeVisible()
-    await expect(uploadButton).not.toBeVisible()
+    // Read-only recipients see write entry points as disabled.
+    await expect(createButton).toBeVisible()
+    await expect(createButton).toBeDisabled()
+    await expect(uploadButton).toBeVisible()
+    await expect(uploadButton).toBeDisabled()
   })
 
   test('the members panel shows Bob as Viewer', async ({


### PR DESCRIPTION
Since https://github.com/linagora/twake-drive/pull/3950 we now disable add and upload buttons on readonly folders and shared drives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated shared-drive coverage to verify that read-only users still see create and upload actions, but in a disabled state rather than hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->