### PR TITLE
fix: Layout shift in virtualized grid view during scroll

### DIFF
--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -73,7 +73,7 @@
         align-items center
 
 .fil-content-grid-item
-    margin .4rem
+    height 12rem
 
 .fil-content-column-selected
     @extend $table-row-selected

--- a/src/styles/folder-view.styl
+++ b/src/styles/folder-view.styl
@@ -1,4 +1,5 @@
 .fil-folder-body-grid
     display grid
-    grid-template-columns repeat(auto-fill, minmax(8.4rem, 1fr))
+    grid-template-columns repeat(auto-fill, 8.4rem)
     padding .5rem
+    gap .8rem // @stylint ignore


### PR DESCRIPTION
The virtualized grid view (VirtuosoGrid) was causing visible item reordering and jumping during smooth scrolling.

Root cause: two CSS properties were incompatible with how VirtuosoGrid internally calculates item positions (paddingTop/paddingBottom offsets to simulate non-rendered items).

1. `margin: .4rem` on grid items — VirtuosoGrid measures items via getBoundingClientRect() which does NOT include margins. This caused it to underestimate item sizes, producing incorrect scroll offsets.

2. `grid-template-columns: repeat(auto-fill, minmax(8.4rem, 1fr))` — the `1fr` stretches items to fill available space, but VirtuosoGrid computes column count mathematically from the measured item width. The mismatch between CSS grid's actual column count and VirtuosoGrid's
   calculated count caused paddingTop to diverge from real item positions.

Fix:
- Replace item `margin` with `gap` on the grid container. VirtuosoGrid reads gap via getComputedStyle(), so it accounts for it correctly.
- Use fixed column size `repeat(auto-fill, 8.4rem)` instead of `minmax(8.4rem, 1fr)` so item width is predictable and consistent with VirtuosoGrid's column calculation.
- Add explicit `height: 12rem` on grid items for stable row height.

https://app.notion.com/p/linagora/Broken-grid-view-38962718bad180548692da3a93622a16?source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the file list layout to use a fixed centered column height for more consistent alignment.
  * Refreshed the folder view grid to use a fixed-width auto-fill column pattern.
  * Added consistent spacing between folder grid items for a cleaner, more uniform presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->