### PR TITLE
fix(public): skip files.settings query on public routes

### DIFF
--- a/src/lib/ViewSwitcherContext.spec.jsx
+++ b/src/lib/ViewSwitcherContext.spec.jsx
@@ -1,0 +1,122 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import { useClient } from 'cozy-client'
+
+import {
+  ViewSwitcherContextProvider,
+  useViewSwitcherContext
+} from './ViewSwitcherContext'
+
+import { DOCTYPE_FILES_SETTINGS } from '@/lib/doctypes'
+import logger from '@/lib/logger'
+import { usePublicContext } from '@/modules/public/PublicProvider'
+
+jest.mock('cozy-client', () => ({
+  useClient: jest.fn(),
+  Q: jest.fn().mockReturnValue('mocked-query')
+}))
+
+jest.mock('@/lib/logger', () => ({
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn()
+}))
+
+jest.mock('@/modules/public/PublicProvider', () => ({
+  usePublicContext: jest.fn()
+}))
+
+const mockUseClient = useClient
+const mockUsePublicContext = usePublicContext
+
+const wrapper = ({ children }) => (
+  <ViewSwitcherContextProvider>{children}</ViewSwitcherContextProvider>
+)
+
+describe('ViewSwitcherContext', () => {
+  let mockClient
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockClient = {
+      save: jest.fn().mockResolvedValue({}),
+      query: jest.fn().mockResolvedValue({ data: [] })
+    }
+    mockUseClient.mockReturnValue(mockClient)
+
+    mockUsePublicContext.mockReturnValue({ isPublic: false })
+  })
+
+  it('loads the preferred view type from settings', async () => {
+    mockClient.query.mockResolvedValue({
+      data: [{ attributes: { preferredDriveViewType: 'grid' } }]
+    })
+
+    const { result } = renderHook(() => useViewSwitcherContext(), { wrapper })
+
+    await waitFor(() => expect(result.current.viewType).toBe('grid'))
+
+    expect(mockClient.query).toHaveBeenCalledWith('mocked-query')
+  })
+
+  it('does not query settings in public view', async () => {
+    mockUsePublicContext.mockReturnValue({ isPublic: true })
+
+    const { result } = renderHook(() => useViewSwitcherContext(), { wrapper })
+
+    expect(result.current.viewType).toBe('list')
+    expect(mockClient.query).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('does not persist the view type in public view', async () => {
+    mockUsePublicContext.mockReturnValue({ isPublic: true })
+
+    const { result } = renderHook(() => useViewSwitcherContext(), { wrapper })
+
+    await act(async () => {
+      await result.current.switchView('grid')
+    })
+
+    expect(result.current.viewType).toBe('grid')
+    expect(mockClient.save).not.toHaveBeenCalled()
+    expect(mockClient.query).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Cannot persist view: in public view'
+    )
+  })
+
+  it('persists the preferred view type when not in public view', async () => {
+    const existing = {
+      _id: 'settings-id',
+      _type: DOCTYPE_FILES_SETTINGS,
+      attributes: { preferredDriveViewType: 'list' }
+    }
+    // First call is the mount load, second is switchView's read-before-save.
+    mockClient.query
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [existing] })
+
+    const { result } = renderHook(() => useViewSwitcherContext(), { wrapper })
+
+    await act(async () => {
+      await result.current.switchView('grid')
+    })
+
+    expect(mockClient.save).toHaveBeenCalledWith({
+      ...existing,
+      attributes: { preferredDriveViewType: 'grid' }
+    })
+  })
+
+  it('keeps DOCTYPE_FILES_SETTINGS as the queried doctype', async () => {
+    renderHook(() => useViewSwitcherContext(), { wrapper })
+
+    await waitFor(() => expect(mockClient.query).toHaveBeenCalled())
+
+    const { Q } = jest.requireMock('cozy-client')
+    expect(Q).toHaveBeenCalledWith(DOCTYPE_FILES_SETTINGS)
+  })
+})

--- a/src/lib/ViewSwitcherContext.tsx
+++ b/src/lib/ViewSwitcherContext.tsx
@@ -5,6 +5,7 @@ import { useClient, Q } from 'cozy-client'
 import logger from './logger'
 
 import { DOCTYPE_FILES_SETTINGS } from '@/lib/doctypes'
+import { usePublicContext } from '@/modules/public/PublicProvider'
 
 interface QueryResult {
   data: [
@@ -30,11 +31,12 @@ const ViewSwitcherContext = createContext<ViewSwitcherContextProps>({
 
 const ViewSwitcherContextProvider: React.FC = ({ children }) => {
   const client = useClient()
+  const { isPublic } = usePublicContext()
   const [viewType, setViewType] = useState(DEFAULT_VIEW_TYPE)
 
   useEffect(() => {
     const load = async (): Promise<void> => {
-      if (!client) return
+      if (!client || isPublic) return
 
       try {
         const result = (await client.query(
@@ -53,12 +55,18 @@ const ViewSwitcherContextProvider: React.FC = ({ children }) => {
     }
 
     void load()
-  }, [client])
+  }, [client, isPublic])
 
   const switchView = async (viewTypeParam: string): Promise<void> => {
     setViewType(viewTypeParam)
     if (!client) {
       logger.warn('Client not available')
+
+      return
+    }
+
+    if (isPublic) {
+      logger.warn('Cannot persist view: in public view')
 
       return
     }


### PR DESCRIPTION
## Problem
On public-share routes the sharecode token has no permission to read `io.cozy.files.settings`. The view-switcher context queried it on every mount anyway, so each public visit got a 403 that was logged to the console and captured by Sentry, thousands of occurrences across over a thousand visitors with no functional benefit (the view just falls back to its default).

## Solution
Skip the settings read and write on public routes by guarding the load effect and the persist path with `isPublic`, the same way `useFolderSort` already does.

Fixes DRIVE-11RR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * View preferences now behave correctly in public view: the app defaults to list mode and won’t try to load or save personal view settings.
  * Switching between views still works normally outside public view, with preferences saved as expected.
  * Added coverage to help ensure view-switching behavior stays consistent in both public and private modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->