### PR TITLE
feat(recent): make recent files react to live store updates

### DIFF
--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -30,6 +30,61 @@ test.describe('Navigation surfaces', () => {
     }
   })
 
+  test('Recent: a trashed file disappears without page reload', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+    const sidebar = new SidebarPage(alicePage)
+    const file = path.join(path.dirname(FIXTURE), `recent-trash-${stamp()}.txt`)
+    await copyFile(FIXTURE, file)
+    try {
+      const fileName = path.basename(file)
+      await aliceDrive.uploadFiles(file)
+      await aliceDrive.row(fileName).waitVisible()
+
+      // The freshly uploaded file appears on /#/recent
+      await sidebar.goToRecent()
+      await alicePage.waitForURL(/\/recent/)
+      await aliceDrive.row(fileName).waitVisible()
+
+      // Trash it directly from the Recent view — sendToTrash's waitHidden
+      // validates that the row disappears live, without navigating away
+      await aliceDrive.row(fileName).sendToTrash()
+    } finally {
+      await safeUnlink(file)
+    }
+  })
+
+  test('Recent: a renamed file updates without page reload', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await alicePage.goto(ALICE_ROOT)
+    const sidebar = new SidebarPage(alicePage)
+    const original = `recent-rename-${stamp()}.txt`
+    const renamed = `recent-renamed-${stamp()}.txt`
+    const file = path.join(path.dirname(FIXTURE), original)
+    await copyFile(FIXTURE, file)
+    try {
+      await aliceDrive.uploadFiles(file)
+      await aliceDrive.row(original).waitVisible()
+
+      // The file appears on /#/recent
+      await sidebar.goToRecent()
+      await alicePage.waitForURL(/\/recent/)
+      await aliceDrive.row(original).waitVisible()
+
+      // Rename directly from the Recent view — rename() self-validates
+      // by waiting for the new name to appear in the file list
+      await aliceDrive.row(original).rename(renamed)
+      await expect(aliceDrive.row(renamed).cell).toBeVisible()
+      await expect(aliceDrive.row(original).cell).toHaveCount(0)
+    } finally {
+      await safeUnlink(file)
+    }
+  })
+
   test('Favorites: a favourited file appears in /#/favorites', async ({
     alicePage,
     aliceDrive

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,12 +1,37 @@
 import { copyFile } from 'fs/promises'
 import path from 'path'
 
+import type { Page } from '@playwright/test'
+
 import { USERS } from '../helpers/config'
 import { test, expect, stamp, safeUnlink } from '../helpers/fixtures'
+import type { DrivePage } from '../pages/DrivePage'
 import { SidebarPage } from '../pages/SidebarPage'
 
 const ALICE_ROOT = `${USERS.alice.appUrl}/#/folder`
 const FIXTURE = path.resolve(__dirname, '..', 'fixtures', 'sample.txt')
+
+const trashRemoteFileIfPresent = async (
+  page: Page,
+  drive: DrivePage,
+  fileName: string | null
+): Promise<void> => {
+  if (!fileName) return
+
+  await page.goto(ALICE_ROOT)
+  const row = drive.row(fileName)
+  const rowFound = await row.cell
+    .waitFor({ state: 'visible', timeout: 15_000 })
+    .then(() => true)
+    .catch((err: Error) => {
+      if (err.name === 'TimeoutError') return false
+      throw err
+    })
+
+  if (!rowFound) return
+
+  await row.sendToTrash()
+}
 
 test.describe('Navigation surfaces', () => {
   test('Recent: a freshly uploaded file shows up at /#/recent', async ({
@@ -17,8 +42,9 @@ test.describe('Navigation surfaces', () => {
     const sidebar = new SidebarPage(alicePage)
     const file = path.join(path.dirname(FIXTURE), `recent-${stamp()}.txt`)
     await copyFile(FIXTURE, file)
+    const fileName = path.basename(file)
+    const currentRemoteFileName = fileName
     try {
-      const fileName = path.basename(file)
       await aliceDrive.uploadFiles(file)
       await aliceDrive.row(fileName).waitVisible()
 
@@ -26,6 +52,11 @@ test.describe('Navigation surfaces', () => {
       await alicePage.waitForURL(/\/recent/)
       await aliceDrive.row(fileName).waitVisible()
     } finally {
+      await trashRemoteFileIfPresent(
+        alicePage,
+        aliceDrive,
+        currentRemoteFileName
+      )
       await safeUnlink(file)
     }
   })
@@ -38,8 +69,9 @@ test.describe('Navigation surfaces', () => {
     const sidebar = new SidebarPage(alicePage)
     const file = path.join(path.dirname(FIXTURE), `recent-trash-${stamp()}.txt`)
     await copyFile(FIXTURE, file)
+    const fileName = path.basename(file)
+    let currentRemoteFileName: string | null = fileName
     try {
-      const fileName = path.basename(file)
       await aliceDrive.uploadFiles(file)
       await aliceDrive.row(fileName).waitVisible()
 
@@ -51,7 +83,13 @@ test.describe('Navigation surfaces', () => {
       // Trash it directly from the Recent view — sendToTrash's waitHidden
       // validates that the row disappears live, without navigating away
       await aliceDrive.row(fileName).sendToTrash()
+      currentRemoteFileName = null
     } finally {
+      await trashRemoteFileIfPresent(
+        alicePage,
+        aliceDrive,
+        currentRemoteFileName
+      )
       await safeUnlink(file)
     }
   })
@@ -66,6 +104,7 @@ test.describe('Navigation surfaces', () => {
     const renamed = `recent-renamed-${stamp()}.txt`
     const file = path.join(path.dirname(FIXTURE), original)
     await copyFile(FIXTURE, file)
+    let currentRemoteFileName: string | null = original
     try {
       await aliceDrive.uploadFiles(file)
       await aliceDrive.row(original).waitVisible()
@@ -78,9 +117,18 @@ test.describe('Navigation surfaces', () => {
       // Rename directly from the Recent view — rename() self-validates
       // by waiting for the new name to appear in the file list
       await aliceDrive.row(original).rename(renamed)
+      currentRemoteFileName = renamed
       await expect(aliceDrive.row(renamed).cell).toBeVisible()
       await expect(aliceDrive.row(original).cell).toHaveCount(0)
     } finally {
+      await trashRemoteFileIfPresent(
+        alicePage,
+        aliceDrive,
+        currentRemoteFileName
+      )
+      if (currentRemoteFileName !== renamed) {
+        await trashRemoteFileIfPresent(alicePage, aliceDrive, renamed)
+      }
       await safeUnlink(file)
     }
   })
@@ -93,8 +141,9 @@ test.describe('Navigation surfaces', () => {
     const sidebar = new SidebarPage(alicePage)
     const file = path.join(path.dirname(FIXTURE), `fav-${stamp()}.txt`)
     await copyFile(FIXTURE, file)
+    const fileName = path.basename(file)
+    const currentRemoteFileName = fileName
     try {
-      const fileName = path.basename(file)
       await aliceDrive.uploadFiles(file)
       const row = aliceDrive.row(fileName)
       await row.waitVisible()
@@ -104,6 +153,11 @@ test.describe('Navigation surfaces', () => {
       await alicePage.waitForURL(/\/favorites/)
       await aliceDrive.row(fileName).waitVisible()
     } finally {
+      await trashRemoteFileIfPresent(
+        alicePage,
+        aliceDrive,
+        currentRemoteFileName
+      )
       await safeUnlink(file)
     }
   })
@@ -115,7 +169,9 @@ test.describe('Navigation surfaces', () => {
     // knows about it — this avoids racing the indexer for a freshly-uploaded
     // fixture.
     await alicePage.goto(`${USERS.alice.appUrl}/#/search`)
-    const searchInput = alicePage.getByRole('textbox', { name: /search/i }).first()
+    const searchInput = alicePage
+      .getByRole('textbox', { name: /search/i })
+      .first()
     await searchInput.waitFor({ state: 'visible' })
     await searchInput.fill('Photos')
     // The suggestion list shows the file path as a secondary line — using

--- a/src/hooks/useRecentFiles.jsx
+++ b/src/hooks/useRecentFiles.jsx
@@ -54,7 +54,10 @@ const useDataProxyRecents = () => {
   }, [dataProxy])
 
   // Proxy path: merge proxy data with real-time store state
-  if (dataProxy.dataProxyServicesAvailable && proxyState.fetchStatus !== 'error') {
+  if (
+    dataProxy.dataProxyServicesAvailable &&
+    proxyState.fetchStatus !== 'error'
+  ) {
     let finalData = []
     if (proxyState.data) {
       finalData = proxyState.data.reduce((acc, file) => {
@@ -63,7 +66,7 @@ const useDataProxyRecents = () => {
           file._id
         )
         if (docInStore) {
-          if (!docInStore.trashed) {
+          if (!file.trashed && !docInStore.trashed) {
             acc.push({ ...file, ...docInStore })
           }
         } else if (!file.trashed) {

--- a/src/hooks/useRecentFiles.jsx
+++ b/src/hooks/useRecentFiles.jsx
@@ -1,59 +1,87 @@
 import { useEffect, useState, useMemo } from 'react'
 
-import { useClient } from 'cozy-client'
+import { useClient, useQuery } from 'cozy-client'
 import { useDataProxy } from 'cozy-dataproxy-lib'
 
 import logger from '@/lib/logger'
 import { buildRecentQuery } from '@/queries'
 
 const useDataProxyRecents = () => {
-  const [data, setData] = useState([])
-  const [fetchStatus, setFetchStatus] = useState('loading')
-  const [error, setError] = useState(null)
+  const [proxyData, setProxyData] = useState(null)
+  const [proxyFetchStatus, setProxyFetchStatus] = useState('loading')
+  const [proxyError, setProxyError] = useState(null)
+
   const dataProxy = useDataProxy()
   const client = useClient()
 
   const recentQuery = useMemo(() => buildRecentQuery(), [])
 
+  // Reactive fallback when proxy is unavailable or fails
+  const fallbackResult = useQuery(recentQuery.definition(), recentQuery.options)
+
   useEffect(() => {
-    const fetchRecents = async () => {
-      setFetchStatus('loading')
-      setError(null)
+    const fetchProxyRecents = async () => {
+      setProxyFetchStatus('loading')
+      setProxyError(null)
 
       if (dataProxy.dataProxyServicesAvailable) {
         try {
           const data = await dataProxy.recents()
-          setData(data || [])
-          setFetchStatus('loaded')
-          return
+          setProxyData(data || [])
+          setProxyFetchStatus('loaded')
         } catch (err) {
           logger.error('Error fetching recents from dataproxy', err)
+          setProxyError(err)
+          setProxyFetchStatus('error')
         }
-      }
-
-      if (client) {
-        try {
-          const result = await client.fetchQueryAndGetFromState({
-            definition: recentQuery.definition(),
-            options: recentQuery.options
-          })
-          setData(result?.data || [])
-          setFetchStatus('loaded')
-        } catch (err) {
-          logger.warn('Error fetching recents from fallback query', err)
-          setError(err)
-          setFetchStatus('error')
-        }
-      } else {
-        setError(new Error('Client not available'))
-        setFetchStatus('error')
       }
     }
 
-    fetchRecents()
-  }, [dataProxy, client, recentQuery])
+    if (dataProxy.dataProxyServicesAvailable) {
+      fetchProxyRecents()
+    }
+  }, [dataProxy])
 
-  return { data, fetchStatus, error }
+  // Proxy path: merge proxy data with real-time store state
+  if (dataProxy.dataProxyServicesAvailable && proxyFetchStatus !== 'error') {
+    let finalData = []
+    if (proxyData) {
+      finalData = proxyData.reduce((acc, file) => {
+        const docInStore = client.getDocumentFromState(
+          'io.cozy.files',
+          file._id
+        )
+        if (docInStore) {
+          if (!docInStore.trashed) {
+            acc.push({ ...file, ...docInStore })
+          }
+        } else if (!file.trashed) {
+          acc.push(file)
+        }
+        return acc
+      }, [])
+    }
+
+    return {
+      data: finalData,
+      fetchStatus: proxyFetchStatus,
+      error: proxyError
+    }
+  }
+
+  // Fallback: use cozy-client query (proxy unavailable or errored)
+  if (fallbackResult.error) {
+    logger.warn(
+      'Error fetching recents from fallback query',
+      fallbackResult.error
+    )
+  }
+
+  return {
+    data: fallbackResult.data || [],
+    fetchStatus: fallbackResult.error ? 'error' : fallbackResult.fetchStatus,
+    error: fallbackResult.error || proxyError
+  }
 }
 
 export default useDataProxyRecents

--- a/src/hooks/useRecentFiles.jsx
+++ b/src/hooks/useRecentFiles.jsx
@@ -7,9 +7,11 @@ import logger from '@/lib/logger'
 import { buildRecentQuery } from '@/queries'
 
 const useDataProxyRecents = () => {
-  const [proxyData, setProxyData] = useState(null)
-  const [proxyFetchStatus, setProxyFetchStatus] = useState('loading')
-  const [proxyError, setProxyError] = useState(null)
+  const [proxyState, setProxyState] = useState({
+    data: null,
+    fetchStatus: 'loading',
+    error: null
+  })
 
   const dataProxy = useDataProxy()
   const client = useClient()
@@ -21,18 +23,27 @@ const useDataProxyRecents = () => {
 
   useEffect(() => {
     const fetchProxyRecents = async () => {
-      setProxyFetchStatus('loading')
-      setProxyError(null)
+      setProxyState({
+        data: null,
+        fetchStatus: 'loading',
+        error: null
+      })
 
       if (dataProxy.dataProxyServicesAvailable) {
         try {
           const data = await dataProxy.recents()
-          setProxyData(data || [])
-          setProxyFetchStatus('loaded')
+          setProxyState({
+            data: data || [],
+            fetchStatus: 'loaded',
+            error: null
+          })
         } catch (err) {
           logger.error('Error fetching recents from dataproxy', err)
-          setProxyError(err)
-          setProxyFetchStatus('error')
+          setProxyState({
+            data: null,
+            fetchStatus: 'error',
+            error: err
+          })
         }
       }
     }
@@ -43,10 +54,10 @@ const useDataProxyRecents = () => {
   }, [dataProxy])
 
   // Proxy path: merge proxy data with real-time store state
-  if (dataProxy.dataProxyServicesAvailable && proxyFetchStatus !== 'error') {
+  if (dataProxy.dataProxyServicesAvailable && proxyState.fetchStatus !== 'error') {
     let finalData = []
-    if (proxyData) {
-      finalData = proxyData.reduce((acc, file) => {
+    if (proxyState.data) {
+      finalData = proxyState.data.reduce((acc, file) => {
         const docInStore = client.getDocumentFromState(
           'io.cozy.files',
           file._id
@@ -64,8 +75,8 @@ const useDataProxyRecents = () => {
 
     return {
       data: finalData,
-      fetchStatus: proxyFetchStatus,
-      error: proxyError
+      fetchStatus: proxyState.fetchStatus,
+      error: proxyState.error
     }
   }
 
@@ -80,7 +91,7 @@ const useDataProxyRecents = () => {
   return {
     data: fallbackResult.data || [],
     fetchStatus: fallbackResult.error ? 'error' : fallbackResult.fetchStatus,
-    error: fallbackResult.error || proxyError
+    error: fallbackResult.error || proxyState.error
   }
 }
 

--- a/src/hooks/useRecentFiles.spec.jsx
+++ b/src/hooks/useRecentFiles.spec.jsx
@@ -63,16 +63,18 @@ describe('useDataProxyRecents', () => {
       const mockData = [
         { _id: '1', name: 'file1', trashed: false },
         { _id: '2', name: 'file2', trashed: true },
-        { _id: '3', name: 'file3', trashed: false }
+        { _id: '3', name: 'file3', trashed: false },
+        { _id: '4', name: 'file4', trashed: true }
       ]
       const mockDataProxy = {
         dataProxyServicesAvailable: true,
         recents: jest.fn().mockResolvedValue(mockData)
       }
 
-      // Simulate file3 trashed in store, file1 renamed in store
+      // Simulate file3 trashed in store, file1 renamed in store, file4 restored only in store
       mockClient.getDocumentFromState.mockImplementation((doctype, id) => {
         if (id === '3') return { _id: '3', trashed: true }
+        if (id === '4') return { _id: '4', trashed: false }
         if (id === '1')
           return { _id: '1', name: 'file1_renamed', trashed: false }
         return null
@@ -192,23 +194,6 @@ describe('useDataProxyRecents', () => {
       expect(result.current.fetchStatus).toBe('loading')
       expect(result.current.data).toEqual([])
       expect(result.current.error).toBe(null)
-    })
-  })
-
-  describe('when client is not available', () => {
-    it('should set error when client is not available', () => {
-      const mockDataProxy = {
-        dataProxyServicesAvailable: false
-      }
-
-      const { result } = renderRecents({
-        dataProxy: mockDataProxy,
-        client: null
-      })
-
-      expect(result.current.fetchStatus).toBe('error')
-      expect(result.current.error).toEqual(new Error('Client not available'))
-      expect(result.current.data).toEqual([])
     })
   })
 })

--- a/src/hooks/useRecentFiles.spec.jsx
+++ b/src/hooks/useRecentFiles.spec.jsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react'
 
-import { useClient } from 'cozy-client'
+import { useClient, useQuery } from 'cozy-client'
 import { useDataProxy } from 'cozy-dataproxy-lib'
 
 import useDataProxyRecents from './useRecentFiles'
@@ -9,7 +9,8 @@ import logger from '@/lib/logger'
 import { buildRecentQuery } from '@/queries'
 
 jest.mock('cozy-client', () => ({
-  useClient: jest.fn()
+  useClient: jest.fn(),
+  useQuery: jest.fn()
 }))
 
 jest.mock('cozy-dataproxy-lib', () => ({
@@ -26,8 +27,16 @@ jest.mock('@/queries', () => ({
 }))
 
 const mockUseClient = useClient
+const mockUseQuery = useQuery
 const mockUseDataProxy = useDataProxy
 const mockBuildRecentQuery = buildRecentQuery
+
+const renderRecents = ({ dataProxy, useQueryResult, client } = {}) => {
+  if (dataProxy) mockUseDataProxy.mockReturnValue(dataProxy)
+  if (useQueryResult) mockUseQuery.mockReturnValue(useQueryResult)
+  if (client !== undefined) mockUseClient.mockReturnValue(client)
+  return renderHook(() => useDataProxyRecents())
+}
 
 describe('useDataProxyRecents', () => {
   let mockClient
@@ -35,38 +44,52 @@ describe('useDataProxyRecents', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockClient = {
-      fetchQueryAndGetFromState: jest.fn()
+      getDocumentFromState: jest.fn()
     }
     mockUseClient.mockReturnValue(mockClient)
     mockBuildRecentQuery.mockReturnValue({
       definition: jest.fn(() => ({})),
       options: {}
     })
+    mockUseQuery.mockReturnValue({
+      data: null,
+      fetchStatus: 'loading',
+      error: null
+    })
   })
 
   describe('when dataProxy is available and succeeds', () => {
-    it('should return data from dataProxy', async () => {
+    it('should return data from dataProxy and filter trashed documents', async () => {
       const mockData = [
-        { id: '1', name: 'file1' },
-        { id: '2', name: 'file2' }
+        { _id: '1', name: 'file1', trashed: false },
+        { _id: '2', name: 'file2', trashed: true },
+        { _id: '3', name: 'file3', trashed: false }
       ]
       const mockDataProxy = {
         dataProxyServicesAvailable: true,
         recents: jest.fn().mockResolvedValue(mockData)
       }
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
+      // Simulate file3 trashed in store, file1 renamed in store
+      mockClient.getDocumentFromState.mockImplementation((doctype, id) => {
+        if (id === '3') return { _id: '3', trashed: true }
+        if (id === '1')
+          return { _id: '1', name: 'file1_renamed', trashed: false }
+        return null
+      })
 
-      const { result } = renderHook(() => useDataProxyRecents())
+      const { result } = renderRecents({ dataProxy: mockDataProxy })
 
       expect(result.current.fetchStatus).toBe('loading')
       expect(result.current.data).toEqual([])
 
       await waitFor(() => expect(result.current.fetchStatus).toBe('loaded'))
-      expect(result.current.data).toEqual(mockData)
+
+      expect(result.current.data).toEqual([
+        { _id: '1', name: 'file1_renamed', trashed: false }
+      ])
       expect(result.current.error).toBe(null)
       expect(mockDataProxy.recents).toHaveBeenCalledTimes(1)
-      expect(mockClient.fetchQueryAndGetFromState).not.toHaveBeenCalled()
       expect(logger.error).not.toHaveBeenCalled()
     })
   })
@@ -78,34 +101,26 @@ describe('useDataProxyRecents', () => {
         dataProxyServicesAvailable: true,
         recents: jest.fn().mockRejectedValue(mockError)
       }
-      const fallbackData = [
-        { id: '3', name: 'file3' },
-        { id: '4', name: 'file4' }
-      ]
+      const fallbackData = [{ _id: '4', name: 'file4' }]
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockClient.fetchQueryAndGetFromState.mockResolvedValue({
-        data: fallbackData
+      const { result } = renderRecents({
+        dataProxy: mockDataProxy,
+        useQueryResult: {
+          data: fallbackData,
+          fetchStatus: 'loaded',
+          error: null
+        }
       })
 
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      expect(result.current.fetchStatus).toBe('loading')
-      expect(result.current.data).toEqual([])
-
-      // Wait for fallback query to complete
+      // Wait for proxy to fail and fallback to be used
       await waitFor(() => expect(result.current.fetchStatus).toBe('loaded'))
+
       expect(result.current.data).toEqual(fallbackData)
-      expect(result.current.error).toBe(null)
+      expect(result.current.error).toBe(mockError)
       expect(logger.error).toHaveBeenCalledWith(
         'Error fetching recents from dataproxy',
         mockError
       )
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledWith({
-        definition: expect.any(Object),
-        options: expect.any(Object)
-      })
     })
 
     it('should handle fallback query error', async () => {
@@ -116,13 +131,18 @@ describe('useDataProxyRecents', () => {
         recents: jest.fn().mockRejectedValue(mockError)
       }
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockClient.fetchQueryAndGetFromState.mockRejectedValue(fallbackError)
+      const { result } = renderRecents({
+        dataProxy: mockDataProxy,
+        useQueryResult: {
+          data: null,
+          fetchStatus: 'failed',
+          error: fallbackError
+        }
+      })
 
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      // Wait for fallback query error to be processed
+      // Wait for proxy to fail
       await waitFor(() => expect(result.current.fetchStatus).toBe('error'))
+
       expect(result.current.error).toEqual(fallbackError)
       expect(logger.error).toHaveBeenCalledWith(
         'Error fetching recents from dataproxy',
@@ -132,78 +152,63 @@ describe('useDataProxyRecents', () => {
         'Error fetching recents from fallback query',
         fallbackError
       )
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('when dataProxy is not available', () => {
-    it('should use fallback query when dataProxy is not available', async () => {
+    it('should use fallback query when dataProxy is not available', () => {
       const mockDataProxy = {
         dataProxyServicesAvailable: false
       }
-      const fallbackData = [
-        { id: '5', name: 'file5' },
-        { id: '6', name: 'file6' }
-      ]
+      const fallbackData = [{ _id: '5', name: 'file5' }]
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockClient.fetchQueryAndGetFromState.mockResolvedValue({
-        data: fallbackData
+      const { result } = renderRecents({
+        dataProxy: mockDataProxy,
+        useQueryResult: {
+          data: fallbackData,
+          fetchStatus: 'loaded',
+          error: null
+        }
       })
 
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      // When dataProxy is not available, the hook should execute fallback query
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
-
-      // Wait for fallback query to complete
-      await waitFor(() => expect(result.current.fetchStatus).toBe('loaded'))
+      expect(result.current.fetchStatus).toBe('loaded')
       expect(result.current.data).toEqual(fallbackData)
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledWith({
-        definition: expect.any(Object),
-        options: expect.any(Object)
-      })
     })
 
-    it('should handle fallback query loading state', async () => {
+    it('should handle fallback query loading state', () => {
       const mockDataProxy = {
         dataProxyServicesAvailable: false
       }
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      // Don't resolve the query immediately to test loading state
-      mockClient.fetchQueryAndGetFromState.mockImplementation(
-        () => new Promise(() => {}) // Never resolves
-      )
-
-      const { result } = renderHook(() => useDataProxyRecents())
+      const { result } = renderRecents({
+        dataProxy: mockDataProxy,
+        useQueryResult: {
+          data: null,
+          fetchStatus: 'loading',
+          error: null
+        }
+      })
 
       expect(result.current.fetchStatus).toBe('loading')
       expect(result.current.data).toEqual([])
       expect(result.current.error).toBe(null)
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('when client is not available', () => {
-    it('should set error when client is not available', async () => {
+    it('should set error when client is not available', () => {
       const mockDataProxy = {
         dataProxyServicesAvailable: false
       }
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockUseClient.mockReturnValue(null)
-
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      // Wait for error to be set
-      await waitFor(() => {
-        expect(result.current.fetchStatus).toBe('error')
+      const { result } = renderRecents({
+        dataProxy: mockDataProxy,
+        client: null
       })
 
+      expect(result.current.fetchStatus).toBe('error')
       expect(result.current.error).toEqual(new Error('Client not available'))
       expect(result.current.data).toEqual([])
-      expect(mockClient.fetchQueryAndGetFromState).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
This only fixes real time update on recents view for local files at the moment

The proxy path now subscribes to the cozy-client store via useQuery so that trashed or renamed documents disappear from the recent view without navigating away: getDocumentFromState merges fresh store data onto stale proxy results on every re-render.

- Replace one-shot fetchQueryAndGetFromState with reactive useQuery
- Merge proxy data with store via getDocumentFromState + spread
- Filter trashed documents from both proxy and store sources
- Unify duplicated fallback return blocks
- Add e2e tests for live trash and rename on /#/recent

https://app.notion.com/p/linagora/recents-cant-delete-file-or-rename-files-38462718bad1806ca5afe2546e29b717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent files can now be managed directly from the Recent view without reloading the page (trash and rename supported).

* **Bug Fixes**
  * Recent entries now stay in sync with the latest document state, including removing trashed items and updating renamed items instantly.

* **Tests**
  * Added end-to-end coverage for trashing and renaming from the Recent view, plus improvements to Favorites cleanup and Search locator formatting.
  * Updated unit tests for the Recent-files hook to use query-based mocking and validate fallback/error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->