### PR TITLE
feat: Remove bar flag from onlyoffice entrypoint

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -95,7 +95,7 @@
       },
       "hash": "/onlyoffice/create/io.cozy.files.root-dir/text",
       "icon": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgZmlsbD0ibm9uZSI+PHBhdGggZmlsbD0iIzAwNzZFRCIgZD0iTTguNCAwQTYuNCA2LjQgMCAwIDAgMiA2LjR2MTkuMkE2LjQgNi40IDAgMCAwIDguNCAzMmgxNmE2LjQgNi40IDAgMCAwIDYuNC02LjRWMTAuNEwyMC40IDBjLTQuMDEzIDAtNCAwIDAgMGgtMTJaIi8+PHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjIuOTA5IiB4PSI4IiB5PSIxMCIgZmlsbD0iI2ZmZiIgcng9IjEuNDU1Ii8+PHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjIuOTA5IiB4PSI4IiB5PSIxNS45MDkiIGZpbGw9IiNmZmYiIHJ4PSIxLjQ1NSIvPjxyZWN0IHdpZHRoPSIxNiIgaGVpZ2h0PSIyLjkwOSIgeD0iOCIgeT0iMjEuODE4IiBmaWxsPSIjZmZmIiByeD0iMS40NTUiLz48cGF0aCBmaWxsPSIjMDA2OEQyIiBkPSJNMzAuOCAxMC44IDIwIDB2NS41ODZjMCAyLjg4IDIuMjU3IDUuMjE0IDUuMDQgNS4yMTRoNS43NloiLz48L3N2Zz4=",
-      "conditions": [{ "type": "flag", "name": "drive.office.enabled", "value": true }, { "type": "flag", "name": "drive.office.write", "value": true }, { "type": "flag", "name": "bar.onlyoffice.enabled", "value": true }]
+      "conditions": [{ "type": "flag", "name": "drive.office.enabled", "value": true }, { "type": "flag", "name": "drive.office.write", "value": true }]
     },
     {
       "name": "new-file-type-sheet",
@@ -107,7 +107,7 @@
       },
       "hash": "/onlyoffice/create/io.cozy.files.root-dir/spreadsheet",
       "icon": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgZmlsbD0ibm9uZSI+PHBhdGggZmlsbD0iIzBEOUUzMCIgZD0iTTguNCAwQTYuNCA2LjQgMCAwIDAgMiA2LjR2MTkuMkE2LjQgNi40IDAgMCAwIDguNCAzMmgxNmE2LjQgNi40IDAgMCAwIDYuNC02LjRWMTAuNEwyMC40IDBjLTQuMDEzIDAtNCAwIDAgMGgtMTJaIi8+PHJlY3Qgd2lkdGg9IjYuODU3IiBoZWlnaHQ9IjYuODU3IiB4PSI4IiB5PSIxMCIgZmlsbD0iI2ZmZiIgcng9Ii40NTciLz48cmVjdCB3aWR0aD0iNi44NTciIGhlaWdodD0iNi44NTciIHg9IjgiIHk9IjE5LjE0MyIgZmlsbD0iI2ZmZiIgcng9Ii40NTciLz48cmVjdCB3aWR0aD0iNi44NTciIGhlaWdodD0iNi44NTciIHg9IjE3LjE0MyIgeT0iMTkuMTQzIiBmaWxsPSIjZmZmIiByeD0iLjQ1NyIvPjxyZWN0IHdpZHRoPSI2Ljg1NyIgaGVpZ2h0PSI2Ljg1NyIgeD0iMTcuMTQzIiB5PSIxMCIgZmlsbD0iI2ZmZiIgcng9Ii40NTciLz48cGF0aCBmaWxsPSIjMDA4NDIwIiBkPSJNMzAuOCAxMC44IDIwIDB2NS41ODZjMCAyLjg4IDIuMjU3IDUuMjE0IDUuMDQgNS4yMTRoNS43NloiLz48L3N2Zz4=",
-      "conditions": [{ "type": "flag", "name": "drive.office.enabled", "value": true }, { "type": "flag", "name": "drive.office.write", "value": true }, { "type": "flag", "name": "bar.onlyoffice.enabled", "value": true }]
+      "conditions": [{ "type": "flag", "name": "drive.office.enabled", "value": true }, { "type": "flag", "name": "drive.office.write", "value": true }]
     },
     {
       "name": "new-file-type-slide",
@@ -119,7 +119,7 @@
       },
       "hash": "/onlyoffice/create/io.cozy.files.root-dir/slide",
       "icon": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgZmlsbD0ibm9uZSI+PHBhdGggZmlsbD0iI0ZGOTUwMCIgZD0iTTguNCAwQTYuNCA2LjQgMCAwIDAgMiA2LjR2MTkuMkE2LjQgNi40IDAgMCAwIDguNCAzMmgxNmE2LjQgNi40IDAgMCAwIDYuNC02LjRWMTAuNEwyMC40IDBjLTQuMDEzIDAtNCAwIDAgMGgtMTJaIi8+PHBhdGggZmlsbD0iI0RGNjMxMCIgZD0iTTMwLjggMTAuOCAyMCAwdjUuNTg2YzAgMi44OCAyLjI1NyA1LjIxNCA1LjA0IDUuMjE0aDUuNzZaIi8+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTE1LjQyMiAxMS4xNTdhNy40MjIgNy40MjIgMCAxIDAgNy40MjEgNy40MjFoLTcuNDIxdi03LjQyMVoiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJNMTYuNTc4IDEwdjcuNDIySDI0QTcuNDIyIDcuNDIyIDAgMCAwIDE2LjU3OCAxMFoiLz48L3N2Zz4=",
-      "conditions": [{ "type": "flag", "name": "drive.office.enabled", "value": true }, { "type": "flag", "name": "drive.office.write", "value": true }, { "type": "flag", "name": "bar.onlyoffice.enabled", "value": true }]
+      "conditions": [{ "type": "flag", "name": "drive.office.enabled", "value": true }, { "type": "flag", "name": "drive.office.write", "value": true }]
     },
     {
       "name": "new-file-type-excalidraw",


### PR DESCRIPTION
This condition was made to enable onlyoffice entrypoint only when the bar was released for every app. Is it not required anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creation of text documents, spreadsheets, and presentations is now available in more cases by reducing the required feature checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->