### PR TITLE
fix(sharings): make sidebar counter consistent with sharings view

### DIFF
--- a/src/modules/navigation/SharingsNavItem.jsx
+++ b/src/modules/navigation/SharingsNavItem.jsx
@@ -1,18 +1,30 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { useQuery } from 'cozy-client'
+import { isSharingShortcutNew } from 'cozy-client/dist/models/file'
+import { useSharingContext } from 'cozy-sharing'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ShareIcon from 'cozy-ui/transpiled/react/Icons/ShareExternal'
 
 import { NavItem } from '@/modules/navigation/NavItem'
-import { buildNewSharingShortcutQuery } from '@/queries'
+import { buildSharingsQuery } from '@/queries'
 
 const SharingsNavItem = ({ clickState }) => {
-  const newSharingShortcutQuery = buildNewSharingShortcutQuery()
-  const newSharingShortcutResult = useQuery(
-    newSharingShortcutQuery.definition,
-    newSharingShortcutQuery.options
+  const { byDocId, allLoaded } = useSharingContext()
+  const sharedDocuments = useMemo(
+    () => [...new Set(Object.keys(byDocId ?? {}))],
+    [byDocId]
   )
+
+  const sharingQuery = useMemo(
+    () =>
+      buildSharingsQuery({
+        ids: sharedDocuments,
+        enabled: allLoaded && sharedDocuments.length > 0
+      }),
+    [sharedDocuments, allLoaded]
+  )
+  const sharingResult = useQuery(sharingQuery.definition, sharingQuery.options)
 
   return (
     <NavItem
@@ -21,7 +33,9 @@ const SharingsNavItem = ({ clickState }) => {
       label="sharings"
       rx={/\/sharings(\/.*)?|\/shareddrive(\/.*)?/}
       clickState={clickState}
-      badgeContent={newSharingShortcutResult.data?.length}
+      badgeContent={
+        sharingResult.data?.filter(isSharingShortcutNew).length ?? 0
+      }
     />
   )
 }

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -324,21 +324,6 @@ export const buildFolderByPathQuery: QueryBuilder<string> = path => ({
   }
 })
 
-export const buildNewSharingShortcutQuery: QueryBuilder = () => ({
-  definition: () =>
-    Q('io.cozy.files')
-      .where({
-        'metadata.sharing.status': 'new',
-        class: 'shortcut',
-        trashed: false
-      })
-      .indexFields(['metadata.sharing.status', 'class', 'trashed']),
-  options: {
-    as: 'io.cozy.files/metadata.sharing.status/new/class/shortcut',
-    fetchPolicy: defaultFetchPolicy
-  }
-})
-
 export const buildTriggersQueryByAccountId: QueryBuilder<
   string
 > = accountId => ({


### PR DESCRIPTION
Problem:

Sometimes we did not have the same number displayed in the sidebar counter of sharings section and the list of new sharings in sharings section body.

Replace the independent CouchDB query for new sharing shortcuts in the sidebar badge with the same query used by the sharings body (buildSharingsQuery via useSharingContext). This ensures the counter only counts items that are actually present in the sharings view.

fixes https://github.com/linagora/twake-drive/issues/3981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Sharings navigation badge so it more reliably reflects the number of new shared items.
  * Updated the Sharings navigation to refresh its results based on the currently shared documents, keeping the badge count consistent with what’s displayed.
  * The badge now safely defaults when results are unavailable, avoiding incorrect or missing counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->