### PR TITLE
feat: dispatch shared-drive realtime events into the store

### DIFF
--- a/e2e/tests/z-shared-drive-folder.spec.ts
+++ b/e2e/tests/z-shared-drive-folder.spec.ts
@@ -1,0 +1,171 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { test, expect, stamp, safeUnlink } from '../helpers/fixtures'
+import {
+  createAndShareFolderWithBob,
+  openOwnerFolder,
+  openSharedDrive
+} from '../helpers/sharing'
+
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+
+// Module-level so these names persist across every serial test in the describe.
+const DRIVE_NAME = `Folder Drive ${stamp()}`
+// Seeded at setup — Alice trashes/renames these from her folder view (Variant A).
+const ALICE_TRASH_FILE = `folder-alice-trash-${stamp()}.txt`
+const ALICE_RENAME_FILE = `folder-alice-rename-${stamp()}.txt`
+const ALICE_RENAMED = `folder-alice-renamed-${stamp()}.txt`
+// Seeded at setup — Bob trashes/renames these from his shared-drive folder view (Variant B).
+const BOB_TRASH_FILE = `folder-bob-trash-${stamp()}.txt`
+const BOB_RENAME_FILE = `folder-bob-rename-${stamp()}.txt`
+const BOB_RENAMED = `folder-bob-renamed-${stamp()}.txt`
+
+test.describe.serial('Shared drive folder live updates', () => {
+  // ─── Setup ───────────────────────────────────────────────────────────────
+  //
+  // Alice creates a shared drive (federated folder), seeds it with four
+  // fixture files — two for Alice's tests, two for Bob's tests — and
+  // shares with Bob as Editor so he can rename/trash.
+
+  test('setup: Alice creates and shares a drive seeded with fixture files', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    const aliceTrashPath = path.join(FIXTURE_DIR, ALICE_TRASH_FILE)
+    const aliceRenamePath = path.join(FIXTURE_DIR, ALICE_RENAME_FILE)
+    const bobTrashPath = path.join(FIXTURE_DIR, BOB_TRASH_FILE)
+    const bobRenamePath = path.join(FIXTURE_DIR, BOB_RENAME_FILE)
+    await copyFile(SAMPLE, aliceTrashPath)
+    await copyFile(SAMPLE, aliceRenamePath)
+    await copyFile(SAMPLE, bobTrashPath)
+    await copyFile(SAMPLE, bobRenamePath)
+    try {
+      await createAndShareFolderWithBob(alicePage, aliceDrive, DRIVE_NAME, {
+        role: 'Editor',
+        seed: async () => {
+          await aliceDrive.uploadFiles([
+            aliceTrashPath,
+            aliceRenamePath,
+            bobTrashPath,
+            bobRenamePath
+          ])
+          await aliceDrive.row(ALICE_TRASH_FILE).waitVisible()
+          await aliceDrive.row(ALICE_RENAME_FILE).waitVisible()
+          await aliceDrive.row(BOB_TRASH_FILE).waitVisible()
+          await aliceDrive.row(BOB_RENAME_FILE).waitVisible()
+        }
+      })
+    } finally {
+      await safeUnlink(aliceTrashPath)
+      await safeUnlink(aliceRenamePath)
+      await safeUnlink(bobTrashPath)
+      await safeUnlink(bobRenamePath)
+    }
+  })
+
+  // ─── Variant A — OWNER instance (Alice) ──────────────────────────────────
+  //
+  // Alice accesses the shared drive through her own /folder route (the drive
+  // is her own folder). Own-instance realtime is expected to push updates
+  // without any manual reload — the whole point of Plan C.
+
+  test('owner (Alice): seeded file disappears live on trash inside folder view', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    // Navigate into the shared-drive folder on Alice's own instance. The drive
+    // is her own folder, so it renders on the regular /folder route — there is
+    // no proxied /shareddrive view on the owner's side.
+    await openOwnerFolder(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+
+    // The seeded file is visible without a reload — Alice owns this folder.
+    await aliceDrive.row(ALICE_TRASH_FILE).waitVisible({ timeout: 10_000 })
+
+    // Trash from the folder view. sendToTrash() opens the More menu, clicks
+    // /^remove$/i, confirms the dialog, and calls waitHidden() internally —
+    // the row should vanish live (own-instance realtime), without a manual
+    // page reload.
+    await aliceDrive.row(ALICE_TRASH_FILE).sendToTrash()
+  })
+
+  test('owner (Alice): file renamed live inside folder view', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    await openOwnerFolder(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+
+    // The seeded file is visible without a reload.
+    await aliceDrive.row(ALICE_RENAME_FILE).waitVisible({ timeout: 10_000 })
+
+    // Rename from the folder view. rename() waits for the new name to be
+    // visible in the current file list — no reload expected (own-instance
+    // realtime).
+    await aliceDrive.row(ALICE_RENAME_FILE).rename(ALICE_RENAMED)
+  })
+
+  // ─── Variant B — RECIPIENT instance (Bob) ────────────────────────────────
+  //
+  // Bob accesses files through the proxied /shareddrive route on his instance.
+  // Cross-instance propagation (Alice → Bob) is not pushed live by the CI
+  // stack, so a reload-and-poll pattern is used instead of relying on the
+  // per-drive realtime socket push.
+  //
+  // Note: true no-reload live updates for the recipient depend on the per-drive
+  // realtime socket being delivered to Bob's stack (Plan A Phase 3). That push
+  // may not fire in the CI stack. The reload-poll keeps these tests stable
+  // while still validating that the reactive store path produces the correct
+  // end state once the data arrives from Alice's instance.
+
+  test('recipient (Bob): shared-drive file appears in folder view via reload-poll, disappears on trash', async ({
+    bobPage,
+    bobDrive
+  }) => {
+    // Open the shared drive so Bob's instance registers and replicates it.
+    // openSharedDrive polls the Sharings tab until the row shows up, then
+    // navigates into the proxied /shareddrive/ folder view.
+    await openSharedDrive(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
+
+    // Poll until the seeded file appears in Bob's folder view. Files proxied
+    // from Alice's instance may take a few seconds to replicate.
+    await expect(async () => {
+      await bobPage.reload()
+      await bobDrive.row(BOB_TRASH_FILE).waitVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000 })
+
+    // Bob trashes from his shared-drive folder view. sendToTrash() opens the
+    // More menu (/^remove$/i), confirms the dialog, and calls waitHidden()
+    // internally — the row should disappear once the proxied stack confirms.
+    // Note: the /^remove$/i confirm-button label is hardcoded in FileRow; on a
+    // proxied /shareddrive route the menu/dialog label may differ if the
+    // recipient UI diverges — update FileRow.sendToTrash if that happens.
+    await bobDrive.row(BOB_TRASH_FILE).sendToTrash()
+  })
+
+  test('recipient (Bob): shared-drive file renamed from folder view is reflected via reload-poll', async ({
+    bobPage,
+    bobDrive
+  }) => {
+    // Fresh per-test context: open the shared drive so Bob's instance
+    // registers/replicates it before the folder view is checked.
+    await openSharedDrive(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
+
+    // Poll until the rename-candidate file appears in Bob's folder view.
+    await expect(async () => {
+      await bobPage.reload()
+      await bobDrive.row(BOB_RENAME_FILE).waitVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000 })
+
+    // Bob renames from his shared-drive folder view. rename() waits for the
+    // new name to be visible in the current file list.
+    await bobDrive.row(BOB_RENAME_FILE).rename(BOB_RENAMED)
+
+    // Confirm the rename is durable: reload and check the new name still appears.
+    await expect(async () => {
+      await bobPage.reload()
+      await bobDrive.row(BOB_RENAMED).waitVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000 })
+  })
+})

--- a/e2e/tests/z-shared-drive-recent.spec.ts
+++ b/e2e/tests/z-shared-drive-recent.spec.ts
@@ -6,7 +6,7 @@ import { test, expect, stamp, safeUnlink } from '../helpers/fixtures'
 import {
   createAndShareFolderWithBob,
   openOwnerFolder,
-  waitForSharingRow
+  openSharedDrive
 } from '../helpers/sharing'
 import { SidebarPage } from '../pages/SidebarPage'
 
@@ -126,10 +126,11 @@ test.describe.serial('Shared drive recents', () => {
     bobPage,
     bobDrive
   }) => {
-    // Ensure the sharing has propagated to Bob's instance before checking
-    // his recent view. waitForSharingRow polls /#/sharings until the drive
-    // row appears.
-    await waitForSharingRow(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
+    // Open the shared drive once so Bob's instance registers and replicates it
+    // (the recipient's drive pouch/realtime subscription is set up on first
+    // visit). openSharedDrive waits for the sharing row, then navigates into
+    // the proxied /shareddrive/ view.
+    await openSharedDrive(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
 
     // Poll until the shared-drive file surfaces in Bob's /#/recent. Files
     // proxied from Alice's instance may take a few seconds to appear.
@@ -147,6 +148,10 @@ test.describe.serial('Shared drive recents', () => {
     bobPage,
     bobDrive
   }) => {
+    // Fresh per-test context: open the shared drive so Bob's instance
+    // registers/replicates it before the recent view is checked.
+    await openSharedDrive(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
+
     // Poll until the rename-candidate file appears in Bob's recent view.
     await expect(async () => {
       await bobPage.goto(`${USERS.bob.appUrl}/#/recent`)

--- a/e2e/tests/z-shared-drive-recent.spec.ts
+++ b/e2e/tests/z-shared-drive-recent.spec.ts
@@ -1,0 +1,166 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { test, expect, stamp, safeUnlink } from '../helpers/fixtures'
+import {
+  createAndShareFolderWithBob,
+  openOwnerFolder,
+  waitForSharingRow
+} from '../helpers/sharing'
+import { SidebarPage } from '../pages/SidebarPage'
+
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+
+// Module-level so these names persist across every serial test in the describe.
+const DRIVE_NAME = `Recent Drive ${stamp()}`
+// Seeded at setup — Alice trashes this from her own-scope recent view (Variant A).
+const ALICE_TRASH_FILE = `recent-alice-trash-${stamp()}.txt`
+// Uploaded by Alice in the rename test; renamed live from her recent view (Variant A).
+const ALICE_RENAME_FILE = `recent-alice-rename-${stamp()}.txt`
+const ALICE_RENAMED = `recent-alice-renamed-${stamp()}.txt`
+// Seeded at setup — Bob trashes/renames these from his shared-drive recent view (Variant B).
+const BOB_TRASH_FILE = `recent-bob-trash-${stamp()}.txt`
+const BOB_RENAME_FILE = `recent-bob-rename-${stamp()}.txt`
+const BOB_RENAMED = `recent-bob-renamed-${stamp()}.txt`
+
+test.describe.serial('Shared drive recents', () => {
+  // ─── Setup ───────────────────────────────────────────────────────────────
+  //
+  // Alice creates a shared drive (federated folder), seeds it with three
+  // fixture files — one for Alice's trash test, two for Bob's tests — and
+  // shares with Bob as Editor so he can trash/rename.
+
+  test('setup: Alice creates and shares a drive seeded with fixture files', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    const aliceTrashPath = path.join(FIXTURE_DIR, ALICE_TRASH_FILE)
+    const bobTrashPath = path.join(FIXTURE_DIR, BOB_TRASH_FILE)
+    const bobRenamePath = path.join(FIXTURE_DIR, BOB_RENAME_FILE)
+    await copyFile(SAMPLE, aliceTrashPath)
+    await copyFile(SAMPLE, bobTrashPath)
+    await copyFile(SAMPLE, bobRenamePath)
+    try {
+      await createAndShareFolderWithBob(alicePage, aliceDrive, DRIVE_NAME, {
+        role: 'Editor',
+        seed: async () => {
+          await aliceDrive.uploadFiles([aliceTrashPath, bobTrashPath, bobRenamePath])
+          await aliceDrive.row(ALICE_TRASH_FILE).waitVisible()
+          await aliceDrive.row(BOB_TRASH_FILE).waitVisible()
+          await aliceDrive.row(BOB_RENAME_FILE).waitVisible()
+        }
+      })
+    } finally {
+      await safeUnlink(aliceTrashPath)
+      await safeUnlink(bobTrashPath)
+      await safeUnlink(bobRenamePath)
+    }
+  })
+
+  // ─── Variant A — OWNER instance (Alice) ──────────────────────────────────
+  //
+  // Alice accesses the shared drive through her own /folder route (the drive
+  // is her own folder). Own-instance realtime is expected to push updates
+  // without any manual reload — the whole point of Plan B.
+
+  test('owner (Alice): seeded shared-drive file appears in recent, disappears live on trash', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    // Start at My Drive so the sidebar is rendered, then click Recent.
+    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+    await new SidebarPage(alicePage).goToRecent()
+    await alicePage.waitForURL(/\/recent/)
+
+    // The seeded file is visible in Alice's own-scope recent without any reload.
+    await aliceDrive.row(ALICE_TRASH_FILE).waitVisible({ timeout: 10_000 })
+
+    // Trash from the recent view. sendToTrash() opens the menu, confirms the
+    // dialog, and calls waitHidden() internally — the row should vanish live
+    // (own-instance realtime), without a manual page reload.
+    await aliceDrive.row(ALICE_TRASH_FILE).sendToTrash()
+  })
+
+  test('owner (Alice): uploaded shared-drive file renamed live in recent', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    // Upload a second file into the shared-drive folder first so it lands in
+    // Alice's own-scope recents, then rename it from the recent view.
+    await openOwnerFolder(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+
+    const aliceRenamePath = path.join(FIXTURE_DIR, ALICE_RENAME_FILE)
+    await copyFile(SAMPLE, aliceRenamePath)
+    try {
+      await aliceDrive.uploadFiles(aliceRenamePath)
+      await aliceDrive.row(ALICE_RENAME_FILE).waitVisible()
+
+      await new SidebarPage(alicePage).goToRecent()
+      await alicePage.waitForURL(/\/recent/)
+      await aliceDrive.row(ALICE_RENAME_FILE).waitVisible({ timeout: 10_000 })
+
+      // Rename from the recent view. rename() waits for the new name to be
+      // visible in the file list — no reload expected (own-instance realtime).
+      await aliceDrive.row(ALICE_RENAME_FILE).rename(ALICE_RENAMED)
+    } finally {
+      await safeUnlink(aliceRenamePath)
+    }
+  })
+
+  // ─── Variant B — RECIPIENT instance (Bob) ────────────────────────────────
+  //
+  // Bob accesses files through the proxied /shareddrive route on his instance.
+  // Cross-instance propagation (Alice → Bob) is not pushed live by the CI
+  // stack, so a reload-and-poll pattern is used instead of relying on the
+  // per-drive realtime socket push.
+  //
+  // Note: true no-reload live updates for the recipient depend on the per-drive
+  // realtime socket being delivered to Bob's stack (Plan A Phase 3). That push
+  // may not fire in the CI stack. The reload-poll keeps these tests stable
+  // while still validating that the reactive store path produces the correct
+  // end state once the data arrives from Alice's instance.
+
+  test('recipient (Bob): shared-drive file appears in recent via reload-poll, disappears on trash', async ({
+    bobPage,
+    bobDrive
+  }) => {
+    // Ensure the sharing has propagated to Bob's instance before checking
+    // his recent view. waitForSharingRow polls /#/sharings until the drive
+    // row appears.
+    await waitForSharingRow(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
+
+    // Poll until the shared-drive file surfaces in Bob's /#/recent. Files
+    // proxied from Alice's instance may take a few seconds to appear.
+    await expect(async () => {
+      await bobPage.goto(`${USERS.bob.appUrl}/#/recent`)
+      await bobDrive.row(BOB_TRASH_FILE).waitVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000 })
+
+    // Bob trashes from his recent view. sendToTrash() calls waitHidden()
+    // internally — the row should disappear once the proxied stack confirms.
+    await bobDrive.row(BOB_TRASH_FILE).sendToTrash()
+  })
+
+  test('recipient (Bob): shared-drive file renamed from recent is reflected via reload-poll', async ({
+    bobPage,
+    bobDrive
+  }) => {
+    // Poll until the rename-candidate file appears in Bob's recent view.
+    await expect(async () => {
+      await bobPage.goto(`${USERS.bob.appUrl}/#/recent`)
+      await bobDrive.row(BOB_RENAME_FILE).waitVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000 })
+
+    // Bob renames from his recent view. rename() waits for the new name to
+    // be visible in the current file list.
+    await bobDrive.row(BOB_RENAME_FILE).rename(BOB_RENAMED)
+
+    // Confirm the rename is durable: reload and check the new name still appears.
+    await expect(async () => {
+      await bobPage.goto(`${USERS.bob.appUrl}/#/recent`)
+      await bobDrive.row(BOB_RENAMED).waitVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000 })
+  })
+})

--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -12,8 +12,7 @@ import styles from './empty.styl'
 import FolderEmptyIllu from '@/assets/icons/illu-folder-empty.svg'
 import TrashIllustration from '@/assets/icons/illu-trash-empty.svg'
 import { TRASH_DIR_ID } from '@/constants/config'
-import { useCurrentFolderId, useDisplayedFolder } from '@/hooks'
-import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
+import { useDisplayedFolder } from '@/hooks'
 import UploadButton from '@/modules/upload/UploadButton'
 
 const EmptyCanvas = ({
@@ -21,15 +20,11 @@ const EmptyCanvas = ({
   canUpload,
   localeKey,
   hasTextMobileVersion,
-  onUploaded,
-  driveId
+  onUploaded
 }) => {
   const { t } = useI18n()
   const { isDesktop } = useBreakpoints()
-  const folderId = useCurrentFolderId()
   const { displayedFolder } = useDisplayedFolder()
-  const { sharedDriveResult } = useSharedDriveFolder({ driveId, folderId })
-  const displayedSharedFolder = sharedDriveResult?.data
 
   const IconToShow = type === 'trash' ? TrashIllustration : FolderEmptyIllu
   const showUploadLayout = type === 'drive'
@@ -62,7 +57,7 @@ const EmptyCanvas = ({
                   button: { variant: 'secondary' }
                 }}
                 label={t('toolbar.menu_upload')}
-                displayedFolder={displayedSharedFolder || displayedFolder}
+                displayedFolder={displayedFolder}
                 onUploaded={onUploaded}
               />
             </span>

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -19,16 +19,26 @@ const bufferDeletedFiles = new Map()
 // Populated by drive-socket handlers; absent (undefined) for own-instance files.
 const driveIdByFileId = new Map()
 
-const getParentFolder = async (client, dirId) => {
+const getParentFolder = async (client, dirId, driveId) => {
   let parentDir = client.getDocumentFromState('io.cozy.files', dirId)
   if (!parentDir) {
-    // Parent is not in the store: query it
-    const parentQuery = buildFileOrFolderByIdQuery(dirId)
-    const parentResult = await client.fetchQueryAndGetFromState({
-      definition: parentQuery.definition(),
-      options: parentQuery.options
-    })
-    parentDir = parentResult.data
+    if (driveId) {
+      // Drive file: resolve the parent via the drive-scoped collection so the
+      // request is authenticated against the correct shared drive.
+      // statById returns { data: folderDoc, included: children, links }.
+      const result = await client
+        .collection('io.cozy.files', { driveId })
+        .statById(dirId)
+      parentDir = result.data
+    } else {
+      // Own-instance file: fall back to the standard store query path.
+      const parentQuery = buildFileOrFolderByIdQuery(dirId)
+      const parentResult = await client.fetchQueryAndGetFromState({
+        definition: parentQuery.definition(),
+        options: parentQuery.options
+      })
+      parentDir = parentResult.data
+    }
   }
   return parentDir
 }
@@ -79,9 +89,17 @@ const processEvents = async (client, mutationType) => {
   }
 
   for (const folderId in filesByFolder) {
+    const filesInFolder = filesByFolder[folderId]
+    // Derive the originating drive ID from the first file in the group.
+    // All files sharing the same dir_id in a given processing cycle come from
+    // the same drive (or from own-instance files which have no entry).
+    const driveId =
+      filesInFolder.length > 0
+        ? driveIdByFileId.get(filesInFolder[0]._id)
+        : undefined
     const files = []
-    const folder = await getParentFolder(client, folderId)
-    for (const file of filesByFolder[folderId]) {
+    const folder = await getParentFolder(client, folderId, driveId)
+    for (const file of filesInFolder) {
       const fileWithPath = ensureFilePath(file, folder)
       files.push(fileWithPath)
     }
@@ -101,10 +119,11 @@ const processEvents = async (client, mutationType) => {
       )
     )
   }
-  // Remove processed files from buffer
+  // Remove processed files from buffer and clear drive-id tracking.
   // Do not clear all at once in case pending events arrived during the processing
   for (const fileId of fileIdsToProcess) {
     bufferFiles.delete(fileId)
+    driveIdByFileId.delete(fileId)
   }
 }
 

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -4,9 +4,7 @@ import { memo, useEffect } from 'react'
 import { useClient, Mutations } from 'cozy-client'
 import { ensureFilePath } from 'cozy-client/dist/models/file'
 import { receiveMutationResult } from 'cozy-client/dist/store'
-import CozyRealtime from 'cozy-realtime'
 
-import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const REALTIME_DEBOUNCE_TIME = 500
@@ -271,54 +269,35 @@ const FilesRealTimeQueries = ({
     computeDocBeforeDispatchDelete
   ])
 
-  // ── Per-recipient-drive subscriptions ──────────────────────────────────────
-  const { recipientDriveIds = [] } = useSharedDrives()
-  // Build a stable string key from the sorted IDs of recipient drives so the
-  // effect below only re-runs when the set of drives actually changes.
-  const recipientDriveKey = [...recipientDriveIds].sort().join(',')
-
+  // ── Data-proxy push (replaces per-drive websockets) ─────────────────────────
   useEffect(() => {
-    if (!recipientDriveKey) return
-
-    const driveIds = recipientDriveKey.split(',').filter(Boolean)
-
-    const realtimeInstances = driveIds.map(driveId => {
-      const rt = new CozyRealtime({ client, sharedDriveId: driveId })
-
-      rt.subscribe('created', 'io.cozy.files', couchDBDoc => {
-        bufferCreatedFiles.set(
-          couchDBDoc._id,
-          normalizeDoc(couchDBDoc, 'io.cozy.files')
-        )
-        driveIdByFileId.set(couchDBDoc._id, driveId)
-        debouncedDispatchEvents(client, 'created')
-      })
-      rt.subscribe('updated', 'io.cozy.files', couchDBDoc => {
-        bufferUpdatedFiles.set(
-          couchDBDoc._id,
-          normalizeDoc(couchDBDoc, 'io.cozy.files')
-        )
-        driveIdByFileId.set(couchDBDoc._id, driveId)
-        debouncedDispatchEvents(client, 'updated')
-      })
-      rt.subscribe('deleted', 'io.cozy.files', couchDBDoc => {
-        bufferDeletedFiles.set(
-          couchDBDoc._id,
-          normalizeDoc(couchDBDoc, 'io.cozy.files')
-        )
-        driveIdByFileId.set(couchDBDoc._id, driveId)
-        debouncedDispatchEvents(client, 'deleted')
-      })
-
-      return rt
-    })
-
-    return () => {
-      realtimeInstances.forEach(rt => rt.stop())
+    const buffers = {
+      updated: bufferUpdatedFiles,
+      created: bufferCreatedFiles,
+      deleted: bufferDeletedFiles
     }
-    // recipientDriveKey encodes all recipient-drive IDs as a sorted string;
-    // re-opening sockets only when the set of drives changes.
-  }, [client, recipientDriveKey])
+
+    const onMessage = event => {
+      if (!event.origin.includes('dataproxy')) return
+      const payload = event.data?.payload
+      if (
+        !payload ||
+        payload.kind !== 'realtime' ||
+        payload.doctype !== 'io.cozy.files' ||
+        !payload.doc?._id
+      ) {
+        return
+      }
+      const buffer = buffers[payload.event]
+      if (!buffer) return
+      buffer.set(payload.doc._id, normalizeDoc(payload.doc, 'io.cozy.files'))
+      driveIdByFileId.set(payload.doc._id, payload.driveId)
+      debouncedDispatchEvents(client, payload.event)
+    }
+
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [client])
 
   return null
 }

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -73,7 +73,15 @@ const dispatchFolderFiles = async (
       ? driveIdByFileId.get(filesInFolder[0]._id)
       : undefined
   const folder = await getParentFolder(client, folderId, driveId)
-  const files = filesInFolder.map(file => ensureFilePath(file, folder))
+  const files = filesInFolder.map(file => {
+    const withPath = ensureFilePath(file, folder)
+    // Drive files carry a synthetic driveId (added by the data-proxy on
+    // replication). Realtime docs come straight from the stack without it, so
+    // reapply it here; otherwise the shared-drive folder query, whose selector
+    // filters on driveId, drops the file from its live results on every update.
+    const fileDriveId = driveIdByFileId.get(file._id)
+    return fileDriveId ? { ...withPath, driveId: fileDriveId } : withPath
+  })
   if (files.length < 1) return
   const mutation =
     files.length > 1 ? mutations.multiple(files) : mutations.single(files[0])

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -19,6 +19,11 @@ const bufferDeletedFiles = new Map()
 // Populated by drive-socket handlers; absent (undefined) for own-instance files.
 const driveIdByFileId = new Map()
 
+// Test-only affordance: resets the module-level driveIdByFileId Map so test
+// isolation is not broken by entries leaking across test cases.
+// eslint-disable-next-line no-underscore-dangle
+export const __resetDriveIdByFileId = () => driveIdByFileId.clear()
+
 const getParentFolder = async (client, dirId, driveId) => {
   let parentDir = client.getDocumentFromState('io.cozy.files', dirId)
   if (!parentDir) {

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -14,7 +14,8 @@ const bufferUpdatedFiles = new Map()
 const bufferDeletedFiles = new Map()
 
 // Tracks which shared-drive ID a buffered file originated from.
-// Populated by drive-socket handlers; absent (undefined) for own-instance files.
+// Populated by the data-proxy push message-listener effect below; absent
+// (undefined) for own-instance files.
 const driveIdByFileId = new Map()
 
 // Test-only affordance: resets the module-level driveIdByFileId Map so test
@@ -279,6 +280,7 @@ const FilesRealTimeQueries = ({
 
     const onMessage = event => {
       if (!event.origin.includes('dataproxy')) return
+      if (event.data?.type !== 'DATAPROXYMESSAGE') return
       const payload = event.data?.payload
       if (
         !payload ||

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -4,14 +4,20 @@ import { memo, useEffect } from 'react'
 import { useClient, Mutations } from 'cozy-client'
 import { ensureFilePath } from 'cozy-client/dist/models/file'
 import { receiveMutationResult } from 'cozy-client/dist/store'
+import CozyRealtime from 'cozy-realtime'
 
 import { buildFileOrFolderByIdQuery } from '@/queries'
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 
 const REALTIME_DEBOUNCE_TIME = 500
 
 const bufferCreatedFiles = new Map()
 const bufferUpdatedFiles = new Map()
 const bufferDeletedFiles = new Map()
+
+// Tracks which shared-drive ID a buffered file originated from.
+// Populated by drive-socket handlers; absent (undefined) for own-instance files.
+const driveIdByFileId = new Map()
 
 const getParentFolder = async (client, dirId) => {
   let parentDir = client.getDocumentFromState('io.cozy.files', dirId)
@@ -169,6 +175,7 @@ const FilesRealTimeQueries = ({
 }) => {
   const client = useClient()
 
+  // ── Global own-file subscription (unchanged) ────────────────────────────────
   useEffect(() => {
     const { realtime } = client.plugins || {}
 
@@ -216,6 +223,63 @@ const FilesRealTimeQueries = ({
     computeDocBeforeDispatchUpdate,
     computeDocBeforeDispatchDelete
   ])
+
+  // ── Per-recipient-drive subscriptions ──────────────────────────────────────
+  // NOTE: owner is typed as optional in the sharing type. The filter below uses
+  // strict === false (as specified). If a drive has owner === undefined it will
+  // not be subscribed; see phase3-report.md for details.
+  const { sharedDrives } = useSharedDrives()
+  // Build a stable string key from the sorted IDs of recipient drives so the
+  // effect below only re-runs when the set of drives actually changes.
+  const recipientDriveKey = sharedDrives
+    .filter(d => d.owner === false)
+    .map(d => d._id)
+    .sort()
+    .join(',')
+
+  useEffect(() => {
+    if (!recipientDriveKey) return
+
+    const driveIds = recipientDriveKey.split(',').filter(Boolean)
+
+    const realtimeInstances = driveIds.map(driveId => {
+      const rt = new CozyRealtime({ client, sharedDriveId: driveId })
+
+      rt.subscribe('created', 'io.cozy.files', couchDBDoc => {
+        bufferCreatedFiles.set(
+          couchDBDoc._id,
+          normalizeDoc(couchDBDoc, 'io.cozy.files')
+        )
+        driveIdByFileId.set(couchDBDoc._id, driveId)
+        debouncedDispatchEvents(client, 'created')
+      })
+      rt.subscribe('updated', 'io.cozy.files', couchDBDoc => {
+        bufferUpdatedFiles.set(
+          couchDBDoc._id,
+          normalizeDoc(couchDBDoc, 'io.cozy.files')
+        )
+        driveIdByFileId.set(couchDBDoc._id, driveId)
+        debouncedDispatchEvents(client, 'updated')
+      })
+      rt.subscribe('deleted', 'io.cozy.files', couchDBDoc => {
+        bufferDeletedFiles.set(
+          couchDBDoc._id,
+          normalizeDoc(couchDBDoc, 'io.cozy.files')
+        )
+        driveIdByFileId.set(couchDBDoc._id, driveId)
+        debouncedDispatchEvents(client, 'deleted')
+      })
+
+      return rt
+    })
+
+    return () => {
+      realtimeInstances.forEach(rt => rt.stop())
+    }
+    // recipientDriveKey encodes all recipient-drive IDs as a sorted string;
+    // re-opening sockets only when the set of drives changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, recipientDriveKey])
 
   return null
 }

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -6,8 +6,8 @@ import { ensureFilePath } from 'cozy-client/dist/models/file'
 import { receiveMutationResult } from 'cozy-client/dist/store'
 import CozyRealtime from 'cozy-realtime'
 
-import { buildFileOrFolderByIdQuery } from '@/queries'
 import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
+import { buildFileOrFolderByIdQuery } from '@/queries'
 
 const REALTIME_DEBOUNCE_TIME = 500
 
@@ -21,7 +21,7 @@ const driveIdByFileId = new Map()
 
 // Test-only affordance: resets the module-level driveIdByFileId Map so test
 // isolation is not broken by entries leaking across test cases.
-// eslint-disable-next-line no-underscore-dangle
+
 export const __resetDriveIdByFileId = () => driveIdByFileId.clear()
 
 const getParentFolder = async (client, dirId, driveId) => {
@@ -302,7 +302,6 @@ const FilesRealTimeQueries = ({
     }
     // recipientDriveKey encodes all recipient-drive IDs as a sorted string;
     // re-opening sockets only when the set of drives changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, recipientDriveKey])
 
   return null

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -28,13 +28,19 @@ const getParentFolder = async (client, dirId, driveId) => {
   let parentDir = client.getDocumentFromState('io.cozy.files', dirId)
   if (!parentDir) {
     if (driveId) {
-      // Drive file: resolve the parent via the drive-scoped collection so the
-      // request is authenticated against the correct shared drive.
-      // statById returns { data: folderDoc, included: children, links }.
-      const result = await client
-        .collection('io.cozy.files', { driveId })
-        .statById(dirId)
-      parentDir = result.data
+      // Drive file: resolve the parent from the drive's locally-replicated pouch
+      // (Plan A capability), not the network, keeping the realtime path reactive.
+      const parentQuery = buildFileOrFolderByIdQuery(dirId)
+      const parentResult = await client.fetchQueryAndGetFromState({
+        definition: parentQuery.definition(),
+        options: {
+          ...parentQuery.options,
+          as: `${parentQuery.options.as}-drive-${driveId}`,
+          driveId,
+          forceLink: 'dataproxy'
+        }
+      })
+      parentDir = parentResult.data
     } else {
       // Own-instance file: fall back to the standard store query path.
       const parentQuery = buildFileOrFolderByIdQuery(dirId)
@@ -249,17 +255,12 @@ const FilesRealTimeQueries = ({
   ])
 
   // ── Per-recipient-drive subscriptions ──────────────────────────────────────
-  // NOTE: owner is typed as optional in the sharing type. The filter below uses
-  // strict === false (as specified). If a drive has owner === undefined it will
-  // not be subscribed; see phase3-report.md for details.
-  const { sharedDrives } = useSharedDrives()
+  // recipientDriveIds is derived in the hook (owner !== true), covering both
+  // owner === false and owner === undefined so no recipient drive is silently skipped.
+  const { recipientDriveIds } = useSharedDrives()
   // Build a stable string key from the sorted IDs of recipient drives so the
   // effect below only re-runs when the set of drives actually changes.
-  const recipientDriveKey = sharedDrives
-    .filter(d => d.owner === false)
-    .map(d => d._id)
-    .sort()
-    .join(',')
+  const recipientDriveKey = [...recipientDriveIds].sort().join(',')
 
   useEffect(() => {
     if (!recipientDriveKey) return

--- a/src/components/FilesRealTimeQueries.jsx
+++ b/src/components/FilesRealTimeQueries.jsx
@@ -61,6 +61,32 @@ export const ensureFileHasPath = async (doc, client) => {
   return ensureFilePath(doc, parentDir)
 }
 
+const dispatchFolderFiles = async (
+  client,
+  folderId,
+  filesInFolder,
+  mutations
+) => {
+  // Derive the originating drive ID from the first file in the group.
+  const driveId =
+    filesInFolder.length > 0
+      ? driveIdByFileId.get(filesInFolder[0]._id)
+      : undefined
+  const folder = await getParentFolder(client, folderId, driveId)
+  const files = filesInFolder.map(file => ensureFilePath(file, folder))
+  if (files.length < 1) return
+  const mutation =
+    files.length > 1 ? mutations.multiple(files) : mutations.single(files[0])
+  client.dispatch(
+    receiveMutationResult(
+      client.generateRandomId(),
+      { data: files },
+      {},
+      mutation
+    )
+  )
+}
+
 /**
  * This method process the bufferised files after debounced realtime events
  * It creates the related mutation and dispatch it to the store.
@@ -71,21 +97,27 @@ export const ensureFileHasPath = async (doc, client) => {
  * @returns {Promise<void>}
  */
 const processEvents = async (client, mutationType) => {
-  let bufferFiles, mutationFn, multipleMutationFn
+  let bufferFiles, mutations
   if (mutationType === 'created') {
     bufferFiles = bufferCreatedFiles
-    mutationFn = Mutations.createDocument
-    multipleMutationFn = Mutations.createDocuments
+    mutations = {
+      single: Mutations.createDocument,
+      multiple: Mutations.createDocuments
+    }
   }
   if (mutationType === 'updated') {
     bufferFiles = bufferUpdatedFiles
-    mutationFn = Mutations.updateDocument
-    multipleMutationFn = Mutations.updateDocuments
+    mutations = {
+      single: Mutations.updateDocument,
+      multiple: Mutations.updateDocuments
+    }
   }
   if (mutationType === 'deleted') {
     bufferFiles = bufferDeletedFiles
-    mutationFn = Mutations.deleteDocument
-    multipleMutationFn = Mutations.deleteDocuments
+    mutations = {
+      single: Mutations.deleteDocument,
+      multiple: Mutations.deleteDocuments
+    }
   }
   if (bufferFiles.size === 0) return
 
@@ -100,34 +132,11 @@ const processEvents = async (client, mutationType) => {
   }
 
   for (const folderId in filesByFolder) {
-    const filesInFolder = filesByFolder[folderId]
-    // Derive the originating drive ID from the first file in the group.
-    // All files sharing the same dir_id in a given processing cycle come from
-    // the same drive (or from own-instance files which have no entry).
-    const driveId =
-      filesInFolder.length > 0
-        ? driveIdByFileId.get(filesInFolder[0]._id)
-        : undefined
-    const files = []
-    const folder = await getParentFolder(client, folderId, driveId)
-    for (const file of filesInFolder) {
-      const fileWithPath = ensureFilePath(file, folder)
-      files.push(fileWithPath)
-    }
-    if (files.length < 1) {
-      // No files to process, early return
-      return
-    }
-    const mutation =
-      files.length > 1 ? multipleMutationFn(files) : mutationFn(files[0])
-
-    client.dispatch(
-      receiveMutationResult(
-        client.generateRandomId(),
-        { data: files },
-        {},
-        mutation
-      )
+    await dispatchFolderFiles(
+      client,
+      folderId,
+      filesByFolder[folderId],
+      mutations
     )
   }
   // Remove processed files from buffer and clear drive-id tracking.
@@ -255,9 +264,7 @@ const FilesRealTimeQueries = ({
   ])
 
   // ── Per-recipient-drive subscriptions ──────────────────────────────────────
-  // recipientDriveIds is derived in the hook (owner !== true), covering both
-  // owner === false and owner === undefined so no recipient drive is silently skipped.
-  const { recipientDriveIds } = useSharedDrives()
+  const { recipientDriveIds = [] } = useSharedDrives()
   // Build a stable string key from the sorted IDs of recipient drives so the
   // effect below only re-runs when the set of drives actually changes.
   const recipientDriveKey = [...recipientDriveIds].sort().join(',')

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -38,6 +38,10 @@ const PARENT_FOLDER = {
 }
 
 const buildMockClient = ({ statByIdFn } = {}) => {
+  // Default statById returns PARENT_FOLDER unless the caller overrides it.
+  const resolvedStatById =
+    statByIdFn || jest.fn().mockResolvedValue({ data: PARENT_FOLDER })
+
   const client = createMockClient({})
   client.dispatch = jest.fn()
   client.getDocumentFromState = jest.fn().mockReturnValue(null)
@@ -45,18 +49,16 @@ const buildMockClient = ({ statByIdFn } = {}) => {
   client.fetchQueryAndGetFromState = jest
     .fn()
     .mockResolvedValue({ data: PARENT_FOLDER })
+  // Always mock collection so drive-scoped statById calls don't hit the real stack.
+  client.collection = jest.fn().mockReturnValue({
+    statById: resolvedStatById
+  })
 
   client.plugins = {
     realtime: {
       subscribe: jest.fn(),
       unsubscribe: jest.fn()
     }
-  }
-
-  if (statByIdFn) {
-    client.collection = jest.fn().mockReturnValue({
-      statById: statByIdFn
-    })
   }
 
   return client

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -147,6 +147,8 @@ describe('FilesRealTimeQueries', () => {
 
   describe('data-proxy realtime push (replaces per-drive websockets)', () => {
     it('does not open per-drive websockets anymore', () => {
+      // Deliberately proves the negative: even with shared drives present,
+      // the component must not fall back to per-drive CozyRealtime sockets.
       useSharedDrives.mockReturnValue({ recipientDriveIds: ['d1', 'd2'] })
       setup()
       expect(CozyRealtime).not.toHaveBeenCalled()
@@ -157,7 +159,6 @@ describe('FilesRealTimeQueries', () => {
       driveClient.fetchQueryAndGetFromState = jest
         .fn()
         .mockResolvedValue({ data: PARENT_FOLDER })
-      useSharedDrives.mockReturnValue({ recipientDriveIds: ['d1'] })
 
       setup(driveClient)
 
@@ -192,7 +193,6 @@ describe('FilesRealTimeQueries', () => {
 
     it('ignores messages from a non data-proxy origin', async () => {
       const driveClient = buildMockClient()
-      useSharedDrives.mockReturnValue({ recipientDriveIds: ['d1'] })
       setup(driveClient)
 
       await act(async () => {
@@ -214,6 +214,89 @@ describe('FilesRealTimeQueries', () => {
       })
 
       expect(driveClient.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('ignores messages with the right payload but a wrong/absent envelope type', async () => {
+      const driveClient = buildMockClient()
+      setup(driveClient)
+
+      const validPayload = {
+        kind: 'realtime',
+        event: 'updated',
+        doctype: 'io.cozy.files',
+        driveId: 'd1',
+        doc: { _id: 'file-envelope', name: 'x.txt', dir_id: 'folder-1' }
+      }
+
+      await act(async () => {
+        // Wrong type
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            origin: 'http://dataproxy.cozy.localhost:8080',
+            data: { type: 'SOMETHING_ELSE', payload: validPayload }
+          })
+        )
+        // Absent type
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            origin: 'http://dataproxy.cozy.localhost:8080',
+            data: { payload: validPayload }
+          })
+        )
+      })
+
+      expect(driveClient.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('dispatches a store mutation when the data-proxy pushes a realtime delete', async () => {
+      const driveClient = buildMockClient()
+      driveClient.fetchQueryAndGetFromState = jest
+        .fn()
+        .mockResolvedValue({ data: PARENT_FOLDER })
+
+      setup(driveClient)
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            origin: 'http://dataproxy.cozy.localhost:8080',
+            data: {
+              type: 'DATAPROXYMESSAGE',
+              payload: {
+                kind: 'realtime',
+                event: 'deleted',
+                doctype: 'io.cozy.files',
+                driveId: 'd1',
+                doc: {
+                  _id: 'file-deleted-1',
+                  name: 'gone.txt',
+                  dir_id: 'io.cozy.files.trash-dir'
+                }
+              }
+            }
+          })
+        )
+      })
+
+      await waitFor(() => expect(driveClient.dispatch).toHaveBeenCalled())
+
+      const action = driveClient.dispatch.mock.calls[0][0]
+      expect(action.response.data[0]._id).toBe('file-deleted-1')
+      expect(action.definition).toBeDefined()
+    })
+
+    it('removes the window message listener on unmount', async () => {
+      jest.spyOn(window, 'removeEventListener')
+
+      const { unmount } = setup()
+      await act(async () => {})
+
+      unmount()
+
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      )
     })
   })
 

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -1,10 +1,12 @@
-import React from 'react'
 import { render, act, waitFor } from '@testing-library/react'
+import React from 'react'
 
 import { createMockClient } from 'cozy-client'
 import CozyRealtime from 'cozy-realtime'
 
-import FilesRealTimeQueries, { __resetDriveIdByFileId } from './FilesRealTimeQueries'
+import FilesRealTimeQueries, {
+  __resetDriveIdByFileId
+} from './FilesRealTimeQueries'
 import AppLike from 'test/components/AppLike'
 
 import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
@@ -394,7 +396,9 @@ describe('FilesRealTimeQueries', () => {
         dir_id: ''
       }
 
-      const statByIdFn = jest.fn().mockResolvedValue({ data: driveParentFolder })
+      const statByIdFn = jest
+        .fn()
+        .mockResolvedValue({ data: driveParentFolder })
       const driveClient = buildMockClient({ statByIdFn })
 
       useSharedDrives.mockReturnValue({

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -96,22 +96,6 @@ describe('FilesRealTimeQueries', () => {
     }
   }
 
-  const setupDriveSocketsWithStop = driveIds => {
-    const mockStop = jest.fn()
-    CozyRealtime.mockImplementation(() => ({
-      subscribe: jest.fn(),
-      stop: mockStop
-    }))
-    useSharedDrives.mockReturnValue({
-      isLoading: false,
-      isLoaded: true,
-      sharedDrives: driveIds.map(id => ({ _id: id, owner: false })),
-      recipientDriveIds: driveIds
-    })
-    const { unmount } = setup()
-    return { unmount, mockStop }
-  }
-
   // ── Task 3.1: subscribe shared-drive sockets ────────────────────────────────
 
   describe('global plugin subscription (no regression)', () => {
@@ -161,181 +145,75 @@ describe('FilesRealTimeQueries', () => {
     })
   })
 
-  describe('shared-drive sockets', () => {
-    it('opens a CozyRealtime socket for each recipient drive (owner === false)', () => {
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }],
-        recipientDriveIds: ['d1']
-      })
-
+  describe('data-proxy realtime push (replaces per-drive websockets)', () => {
+    it('does not open per-drive websockets anymore', () => {
+      useSharedDrives.mockReturnValue({ recipientDriveIds: ['d1', 'd2'] })
       setup()
-
-      expect(CozyRealtime).toHaveBeenCalledWith({
-        client,
-        sharedDriveId: 'd1'
-      })
-    })
-
-    it('opens one socket per recipient drive when multiple exist', () => {
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [
-          { _id: 'd1', owner: false },
-          { _id: 'd2', owner: false }
-        ],
-        recipientDriveIds: ['d1', 'd2']
-      })
-
-      setup()
-
-      expect(CozyRealtime).toHaveBeenCalledTimes(2)
-      expect(CozyRealtime).toHaveBeenCalledWith({
-        client,
-        sharedDriveId: 'd1'
-      })
-      expect(CozyRealtime).toHaveBeenCalledWith({
-        client,
-        sharedDriveId: 'd2'
-      })
-    })
-
-    it('does not open a socket for owned drives (owner === true)', () => {
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [{ _id: 'd2', owner: true }],
-        recipientDriveIds: []
-      })
-
-      setup()
-
       expect(CozyRealtime).not.toHaveBeenCalled()
     })
 
-    it('dispatches drive-file events into the store with _type io.cozy.files', async () => {
-      let capturedUpdatedCallback
-      CozyRealtime.mockImplementation(() => ({
-        subscribe: jest.fn((event, _doctype, callback) => {
-          if (event === 'updated') capturedUpdatedCallback = callback
-        }),
-        stop: jest.fn()
-      }))
+    it('dispatches a store mutation when the data-proxy pushes a realtime update', async () => {
+      const driveClient = buildMockClient()
+      driveClient.fetchQueryAndGetFromState = jest
+        .fn()
+        .mockResolvedValue({ data: PARENT_FOLDER })
+      useSharedDrives.mockReturnValue({ recipientDriveIds: ['d1'] })
 
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }],
-        recipientDriveIds: ['d1']
+      setup(driveClient)
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            origin: 'http://dataproxy.cozy.localhost:8080',
+            data: {
+              type: 'DATAPROXYMESSAGE',
+              payload: {
+                kind: 'realtime',
+                event: 'updated',
+                doctype: 'io.cozy.files',
+                driveId: 'd1',
+                doc: { _id: 'file-1', name: 'renamed.txt', dir_id: 'folder-1' }
+              }
+            }
+          })
+        )
       })
 
-      setup()
-
-      expect(capturedUpdatedCallback).toBeDefined()
-
-      const driveFileDoc = {
-        _id: 'drive-file-1',
-        name: 'shared-doc.txt',
-        dir_id: PARENT_FOLDER._id,
-        type: 'file'
-      }
-
-      act(() => {
-        capturedUpdatedCallback(driveFileDoc)
-      })
-
-      await waitFor(() => expect(client.dispatch).toHaveBeenCalled())
-
-      const action = client.dispatch.mock.calls[0][0]
-      expect(action.response.data[0]._type).toBe('io.cozy.files')
-      expect(action.response.data[0]._id).toBe('drive-file-1')
-      // Path must be resolved via the local-pouch fetchQueryAndGetFromState (parent.path + '/' + name)
-      expect(action.response.data[0].path).toBe(
-        `${PARENT_FOLDER.path}/shared-doc.txt`
+      await waitFor(() => expect(driveClient.dispatch).toHaveBeenCalled())
+      expect(driveClient.fetchQueryAndGetFromState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            driveId: 'd1',
+            forceLink: 'dataproxy'
+          })
+        })
       )
     })
 
-    it('subscribes to created, updated, and deleted events on the drive socket', () => {
-      const mockSubscribe = jest.fn()
-      CozyRealtime.mockImplementation(() => ({
-        subscribe: mockSubscribe,
-        stop: jest.fn()
-      }))
+    it('ignores messages from a non data-proxy origin', async () => {
+      const driveClient = buildMockClient()
+      useSharedDrives.mockReturnValue({ recipientDriveIds: ['d1'] })
+      setup(driveClient)
 
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }],
-        recipientDriveIds: ['d1']
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            origin: 'http://evil.example.com',
+            data: {
+              type: 'DATAPROXYMESSAGE',
+              payload: {
+                kind: 'realtime',
+                event: 'updated',
+                doctype: 'io.cozy.files',
+                driveId: 'd1',
+                doc: { _id: 'x' }
+              }
+            }
+          })
+        )
       })
 
-      setup()
-
-      expectThreeEvents(mockSubscribe)
-    })
-
-    it('calls stop() on each drive socket when the component unmounts', () => {
-      const { unmount, mockStop } = setupDriveSocketsWithStop(['d1'])
-      unmount()
-      expect(mockStop).toHaveBeenCalledTimes(1)
-    })
-
-    it('calls stop() on all drive sockets when the component unmounts', () => {
-      const { unmount, mockStop } = setupDriveSocketsWithStop(['d1', 'd2'])
-      unmount()
-      expect(mockStop).toHaveBeenCalledTimes(2)
-    })
-
-    it('stops the d1 socket and opens a d2 socket when the recipient-drive list changes mid-lifecycle', () => {
-      const instances = []
-      CozyRealtime.mockImplementation(({ sharedDriveId }) => {
-        const inst = {
-          subscribe: jest.fn(),
-          stop: jest.fn(),
-          _driveId: sharedDriveId
-        }
-        instances.push(inst)
-        return inst
-      })
-
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }],
-        recipientDriveIds: ['d1']
-      })
-
-      const { rerender } = setup()
-
-      expect(CozyRealtime).toHaveBeenCalledTimes(1)
-      expect(CozyRealtime).toHaveBeenCalledWith({ client, sharedDriveId: 'd1' })
-
-      // Replace the drive list with d2 only — the effect deps change
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [{ _id: 'd2', owner: false }],
-        recipientDriveIds: ['d2']
-      })
-
-      rerender(
-        <AppLike client={client}>
-          <FilesRealTimeQueries />
-        </AppLike>
-      )
-
-      // The d1 socket must have been stopped by the effect cleanup
-      expect(instances[0]._driveId).toBe('d1')
-      expect(instances[0].stop).toHaveBeenCalledTimes(1)
-
-      // CozyRealtime was constructed exactly twice (once for d1, once for d2)
-      expect(CozyRealtime).toHaveBeenCalledTimes(2)
-      expect(CozyRealtime).toHaveBeenNthCalledWith(2, {
-        client,
-        sharedDriveId: 'd2'
-      })
+      expect(driveClient.dispatch).not.toHaveBeenCalled()
     })
   })
 
@@ -364,17 +242,7 @@ describe('FilesRealTimeQueries', () => {
         recipientDriveIds: ['d1']
       })
 
-      let capturedCreatedCallback
-      CozyRealtime.mockImplementation(() => ({
-        subscribe: jest.fn((event, _doctype, callback) => {
-          if (event === 'created') capturedCreatedCallback = callback
-        }),
-        stop: jest.fn()
-      }))
-
       setup(driveClient)
-
-      expect(capturedCreatedCallback).toBeDefined()
 
       const driveFileDoc = {
         _id: 'drive-file-new',
@@ -383,8 +251,22 @@ describe('FilesRealTimeQueries', () => {
         type: 'file'
       }
 
-      act(() => {
-        capturedCreatedCallback(driveFileDoc)
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            origin: 'http://dataproxy.cozy.localhost:8080',
+            data: {
+              type: 'DATAPROXYMESSAGE',
+              payload: {
+                kind: 'realtime',
+                event: 'created',
+                doctype: 'io.cozy.files',
+                driveId: 'd1',
+                doc: driveFileDoc
+              }
+            }
+          })
+        )
       })
 
       await waitFor(() => expect(driveClient.dispatch).toHaveBeenCalled())

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -39,11 +39,7 @@ const PARENT_FOLDER = {
   dir_id: ''
 }
 
-const buildMockClient = ({ statByIdFn } = {}) => {
-  // Default statById returns PARENT_FOLDER unless the caller overrides it.
-  const resolvedStatById =
-    statByIdFn || jest.fn().mockResolvedValue({ data: PARENT_FOLDER })
-
+const buildMockClient = () => {
   const client = createMockClient({})
   client.dispatch = jest.fn()
   client.getDocumentFromState = jest.fn().mockReturnValue(null)
@@ -51,9 +47,8 @@ const buildMockClient = ({ statByIdFn } = {}) => {
   client.fetchQueryAndGetFromState = jest
     .fn()
     .mockResolvedValue({ data: PARENT_FOLDER })
-  // Always mock collection so drive-scoped statById calls don't hit the real stack.
   client.collection = jest.fn().mockReturnValue({
-    statById: resolvedStatById
+    statById: jest.fn().mockResolvedValue({ data: PARENT_FOLDER })
   })
 
   client.plugins = {
@@ -78,7 +73,8 @@ describe('FilesRealTimeQueries', () => {
     useSharedDrives.mockReturnValue({
       isLoading: false,
       isLoaded: true,
-      sharedDrives: []
+      sharedDrives: [],
+      recipientDriveIds: []
     })
   })
 
@@ -172,7 +168,8 @@ describe('FilesRealTimeQueries', () => {
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }]
+        sharedDrives: [{ _id: 'd1', owner: false }],
+        recipientDriveIds: ['d1']
       })
 
       setup()
@@ -190,7 +187,8 @@ describe('FilesRealTimeQueries', () => {
         sharedDrives: [
           { _id: 'd1', owner: false },
           { _id: 'd2', owner: false }
-        ]
+        ],
+        recipientDriveIds: ['d1', 'd2']
       })
 
       setup()
@@ -210,7 +208,8 @@ describe('FilesRealTimeQueries', () => {
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd2', owner: true }]
+        sharedDrives: [{ _id: 'd2', owner: true }],
+        recipientDriveIds: []
       })
 
       setup()
@@ -230,7 +229,8 @@ describe('FilesRealTimeQueries', () => {
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }]
+        sharedDrives: [{ _id: 'd1', owner: false }],
+        recipientDriveIds: ['d1']
       })
 
       setup()
@@ -253,7 +253,7 @@ describe('FilesRealTimeQueries', () => {
       const action = client.dispatch.mock.calls[0][0]
       expect(action.response.data[0]._type).toBe('io.cozy.files')
       expect(action.response.data[0]._id).toBe('drive-file-1')
-      // Path must be resolved via the drive-scoped statById (parent.path + '/' + name)
+      // Path must be resolved via the local-pouch fetchQueryAndGetFromState (parent.path + '/' + name)
       expect(action.response.data[0].path).toBe(
         `${PARENT_FOLDER.path}/shared-doc.txt`
       )
@@ -269,7 +269,8 @@ describe('FilesRealTimeQueries', () => {
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }]
+        sharedDrives: [{ _id: 'd1', owner: false }],
+        recipientDriveIds: ['d1']
       })
 
       setup()
@@ -301,7 +302,8 @@ describe('FilesRealTimeQueries', () => {
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }]
+        sharedDrives: [{ _id: 'd1', owner: false }],
+        recipientDriveIds: ['d1']
       })
 
       const { unmount } = setup()
@@ -324,7 +326,8 @@ describe('FilesRealTimeQueries', () => {
         sharedDrives: [
           { _id: 'd1', owner: false },
           { _id: 'd2', owner: false }
-        ]
+        ],
+        recipientDriveIds: ['d1', 'd2']
       })
 
       const { unmount } = setup()
@@ -349,7 +352,8 @@ describe('FilesRealTimeQueries', () => {
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }]
+        sharedDrives: [{ _id: 'd1', owner: false }],
+        recipientDriveIds: ['d1']
       })
 
       const { rerender } = setup()
@@ -361,7 +365,8 @@ describe('FilesRealTimeQueries', () => {
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd2', owner: false }]
+        sharedDrives: [{ _id: 'd2', owner: false }],
+        recipientDriveIds: ['d2']
       })
 
       rerender(
@@ -386,7 +391,7 @@ describe('FilesRealTimeQueries', () => {
   // ── Task 3.2: drive-scoped path resolution ─────────────────────────────────
 
   describe('drive-scoped path resolution', () => {
-    it('resolves parent folder via drive-scoped statById for drive files', async () => {
+    it('resolves parent folder via fetchQueryAndGetFromState (local pouch) for drive files', async () => {
       const driveParentFolder = {
         _id: 'drive-folder-parent',
         _type: 'io.cozy.files',
@@ -396,15 +401,16 @@ describe('FilesRealTimeQueries', () => {
         dir_id: ''
       }
 
-      const statByIdFn = jest
+      const driveClient = buildMockClient()
+      driveClient.fetchQueryAndGetFromState = jest
         .fn()
         .mockResolvedValue({ data: driveParentFolder })
-      const driveClient = buildMockClient({ statByIdFn })
 
       useSharedDrives.mockReturnValue({
         isLoading: false,
         isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }]
+        sharedDrives: [{ _id: 'd1', owner: false }],
+        recipientDriveIds: ['d1']
       })
 
       let capturedCreatedCallback
@@ -435,15 +441,22 @@ describe('FilesRealTimeQueries', () => {
       const action = driveClient.dispatch.mock.calls[0][0]
       const dispatchedDoc = action.response.data[0]
 
-      // The path must be resolved via the drive-scoped statById
+      // The path must be resolved via the local-pouch fetchQueryAndGetFromState
       expect(dispatchedDoc.path).toBe('/Shared Drive/new-doc.txt')
 
-      // The drive-scoped collection must have been used, not fetchQueryAndGetFromState
-      expect(driveClient.collection).toHaveBeenCalledWith('io.cozy.files', {
+      // Must use fetchQueryAndGetFromState with driveId and forceLink: 'dataproxy'
+      expect(driveClient.fetchQueryAndGetFromState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            driveId: 'd1',
+            forceLink: 'dataproxy'
+          })
+        })
+      )
+      // The network drive-scoped collection (statById) must NOT have been used
+      expect(driveClient.collection).not.toHaveBeenCalledWith('io.cozy.files', {
         driveId: 'd1'
       })
-      expect(statByIdFn).toHaveBeenCalledWith(driveParentFolder._id)
-      expect(driveClient.fetchQueryAndGetFromState).not.toHaveBeenCalled()
     })
 
     it('resolves parent folder via fetchQueryAndGetFromState for own files (no driveId)', async () => {

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -4,7 +4,7 @@ import { render, act, waitFor } from '@testing-library/react'
 import { createMockClient } from 'cozy-client'
 import CozyRealtime from 'cozy-realtime'
 
-import FilesRealTimeQueries from './FilesRealTimeQueries'
+import FilesRealTimeQueries, { __resetDriveIdByFileId } from './FilesRealTimeQueries'
 import AppLike from 'test/components/AppLike'
 
 import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
@@ -69,6 +69,7 @@ describe('FilesRealTimeQueries', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    __resetDriveIdByFileId()
     client = buildMockClient()
 
     // Default: no shared drives
@@ -250,6 +251,10 @@ describe('FilesRealTimeQueries', () => {
       const action = client.dispatch.mock.calls[0][0]
       expect(action.response.data[0]._type).toBe('io.cozy.files')
       expect(action.response.data[0]._id).toBe('drive-file-1')
+      // Path must be resolved via the drive-scoped statById (parent.path + '/' + name)
+      expect(action.response.data[0].path).toBe(
+        `${PARENT_FOLDER.path}/shared-doc.txt`
+      )
     })
 
     it('subscribes to created, updated, and deleted events on the drive socket', () => {
@@ -325,6 +330,54 @@ describe('FilesRealTimeQueries', () => {
       unmount()
 
       expect(mockStop).toHaveBeenCalledTimes(2)
+    })
+
+    it('stops the d1 socket and opens a d2 socket when the recipient-drive list changes mid-lifecycle', () => {
+      const instances = []
+      CozyRealtime.mockImplementation(({ sharedDriveId }) => {
+        const inst = {
+          subscribe: jest.fn(),
+          stop: jest.fn(),
+          _driveId: sharedDriveId
+        }
+        instances.push(inst)
+        return inst
+      })
+
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd1', owner: false }]
+      })
+
+      const { rerender } = setup()
+
+      expect(CozyRealtime).toHaveBeenCalledTimes(1)
+      expect(CozyRealtime).toHaveBeenCalledWith({ client, sharedDriveId: 'd1' })
+
+      // Replace the drive list with d2 only — the effect deps change
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd2', owner: false }]
+      })
+
+      rerender(
+        <AppLike client={client}>
+          <FilesRealTimeQueries />
+        </AppLike>
+      )
+
+      // The d1 socket must have been stopped by the effect cleanup
+      expect(instances[0]._driveId).toBe('d1')
+      expect(instances[0].stop).toHaveBeenCalledTimes(1)
+
+      // CozyRealtime was constructed exactly twice (once for d1, once for d2)
+      expect(CozyRealtime).toHaveBeenCalledTimes(2)
+      expect(CozyRealtime).toHaveBeenNthCalledWith(2, {
+        client,
+        sharedDriveId: 'd2'
+      })
     })
   })
 

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -146,6 +146,36 @@ describe('FilesRealTimeQueries', () => {
   })
 
   describe('data-proxy realtime push (replaces per-drive websockets)', () => {
+    const DATAPROXY_ORIGIN = 'http://dataproxy.cozy.localhost:8080'
+
+    const buildDriveClient = () => {
+      const driveClient = buildMockClient()
+      driveClient.fetchQueryAndGetFromState = jest
+        .fn()
+        .mockResolvedValue({ data: PARENT_FOLDER })
+      return driveClient
+    }
+
+    const realtimePayload = (event, doc, driveId = 'd1') => ({
+      kind: 'realtime',
+      event,
+      doctype: 'io.cozy.files',
+      driveId,
+      doc
+    })
+
+    const dispatchPush = async ({
+      origin = DATAPROXY_ORIGIN,
+      type = 'DATAPROXYMESSAGE',
+      payload
+    }) => {
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', { origin, data: { type, payload } })
+        )
+      })
+    }
+
     it('does not open per-drive websockets anymore', () => {
       // Deliberately proves the negative: even with shared drives present,
       // the component must not fall back to per-drive CozyRealtime sockets.
@@ -155,29 +185,15 @@ describe('FilesRealTimeQueries', () => {
     })
 
     it('dispatches a store mutation when the data-proxy pushes a realtime update', async () => {
-      const driveClient = buildMockClient()
-      driveClient.fetchQueryAndGetFromState = jest
-        .fn()
-        .mockResolvedValue({ data: PARENT_FOLDER })
-
+      const driveClient = buildDriveClient()
       setup(driveClient)
 
-      await act(async () => {
-        window.dispatchEvent(
-          new MessageEvent('message', {
-            origin: 'http://dataproxy.cozy.localhost:8080',
-            data: {
-              type: 'DATAPROXYMESSAGE',
-              payload: {
-                kind: 'realtime',
-                event: 'updated',
-                doctype: 'io.cozy.files',
-                driveId: 'd1',
-                doc: { _id: 'file-1', name: 'renamed.txt', dir_id: 'folder-1' }
-              }
-            }
-          })
-        )
+      await dispatchPush({
+        payload: realtimePayload('updated', {
+          _id: 'file-1',
+          name: 'renamed.txt',
+          dir_id: 'folder-1'
+        })
       })
 
       await waitFor(() => expect(driveClient.dispatch).toHaveBeenCalled())
@@ -191,26 +207,32 @@ describe('FilesRealTimeQueries', () => {
       )
     })
 
+    it('dispatches a store mutation when the data-proxy pushes a realtime delete', async () => {
+      const driveClient = buildDriveClient()
+      setup(driveClient)
+
+      await dispatchPush({
+        payload: realtimePayload('deleted', {
+          _id: 'file-deleted-1',
+          name: 'gone.txt',
+          dir_id: 'io.cozy.files.trash-dir'
+        })
+      })
+
+      await waitFor(() => expect(driveClient.dispatch).toHaveBeenCalled())
+
+      const action = driveClient.dispatch.mock.calls[0][0]
+      expect(action.response.data[0]._id).toBe('file-deleted-1')
+      expect(action.definition).toBeDefined()
+    })
+
     it('ignores messages from a non data-proxy origin', async () => {
       const driveClient = buildMockClient()
       setup(driveClient)
 
-      await act(async () => {
-        window.dispatchEvent(
-          new MessageEvent('message', {
-            origin: 'http://evil.example.com',
-            data: {
-              type: 'DATAPROXYMESSAGE',
-              payload: {
-                kind: 'realtime',
-                event: 'updated',
-                doctype: 'io.cozy.files',
-                driveId: 'd1',
-                doc: { _id: 'x' }
-              }
-            }
-          })
-        )
+      await dispatchPush({
+        origin: 'http://evil.example.com',
+        payload: realtimePayload('updated', { _id: 'x' })
       })
 
       expect(driveClient.dispatch).not.toHaveBeenCalled()
@@ -220,69 +242,16 @@ describe('FilesRealTimeQueries', () => {
       const driveClient = buildMockClient()
       setup(driveClient)
 
-      const validPayload = {
-        kind: 'realtime',
-        event: 'updated',
-        doctype: 'io.cozy.files',
-        driveId: 'd1',
-        doc: { _id: 'file-envelope', name: 'x.txt', dir_id: 'folder-1' }
-      }
-
-      await act(async () => {
-        // Wrong type
-        window.dispatchEvent(
-          new MessageEvent('message', {
-            origin: 'http://dataproxy.cozy.localhost:8080',
-            data: { type: 'SOMETHING_ELSE', payload: validPayload }
-          })
-        )
-        // Absent type
-        window.dispatchEvent(
-          new MessageEvent('message', {
-            origin: 'http://dataproxy.cozy.localhost:8080',
-            data: { payload: validPayload }
-          })
-        )
+      const payload = realtimePayload('updated', {
+        _id: 'file-envelope',
+        name: 'x.txt',
+        dir_id: 'folder-1'
       })
+
+      await dispatchPush({ type: 'SOMETHING_ELSE', payload })
+      await dispatchPush({ type: null, payload })
 
       expect(driveClient.dispatch).not.toHaveBeenCalled()
-    })
-
-    it('dispatches a store mutation when the data-proxy pushes a realtime delete', async () => {
-      const driveClient = buildMockClient()
-      driveClient.fetchQueryAndGetFromState = jest
-        .fn()
-        .mockResolvedValue({ data: PARENT_FOLDER })
-
-      setup(driveClient)
-
-      await act(async () => {
-        window.dispatchEvent(
-          new MessageEvent('message', {
-            origin: 'http://dataproxy.cozy.localhost:8080',
-            data: {
-              type: 'DATAPROXYMESSAGE',
-              payload: {
-                kind: 'realtime',
-                event: 'deleted',
-                doctype: 'io.cozy.files',
-                driveId: 'd1',
-                doc: {
-                  _id: 'file-deleted-1',
-                  name: 'gone.txt',
-                  dir_id: 'io.cozy.files.trash-dir'
-                }
-              }
-            }
-          })
-        )
-      })
-
-      await waitFor(() => expect(driveClient.dispatch).toHaveBeenCalled())
-
-      const action = driveClient.dispatch.mock.calls[0][0]
-      expect(action.response.data[0]._id).toBe('file-deleted-1')
-      expect(action.definition).toBeDefined()
     })
 
     it('removes the window message listener on unmount', async () => {

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -86,6 +86,32 @@ describe('FilesRealTimeQueries', () => {
     )
   }
 
+  const expectThreeEvents = mockFn => {
+    for (const event of ['created', 'updated', 'deleted']) {
+      expect(mockFn).toHaveBeenCalledWith(
+        event,
+        'io.cozy.files',
+        expect.any(Function)
+      )
+    }
+  }
+
+  const setupDriveSocketsWithStop = driveIds => {
+    const mockStop = jest.fn()
+    CozyRealtime.mockImplementation(() => ({
+      subscribe: jest.fn(),
+      stop: mockStop
+    }))
+    useSharedDrives.mockReturnValue({
+      isLoading: false,
+      isLoaded: true,
+      sharedDrives: driveIds.map(id => ({ _id: id, owner: false })),
+      recipientDriveIds: driveIds
+    })
+    const { unmount } = setup()
+    return { unmount, mockStop }
+  }
+
   // ── Task 3.1: subscribe shared-drive sockets ────────────────────────────────
 
   describe('global plugin subscription (no regression)', () => {
@@ -94,21 +120,7 @@ describe('FilesRealTimeQueries', () => {
       // subscribeToEvents() is async; flush microtasks to let it complete
       await act(async () => {})
 
-      expect(client.plugins.realtime.subscribe).toHaveBeenCalledWith(
-        'created',
-        'io.cozy.files',
-        expect.any(Function)
-      )
-      expect(client.plugins.realtime.subscribe).toHaveBeenCalledWith(
-        'updated',
-        'io.cozy.files',
-        expect.any(Function)
-      )
-      expect(client.plugins.realtime.subscribe).toHaveBeenCalledWith(
-        'deleted',
-        'io.cozy.files',
-        expect.any(Function)
-      )
+      expectThreeEvents(client.plugins.realtime.subscribe)
     })
 
     it('dispatches own-file events into the store with _type io.cozy.files', async () => {
@@ -145,21 +157,7 @@ describe('FilesRealTimeQueries', () => {
 
       unmount()
 
-      expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledWith(
-        'created',
-        'io.cozy.files',
-        expect.any(Function)
-      )
-      expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledWith(
-        'updated',
-        'io.cozy.files',
-        expect.any(Function)
-      )
-      expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledWith(
-        'deleted',
-        'io.cozy.files',
-        expect.any(Function)
-      )
+      expectThreeEvents(client.plugins.realtime.unsubscribe)
     })
   })
 
@@ -275,65 +273,18 @@ describe('FilesRealTimeQueries', () => {
 
       setup()
 
-      expect(mockSubscribe).toHaveBeenCalledWith(
-        'created',
-        'io.cozy.files',
-        expect.any(Function)
-      )
-      expect(mockSubscribe).toHaveBeenCalledWith(
-        'updated',
-        'io.cozy.files',
-        expect.any(Function)
-      )
-      expect(mockSubscribe).toHaveBeenCalledWith(
-        'deleted',
-        'io.cozy.files',
-        expect.any(Function)
-      )
+      expectThreeEvents(mockSubscribe)
     })
 
     it('calls stop() on each drive socket when the component unmounts', () => {
-      const mockStop = jest.fn()
-      CozyRealtime.mockImplementation(() => ({
-        subscribe: jest.fn(),
-        stop: mockStop
-      }))
-
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [{ _id: 'd1', owner: false }],
-        recipientDriveIds: ['d1']
-      })
-
-      const { unmount } = setup()
-
+      const { unmount, mockStop } = setupDriveSocketsWithStop(['d1'])
       unmount()
-
       expect(mockStop).toHaveBeenCalledTimes(1)
     })
 
     it('calls stop() on all drive sockets when the component unmounts', () => {
-      const mockStop = jest.fn()
-      CozyRealtime.mockImplementation(() => ({
-        subscribe: jest.fn(),
-        stop: mockStop
-      }))
-
-      useSharedDrives.mockReturnValue({
-        isLoading: false,
-        isLoaded: true,
-        sharedDrives: [
-          { _id: 'd1', owner: false },
-          { _id: 'd2', owner: false }
-        ],
-        recipientDriveIds: ['d1', 'd2']
-      })
-
-      const { unmount } = setup()
-
+      const { unmount, mockStop } = setupDriveSocketsWithStop(['d1', 'd2'])
       unmount()
-
       expect(mockStop).toHaveBeenCalledTimes(2)
     })
 

--- a/src/components/FilesRealTimeQueries.spec.jsx
+++ b/src/components/FilesRealTimeQueries.spec.jsx
@@ -1,0 +1,420 @@
+import React from 'react'
+import { render, act, waitFor } from '@testing-library/react'
+
+import { createMockClient } from 'cozy-client'
+import CozyRealtime from 'cozy-realtime'
+
+import FilesRealTimeQueries from './FilesRealTimeQueries'
+import AppLike from 'test/components/AppLike'
+
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
+
+jest.mock('cozy-realtime', () =>
+  jest.fn().mockImplementation(() => ({
+    subscribe: jest.fn(),
+    stop: jest.fn()
+  }))
+)
+
+jest.mock('lodash/debounce', () =>
+  jest.fn(fn => {
+    const immediate = (...args) => fn(...args)
+    immediate.cancel = jest.fn()
+    return immediate
+  })
+)
+
+jest.mock('@/modules/shareddrives/hooks/useSharedDrives', () => ({
+  useSharedDrives: jest.fn()
+}))
+
+const PARENT_FOLDER = {
+  _id: 'folder-parent',
+  _type: 'io.cozy.files',
+  type: 'directory',
+  path: '/My Files',
+  name: 'My Files',
+  dir_id: ''
+}
+
+const buildMockClient = ({ statByIdFn } = {}) => {
+  const client = createMockClient({})
+  client.dispatch = jest.fn()
+  client.getDocumentFromState = jest.fn().mockReturnValue(null)
+  client.generateRandomId = jest.fn().mockReturnValue('mock-id')
+  client.fetchQueryAndGetFromState = jest
+    .fn()
+    .mockResolvedValue({ data: PARENT_FOLDER })
+
+  client.plugins = {
+    realtime: {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn()
+    }
+  }
+
+  if (statByIdFn) {
+    client.collection = jest.fn().mockReturnValue({
+      statById: statByIdFn
+    })
+  }
+
+  return client
+}
+
+describe('FilesRealTimeQueries', () => {
+  let client
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    client = buildMockClient()
+
+    // Default: no shared drives
+    useSharedDrives.mockReturnValue({
+      isLoading: false,
+      isLoaded: true,
+      sharedDrives: []
+    })
+  })
+
+  const setup = (overrideClient = client) => {
+    return render(
+      <AppLike client={overrideClient}>
+        <FilesRealTimeQueries />
+      </AppLike>
+    )
+  }
+
+  // ── Task 3.1: subscribe shared-drive sockets ────────────────────────────────
+
+  describe('global plugin subscription (no regression)', () => {
+    it('subscribes to created, updated, and deleted events via the global plugin', async () => {
+      setup()
+      // subscribeToEvents() is async; flush microtasks to let it complete
+      await act(async () => {})
+
+      expect(client.plugins.realtime.subscribe).toHaveBeenCalledWith(
+        'created',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+      expect(client.plugins.realtime.subscribe).toHaveBeenCalledWith(
+        'updated',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+      expect(client.plugins.realtime.subscribe).toHaveBeenCalledWith(
+        'deleted',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+    })
+
+    it('dispatches own-file events into the store with _type io.cozy.files', async () => {
+      setup()
+      await act(async () => {})
+
+      // Capture the handler registered for the 'updated' event
+      const subscribeCalls = client.plugins.realtime.subscribe.mock.calls
+      const updatedCall = subscribeCalls.find(([event]) => event === 'updated')
+      expect(updatedCall).toBeDefined()
+      const handler = updatedCall[2]
+
+      const ownFileDoc = {
+        _id: 'own-file-1',
+        name: 'report.pdf',
+        dir_id: PARENT_FOLDER._id,
+        type: 'file'
+      }
+
+      act(() => {
+        handler(ownFileDoc)
+      })
+
+      await waitFor(() => expect(client.dispatch).toHaveBeenCalled())
+
+      const action = client.dispatch.mock.calls[0][0]
+      expect(action.response.data[0]._type).toBe('io.cozy.files')
+      expect(action.response.data[0]._id).toBe('own-file-1')
+    })
+
+    it('unsubscribes from global plugin events on unmount', async () => {
+      const { unmount } = setup()
+      await act(async () => {})
+
+      unmount()
+
+      expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledWith(
+        'created',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+      expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledWith(
+        'updated',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+      expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledWith(
+        'deleted',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe('shared-drive sockets', () => {
+    it('opens a CozyRealtime socket for each recipient drive (owner === false)', () => {
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd1', owner: false }]
+      })
+
+      setup()
+
+      expect(CozyRealtime).toHaveBeenCalledWith({
+        client,
+        sharedDriveId: 'd1'
+      })
+    })
+
+    it('opens one socket per recipient drive when multiple exist', () => {
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [
+          { _id: 'd1', owner: false },
+          { _id: 'd2', owner: false }
+        ]
+      })
+
+      setup()
+
+      expect(CozyRealtime).toHaveBeenCalledTimes(2)
+      expect(CozyRealtime).toHaveBeenCalledWith({
+        client,
+        sharedDriveId: 'd1'
+      })
+      expect(CozyRealtime).toHaveBeenCalledWith({
+        client,
+        sharedDriveId: 'd2'
+      })
+    })
+
+    it('does not open a socket for owned drives (owner === true)', () => {
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd2', owner: true }]
+      })
+
+      setup()
+
+      expect(CozyRealtime).not.toHaveBeenCalled()
+    })
+
+    it('dispatches drive-file events into the store with _type io.cozy.files', async () => {
+      let capturedUpdatedCallback
+      CozyRealtime.mockImplementation(() => ({
+        subscribe: jest.fn((event, _doctype, callback) => {
+          if (event === 'updated') capturedUpdatedCallback = callback
+        }),
+        stop: jest.fn()
+      }))
+
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd1', owner: false }]
+      })
+
+      setup()
+
+      expect(capturedUpdatedCallback).toBeDefined()
+
+      const driveFileDoc = {
+        _id: 'drive-file-1',
+        name: 'shared-doc.txt',
+        dir_id: PARENT_FOLDER._id,
+        type: 'file'
+      }
+
+      act(() => {
+        capturedUpdatedCallback(driveFileDoc)
+      })
+
+      await waitFor(() => expect(client.dispatch).toHaveBeenCalled())
+
+      const action = client.dispatch.mock.calls[0][0]
+      expect(action.response.data[0]._type).toBe('io.cozy.files')
+      expect(action.response.data[0]._id).toBe('drive-file-1')
+    })
+
+    it('subscribes to created, updated, and deleted events on the drive socket', () => {
+      const mockSubscribe = jest.fn()
+      CozyRealtime.mockImplementation(() => ({
+        subscribe: mockSubscribe,
+        stop: jest.fn()
+      }))
+
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd1', owner: false }]
+      })
+
+      setup()
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'created',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'updated',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'deleted',
+        'io.cozy.files',
+        expect.any(Function)
+      )
+    })
+
+    it('calls stop() on each drive socket when the component unmounts', () => {
+      const mockStop = jest.fn()
+      CozyRealtime.mockImplementation(() => ({
+        subscribe: jest.fn(),
+        stop: mockStop
+      }))
+
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd1', owner: false }]
+      })
+
+      const { unmount } = setup()
+
+      unmount()
+
+      expect(mockStop).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls stop() on all drive sockets when the component unmounts', () => {
+      const mockStop = jest.fn()
+      CozyRealtime.mockImplementation(() => ({
+        subscribe: jest.fn(),
+        stop: mockStop
+      }))
+
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [
+          { _id: 'd1', owner: false },
+          { _id: 'd2', owner: false }
+        ]
+      })
+
+      const { unmount } = setup()
+
+      unmount()
+
+      expect(mockStop).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // ── Task 3.2: drive-scoped path resolution ─────────────────────────────────
+
+  describe('drive-scoped path resolution', () => {
+    it('resolves parent folder via drive-scoped statById for drive files', async () => {
+      const driveParentFolder = {
+        _id: 'drive-folder-parent',
+        _type: 'io.cozy.files',
+        type: 'directory',
+        path: '/Shared Drive',
+        name: 'Shared Drive',
+        dir_id: ''
+      }
+
+      const statByIdFn = jest.fn().mockResolvedValue({ data: driveParentFolder })
+      const driveClient = buildMockClient({ statByIdFn })
+
+      useSharedDrives.mockReturnValue({
+        isLoading: false,
+        isLoaded: true,
+        sharedDrives: [{ _id: 'd1', owner: false }]
+      })
+
+      let capturedCreatedCallback
+      CozyRealtime.mockImplementation(() => ({
+        subscribe: jest.fn((event, _doctype, callback) => {
+          if (event === 'created') capturedCreatedCallback = callback
+        }),
+        stop: jest.fn()
+      }))
+
+      setup(driveClient)
+
+      expect(capturedCreatedCallback).toBeDefined()
+
+      const driveFileDoc = {
+        _id: 'drive-file-new',
+        name: 'new-doc.txt',
+        dir_id: driveParentFolder._id,
+        type: 'file'
+      }
+
+      act(() => {
+        capturedCreatedCallback(driveFileDoc)
+      })
+
+      await waitFor(() => expect(driveClient.dispatch).toHaveBeenCalled())
+
+      const action = driveClient.dispatch.mock.calls[0][0]
+      const dispatchedDoc = action.response.data[0]
+
+      // The path must be resolved via the drive-scoped statById
+      expect(dispatchedDoc.path).toBe('/Shared Drive/new-doc.txt')
+
+      // The drive-scoped collection must have been used, not fetchQueryAndGetFromState
+      expect(driveClient.collection).toHaveBeenCalledWith('io.cozy.files', {
+        driveId: 'd1'
+      })
+      expect(statByIdFn).toHaveBeenCalledWith(driveParentFolder._id)
+      expect(driveClient.fetchQueryAndGetFromState).not.toHaveBeenCalled()
+    })
+
+    it('resolves parent folder via fetchQueryAndGetFromState for own files (no driveId)', async () => {
+      setup()
+      await act(async () => {})
+
+      const subscribeCalls = client.plugins.realtime.subscribe.mock.calls
+      const createdCall = subscribeCalls.find(([event]) => event === 'created')
+      const handler = createdCall[2]
+
+      const ownFileDoc = {
+        _id: 'own-file-new',
+        name: 'local-doc.txt',
+        dir_id: PARENT_FOLDER._id,
+        type: 'file'
+      }
+
+      act(() => {
+        handler(ownFileDoc)
+      })
+
+      await waitFor(() => expect(client.dispatch).toHaveBeenCalled())
+
+      const action = client.dispatch.mock.calls[0][0]
+      const dispatchedDoc = action.response.data[0]
+
+      // Path resolves correctly from the mock parent returned by fetchQueryAndGetFromState
+      expect(dispatchedDoc.path).toBe('/My Files/local-doc.txt')
+      // The non-drive path uses fetchQueryAndGetFromState, not drive-scoped collection
+      expect(client.fetchQueryAndGetFromState).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/FolderPicker/FolderPickerContentSharedDrive.tsx
+++ b/src/components/FolderPicker/FolderPickerContentSharedDrive.tsx
@@ -41,9 +41,9 @@ const FolderPickerContentSharedDrive: React.FC<
 
   const { fetchStatus, files } = useMemo(
     () =>
-      sharedDriveResult.included || sharedDriveResult.data
-        ? { fetchStatus: 'loaded', files: sharedDriveResult.included ?? [] }
-        : { fetchStatus: 'loading', files: [] },
+      sharedDriveResult.data != null
+        ? { fetchStatus: 'loaded' as const, files: sharedDriveResult.data }
+        : { fetchStatus: 'loading' as const, files: [] as IOCozyFile[] },
     [sharedDriveResult]
   )
 

--- a/src/hooks/useRecentFiles.jsx
+++ b/src/hooks/useRecentFiles.jsx
@@ -1,59 +1,98 @@
-import { useEffect, useState, useMemo } from 'react'
+import React, { useState, useMemo, useCallback } from 'react'
 
-import { useClient } from 'cozy-client'
-import { useDataProxy } from 'cozy-dataproxy-lib'
+import { useClient, DataProxyLink } from 'cozy-client'
 
-import logger from '@/lib/logger'
-import { buildRecentQuery } from '@/queries'
+import RecentScopeQuery from '@/hooks/useRecentFiles/RecentScopeQuery'
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 
-const useDataProxyRecents = () => {
-  const [data, setData] = useState([])
-  const [fetchStatus, setFetchStatus] = useState('loading')
-  const [error, setError] = useState(null)
-  const dataProxy = useDataProxy()
+const useRecentFiles = () => {
   const client = useClient()
+  const { recipientDriveIds } = useSharedDrives()
 
-  const recentQuery = useMemo(() => buildRecentQuery(), [])
+  const hasDataProxy = useMemo(
+    () =>
+      Array.isArray(client?.links) &&
+      client.links.some(link => link instanceof DataProxyLink),
+    [client]
+  )
 
-  useEffect(() => {
-    const fetchRecents = async () => {
-      setFetchStatus('loading')
-      setError(null)
+  const driveScopeIds = useMemo(
+    () => (hasDataProxy ? recipientDriveIds : []),
+    [hasDataProxy, recipientDriveIds]
+  )
 
-      if (dataProxy.dataProxyServicesAvailable) {
-        try {
-          const data = await dataProxy.recents()
-          setData(data || [])
-          setFetchStatus('loaded')
-          return
-        } catch (err) {
-          logger.error('Error fetching recents from dataproxy', err)
-        }
-      }
+  const activeScopeKeys = useMemo(
+    () => ['recents-own', ...driveScopeIds.map(id => `recents-drive-${id}`)],
+    [driveScopeIds]
+  )
 
-      if (client) {
-        try {
-          const result = await client.fetchQueryAndGetFromState({
-            definition: recentQuery.definition(),
-            options: recentQuery.options
-          })
-          setData(result?.data || [])
-          setFetchStatus('loaded')
-        } catch (err) {
-          logger.warn('Error fetching recents from fallback query', err)
-          setError(err)
-          setFetchStatus('error')
-        }
-      } else {
-        setError(new Error('Client not available'))
-        setFetchStatus('error')
-      }
+  const [resultsByScope, setResultsByScope] = useState({})
+
+  const handleResult = useCallback((scopeKey, result) => {
+    setResultsByScope(prev => ({ ...prev, [scopeKey]: result }))
+  }, [])
+
+  const scopeQueries = useMemo(
+    () => [
+      <RecentScopeQuery
+        key="recents-own"
+        scopeKey="recents-own"
+        onResult={handleResult}
+      />,
+      ...driveScopeIds.map(id => (
+        <RecentScopeQuery
+          key={`recents-drive-${id}`}
+          scopeKey={`recents-drive-${id}`}
+          driveId={id}
+          onResult={handleResult}
+        />
+      ))
+    ],
+    [driveScopeIds, handleResult]
+  )
+
+  const { data, fetchStatus, error } = useMemo(() => {
+    const activeScopeKeysSet = new Set(activeScopeKeys)
+
+    // Filter to only active scopes — pruning stale entries at compute time
+    const activeResults = Object.fromEntries(
+      Object.entries(resultsByScope).filter(([k]) => activeScopeKeysSet.has(k))
+    )
+
+    const allReported = activeScopeKeys.every(k => k in activeResults)
+
+    // Surface own-scope hard errors
+    const ownResult = activeResults['recents-own']
+    if (ownResult?.fetchStatus === 'error') {
+      return { data: [], fetchStatus: 'error', error: ownResult.error }
     }
 
-    fetchRecents()
-  }, [dataProxy, client, recentQuery])
+    // Gather files from all reported active scopes
+    const allFiles = Object.values(activeResults).flatMap(r => r?.data || [])
 
-  return { data, fetchStatus, error }
+    const nonTrashed = allFiles.filter(f => !f.trashed)
+
+    const sorted = [...nonTrashed].sort(
+      (a, b) => new Date(b.updated_at) - new Date(a.updated_at)
+    )
+
+    const seen = new Set()
+    const deduped = sorted.filter(f => {
+      if (seen.has(f._id)) return false
+      seen.add(f._id)
+      return true
+    })
+
+    const capped = deduped.slice(0, 50)
+
+    return {
+      data: capped,
+      fetchStatus: allReported ? 'loaded' : 'loading',
+      error: null
+    }
+  }, [resultsByScope, activeScopeKeys])
+
+  return { data, fetchStatus, error, scopeQueries }
 }
 
-export default useDataProxyRecents
+export default useRecentFiles

--- a/src/hooks/useRecentFiles.spec.jsx
+++ b/src/hooks/useRecentFiles.spec.jsx
@@ -1,11 +1,11 @@
-import { render, act, waitFor } from '@testing-library/react'
+import { render, act } from '@testing-library/react'
 import React from 'react'
-
-import { useClient, DataProxyLink } from 'cozy-client'
 
 import useRecentFiles from './useRecentFiles'
 
 import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
+
+import { useClient } from 'cozy-client'
 
 // Mock cozy-client: create a fake DataProxyLink class that can be used with instanceof
 jest.mock('cozy-client', () => {
@@ -25,14 +25,14 @@ jest.mock('@/hooks/useRecentFiles/RecentScopeQuery', () => ({
   default: jest.fn()
 }))
 
-const MockRecentScopeQuery = require('@/hooks/useRecentFiles/RecentScopeQuery')
-  .default
-
 const mockUseClient = useClient
 const mockUseSharedDrives = useSharedDrives
 
 // Get the FakeDataProxyLink class to create instances
 const { DataProxyLink: FakeDataProxyLink } = require('cozy-client')
+
+const MockRecentScopeQuery =
+  require('@/hooks/useRecentFiles/RecentScopeQuery').default
 
 const makeClientWithDataProxy = () => ({
   links: [new FakeDataProxyLink()]
@@ -58,16 +58,18 @@ const makeFile = (id, updated_at, extra = {}) => ({
  * onResultRegistry. Returns a ref object that always holds the latest result.
  */
 const renderHookWithScopes = () => {
-  const ref = { current: null }
+  const resultRef = React.createRef()
 
   const TestComponent = () => {
     const result = useRecentFiles()
-    ref.current = result
+    React.useEffect(() => {
+      resultRef.current = result
+    })
     return <>{result.scopeQueries}</>
   }
 
   const renderResult = render(<TestComponent />)
-  return { ref, renderResult }
+  return { ref: resultRef, renderResult }
 }
 
 describe('useRecentFiles', () => {

--- a/src/hooks/useRecentFiles.spec.jsx
+++ b/src/hooks/useRecentFiles.spec.jsx
@@ -1,209 +1,327 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { render, act, waitFor } from '@testing-library/react'
+import React from 'react'
 
-import { useClient } from 'cozy-client'
-import { useDataProxy } from 'cozy-dataproxy-lib'
+import { useClient, DataProxyLink } from 'cozy-client'
 
-import useDataProxyRecents from './useRecentFiles'
+import useRecentFiles from './useRecentFiles'
 
-import logger from '@/lib/logger'
-import { buildRecentQuery } from '@/queries'
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 
-jest.mock('cozy-client', () => ({
-  useClient: jest.fn()
+// Mock cozy-client: create a fake DataProxyLink class that can be used with instanceof
+jest.mock('cozy-client', () => {
+  class FakeDataProxyLink {}
+  return {
+    useClient: jest.fn(),
+    DataProxyLink: FakeDataProxyLink
+  }
+})
+
+jest.mock('@/modules/shareddrives/hooks/useSharedDrives', () => ({
+  useSharedDrives: jest.fn()
 }))
 
-jest.mock('cozy-dataproxy-lib', () => ({
-  useDataProxy: jest.fn()
+jest.mock('@/hooks/useRecentFiles/RecentScopeQuery', () => ({
+  __esModule: true,
+  default: jest.fn()
 }))
 
-jest.mock('@/lib/logger', () => ({
-  warn: jest.fn(),
-  error: jest.fn()
-}))
-
-jest.mock('@/queries', () => ({
-  buildRecentQuery: jest.fn()
-}))
+const MockRecentScopeQuery = require('@/hooks/useRecentFiles/RecentScopeQuery')
+  .default
 
 const mockUseClient = useClient
-const mockUseDataProxy = useDataProxy
-const mockBuildRecentQuery = buildRecentQuery
+const mockUseSharedDrives = useSharedDrives
 
-describe('useDataProxyRecents', () => {
-  let mockClient
+// Get the FakeDataProxyLink class to create instances
+const { DataProxyLink: FakeDataProxyLink } = require('cozy-client')
+
+const makeClientWithDataProxy = () => ({
+  links: [new FakeDataProxyLink()]
+})
+
+const makeClientWithoutDataProxy = () => ({
+  links: []
+})
+
+const makeFile = (id, updated_at, extra = {}) => ({
+  _id: id,
+  id,
+  updated_at,
+  trashed: false,
+  type: 'file',
+  name: `file-${id}`,
+  ...extra
+})
+
+/**
+ * Renders a TestComponent that calls useRecentFiles and also mounts the
+ * scopeQueries elements so MockRecentScopeQuery is invoked and populates
+ * onResultRegistry. Returns a ref object that always holds the latest result.
+ */
+const renderHookWithScopes = () => {
+  const ref = { current: null }
+
+  const TestComponent = () => {
+    const result = useRecentFiles()
+    ref.current = result
+    return <>{result.scopeQueries}</>
+  }
+
+  const renderResult = render(<TestComponent />)
+  return { ref, renderResult }
+}
+
+describe('useRecentFiles', () => {
+  let onResultRegistry
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockClient = {
-      fetchQueryAndGetFromState: jest.fn()
-    }
-    mockUseClient.mockReturnValue(mockClient)
-    mockBuildRecentQuery.mockReturnValue({
-      definition: jest.fn(() => ({})),
-      options: {}
+    onResultRegistry = {}
+
+    MockRecentScopeQuery.mockImplementation(({ scopeKey, onResult }) => {
+      onResultRegistry[scopeKey] = onResult
+      return null
+    })
+
+    mockUseSharedDrives.mockReturnValue({ recipientDriveIds: [] })
+    mockUseClient.mockReturnValue(makeClientWithDataProxy())
+  })
+
+  describe('merge, sort, dedup, and cap', () => {
+    it('merges own and drive scopes sorted by updated_at desc, filtered, deduped, capped at 50', async () => {
+      const driveId = 'drive-1'
+      mockUseSharedDrives.mockReturnValue({ recipientDriveIds: [driveId] })
+
+      const fileA = makeFile('A', '2020-01-01T00:00:01Z')
+      const fileB = makeFile('B', '2020-01-01T00:00:02Z')
+      const fileC = makeFile('C', '2020-01-01T00:00:03Z')
+
+      const { ref } = renderHookWithScopes()
+
+      // Initially loading (no scopes have reported yet)
+      expect(ref.current.fetchStatus).toBe('loading')
+      expect(ref.current.data).toEqual([])
+
+      // Own scope reports: A and C
+      act(() => {
+        onResultRegistry['recents-own']('recents-own', {
+          data: [fileA, fileC],
+          fetchStatus: 'loaded',
+          error: null
+        })
+      })
+
+      // Drive scope hasn't reported yet — still loading but partial data visible
+      expect(ref.current.fetchStatus).toBe('loading')
+      // Partial data: C then A (sorted desc)
+      expect(ref.current.data.map(f => f._id)).toEqual(['C', 'A'])
+
+      // Drive scope reports: B
+      act(() => {
+        onResultRegistry[`recents-drive-${driveId}`](
+          `recents-drive-${driveId}`,
+          {
+            data: [fileB],
+            fetchStatus: 'loaded',
+            error: null
+          }
+        )
+      })
+
+      // All scopes reported → loaded
+      expect(ref.current.fetchStatus).toBe('loaded')
+      // Sorted desc: C(3) > B(2) > A(1)
+      expect(ref.current.data.map(f => f._id)).toEqual(['C', 'B', 'A'])
+      expect(ref.current.error).toBeNull()
+    })
+
+    it('filters out trashed files', () => {
+      const trashedFile = makeFile('T', '2020-01-01T00:00:05Z', {
+        trashed: true
+      })
+      const okFile = makeFile('OK', '2020-01-01T00:00:01Z')
+
+      const { ref } = renderHookWithScopes()
+
+      act(() => {
+        onResultRegistry['recents-own']('recents-own', {
+          data: [trashedFile, okFile],
+          fetchStatus: 'loaded',
+          error: null
+        })
+      })
+
+      expect(ref.current.data.map(f => f._id)).toEqual(['OK'])
+    })
+
+    it('caps results at 50', () => {
+      const files = Array.from({ length: 60 }, (_, i) =>
+        makeFile(`f${i}`, `2020-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`)
+      )
+
+      const { ref } = renderHookWithScopes()
+
+      act(() => {
+        onResultRegistry['recents-own']('recents-own', {
+          data: files,
+          fetchStatus: 'loaded',
+          error: null
+        })
+      })
+
+      expect(ref.current.data).toHaveLength(50)
+    })
+
+    it('deduplicates by _id keeping the most-recently-updated occurrence', () => {
+      const driveId = 'drive-1'
+      mockUseSharedDrives.mockReturnValue({ recipientDriveIds: [driveId] })
+
+      // Same _id in both own and drive — drive has newer timestamp
+      const fileFromOwn = makeFile('SHARED', '2020-01-01T00:00:01Z')
+      const fileFromDrive = makeFile('SHARED', '2020-01-01T00:00:05Z')
+      const uniqueFile = makeFile('UNIQUE', '2020-01-01T00:00:03Z')
+
+      const { ref } = renderHookWithScopes()
+
+      act(() => {
+        onResultRegistry['recents-own']('recents-own', {
+          data: [fileFromOwn, uniqueFile],
+          fetchStatus: 'loaded',
+          error: null
+        })
+        onResultRegistry[`recents-drive-${driveId}`](
+          `recents-drive-${driveId}`,
+          {
+            data: [fileFromDrive],
+            fetchStatus: 'loaded',
+            error: null
+          }
+        )
+      })
+
+      // SHARED appears once, drive version wins (updated_at=5 > 3 > 1)
+      expect(ref.current.data.map(f => f._id)).toEqual(['SHARED', 'UNIQUE'])
+      expect(ref.current.data).toHaveLength(2)
     })
   })
 
-  describe('when dataProxy is available and succeeds', () => {
-    it('should return data from dataProxy', async () => {
-      const mockData = [
-        { id: '1', name: 'file1' },
-        { id: '2', name: 'file2' }
-      ]
-      const mockDataProxy = {
-        dataProxyServicesAvailable: true,
-        recents: jest.fn().mockResolvedValue(mockData)
-      }
+  describe('fetchStatus semantics', () => {
+    it('is loading until all active scopes have reported at least once', () => {
+      const driveId = 'drive-1'
+      mockUseSharedDrives.mockReturnValue({ recipientDriveIds: [driveId] })
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
+      const { ref } = renderHookWithScopes()
 
-      const { result } = renderHook(() => useDataProxyRecents())
+      expect(ref.current.fetchStatus).toBe('loading')
 
-      expect(result.current.fetchStatus).toBe('loading')
-      expect(result.current.data).toEqual([])
+      act(() => {
+        onResultRegistry['recents-own']('recents-own', {
+          data: [],
+          fetchStatus: 'loaded',
+          error: null
+        })
+      })
 
-      await waitFor(() => expect(result.current.fetchStatus).toBe('loaded'))
-      expect(result.current.data).toEqual(mockData)
-      expect(result.current.error).toBe(null)
-      expect(mockDataProxy.recents).toHaveBeenCalledTimes(1)
-      expect(mockClient.fetchQueryAndGetFromState).not.toHaveBeenCalled()
-      expect(logger.error).not.toHaveBeenCalled()
+      // Drive scope not yet reported
+      expect(ref.current.fetchStatus).toBe('loading')
+
+      act(() => {
+        onResultRegistry[`recents-drive-${driveId}`](
+          `recents-drive-${driveId}`,
+          {
+            data: [],
+            fetchStatus: 'loaded',
+            error: null
+          }
+        )
+      })
+
+      expect(ref.current.fetchStatus).toBe('loaded')
+    })
+
+    it('returns loading + partial data while drive scopes have not yet reported', () => {
+      const driveId = 'drive-1'
+      mockUseSharedDrives.mockReturnValue({ recipientDriveIds: [driveId] })
+      const ownFile = makeFile('OWN', '2020-01-01T00:00:01Z')
+
+      const { ref } = renderHookWithScopes()
+
+      act(() => {
+        onResultRegistry['recents-own']('recents-own', {
+          data: [ownFile],
+          fetchStatus: 'loaded',
+          error: null
+        })
+      })
+
+      // Own reported, drive has not — partial data + loading (isFetchingMore semantics)
+      expect(ref.current.fetchStatus).toBe('loading')
+      expect(ref.current.data).toHaveLength(1)
+      expect(ref.current.data[0]._id).toBe('OWN')
     })
   })
 
-  describe('when dataProxy throws an error', () => {
-    it('should use fallback query when dataProxy fails', async () => {
-      const mockError = new Error('DataProxy error')
-      const mockDataProxy = {
-        dataProxyServicesAvailable: true,
-        recents: jest.fn().mockRejectedValue(mockError)
-      }
-      const fallbackData = [
-        { id: '3', name: 'file3' },
-        { id: '4', name: 'file4' }
-      ]
+  describe('degrade without data-proxy link', () => {
+    it('renders only the own scope when client has no DataProxyLink', () => {
+      mockUseClient.mockReturnValue(makeClientWithoutDataProxy())
+      mockUseSharedDrives.mockReturnValue({ recipientDriveIds: ['drive-x'] })
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockClient.fetchQueryAndGetFromState.mockResolvedValue({
-        data: fallbackData
+      const { ref } = renderHookWithScopes()
+
+      // Only one scope element (own)
+      expect(ref.current.scopeQueries).toHaveLength(1)
+
+      // Only 'recents-own' is registered — no drive scope
+      expect(Object.keys(onResultRegistry)).toEqual(['recents-own'])
+
+      const ownFile = makeFile('OWN', '2020-01-01T00:00:01Z')
+      act(() => {
+        onResultRegistry['recents-own']('recents-own', {
+          data: [ownFile],
+          fetchStatus: 'loaded',
+          error: null
+        })
       })
 
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      expect(result.current.fetchStatus).toBe('loading')
-      expect(result.current.data).toEqual([])
-
-      // Wait for fallback query to complete
-      await waitFor(() => expect(result.current.fetchStatus).toBe('loaded'))
-      expect(result.current.data).toEqual(fallbackData)
-      expect(result.current.error).toBe(null)
-      expect(logger.error).toHaveBeenCalledWith(
-        'Error fetching recents from dataproxy',
-        mockError
-      )
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledWith({
-        definition: expect.any(Object),
-        options: expect.any(Object)
-      })
+      expect(ref.current.fetchStatus).toBe('loaded')
+      expect(ref.current.data.map(f => f._id)).toEqual(['OWN'])
     })
 
-    it('should handle fallback query error', async () => {
-      const mockError = new Error('DataProxy error')
-      const fallbackError = new Error('Fallback query error')
-      const mockDataProxy = {
-        dataProxyServicesAvailable: true,
-        recents: jest.fn().mockRejectedValue(mockError)
-      }
+    it('renders only the own scope when client.links is absent', () => {
+      mockUseClient.mockReturnValue({ links: null })
+      mockUseSharedDrives.mockReturnValue({ recipientDriveIds: ['drive-x'] })
 
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockClient.fetchQueryAndGetFromState.mockRejectedValue(fallbackError)
+      const { ref } = renderHookWithScopes()
 
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      // Wait for fallback query error to be processed
-      await waitFor(() => expect(result.current.fetchStatus).toBe('error'))
-      expect(result.current.error).toEqual(fallbackError)
-      expect(logger.error).toHaveBeenCalledWith(
-        'Error fetching recents from dataproxy',
-        mockError
-      )
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Error fetching recents from fallback query',
-        fallbackError
-      )
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
+      expect(ref.current.scopeQueries).toHaveLength(1)
     })
   })
 
-  describe('when dataProxy is not available', () => {
-    it('should use fallback query when dataProxy is not available', async () => {
-      const mockDataProxy = {
-        dataProxyServicesAvailable: false
-      }
-      const fallbackData = [
-        { id: '5', name: 'file5' },
-        { id: '6', name: 'file6' }
-      ]
-
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockClient.fetchQueryAndGetFromState.mockResolvedValue({
-        data: fallbackData
+  describe('scopeQueries elements', () => {
+    it('renders one own scope + one per drive', () => {
+      mockUseSharedDrives.mockReturnValue({
+        recipientDriveIds: ['d1', 'd2']
       })
 
-      const { result } = renderHook(() => useDataProxyRecents())
+      const { ref } = renderHookWithScopes()
 
-      // When dataProxy is not available, the hook should execute fallback query
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
+      expect(ref.current.scopeQueries).toHaveLength(3)
 
-      // Wait for fallback query to complete
-      await waitFor(() => expect(result.current.fetchStatus).toBe('loaded'))
-      expect(result.current.data).toEqual(fallbackData)
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledWith({
-        definition: expect.any(Object),
-        options: expect.any(Object)
-      })
-    })
-
-    it('should handle fallback query loading state', async () => {
-      const mockDataProxy = {
-        dataProxyServicesAvailable: false
-      }
-
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      // Don't resolve the query immediately to test loading state
-      mockClient.fetchQueryAndGetFromState.mockImplementation(
-        () => new Promise(() => {}) // Never resolves
+      // Check MockRecentScopeQuery was called with the expected scopeKeys
+      const calls = MockRecentScopeQuery.mock.calls.map(
+        ([{ scopeKey }]) => scopeKey
       )
-
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      expect(result.current.fetchStatus).toBe('loading')
-      expect(result.current.data).toEqual([])
-      expect(result.current.error).toBe(null)
-      expect(mockClient.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
+      expect(calls).toContain('recents-own')
+      expect(calls).toContain('recents-drive-d1')
+      expect(calls).toContain('recents-drive-d2')
     })
   })
 
-  describe('when client is not available', () => {
-    it('should set error when client is not available', async () => {
-      const mockDataProxy = {
-        dataProxyServicesAvailable: false
-      }
-
-      mockUseDataProxy.mockReturnValue(mockDataProxy)
-      mockUseClient.mockReturnValue(null)
-
-      const { result } = renderHook(() => useDataProxyRecents())
-
-      // Wait for error to be set
-      await waitFor(() => {
-        expect(result.current.fetchStatus).toBe('error')
-      })
-
-      expect(result.current.error).toEqual(new Error('Client not available'))
-      expect(result.current.data).toEqual([])
-      expect(mockClient.fetchQueryAndGetFromState).not.toHaveBeenCalled()
+  describe('no dependency on useDataProxy or dataProxy.recents()', () => {
+    it('does not import useDataProxy and runs correctly without cozy-dataproxy-lib', () => {
+      // If the hook still imported cozy-dataproxy-lib, this test would fail
+      // because we don't mock it — any call would throw. We confirm by running
+      // the hook and asserting it works without that dependency.
+      expect(() => renderHookWithScopes()).not.toThrow()
     })
   })
 })

--- a/src/hooks/useRecentFiles/RecentScopeQuery.spec.jsx
+++ b/src/hooks/useRecentFiles/RecentScopeQuery.spec.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import { render } from '@testing-library/react'
+import { useQuery } from 'cozy-client'
+
+import RecentScopeQuery from './RecentScopeQuery'
+
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  useQuery: jest.fn()
+}))
+
+jest.mock('@/queries', () => ({
+  buildRecentsScopedQuery: jest.fn().mockReturnValue({
+    definition: jest.fn(),
+    options: {}
+  })
+}))
+
+describe('RecentScopeQuery', () => {
+  it('calls onResult with data when query loads successfully', () => {
+    useQuery.mockReturnValue({
+      data: [{ _id: 'a' }],
+      fetchStatus: 'loaded',
+      error: null
+    })
+    const onResult = jest.fn()
+
+    render(<RecentScopeQuery scopeKey="own" onResult={onResult} />)
+
+    expect(onResult).toHaveBeenCalledWith('own', {
+      data: [{ _id: 'a' }],
+      fetchStatus: 'loaded',
+      error: null
+    })
+  })
+
+  it('reports empty-loaded for a 403 error', () => {
+    useQuery.mockReturnValue({
+      data: undefined,
+      fetchStatus: 'failed',
+      error: { status: 403 }
+    })
+    const onResult = jest.fn()
+
+    render(
+      <RecentScopeQuery scopeKey="drive-abc" driveId="abc" onResult={onResult} />
+    )
+
+    expect(onResult).toHaveBeenCalledWith('drive-abc', {
+      data: [],
+      fetchStatus: 'loaded',
+      error: null
+    })
+  })
+
+  it('renders null (empty DOM)', () => {
+    useQuery.mockReturnValue({ data: [], fetchStatus: 'loaded', error: null })
+    const { container } = render(
+      <RecentScopeQuery scopeKey="own" onResult={jest.fn()} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/hooks/useRecentFiles/RecentScopeQuery.spec.jsx
+++ b/src/hooks/useRecentFiles/RecentScopeQuery.spec.jsx
@@ -1,6 +1,6 @@
+import { render } from '@testing-library/react'
 import React from 'react'
 
-import { render } from '@testing-library/react'
 import { useQuery } from 'cozy-client'
 
 import RecentScopeQuery from './RecentScopeQuery'
@@ -44,7 +44,11 @@ describe('RecentScopeQuery', () => {
     const onResult = jest.fn()
 
     render(
-      <RecentScopeQuery scopeKey="drive-abc" driveId="abc" onResult={onResult} />
+      <RecentScopeQuery
+        scopeKey="drive-abc"
+        driveId="abc"
+        onResult={onResult}
+      />
     )
 
     expect(onResult).toHaveBeenCalledWith('drive-abc', {

--- a/src/hooks/useRecentFiles/RecentScopeQuery.tsx
+++ b/src/hooks/useRecentFiles/RecentScopeQuery.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useMemo } from 'react'
+
+import { useQuery } from 'cozy-client'
+
+import { buildRecentsScopedQuery } from '@/queries'
+
+interface RecentResult {
+  data: unknown[]
+  fetchStatus: string
+  error: unknown
+}
+
+interface RecentScopeQueryProps {
+  driveId?: string
+  scopeKey: string
+  onResult: (scopeKey: string, result: RecentResult) => void
+}
+
+const RecentScopeQuery = ({
+  driveId,
+  scopeKey,
+  onResult
+}: RecentScopeQueryProps): null => {
+  const q = useMemo(() => buildRecentsScopedQuery({ driveId }), [driveId])
+  const r = useQuery(q.definition, q.options)
+
+  useEffect(() => {
+    const is403 = (r.error as { status?: number } | null)?.status === 403
+    const result: RecentResult = is403
+      ? { data: [], fetchStatus: 'loaded', error: null }
+      : { data: r.data ?? [], fetchStatus: r.fetchStatus, error: r.error }
+    onResult(scopeKey, result)
+  }, [r.data, r.fetchStatus, r.error, scopeKey, onResult])
+
+  return null
+}
+
+export default RecentScopeQuery

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -779,5 +779,8 @@
       "SHARING_LINK_FAILED": "Could not generate a sharing link.",
       "DOWNLOAD_LINK_FAILED": "Could not generate a download link."
     }
+  },
+  "SharedDrive": {
+    "access_revoked": "You no longer have access to this shared drive."
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -776,5 +776,8 @@
       "SHARING_LINK_FAILED": "Impossible de générer le lien de partage.",
       "DOWNLOAD_LINK_FAILED": "Impossible de générer le lien de téléchargement."
     }
+  },
+  "SharedDrive": {
+    "access_revoked": "Vous n'avez plus accès à ce drive partagé."
   }
 }

--- a/src/modules/shareddrives/hooks/useRedirectOnRevokedDrive.js
+++ b/src/modules/shareddrives/hooks/useRedirectOnRevokedDrive.js
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+import { useI18n } from 'twake-i18n'
+
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
+
+/**
+ * Redirects to /sharings?tab=1 with an alert when the current drive is no
+ * longer among the recipient's shared drives (i.e. access has been revoked).
+ *
+ * @param {string|undefined} driveId - the shared-drive id being viewed
+ */
+export const useRedirectOnRevokedDrive = driveId => {
+  const navigate = useNavigate()
+  const { showAlert } = useAlert()
+  const { t } = useI18n()
+  const { recipientDriveIds, isLoaded } = useSharedDrives()
+
+  useEffect(() => {
+    if (!driveId || !isLoaded) return
+    if (!recipientDriveIds.includes(driveId)) {
+      showAlert({
+        message: t('SharedDrive.access_revoked'),
+        severity: 'secondary'
+      })
+      navigate('/sharings?tab=1', { replace: true })
+    }
+  }, [driveId, isLoaded, recipientDriveIds, navigate, showAlert, t])
+}

--- a/src/modules/shareddrives/hooks/useRedirectOnRevokedDrive.spec.jsx
+++ b/src/modules/shareddrives/hooks/useRedirectOnRevokedDrive.spec.jsx
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react'
+
+// --- router mock ---
+const mockNavigate = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate
+}))
+
+// --- alert / i18n mocks ---
+const mockShowAlert = jest.fn()
+const mockT = key => key
+
+jest.mock('cozy-ui/transpiled/react/providers/Alert', () => ({
+  useAlert: () => ({ showAlert: mockShowAlert })
+}))
+
+jest.mock('twake-i18n', () => ({
+  useI18n: () => ({ t: mockT })
+}))
+
+// --- useSharedDrives mock ---
+const mockUseSharedDrives = jest.fn()
+
+jest.mock('@/modules/shareddrives/hooks/useSharedDrives', () => ({
+  useSharedDrives: (...args) => mockUseSharedDrives(...args)
+}))
+
+import { useRedirectOnRevokedDrive } from './useRedirectOnRevokedDrive'
+
+const DRIVE_ID = 'drive-1'
+
+describe('useRedirectOnRevokedDrive', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('redirects to /sharings?tab=1 and shows an alert when driveId is no longer in recipientDriveIds', () => {
+    mockUseSharedDrives.mockReturnValue({
+      isLoaded: true,
+      recipientDriveIds: ['other-drive']
+    })
+
+    renderHook(() => useRedirectOnRevokedDrive(DRIVE_ID))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/sharings?tab=1', {
+      replace: true
+    })
+    expect(mockShowAlert).toHaveBeenCalledWith({
+      message: 'SharedDrive.access_revoked',
+      severity: 'secondary'
+    })
+  })
+
+  it('does not redirect when driveId is still in recipientDriveIds', () => {
+    mockUseSharedDrives.mockReturnValue({
+      isLoaded: true,
+      recipientDriveIds: [DRIVE_ID]
+    })
+
+    renderHook(() => useRedirectOnRevokedDrive(DRIVE_ID))
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(mockShowAlert).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect before shared drives finish loading (no premature redirect)', () => {
+    mockUseSharedDrives.mockReturnValue({
+      isLoaded: false,
+      recipientDriveIds: []
+    })
+
+    renderHook(() => useRedirectOnRevokedDrive(DRIVE_ID))
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(mockShowAlert).not.toHaveBeenCalled()
+  })
+})

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
@@ -1,35 +1,27 @@
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import React from 'react'
 
-import { createMockClient } from 'cozy-client'
-import CozyRealtime from 'cozy-realtime'
+import { useQuery, createMockClient } from 'cozy-client'
 
 import { useSharedDriveFolder } from './useSharedDriveFolder'
 import AppLike from 'test/components/AppLike'
 
-import logger from '@/lib/logger'
+import { useFolderSort } from '@/hooks'
 
-jest.mock('cozy-realtime', () => {
-  return jest.fn().mockImplementation(() => ({
-    subscribe: jest.fn(),
-    stop: jest.fn()
-  }))
-})
-
-jest.mock('lodash/debounce', () =>
-  jest.fn(fn => {
-    const immediate = (...args) => fn(...args)
-    immediate.cancel = jest.fn()
-    return immediate
-  })
-)
-
-jest.mock('@/lib/logger', () => ({
-  __esModule: true,
-  default: {
-    error: jest.fn()
-  }
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  useQuery: jest.fn()
 }))
+
+jest.mock('@/hooks', () => ({
+  ...jest.requireActual('@/hooks'),
+  useFolderSort: jest.fn()
+}))
+
+// Ensure the legacy machinery is gone from the module source
+jest.mock('cozy-realtime', () => {
+  throw new Error('cozy-realtime must not be imported by useSharedDriveFolder')
+})
 
 describe('useSharedDriveFolder', () => {
   const mockDriveId = 'drive-id-1'
@@ -39,21 +31,32 @@ describe('useSharedDriveFolder', () => {
     { _id: '2', name: 'file-2.txt', type: 'file' }
   ]
 
-  const makeMockClient = statByIdFn => {
-    const mockClient = createMockClient({})
-    mockClient.getStackClient = () => ({
-      collection: () => ({
-        statById: statByIdFn
-      })
-    })
-    return mockClient
+  const defaultQueryResult = {
+    data: mockData,
+    fetchStatus: 'loaded',
+    lastUpdate: 1234567890,
+    hasMore: false,
+    fetchMore: jest.fn()
   }
 
-  const setup = mockClient => {
+  beforeEach(() => {
+    useFolderSort.mockReturnValue([
+      { attribute: 'name', order: 'asc' },
+      jest.fn(),
+      true
+    ])
+    useQuery.mockReturnValue(defaultQueryResult)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const setup = () => {
+    const mockClient = createMockClient({})
     const wrapper = ({ children }) => (
       <AppLike client={mockClient}>{children}</AppLike>
     )
-
     return renderHook(
       () =>
         useSharedDriveFolder({ driveId: mockDriveId, folderId: mockFolderId }),
@@ -61,358 +64,80 @@ describe('useSharedDriveFolder', () => {
     )
   }
 
-  afterEach(() => {
-    jest.clearAllMocks()
+  it('exposes children via sharedDriveResult.data when useQuery returns data', () => {
+    const { result } = setup()
+    expect(result.current.sharedDriveResult.data).toEqual(mockData)
   })
 
-  it('should fetch initial data', async () => {
-    const statByIdMock = jest.fn().mockResolvedValue({
-      included: mockData,
-      links: {}
-    })
-    const mockClient = makeMockClient(statByIdMock)
-
-    const { result } = setup(mockClient)
-
-    expect(result.current.sharedDriveResult.data).toBeUndefined()
-
-    await waitFor(() => {
-      expect(result.current.sharedDriveResult.included).toEqual(mockData)
-    })
-
-    expect(result.current.hasMore).toBe(false)
+  it('exposes null sharedDriveResult.data when useQuery returns null', () => {
+    useQuery.mockReturnValue({ ...defaultQueryResult, data: null })
+    const { result } = setup()
+    expect(result.current.sharedDriveResult.data).toBeNull()
   })
 
-  it('exposes a lastUpdate timestamp once data has loaded', async () => {
-    const statByIdMock = jest.fn().mockResolvedValue({
-      included: mockData,
-      links: {}
-    })
-    const mockClient = makeMockClient(statByIdMock)
-
-    const { result } = setup(mockClient)
-
-    expect(result.current.lastUpdate).toBeNull()
-
-    await waitFor(() => {
-      expect(result.current.lastUpdate).toEqual(expect.any(Number))
-    })
+  it('delegates fetchMore to query.fetchMore', () => {
+    const mockFetchMore = jest.fn()
+    useQuery.mockReturnValue({ ...defaultQueryResult, fetchMore: mockFetchMore })
+    const { result } = setup()
+    result.current.fetchMore()
+    expect(mockFetchMore).toHaveBeenCalledTimes(1)
   })
 
-  it('should indicate when there is more data to fetch', async () => {
-    const cursor = 'next-page-cursor'
-    const statByIdMock = jest.fn().mockResolvedValue({
-      included: mockData,
-      links: {
-        next: `/relative/link?page[cursor]=${cursor}&other=params`
-      }
-    })
-    const mockClient = makeMockClient(statByIdMock)
-
-    const { result } = setup(mockClient)
-
-    await waitFor(() => {
-      expect(result.current.hasMore).toBe(true)
-    })
-  })
-
-  it('should fetch more data when fetchMore is called', async () => {
-    const cursor = 'next-page-cursor'
-    const nextPageData = [
-      { _id: '3', name: 'file-3.txt', type: 'file' },
-      { _id: '4', name: 'file-4.txt', type: 'file' }
-    ]
-
-    const statByIdMock = jest
-      .fn()
-      .mockResolvedValueOnce({
-        included: mockData,
-        links: { next: `/relative/link?page[cursor]=${cursor}` }
-      })
-      .mockResolvedValueOnce({
-        included: nextPageData,
-        links: {}
-      })
-    const mockClient = makeMockClient(statByIdMock)
-
-    const { result } = setup(mockClient)
-
-    await waitFor(() => expect(result.current.hasMore).toBe(true))
-
-    await act(() => result.current.fetchMore())
-
-    expect(statByIdMock).toHaveBeenLastCalledWith(mockFolderId, {
-      'page[cursor]': cursor,
-      'page[limit]': 100
-    })
-
-    await waitFor(() => {
-      expect(result.current.sharedDriveResult.included).toEqual([
-        ...mockData,
-        ...nextPageData
-      ])
-    })
-
-    expect(result.current.hasMore).toBe(false)
-  })
-
-  it('should handle empty response', async () => {
-    const statByIdMock = jest.fn().mockResolvedValue({
-      included: [],
-      links: {}
-    })
-    const mockClient = makeMockClient(statByIdMock)
-
-    const { result } = setup(mockClient)
-
-    await waitFor(() => {
-      expect(result.current.sharedDriveResult.included).toEqual([])
-    })
-
-    expect(result.current.hasMore).toBe(false)
-  })
-
-  it('should handle errors during fetchMore and keep existing data', async () => {
-    const cursor = 'next-page-cursor'
-    const statByIdMock = jest
-      .fn()
-      .mockResolvedValueOnce({
-        included: mockData,
-        links: { next: `/relative/link?page[cursor]=${cursor}` }
-      })
-      .mockRejectedValueOnce(new Error('Network error'))
-    const mockClient = makeMockClient(statByIdMock)
-
-    const { result } = setup(mockClient)
-
-    await waitFor(() => expect(result.current.hasMore).toBe(true))
-
-    await act(() => result.current.fetchMore())
-
-    expect(result.current.sharedDriveResult.included).toEqual(mockData)
+  it('reflects hasMore: true from useQuery', () => {
+    useQuery.mockReturnValue({ ...defaultQueryResult, hasMore: true })
+    const { result } = setup()
     expect(result.current.hasMore).toBe(true)
-    expect(logger.error).toHaveBeenCalledWith(
-      'Error fetching more shared drive files:',
-      expect.any(Error)
+  })
+
+  it('reflects hasMore: false from useQuery', () => {
+    useQuery.mockReturnValue({ ...defaultQueryResult, hasMore: false })
+    const { result } = setup()
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it('passes fetchStatus through from useQuery', () => {
+    useQuery.mockReturnValue({ ...defaultQueryResult, fetchStatus: 'loading' })
+    const { result } = setup()
+    expect(result.current.fetchStatus).toBe('loading')
+  })
+
+  it('passes lastUpdate through from useQuery', () => {
+    useQuery.mockReturnValue({ ...defaultQueryResult, lastUpdate: 9999 })
+    const { result } = setup()
+    expect(result.current.lastUpdate).toBe(9999)
+  })
+
+  it('gates the query on isSettingsLoaded via enabled option', () => {
+    useFolderSort.mockReturnValue([
+      { attribute: 'name', order: 'asc' },
+      jest.fn(),
+      false // not yet loaded
+    ])
+    setup()
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ enabled: false })
     )
   })
 
-  it('should not fetch more if already fetching', async () => {
-    const cursor = 'next-page-cursor'
-    const statByIdMock = jest.fn().mockResolvedValue({
-      included: mockData,
-      links: { next: `/relative/link?page[cursor]=${cursor}` }
-    })
-    const mockClient = makeMockClient(statByIdMock)
-
-    const { result } = setup(mockClient)
-
-    await waitFor(() => expect(result.current.hasMore).toBe(true))
-
-    await act(async () => {
-      const fetchPromise = result.current.fetchMore()
-      await result.current.fetchMore()
-      await fetchPromise
-    })
-
-    expect(statByIdMock).toHaveBeenCalledTimes(2)
+  it('enables the query when isSettingsLoaded is true and params are present', () => {
+    useFolderSort.mockReturnValue([
+      { attribute: 'name', order: 'asc' },
+      jest.fn(),
+      true
+    ])
+    setup()
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ enabled: true })
+    )
   })
 
-  describe('realtime re-fetch', () => {
-    let triggerRealtimeEvent
-
-    beforeEach(() => {
-      CozyRealtime.mockImplementation(() => ({
-        subscribe: jest.fn((_event, _doctype, callback) => {
-          triggerRealtimeEvent = callback
-        }),
-        stop: jest.fn()
-      }))
-    })
-
-    it('should keep the current list visible while a realtime re-fetch is in flight', async () => {
-      const page1 = [{ _id: '1', name: 'file-1.txt', type: 'file' }]
-      const refreshedPage1 = [
-        { _id: '1', name: 'file-1.txt', type: 'file' },
-        { _id: '2', name: 'file-2.txt', type: 'file' }
-      ]
-
-      let resolveRefetch
-      const refetchPromise = new Promise(resolve => {
-        resolveRefetch = resolve
-      })
-
-      const statByIdMock = jest
-        .fn()
-        .mockResolvedValueOnce({ included: page1, links: {} })
-        .mockReturnValueOnce(refetchPromise)
-      const mockClient = makeMockClient(statByIdMock)
-      const { result } = setup(mockClient)
-
-      await waitFor(() =>
-        expect(result.current.sharedDriveResult.included).toEqual(page1)
-      )
-      expect(result.current.fetchStatus).toBe('loaded')
-
-      // A realtime event triggers a background re-fetch.
-      await act(async () => {
-        triggerRealtimeEvent()
-      })
-
-      // While the re-fetch is in flight the existing list must stay on screen:
-      // no data wipe and no flip back to 'loading' (otherwise the file list is
-      // replaced by the loading skeleton and the screen blinks).
-      expect(result.current.sharedDriveResult.included).toEqual(page1)
-      expect(result.current.fetchStatus).toBe('loaded')
-
-      await act(async () => {
-        resolveRefetch({ included: refreshedPage1, links: {} })
-      })
-
-      await waitFor(() =>
-        expect(result.current.sharedDriveResult.included).toEqual(
-          refreshedPage1
-        )
-      )
-      expect(result.current.fetchStatus).toBe('loaded')
-    })
-
-    it('should keep the current list when a realtime re-fetch fails', async () => {
-      const page1 = [{ _id: '1', name: 'file-1.txt', type: 'file' }]
-
-      const statByIdMock = jest
-        .fn()
-        .mockResolvedValueOnce({ included: page1, links: {} })
-        .mockRejectedValueOnce(new Error('Network error'))
-      const mockClient = makeMockClient(statByIdMock)
-      const { result } = setup(mockClient)
-
-      await waitFor(() =>
-        expect(result.current.sharedDriveResult.included).toEqual(page1)
-      )
-
-      await act(async () => {
-        triggerRealtimeEvent()
-      })
-
-      // A failed background refresh must not wipe the list or flip to an error
-      // state once data is already on screen.
-      expect(result.current.sharedDriveResult.included).toEqual(page1)
-      expect(result.current.fetchStatus).toBe('loaded')
-      expect(logger.error).toHaveBeenCalledWith(
-        'Error fetching shared drive folder:',
-        expect.any(Error)
-      )
-    })
-
-    it('should re-fetch only page 1 when realtime fires before any fetchMore', async () => {
-      const cursor = 'cursor-page-2'
-      const page1 = [{ _id: '1', name: 'file-1.txt', type: 'file' }]
-      const refreshedPage1 = [
-        { _id: '1', name: 'file-1-renamed.txt', type: 'file' }
-      ]
-
-      const statByIdMock = jest
-        .fn()
-        .mockResolvedValueOnce({
-          included: page1,
-          links: { next: `/link?page[cursor]=${cursor}` }
-        })
-        .mockResolvedValueOnce({
-          included: refreshedPage1,
-          links: { next: `/link?page[cursor]=${cursor}` }
-        })
-      const mockClient = makeMockClient(statByIdMock)
-      const { result } = setup(mockClient)
-
-      await waitFor(() =>
-        expect(result.current.sharedDriveResult.included).toEqual(page1)
-      )
-      expect(statByIdMock).toHaveBeenCalledTimes(1)
-
-      await act(async () => {
-        triggerRealtimeEvent()
-      })
-
-      await waitFor(() =>
-        expect(result.current.sharedDriveResult.included).toEqual(
-          refreshedPage1
-        )
-      )
-      // 1 initial + 1 re-fetch (page 1 only)
-      expect(statByIdMock).toHaveBeenCalledTimes(2)
-    })
-
-    it('should re-fetch all loaded pages when realtime fires after fetchMore', async () => {
-      const cursor1 = 'cursor-page-2'
-      const cursor2 = 'cursor-page-3'
-
-      const page1 = [{ _id: '1', name: 'file-1.txt', type: 'file' }]
-      const page2 = [{ _id: '2', name: 'file-2.txt', type: 'file' }]
-      const page3 = [{ _id: '3', name: 'file-3.txt', type: 'file' }]
-      const refreshedPage1 = [
-        { _id: '1', name: 'file-1-renamed.txt', type: 'file' }
-      ]
-      const refreshedPage2 = [{ _id: '2', name: 'file-2.txt', type: 'file' }]
-      const refreshedPage3 = [{ _id: '3', name: 'file-3.txt', type: 'file' }]
-
-      const statByIdMock = jest
-        .fn()
-        // Initial fetch: page 1
-        .mockResolvedValueOnce({
-          included: page1,
-          links: { next: `/link?page[cursor]=${cursor1}` }
-        })
-        // fetchMore: page 2
-        .mockResolvedValueOnce({
-          included: page2,
-          links: { next: `/link?page[cursor]=${cursor2}` }
-        })
-        // fetchMore: page 3
-        .mockResolvedValueOnce({ included: page3, links: {} })
-        // Realtime re-fetch: page 1
-        .mockResolvedValueOnce({
-          included: refreshedPage1,
-          links: { next: `/link?page[cursor]=${cursor1}` }
-        })
-        // Realtime re-fetch: page 2
-        .mockResolvedValueOnce({
-          included: refreshedPage2,
-          links: { next: `/link?page[cursor]=${cursor2}` }
-        })
-        // Realtime re-fetch: page 3
-        .mockResolvedValueOnce({ included: refreshedPage3, links: {} })
-
-      const mockClient = makeMockClient(statByIdMock)
-      const { result } = setup(mockClient)
-
-      await waitFor(() => expect(result.current.hasMore).toBe(true))
-
-      await act(() => result.current.fetchMore())
-      await act(() => result.current.fetchMore())
-
-      await waitFor(() =>
-        expect(result.current.sharedDriveResult.included).toEqual([
-          ...page1,
-          ...page2,
-          ...page3
-        ])
-      )
-      expect(statByIdMock).toHaveBeenCalledTimes(3)
-
-      await act(async () => {
-        triggerRealtimeEvent()
-      })
-
-      await waitFor(() =>
-        expect(result.current.sharedDriveResult.included).toEqual([
-          ...refreshedPage1,
-          ...refreshedPage2,
-          ...refreshedPage3
-        ])
-      )
-      // 3 initial + 3 re-fetch (all pages)
-      expect(statByIdMock).toHaveBeenCalledTimes(6)
-    })
+  it('sets forceLink dataproxy in the query options', () => {
+    setup()
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ forceLink: 'dataproxy' })
+    )
   })
 })

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
@@ -77,7 +77,10 @@ describe('useSharedDriveFolder', () => {
 
   it('delegates fetchMore to query.fetchMore', () => {
     const mockFetchMore = jest.fn()
-    useQuery.mockReturnValue({ ...defaultQueryResult, fetchMore: mockFetchMore })
+    useQuery.mockReturnValue({
+      ...defaultQueryResult,
+      fetchMore: mockFetchMore
+    })
     const { result } = setup()
     result.current.fetchMore()
     expect(mockFetchMore).toHaveBeenCalledTimes(1)

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
@@ -110,30 +110,25 @@ describe('useSharedDriveFolder', () => {
     expect(result.current.lastUpdate).toBe(9999)
   })
 
-  it('gates the query on isSettingsLoaded via enabled option', () => {
+  const expectQueryEnabled = (isSettingsLoaded, expectedEnabled) => {
     useFolderSort.mockReturnValue([
       { attribute: 'name', order: 'asc' },
       jest.fn(),
-      false // not yet loaded
+      isSettingsLoaded
     ])
     setup()
     expect(useQuery).toHaveBeenCalledWith(
       expect.any(Function),
-      expect.objectContaining({ enabled: false })
+      expect.objectContaining({ enabled: expectedEnabled })
     )
+  }
+
+  it('gates the query on isSettingsLoaded via enabled option', () => {
+    expectQueryEnabled(false, false)
   })
 
   it('enables the query when isSettingsLoaded is true and params are present', () => {
-    useFolderSort.mockReturnValue([
-      { attribute: 'name', order: 'asc' },
-      jest.fn(),
-      true
-    ])
-    setup()
-    expect(useQuery).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({ enabled: true })
-    )
+    expectQueryEnabled(true, true)
   })
 
   it('sets forceLink dataproxy in the query options', () => {

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
@@ -140,4 +140,34 @@ describe('useSharedDriveFolder', () => {
       expect.objectContaining({ forceLink: 'dataproxy' })
     )
   })
+
+  describe('fetchStatus while sort settings load', () => {
+    it('returns "loading" (not "pending") when isSettingsLoaded is false', () => {
+      useFolderSort.mockReturnValue([
+        { attribute: 'name', order: 'asc' },
+        jest.fn(),
+        false // settings not yet loaded
+      ])
+      // useQuery returns 'pending' when the query is gated off via enabled: false
+      useQuery.mockReturnValue({
+        ...defaultQueryResult,
+        fetchStatus: 'pending',
+        lastUpdate: undefined
+      })
+      const { result } = setup()
+      expect(result.current.fetchStatus).toBe('loading')
+      expect(result.current.lastUpdate).toBeFalsy()
+    })
+
+    it('passes through query.fetchStatus when isSettingsLoaded is true', () => {
+      useFolderSort.mockReturnValue([
+        { attribute: 'name', order: 'asc' },
+        jest.fn(),
+        true
+      ])
+      useQuery.mockReturnValue({ ...defaultQueryResult, fetchStatus: 'loaded' })
+      const { result } = setup()
+      expect(result.current.fetchStatus).toBe('loaded')
+    })
+  })
 })

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
@@ -39,10 +39,16 @@ const useSharedDriveFolder = ({
     enabled: isSettingsLoaded && !!driveId && !!folderId
   })
 
+  // While sort settings are loading, the query is gated off and useQuery
+  // returns fetchStatus: 'pending'. getFolderViewState only treats 'loading'
+  // (with no lastUpdate) as a loading state, so we normalise to 'loading'
+  // to avoid a brief empty-state flash before settings are ready.
+  const fetchStatus = isSettingsLoaded ? query.fetchStatus : 'loading'
+
   return {
     sharedDriveQuery: q,
     sharedDriveResult: { data: query.data },
-    fetchStatus: query.fetchStatus,
+    fetchStatus,
     lastUpdate: query.lastUpdate,
     hasMore: query.hasMore,
     fetchMore: query.fetchMore

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
@@ -1,13 +1,8 @@
-import debounce from 'lodash/debounce'
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
-
-import { useClient } from 'cozy-client'
+import { useQuery } from 'cozy-client'
 import type { IOCozyFile } from 'cozy-client/types/types'
-import CozyRealtime from 'cozy-realtime'
 
-import { paginatedStatById, type PaginatedStatByIdResult } from '@/lib/files'
-import logger from '@/lib/logger'
-import { buildSharedDriveFolderQuery } from '@/queries'
+import { useFolderSort } from '@/hooks'
+import { buildSharedDriveFolderMangoQuery } from '@/queries'
 import type { QueryConfig } from '@/queries'
 
 interface SharedDriveFolderProps {
@@ -16,17 +11,11 @@ interface SharedDriveFolderProps {
 }
 
 interface SharedDriveFolderReturn {
-  // FIXME: We should use useQuery hook here but it doesn't allow to get included data
-  // See https://github.com/cozy/cozy-client/issues/1620
   sharedDriveQuery: QueryConfig
   sharedDriveResult: {
     data?: IOCozyFile[] | null
-    included?: IOCozyFile[] | null
   }
-  fetchStatus: 'loading' | 'loaded' | 'failed'
-  // Timestamp of the last successful load, kept across in-folder refreshes.
-  // The folder view uses it (like cozy-client's query lastUpdate) to avoid
-  // dropping an already-loaded folder back to the loading skeleton on refetch.
+  fetchStatus: string
   lastUpdate: number | null
   hasMore: boolean
   fetchMore: () => Promise<void>
@@ -36,167 +25,27 @@ const useSharedDriveFolder = ({
   driveId,
   folderId
 }: SharedDriveFolderProps): SharedDriveFolderReturn => {
-  const client = useClient()
-  const [sharedDriveResult, setSharedDriveResult] = useState<
-    SharedDriveFolderReturn['sharedDriveResult']
-  >({ data: undefined })
-  const [fetchStatus, setFetchStatus] =
-    useState<SharedDriveFolderReturn['fetchStatus']>('loading')
-  const [lastUpdate, setLastUpdate] = useState<number | null>(null)
-  const [nextCursor, setNextCursor] = useState<string | null>(null)
-  const nextCursorRef = useRef<string | null>(null)
-  const isFetchingMore = useRef(false)
-  const fetchGeneration = useRef(0)
-  const loadedPagesCount = useRef(0)
+  const [sort, , isSettingsLoaded] = useFolderSort(folderId)
 
-  const sharedDriveQuery = useMemo(
-    () =>
-      buildSharedDriveFolderQuery({
-        driveId,
-        folderId
-      }),
-    [driveId, folderId]
-  )
+  const q = buildSharedDriveFolderMangoQuery({
+    driveId,
+    folderId,
+    sortAttribute: sort.attribute,
+    sortOrder: sort.order
+  })
 
-  const statById = useMemo(
-    () => paginatedStatById(client, driveId),
-    [client, driveId]
-  )
-
-  // Forget the previous folder's load when navigating to a different folder so
-  // its first load shows the skeleton. Within the same folder lastUpdate is
-  // kept, so an in-folder refetch (realtime, or a re-run of the effect below)
-  // never drops the view back to the skeleton.
-  useEffect(() => {
-    setLastUpdate(null)
-  }, [driveId, folderId])
-
-  useEffect(() => {
-    const fetchSharedDriveFolder = async (
-      pagesToLoad = 1,
-      { isRefresh = false }: { isRefresh?: boolean } = {}
-    ): Promise<void> => {
-      fetchGeneration.current += 1
-      const currentGeneration = fetchGeneration.current
-
-      // On a realtime-triggered refresh, keep the current list and cursor on
-      // screen and refetch in the background; only swap once the new data
-      // arrives. Wiping to a loading state here would replace the list with the
-      // loading skeleton on every realtime event and make the view blink while
-      // files are being added.
-      if (!isRefresh) {
-        setSharedDriveResult({ data: undefined, included: undefined })
-        setFetchStatus('loading')
-        nextCursorRef.current = null
-        setNextCursor(null)
-        loadedPagesCount.current = 0
-      }
-
-      try {
-        let allIncluded: IOCozyFile[] = []
-        let cursor: string | null = null
-
-        for (let page = 0; page < pagesToLoad; page++) {
-          const result: PaginatedStatByIdResult = await statById(
-            folderId,
-            cursor
-          )
-          allIncluded = [...allIncluded, ...(result.included ?? [])]
-          cursor = result.nextCursor
-          if (!result.nextCursor) break
-        }
-
-        if (fetchGeneration.current === currentGeneration) {
-          setSharedDriveResult({ included: allIncluded })
-          setFetchStatus('loaded')
-          setLastUpdate(Date.now())
-          nextCursorRef.current = cursor
-          setNextCursor(cursor)
-          loadedPagesCount.current = pagesToLoad
-        }
-      } catch (error) {
-        logger.error('Error fetching shared drive folder:', error)
-        // A failed background refresh keeps the data already on screen rather
-        // than dropping the user into an error state. But if nothing has loaded
-        // yet (a refresh racing the very first load), surface the error instead
-        // of leaving the view stuck on the loading skeleton.
-        const hasLoadedData = loadedPagesCount.current > 0
-        if (
-          fetchGeneration.current === currentGeneration &&
-          (!isRefresh || !hasLoadedData)
-        ) {
-          setSharedDriveResult({ data: undefined, included: undefined })
-          setFetchStatus('failed')
-          nextCursorRef.current = null
-          setNextCursor(null)
-        }
-      }
-    }
-
-    if (client && driveId && folderId) {
-      void fetchSharedDriveFolder()
-    }
-
-    const debouncedFetch = debounce(() => {
-      void fetchSharedDriveFolder(Math.max(1, loadedPagesCount.current), {
-        isRefresh: true
-      })
-    }, 500)
-
-    let realtime: CozyRealtime | undefined
-    if (client && driveId) {
-      realtime = new CozyRealtime({ client, sharedDriveId: driveId })
-      realtime.subscribe('updated', 'io.cozy.files', debouncedFetch)
-      realtime.subscribe('created', 'io.cozy.files', debouncedFetch)
-      realtime.subscribe('deleted', 'io.cozy.files', debouncedFetch)
-    }
-
-    return (): void => {
-      if (realtime) {
-        realtime.stop()
-      }
-      debouncedFetch.cancel()
-    }
-  }, [client, driveId, folderId, statById])
-
-  const fetchMore = useCallback(async (): Promise<void> => {
-    if (isFetchingMore.current || !nextCursorRef.current || !client) return
-
-    isFetchingMore.current = true
-    const currentGeneration = fetchGeneration.current
-
-    try {
-      const { included, nextCursor: cursor } = await statById(
-        folderId,
-        nextCursorRef.current
-      )
-
-      if (fetchGeneration.current !== currentGeneration) return
-
-      setSharedDriveResult(prev => ({
-        ...prev,
-
-        included: [...(prev.included ?? []), ...(included ?? [])]
-      }))
-      nextCursorRef.current = cursor
-      setNextCursor(cursor)
-      loadedPagesCount.current += 1
-    } catch (error) {
-      logger.error('Error fetching more shared drive files:', error)
-    } finally {
-      isFetchingMore.current = false
-    }
-  }, [client, folderId, statById])
-
-  const hasMore = !!nextCursor
+  const query = useQuery(q.definition, {
+    ...q.options,
+    enabled: isSettingsLoaded && !!driveId && !!folderId
+  })
 
   return {
-    sharedDriveQuery,
-    sharedDriveResult,
-    fetchStatus,
-    lastUpdate,
-    hasMore,
-    fetchMore
+    sharedDriveQuery: q,
+    sharedDriveResult: { data: query.data },
+    fetchStatus: query.fetchStatus,
+    lastUpdate: query.lastUpdate,
+    hasMore: query.hasMore,
+    fetchMore: query.fetchMore
   }
 }
 

--- a/src/modules/shareddrives/hooks/useSharedDriveFolderActions.js
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolderActions.js
@@ -1,0 +1,91 @@
+import { useMemo } from 'react'
+
+import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
+
+import {
+  download,
+  hr,
+  infos,
+  rename,
+  share,
+  trash,
+  versions
+} from '@/modules/actions'
+import { duplicateTo } from '@/modules/actions/components/duplicateTo'
+import { moveTo } from '@/modules/actions/components/moveTo'
+import { personalizeFolder } from '@/modules/actions/components/personalizeFolder'
+
+const ACTION_LIST = [
+  share,
+  download,
+  hr,
+  rename,
+  moveTo,
+  duplicateTo,
+  personalizeFolder,
+  infos,
+  hr,
+  versions,
+  hr,
+  trash
+]
+
+export const useSharedDriveFolderActions = ({
+  client,
+  t,
+  vaultClient,
+  pathname,
+  isOwner,
+  isMobile,
+  driveId,
+  canWriteToCurrentFolder,
+  byDocId,
+  dispatch,
+  navigate,
+  showAlert,
+  pushModal,
+  popModal,
+  refresh,
+  allLoaded
+}) =>
+  useMemo(
+    () =>
+      makeActions(ACTION_LIST, {
+        client,
+        t,
+        vaultClient,
+        pathname,
+        isOwner,
+        isMobile,
+        driveId,
+        hasWriteAccess: canWriteToCurrentFolder,
+        byDocId,
+        dispatch,
+        canMove: canWriteToCurrentFolder,
+        canDuplicate: canWriteToCurrentFolder,
+        navigate,
+        showAlert,
+        pushModal,
+        popModal,
+        refresh,
+        allLoaded
+      }),
+    [
+      client,
+      t,
+      vaultClient,
+      pathname,
+      isOwner,
+      isMobile,
+      driveId,
+      canWriteToCurrentFolder,
+      byDocId,
+      dispatch,
+      navigate,
+      showAlert,
+      pushModal,
+      popModal,
+      refresh,
+      allLoaded
+    ]
+  )

--- a/src/modules/shareddrives/hooks/useSharedDrives.js
+++ b/src/modules/shareddrives/hooks/useSharedDrives.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 
 import { useClient } from 'cozy-client'
 
@@ -67,5 +67,13 @@ export const useSharedDrives = () => {
     }
   }, [client])
 
-  return { isLoading, isLoaded, sharedDrives }
+  const recipientDriveIds = useMemo(
+    () =>
+      sharedDrives
+        .filter(drive => drive.owner !== true)
+        .map(drive => drive._id),
+    [sharedDrives]
+  )
+
+  return { isLoading, isLoaded, sharedDrives, recipientDriveIds }
 }

--- a/src/modules/shareddrives/hooks/useSharedDrives.spec.js
+++ b/src/modules/shareddrives/hooks/useSharedDrives.spec.js
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient } from 'cozy-client'
+
+import { useSharedDrives } from './useSharedDrives'
+import AppLike from 'test/components/AppLike'
+
+const buildMockClient = (sharedDrivesData = []) => {
+  const client = createMockClient({})
+  client.collection = jest.fn().mockReturnValue({
+    fetchSharedDrives: jest.fn().mockResolvedValue({ data: sharedDrivesData })
+  })
+  client.plugins = {}
+  return client
+}
+
+const wrapper =
+  client =>
+  ({ children }) =>
+    React.createElement(AppLike, { client }, children)
+
+describe('useSharedDrives', () => {
+  describe('recipientDriveIds', () => {
+    it('includes drives with owner === false', async () => {
+      const client = buildMockClient([{ _id: 'd1', owner: false }])
+
+      const { result } = renderHook(() => useSharedDrives(), {
+        wrapper: wrapper(client)
+      })
+
+      await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+      expect(result.current.recipientDriveIds).toContain('d1')
+    })
+
+    it('includes drives with owner === undefined (field absent)', async () => {
+      const client = buildMockClient([{ _id: 'd2' }])
+
+      const { result } = renderHook(() => useSharedDrives(), {
+        wrapper: wrapper(client)
+      })
+
+      await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+      expect(result.current.recipientDriveIds).toContain('d2')
+    })
+
+    it('excludes drives with owner === true', async () => {
+      const client = buildMockClient([{ _id: 'd3', owner: true }])
+
+      const { result } = renderHook(() => useSharedDrives(), {
+        wrapper: wrapper(client)
+      })
+
+      await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+      expect(result.current.recipientDriveIds).not.toContain('d3')
+    })
+
+    it('returns only recipient ids when drives have mixed ownership', async () => {
+      const client = buildMockClient([
+        { _id: 'owned', owner: true },
+        { _id: 'recipient-explicit', owner: false },
+        { _id: 'recipient-implicit' }
+      ])
+
+      const { result } = renderHook(() => useSharedDrives(), {
+        wrapper: wrapper(client)
+      })
+
+      await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+      expect(result.current.recipientDriveIds).toEqual([
+        'recipient-explicit',
+        'recipient-implicit'
+      ])
+    })
+
+    it('still exposes sharedDrives, isLoading, isLoaded (additive change)', async () => {
+      const client = buildMockClient([{ _id: 'd1', owner: false }])
+
+      const { result } = renderHook(() => useSharedDrives(), {
+        wrapper: wrapper(client)
+      })
+
+      await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+      expect(result.current.sharedDrives).toBeDefined()
+      expect(typeof result.current.isLoading).toBe('boolean')
+      expect(typeof result.current.isLoaded).toBe('boolean')
+    })
+  })
+})

--- a/src/modules/views/Recent/index.jsx
+++ b/src/modules/views/Recent/index.jsx
@@ -51,15 +51,17 @@ export const RecentView = () => {
     useFolderSort(RECENT_FOLDER_ID)
 
   const recentsResult = useRecentFiles()
+  const { scopeQueries, ...recentsResultWithoutScopes } = recentsResult
 
   // Shared-drive and federated files arrive from the dataproxy seconds after
   // the local files; surface that background fetch once a list is on screen.
   const isFetchingMore =
-    recentsResult?.fetchStatus === 'loading' && recentsResult?.data?.length > 0
+    recentsResultWithoutScopes?.fetchStatus === 'loading' &&
+    recentsResultWithoutScopes?.data?.length > 0
 
   useKeyboardShortcuts({
     client: base.client,
-    items: recentsResult?.data || [],
+    items: recentsResultWithoutScopes?.data || [],
     sharingContext,
     allowCopy: false,
     pushModal: base.pushModal,
@@ -77,7 +79,8 @@ export const RecentView = () => {
     allLoaded,
     isOwner,
     byDocId,
-    selectAll: () => base.toggleSelectAllItems(recentsResult?.data || [])
+    selectAll: () =>
+      base.toggleSelectAllItems(recentsResultWithoutScopes?.data || [])
   }
 
   const actions = makeActions(
@@ -104,6 +107,7 @@ export const RecentView = () => {
 
   return (
     <FolderView>
+      {scopeQueries}
       <Content className={base.isMobile ? '' : 'u-pt-1'}>
         <FolderViewHeader>
           <Breadcrumb path={[{ name: base.t('breadcrumb.title_recent') }]} />
@@ -113,7 +117,7 @@ export const RecentView = () => {
         {flag('drive.virtualization.enabled') && !base.isMobile ? (
           <FolderViewBodyVz
             actions={actions}
-            queryResults={[recentsResult]}
+            queryResults={[recentsResultWithoutScopes]}
             withFilePath={true}
             orderProps={{
               sortOrder,
@@ -124,7 +128,7 @@ export const RecentView = () => {
         ) : (
           <FolderViewBody
             actions={actions}
-            queryResults={[recentsResult]}
+            queryResults={[recentsResultWithoutScopes]}
             withFilePath={true}
           />
         )}

--- a/src/modules/views/Recent/index.loading.spec.jsx
+++ b/src/modules/views/Recent/index.loading.spec.jsx
@@ -35,9 +35,6 @@ jest.mock('cozy-sharing', () => ({
   ...jest.requireActual('cozy-sharing'),
   useSharingContext: jest.fn()
 }))
-jest.mock('cozy-dataproxy-lib', () => ({
-  useDataProxy: jest.fn(() => ({ dataProxyServicesAvailable: false }))
-}))
 jest.mock('@/hooks/useRecentFiles', () => ({
   __esModule: true,
   default: jest.fn()
@@ -55,7 +52,10 @@ const renderRecentView = recentsResult => {
     .fn()
     .mockReturnValue({ data: [], rows: [] })
 
-  mockUseRecentFiles.mockReturnValue(recentsResult)
+  mockUseRecentFiles.mockReturnValue({
+    scopeQueries: [],
+    ...recentsResult
+  })
 
   return render(
     <AppLike client={client} store={store}>

--- a/src/modules/views/Recent/index.spec.jsx
+++ b/src/modules/views/Recent/index.spec.jsx
@@ -43,11 +43,12 @@ jest.mock('cozy-sharing', () => ({
   useSharingContext: jest.fn()
 }))
 
-jest.mock('cozy-dataproxy-lib', () => ({
-  useDataProxy: jest.fn()
+jest.mock('@/hooks/useRecentFiles', () => ({
+  __esModule: true,
+  default: jest.fn()
 }))
 
-const mockUseDataProxy = require('cozy-dataproxy-lib').useDataProxy
+const mockUseRecentFiles = require('@/hooks/useRecentFiles').default
 
 useSharingContext.mockReturnValue({ byDocId: [] })
 
@@ -75,10 +76,11 @@ const setup = ({ nbFiles, path, dir_id, updated_at }) => {
     displayedPath: path
   }))
 
-  // Mock useDataProxy to return a dataProxy object
-  mockUseDataProxy.mockReturnValue({
-    dataProxyServicesAvailable: true,
-    recents: jest.fn().mockResolvedValue(filesWithPath)
+  mockUseRecentFiles.mockReturnValue({
+    data: filesWithPath,
+    fetchStatus: 'loaded',
+    error: null,
+    scopeQueries: []
   })
 
   const rendered = render(

--- a/src/modules/views/SharedDrive/SharedDriveFolderContent.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderContent.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { Outlet } from 'react-router-dom'
+
+import flag from 'cozy-flags'
+
+import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
+import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
+import Toolbar from '@/modules/drive/Toolbar'
+import { SharedDriveBreadcrumb } from '@/modules/shareddrives/components/SharedDriveBreadcrumb'
+import { SharedDriveFolderBody } from '@/modules/shareddrives/components/SharedDriveFolderBody'
+import Dropzone from '@/modules/upload/Dropzone'
+import DropzoneDnD from '@/modules/upload/DropzoneDnD'
+import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
+import FolderViewBodyVz from '@/modules/views/Folder/virtualized/FolderViewBody'
+
+const SharedDriveFolderContent = ({
+  actions,
+  queryResults,
+  folderId,
+  displayedFolder,
+  canWriteToCurrentFolder,
+  driveId,
+  isInRootOfSharedDrive,
+  sortOrder,
+  setSortOrder,
+  isSettingsLoaded,
+  isFabDisplayed,
+  refresh,
+  isSelectionBarVisible,
+  isMobile
+}) => {
+  const DropzoneComp =
+    flag('drive.virtualization.enabled') && !isMobile ? DropzoneDnD : Dropzone
+
+  return (
+    <DropzoneComp
+      disabled={!canWriteToCurrentFolder}
+      displayedFolder={displayedFolder}
+    >
+      <FolderViewHeader>
+        <SharedDriveBreadcrumb driveId={driveId} folderId={folderId} />
+        <Toolbar
+          canUpload={false}
+          canCreateFolder={canWriteToCurrentFolder}
+          driveId={driveId}
+          showShareButton={isInRootOfSharedDrive}
+        />
+      </FolderViewHeader>
+
+      {flag('drive.virtualization.enabled') && !isMobile ? (
+        <FolderViewBodyVz
+          actions={actions}
+          queryResults={queryResults}
+          currentFolderId={folderId}
+          displayedFolder={displayedFolder}
+          canDrag
+          canUpload={canWriteToCurrentFolder}
+          withFilePath={false}
+          driveId={driveId}
+          orderProps={{
+            sortOrder,
+            setOrder: setSortOrder,
+            isSettingsLoaded
+          }}
+        />
+      ) : (
+        <SharedDriveFolderBody
+          folderId={folderId}
+          queryResults={queryResults}
+        />
+      )}
+      <Outlet />
+      {isFabDisplayed && (
+        <AddMenuProvider
+          componentsProps={{
+            AddMenu: {
+              anchorOrigin: {
+                vertical: 'top',
+                horizontal: 'left'
+              }
+            }
+          }}
+          canCreateFolder={true}
+          canUpload={true}
+          disabled={false}
+          refreshFolderContent={refresh}
+          displayedFolder={displayedFolder}
+          isSelectionBarVisible={isSelectionBarVisible}
+        >
+          <FabWithAddMenuContext />
+        </AddMenuProvider>
+      )}
+    </DropzoneComp>
+  )
+}
+
+export { SharedDriveFolderContent }

--- a/src/modules/views/SharedDrive/SharedDriveFolderContent.spec.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderContent.spec.jsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+jest.mock('react-router-dom', () => ({
+  Outlet: () => null
+}))
+
+jest.mock('cozy-flags', () => ({
+  __esModule: true,
+  default: () => false
+}))
+
+jest.mock('@/modules/drive/AddMenu/AddMenuProvider', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/drive/FabWithAddMenuContext', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+jest.mock('@/modules/drive/Toolbar', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+jest.mock('@/modules/shareddrives/components/SharedDriveBreadcrumb', () => ({
+  SharedDriveBreadcrumb: () => null
+}))
+
+jest.mock('@/modules/shareddrives/components/SharedDriveFolderBody', () => ({
+  SharedDriveFolderBody: () => null
+}))
+
+jest.mock('@/modules/upload/Dropzone', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/upload/DropzoneDnD', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/views/Folder/FolderViewHeader', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/views/Folder/virtualized/FolderViewBody', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+import { SharedDriveFolderContent } from './SharedDriveFolderContent'
+
+const baseProps = {
+  actions: [],
+  queryResults: [{ fetchStatus: 'loaded', data: [], hasMore: false }],
+  folderId: 'folder-1',
+  displayedFolder: null,
+  canWriteToCurrentFolder: false,
+  driveId: 'drive-1',
+  isInRootOfSharedDrive: false,
+  sortOrder: { attribute: 'name', order: 'asc' },
+  setSortOrder: jest.fn(),
+  isSettingsLoaded: true,
+  isFabDisplayed: false,
+  refresh: jest.fn(),
+  isSelectionBarVisible: false,
+  isMobile: false
+}
+
+describe('SharedDriveFolderContent', () => {
+  it('renders without errors', () => {
+    render(<SharedDriveFolderContent {...baseProps} />)
+  })
+
+  it('renders Fab when isFabDisplayed is true', () => {
+    render(<SharedDriveFolderContent {...baseProps} isFabDisplayed={true} />)
+  })
+})

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -74,7 +74,7 @@ const SharedDriveFolderView = () => {
     {
       fetchStatus,
       lastUpdate,
-      data: sharedDriveResult.included ?? [],
+      data: sharedDriveResult.data ?? [],
       hasMore,
       fetchMore
     }
@@ -96,7 +96,7 @@ const SharedDriveFolderView = () => {
   useKeyboardShortcuts({
     canPaste: hasClipboardData && canWriteToCurrentFolder,
     client,
-    items: sharedDriveResult?.included || [],
+    items: sharedDriveResult?.data || [],
     sharingContext,
     allowCut: canWriteToCurrentFolder,
     allowCopy: false,

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -37,6 +37,7 @@ import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import { SharedDriveBreadcrumb } from '@/modules/shareddrives/components/SharedDriveBreadcrumb'
 import { SharedDriveFolderBody } from '@/modules/shareddrives/components/SharedDriveFolderBody'
 import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 import Dropzone from '@/modules/upload/Dropzone'
 import DropzoneDnD from '@/modules/upload/DropzoneDnD'
 import FolderView from '@/modules/views/Folder/FolderView'
@@ -63,6 +64,27 @@ const SharedDriveFolderView = () => {
   const isInRootOfSharedDrive = displayedFolder?.dir_id === SHARED_DRIVES_DIR_ID
   const { isFabDisplayed, setIsFabDisplayed } = useContext(FabContext)
   const { isSelectionBarVisible } = useSelectionContext()
+
+  const { recipientDriveIds, isLoaded: areSharedDrivesLoaded } =
+    useSharedDrives()
+
+  useEffect(() => {
+    if (!driveId || !areSharedDrivesLoaded) return
+    if (!recipientDriveIds.includes(driveId)) {
+      showAlert({
+        message: t('SharedDrive.access_revoked'),
+        severity: 'secondary'
+      })
+      navigate('/sharings?tab=1', { replace: true })
+    }
+  }, [
+    driveId,
+    areSharedDrivesLoaded,
+    recipientDriveIds,
+    navigate,
+    showAlert,
+    t
+  ])
 
   const { sharedDriveResult, fetchStatus, lastUpdate, hasMore, fetchMore } =
     useSharedDriveFolder({

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -1,12 +1,10 @@
-import React, { useMemo, useContext, useEffect } from 'react'
+import React, { useContext, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
-import { Outlet, useParams, useNavigate, useLocation } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
-import flag from 'cozy-flags'
 import { useVaultClient } from 'cozy-keys-lib'
 import { useSharingContext } from 'cozy-sharing'
-import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
@@ -18,31 +16,12 @@ import { useDisplayedFolder, useFolderSort } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { FabContext } from '@/lib/FabProvider'
 import { useModalContext } from '@/lib/ModalContext'
-import {
-  download,
-  infos,
-  versions,
-  rename,
-  trash,
-  hr,
-  share
-} from '@/modules/actions'
-import { duplicateTo } from '@/modules/actions/components/duplicateTo'
-import { moveTo } from '@/modules/actions/components/moveTo'
-import { personalizeFolder } from '@/modules/actions/components/personalizeFolder'
-import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
-import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
-import Toolbar from '@/modules/drive/Toolbar'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
-import { SharedDriveBreadcrumb } from '@/modules/shareddrives/components/SharedDriveBreadcrumb'
-import { SharedDriveFolderBody } from '@/modules/shareddrives/components/SharedDriveFolderBody'
 import { useRedirectOnRevokedDrive } from '@/modules/shareddrives/hooks/useRedirectOnRevokedDrive'
 import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
-import Dropzone from '@/modules/upload/Dropzone'
-import DropzoneDnD from '@/modules/upload/DropzoneDnD'
+import { useSharedDriveFolderActions } from '@/modules/shareddrives/hooks/useSharedDriveFolderActions'
 import FolderView from '@/modules/views/Folder/FolderView'
-import FolderViewHeader from '@/modules/views/Folder/FolderViewHeader'
-import FolderViewBodyVz from '@/modules/views/Folder/virtualized/FolderViewBody'
+import { SharedDriveFolderContent } from '@/modules/views/SharedDrive/SharedDriveFolderContent'
 
 const SharedDriveFolderView = () => {
   const client = useClient()
@@ -108,132 +87,44 @@ const SharedDriveFolderView = () => {
     popModal,
     refresh
   })
-  const actionsOptions = useMemo(
-    () => ({
-      client,
-      t,
-      vaultClient,
-      pathname,
-      isOwner,
-      isMobile,
-      driveId,
-      hasWriteAccess: canWriteToCurrentFolder,
-      byDocId,
-      dispatch,
-      canMove: canWriteToCurrentFolder,
-      canDuplicate: canWriteToCurrentFolder,
-      navigate,
-      showAlert,
-      pushModal,
-      popModal,
-      refresh,
-      allLoaded
-    }),
-    [
-      client,
-      t,
-      vaultClient,
-      pathname,
-      isOwner,
-      isMobile,
-      driveId,
-      canWriteToCurrentFolder,
-      byDocId,
-      dispatch,
-      navigate,
-      showAlert,
-      pushModal,
-      popModal,
-      refresh,
-      allLoaded
-    ]
-  )
 
-  const actions = useMemo(
-    () =>
-      makeActions(
-        [
-          share,
-          download,
-          hr,
-          rename,
-          moveTo,
-          duplicateTo,
-          personalizeFolder,
-          infos,
-          hr,
-          versions,
-          hr,
-          trash
-        ],
-        actionsOptions
-      ),
-    [actionsOptions]
-  )
-
-  const DropzoneComp =
-    flag('drive.virtualization.enabled') && !isMobile ? DropzoneDnD : Dropzone
+  const actions = useSharedDriveFolderActions({
+    client,
+    t,
+    vaultClient,
+    pathname,
+    isOwner,
+    isMobile,
+    driveId,
+    canWriteToCurrentFolder,
+    byDocId,
+    dispatch,
+    navigate,
+    showAlert,
+    pushModal,
+    popModal,
+    refresh,
+    allLoaded
+  })
 
   return (
     <FolderView>
-      <DropzoneComp
-        disabled={!canWriteToCurrentFolder}
+      <SharedDriveFolderContent
+        actions={actions}
+        queryResults={queryResults}
+        folderId={folderId}
         displayedFolder={displayedFolder}
-      >
-        <FolderViewHeader>
-          <SharedDriveBreadcrumb driveId={driveId} folderId={folderId} />
-          <Toolbar
-            canUpload={false}
-            canCreateFolder={canWriteToCurrentFolder}
-            driveId={driveId}
-            showShareButton={isInRootOfSharedDrive}
-          />
-        </FolderViewHeader>
-
-        {flag('drive.virtualization.enabled') && !isMobile ? (
-          <FolderViewBodyVz
-            actions={actions}
-            queryResults={queryResults}
-            currentFolderId={folderId}
-            displayedFolder={displayedFolder}
-            canDrag
-            canUpload={canWriteToCurrentFolder}
-            withFilePath={false}
-            driveId={driveId}
-            orderProps={{
-              sortOrder,
-              setOrder: setSortOrder,
-              isSettingsLoaded
-            }}
-          />
-        ) : (
-          <SharedDriveFolderBody
-            folderId={folderId}
-            queryResults={queryResults}
-          />
-        )}
-        <Outlet />
-        {isFabDisplayed && (
-          <AddMenuProvider
-            componentsProps={{
-              AddMenu: {
-                anchorOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left'
-                }
-              }
-            }}
-            canCreateFolder={true}
-            canUpload={true}
-            disabled={false}
-            refreshFolderContent={refresh}
-            displayedFolder={displayedFolder}
-            isSelectionBarVisible={isSelectionBarVisible}
-          >
-            <FabWithAddMenuContext />
-          </AddMenuProvider>
-        )}
-      </DropzoneComp>
+        canWriteToCurrentFolder={canWriteToCurrentFolder}
+        driveId={driveId}
+        isInRootOfSharedDrive={isInRootOfSharedDrive}
+        sortOrder={sortOrder}
+        setSortOrder={setSortOrder}
+        isSettingsLoaded={isSettingsLoaded}
+        isFabDisplayed={isFabDisplayed}
+        refresh={refresh}
+        isSelectionBarVisible={isSelectionBarVisible}
+        isMobile={isMobile}
+      />
     </FolderView>
   )
 }

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -36,8 +36,8 @@ import Toolbar from '@/modules/drive/Toolbar'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import { SharedDriveBreadcrumb } from '@/modules/shareddrives/components/SharedDriveBreadcrumb'
 import { SharedDriveFolderBody } from '@/modules/shareddrives/components/SharedDriveFolderBody'
+import { useRedirectOnRevokedDrive } from '@/modules/shareddrives/hooks/useRedirectOnRevokedDrive'
 import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
-import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 import Dropzone from '@/modules/upload/Dropzone'
 import DropzoneDnD from '@/modules/upload/DropzoneDnD'
 import FolderView from '@/modules/views/Folder/FolderView'
@@ -65,26 +65,7 @@ const SharedDriveFolderView = () => {
   const { isFabDisplayed, setIsFabDisplayed } = useContext(FabContext)
   const { isSelectionBarVisible } = useSelectionContext()
 
-  const { recipientDriveIds, isLoaded: areSharedDrivesLoaded } =
-    useSharedDrives()
-
-  useEffect(() => {
-    if (!driveId || !areSharedDrivesLoaded) return
-    if (!recipientDriveIds.includes(driveId)) {
-      showAlert({
-        message: t('SharedDrive.access_revoked'),
-        severity: 'secondary'
-      })
-      navigate('/sharings?tab=1', { replace: true })
-    }
-  }, [
-    driveId,
-    areSharedDrivesLoaded,
-    recipientDriveIds,
-    navigate,
-    showAlert,
-    t
-  ])
+  useRedirectOnRevokedDrive(driveId)
 
   const { sharedDriveResult, fetchStatus, lastUpdate, hasMore, fetchMore } =
     useSharedDriveFolder({

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.spec.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.spec.jsx
@@ -30,6 +30,14 @@ jest.mock('@/modules/shareddrives/hooks/useRedirectOnRevokedDrive', () => ({
   useRedirectOnRevokedDrive: jest.fn()
 }))
 
+jest.mock('@/modules/shareddrives/hooks/useSharedDriveFolderActions', () => ({
+  useSharedDriveFolderActions: () => []
+}))
+
+jest.mock('@/modules/views/SharedDrive/SharedDriveFolderContent', () => ({
+  SharedDriveFolderContent: () => null
+}))
+
 // --- stub out everything else the component imports so it can render ---
 jest.mock('react-redux', () => ({
   useDispatch: () => jest.fn()

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.spec.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.spec.jsx
@@ -1,0 +1,239 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+// --- navigate / router mocks ---
+const mockNavigate = jest.fn()
+const mockUseParams = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => mockUseParams(),
+  useLocation: () => ({ pathname: '/shareddrive/drive-1/folder-1' }),
+  Outlet: () => null
+}))
+
+// --- alert / i18n mocks ---
+const mockShowAlert = jest.fn()
+const mockT = key => key
+
+jest.mock('cozy-ui/transpiled/react/providers/Alert', () => ({
+  useAlert: () => ({ showAlert: mockShowAlert })
+}))
+
+jest.mock('twake-i18n', () => ({
+  useI18n: () => ({ t: mockT })
+}))
+
+// --- useSharedDrives mock ---
+const mockUseSharedDrives = jest.fn()
+
+jest.mock('@/modules/shareddrives/hooks/useSharedDrives', () => ({
+  useSharedDrives: (...args) => mockUseSharedDrives(...args)
+}))
+
+// --- stub out everything else the component imports so it can render ---
+jest.mock('react-redux', () => ({
+  useDispatch: () => jest.fn()
+}))
+
+jest.mock('cozy-client', () => ({
+  useClient: () => ({})
+}))
+
+jest.mock('cozy-flags', () => ({
+  __esModule: true,
+  default: () => false
+}))
+
+jest.mock('cozy-keys-lib', () => ({
+  useVaultClient: () => ({})
+}))
+
+jest.mock('cozy-sharing', () => ({
+  useSharingContext: () => ({
+    isOwner: () => false,
+    byDocId: {},
+    hasWriteAccess: () => false,
+    refresh: jest.fn(),
+    allLoaded: true
+  })
+}))
+
+jest.mock('cozy-ui/transpiled/react/ActionsMenu/Actions', () => ({
+  makeActions: () => []
+}))
+
+jest.mock('cozy-ui/transpiled/react/providers/Breakpoints', () => ({
+  __esModule: true,
+  default: () => ({ isMobile: false })
+}))
+
+jest.mock('@/components/useHead', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+jest.mock('@/constants/config', () => ({
+  SHARED_DRIVES_DIR_ID: 'shared-drives-dir-id',
+  SHARING_TAB_DRIVES: 1
+}))
+
+jest.mock('@/contexts/ClipboardProvider', () => ({
+  useClipboardContext: () => ({ hasClipboardData: false })
+}))
+
+jest.mock('@/hooks', () => ({
+  useDisplayedFolder: () => ({ displayedFolder: null }),
+  useFolderSort: () => [{ attribute: 'name', order: 'asc' }, jest.fn(), true]
+}))
+
+jest.mock('@/hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: jest.fn()
+}))
+
+jest.mock('@/lib/FabProvider', () => ({
+  FabContext: React.createContext({
+    isFabDisplayed: false,
+    setIsFabDisplayed: jest.fn()
+  })
+}))
+
+jest.mock('@/lib/ModalContext', () => ({
+  useModalContext: () => ({ pushModal: jest.fn(), popModal: jest.fn() })
+}))
+
+jest.mock('@/modules/actions', () => ({
+  download: {},
+  infos: {},
+  versions: {},
+  rename: {},
+  trash: {},
+  hr: {},
+  share: {}
+}))
+
+jest.mock('@/modules/actions/components/duplicateTo', () => ({
+  duplicateTo: {}
+}))
+
+jest.mock('@/modules/actions/components/moveTo', () => ({
+  moveTo: {}
+}))
+
+jest.mock('@/modules/actions/components/personalizeFolder', () => ({
+  personalizeFolder: {}
+}))
+
+jest.mock('@/modules/drive/AddMenu/AddMenuProvider', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/drive/FabWithAddMenuContext', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+jest.mock('@/modules/drive/Toolbar', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+jest.mock('@/modules/selection/SelectionProvider', () => ({
+  useSelectionContext: () => ({ isSelectionBarVisible: false })
+}))
+
+jest.mock('@/modules/shareddrives/components/SharedDriveBreadcrumb', () => ({
+  SharedDriveBreadcrumb: () => null
+}))
+
+jest.mock('@/modules/shareddrives/components/SharedDriveFolderBody', () => ({
+  SharedDriveFolderBody: () => null
+}))
+
+jest.mock('@/modules/shareddrives/hooks/useSharedDriveFolder', () => ({
+  useSharedDriveFolder: () => ({
+    sharedDriveResult: { data: [] },
+    fetchStatus: 'loaded',
+    lastUpdate: null,
+    hasMore: false,
+    fetchMore: jest.fn()
+  })
+}))
+
+jest.mock('@/modules/upload/Dropzone', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/upload/DropzoneDnD', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/views/Folder/FolderView', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/views/Folder/FolderViewHeader', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>
+}))
+
+jest.mock('@/modules/views/Folder/virtualized/FolderViewBody', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+import { SharedDriveFolderView } from './SharedDriveFolderView'
+
+const DRIVE_ID = 'drive-1'
+
+describe('SharedDriveFolderView — revocation redirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseParams.mockReturnValue({ driveId: DRIVE_ID, folderId: 'folder-1' })
+  })
+
+  it('redirects to /sharings?tab=1 and shows an alert when driveId is no longer in recipientDriveIds', () => {
+    mockUseSharedDrives.mockReturnValue({
+      isLoaded: true,
+      recipientDriveIds: ['other-drive']
+    })
+
+    render(<SharedDriveFolderView />)
+
+    expect(mockNavigate).toHaveBeenCalledWith('/sharings?tab=1', {
+      replace: true
+    })
+    expect(mockShowAlert).toHaveBeenCalledWith({
+      message: 'SharedDrive.access_revoked',
+      severity: 'secondary'
+    })
+  })
+
+  it('does not redirect when driveId is still in recipientDriveIds', () => {
+    mockUseSharedDrives.mockReturnValue({
+      isLoaded: true,
+      recipientDriveIds: [DRIVE_ID]
+    })
+
+    render(<SharedDriveFolderView />)
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(mockShowAlert).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect before shared drives finish loading (no premature redirect)', () => {
+    mockUseSharedDrives.mockReturnValue({
+      isLoaded: false,
+      recipientDriveIds: []
+    })
+
+    render(<SharedDriveFolderView />)
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(mockShowAlert).not.toHaveBeenCalled()
+  })
+})

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.spec.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.spec.jsx
@@ -24,11 +24,10 @@ jest.mock('twake-i18n', () => ({
   useI18n: () => ({ t: mockT })
 }))
 
-// --- useSharedDrives mock ---
-const mockUseSharedDrives = jest.fn()
-
-jest.mock('@/modules/shareddrives/hooks/useSharedDrives', () => ({
-  useSharedDrives: (...args) => mockUseSharedDrives(...args)
+// --- useRedirectOnRevokedDrive is now a no-op in view tests; redirect
+//     behaviour is covered by useRedirectOnRevokedDrive.spec.jsx ---
+jest.mock('@/modules/shareddrives/hooks/useRedirectOnRevokedDrive', () => ({
+  useRedirectOnRevokedDrive: jest.fn()
 }))
 
 // --- stub out everything else the component imports so it can render ---
@@ -190,50 +189,13 @@ import { SharedDriveFolderView } from './SharedDriveFolderView'
 
 const DRIVE_ID = 'drive-1'
 
-describe('SharedDriveFolderView — revocation redirect', () => {
+describe('SharedDriveFolderView', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseParams.mockReturnValue({ driveId: DRIVE_ID, folderId: 'folder-1' })
   })
 
-  it('redirects to /sharings?tab=1 and shows an alert when driveId is no longer in recipientDriveIds', () => {
-    mockUseSharedDrives.mockReturnValue({
-      isLoaded: true,
-      recipientDriveIds: ['other-drive']
-    })
-
+  it('renders without errors', () => {
     render(<SharedDriveFolderView />)
-
-    expect(mockNavigate).toHaveBeenCalledWith('/sharings?tab=1', {
-      replace: true
-    })
-    expect(mockShowAlert).toHaveBeenCalledWith({
-      message: 'SharedDrive.access_revoked',
-      severity: 'secondary'
-    })
-  })
-
-  it('does not redirect when driveId is still in recipientDriveIds', () => {
-    mockUseSharedDrives.mockReturnValue({
-      isLoaded: true,
-      recipientDriveIds: [DRIVE_ID]
-    })
-
-    render(<SharedDriveFolderView />)
-
-    expect(mockNavigate).not.toHaveBeenCalled()
-    expect(mockShowAlert).not.toHaveBeenCalled()
-  })
-
-  it('does not redirect before shared drives finish loading (no premature redirect)', () => {
-    mockUseSharedDrives.mockReturnValue({
-      isLoaded: false,
-      recipientDriveIds: []
-    })
-
-    render(<SharedDriveFolderView />)
-
-    expect(mockNavigate).not.toHaveBeenCalled()
-    expect(mockShowAlert).not.toHaveBeenCalled()
   })
 })

--- a/src/queries/index.spec.ts
+++ b/src/queries/index.spec.ts
@@ -1,0 +1,75 @@
+import { buildRecentsScopedQuery } from '@/queries'
+import {
+  SHARED_DRIVES_DIR_ID,
+  TRASH_DIR_ID
+} from '@/constants/config'
+
+describe('buildRecentsScopedQuery', () => {
+  describe('own scope (no driveId)', () => {
+    it('sets options.as to recents-own', () => {
+      const q = buildRecentsScopedQuery({})
+      expect(q.options.as).toBe('recents-own')
+    })
+
+    it('leaves options.driveId undefined', () => {
+      const q = buildRecentsScopedQuery({})
+      expect(q.options.driveId).toBeUndefined()
+    })
+
+    it('leaves options.forceLink undefined', () => {
+      const q = buildRecentsScopedQuery({})
+      expect(q.options.forceLink).toBeUndefined()
+    })
+
+    it('definition sorts by updated_at desc and limits to 50', () => {
+      const q = buildRecentsScopedQuery({})
+      const def = q.definition().toDefinition()
+      expect(def.sort).toEqual([{ updated_at: 'desc' }])
+      expect(def.limit).toBe(50)
+    })
+
+    it('definition partialIndex excludes SHARED_DRIVES_DIR_ID and TRASH_DIR_ID', () => {
+      const q = buildRecentsScopedQuery({})
+      const def = q.definition().toDefinition()
+      expect(def.partialFilter).toMatchObject({
+        dir_id: {
+          $nin: expect.arrayContaining([SHARED_DRIVES_DIR_ID, TRASH_DIR_ID])
+        }
+      })
+    })
+  })
+
+  describe('drive scope (with driveId)', () => {
+    it('sets options.as to recents-drive-{driveId}', () => {
+      const q = buildRecentsScopedQuery({ driveId: 'abc' })
+      expect(q.options.as).toBe('recents-drive-abc')
+    })
+
+    it('sets options.driveId to the provided driveId', () => {
+      const q = buildRecentsScopedQuery({ driveId: 'abc' })
+      expect(q.options.driveId).toBe('abc')
+    })
+
+    it('sets options.forceLink to dataproxy', () => {
+      const q = buildRecentsScopedQuery({ driveId: 'abc' })
+      expect(q.options.forceLink).toBe('dataproxy')
+    })
+
+    it('definition sorts by updated_at desc and limits to 50', () => {
+      const q = buildRecentsScopedQuery({ driveId: 'abc' })
+      const def = q.definition().toDefinition()
+      expect(def.sort).toEqual([{ updated_at: 'desc' }])
+      expect(def.limit).toBe(50)
+    })
+
+    it('definition partialIndex excludes SHARED_DRIVES_DIR_ID and TRASH_DIR_ID', () => {
+      const q = buildRecentsScopedQuery({ driveId: 'abc' })
+      const def = q.definition().toDefinition()
+      expect(def.partialFilter).toMatchObject({
+        dir_id: {
+          $nin: expect.arrayContaining([SHARED_DRIVES_DIR_ID, TRASH_DIR_ID])
+        }
+      })
+    })
+  })
+})

--- a/src/queries/index.spec.ts
+++ b/src/queries/index.spec.ts
@@ -1,8 +1,8 @@
-import { buildRecentsScopedQuery, buildSharedDriveFolderMangoQuery } from '@/queries'
 import {
-  SHARED_DRIVES_DIR_ID,
-  TRASH_DIR_ID
-} from '@/constants/config'
+  buildRecentsScopedQuery,
+  buildSharedDriveFolderMangoQuery
+} from '@/queries'
+import { SHARED_DRIVES_DIR_ID, TRASH_DIR_ID } from '@/constants/config'
 
 describe('buildSharedDriveFolderMangoQuery', () => {
   const params = {
@@ -34,7 +34,10 @@ describe('buildSharedDriveFolderMangoQuery', () => {
 
   it('generates distinct as values for different param combinations', () => {
     const q1 = buildSharedDriveFolderMangoQuery(params)
-    const q2 = buildSharedDriveFolderMangoQuery({ ...params, sortOrder: 'desc' })
+    const q2 = buildSharedDriveFolderMangoQuery({
+      ...params,
+      sortOrder: 'desc'
+    })
     expect(q1.options.as).not.toBe(q2.options.as)
   })
 
@@ -88,7 +91,10 @@ describe('buildRecentsScopedQuery', () => {
       const def = q.definition().toDefinition()
       expect(def.partialFilter).toMatchObject({
         dir_id: {
-          $nin: expect.arrayContaining([SHARED_DRIVES_DIR_ID, TRASH_DIR_ID])
+          $nin: expect.arrayContaining([
+            SHARED_DRIVES_DIR_ID,
+            TRASH_DIR_ID
+          ]) as string[]
         }
       })
     })
@@ -122,7 +128,10 @@ describe('buildRecentsScopedQuery', () => {
       const def = q.definition().toDefinition()
       expect(def.partialFilter).toMatchObject({
         dir_id: {
-          $nin: expect.arrayContaining([SHARED_DRIVES_DIR_ID, TRASH_DIR_ID])
+          $nin: expect.arrayContaining([
+            SHARED_DRIVES_DIR_ID,
+            TRASH_DIR_ID
+          ]) as string[]
         }
       })
     })

--- a/src/queries/index.spec.ts
+++ b/src/queries/index.spec.ts
@@ -1,8 +1,63 @@
-import { buildRecentsScopedQuery } from '@/queries'
+import { buildRecentsScopedQuery, buildSharedDriveFolderMangoQuery } from '@/queries'
 import {
   SHARED_DRIVES_DIR_ID,
   TRASH_DIR_ID
 } from '@/constants/config'
+
+describe('buildSharedDriveFolderMangoQuery', () => {
+  const params = {
+    driveId: 'drive-abc',
+    folderId: 'folder-xyz',
+    sortAttribute: 'name',
+    sortOrder: 'asc'
+  }
+
+  it('sets options.driveId to the provided driveId', () => {
+    const q = buildSharedDriveFolderMangoQuery(params)
+    expect(q.options.driveId).toBe('drive-abc')
+  })
+
+  it('sets options.forceLink to dataproxy', () => {
+    const q = buildSharedDriveFolderMangoQuery(params)
+    expect(q.options.forceLink).toBe('dataproxy')
+  })
+
+  it('generates a stable options.as keyed by all four params', () => {
+    const q1 = buildSharedDriveFolderMangoQuery(params)
+    const q2 = buildSharedDriveFolderMangoQuery(params)
+    expect(q1.options.as).toBe(q2.options.as)
+    expect(q1.options.as).toContain('drive-abc')
+    expect(q1.options.as).toContain('folder-xyz')
+    expect(q1.options.as).toContain('name')
+    expect(q1.options.as).toContain('asc')
+  })
+
+  it('generates distinct as values for different param combinations', () => {
+    const q1 = buildSharedDriveFolderMangoQuery(params)
+    const q2 = buildSharedDriveFolderMangoQuery({ ...params, sortOrder: 'desc' })
+    expect(q1.options.as).not.toBe(q2.options.as)
+  })
+
+  it('includes driveId in the definition where clause', () => {
+    const q = buildSharedDriveFolderMangoQuery(params)
+    const def = q.definition().toDefinition()
+    expect(def.selector).toMatchObject({ driveId: 'drive-abc' })
+  })
+
+  it('does not filter by type (returns both folders and files)', () => {
+    const q = buildSharedDriveFolderMangoQuery(params)
+    const def = q.definition().toDefinition()
+    expect(def.selector).not.toHaveProperty('type')
+  })
+
+  it('definition includes dir_id and driveId in indexedFields', () => {
+    const q = buildSharedDriveFolderMangoQuery(params)
+    const def = q.definition().toDefinition()
+    expect(def.indexedFields).toEqual(
+      expect.arrayContaining(['dir_id', 'driveId', 'name'])
+    )
+  })
+})
 
 describe('buildRecentsScopedQuery', () => {
   describe('own scope (no driveId)', () => {

--- a/src/queries/index.spec.ts
+++ b/src/queries/index.spec.ts
@@ -62,6 +62,20 @@ describe('buildSharedDriveFolderMangoQuery', () => {
   })
 })
 
+const expectPartialIndexExcludesDirs = (
+  q: ReturnType<typeof buildRecentsScopedQuery>
+): void => {
+  const def = q.definition().toDefinition()
+  expect(def.partialFilter).toMatchObject({
+    dir_id: {
+      $nin: expect.arrayContaining([
+        SHARED_DRIVES_DIR_ID,
+        TRASH_DIR_ID
+      ]) as string[]
+    }
+  })
+}
+
 describe('buildRecentsScopedQuery', () => {
   describe('own scope (no driveId)', () => {
     it('sets options.as to recents-own', () => {
@@ -87,16 +101,7 @@ describe('buildRecentsScopedQuery', () => {
     })
 
     it('definition partialIndex excludes SHARED_DRIVES_DIR_ID and TRASH_DIR_ID', () => {
-      const q = buildRecentsScopedQuery({})
-      const def = q.definition().toDefinition()
-      expect(def.partialFilter).toMatchObject({
-        dir_id: {
-          $nin: expect.arrayContaining([
-            SHARED_DRIVES_DIR_ID,
-            TRASH_DIR_ID
-          ]) as string[]
-        }
-      })
+      expectPartialIndexExcludesDirs(buildRecentsScopedQuery({}))
     })
   })
 
@@ -124,16 +129,9 @@ describe('buildRecentsScopedQuery', () => {
     })
 
     it('definition partialIndex excludes SHARED_DRIVES_DIR_ID and TRASH_DIR_ID', () => {
-      const q = buildRecentsScopedQuery({ driveId: 'abc' })
-      const def = q.definition().toDefinition()
-      expect(def.partialFilter).toMatchObject({
-        dir_id: {
-          $nin: expect.arrayContaining([
-            SHARED_DRIVES_DIR_ID,
-            TRASH_DIR_ID
-          ]) as string[]
-        }
-      })
+      expectPartialIndexExcludesDirs(
+        buildRecentsScopedQuery({ driveId: 'abc' })
+      )
     })
   })
 })

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -111,9 +111,9 @@ interface BuildRecentsScopedQueryParams {
   driveId?: string
 }
 
-export const buildRecentsScopedQuery = ({
-  driveId
-}: BuildRecentsScopedQueryParams) => ({
+export const buildRecentsScopedQuery: QueryBuilder<
+  BuildRecentsScopedQueryParams
+> = ({ driveId }) => ({
   definition: () =>
     Q('io.cozy.files')
       .where({

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -571,7 +571,11 @@ export const buildSharedDriveFolderMangoQuery: QueryBuilder<
         [sortAttribute]: { $gt: null }
       })
       .indexFields(['dir_id', 'driveId', sortAttribute])
-      .sortBy([{ dir_id: sortOrder }, { [sortAttribute]: sortOrder }])
+      .sortBy([
+        { dir_id: sortOrder },
+        { driveId: sortOrder },
+        { [sortAttribute]: sortOrder }
+      ])
       .include(['encryption'])
       .limitBy(100),
   options: {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -85,22 +85,20 @@ export const buildDriveQuery: QueryBuilder<buildDriveQueryParams> = ({
   }
 })
 
+const buildRecentsDefinition = (): QueryDefinition =>
+  Q('io.cozy.files')
+    .where({ updated_at: { $gt: null } })
+    .partialIndex({
+      type: 'file',
+      trashed: false,
+      dir_id: { $nin: [SHARED_DRIVES_DIR_ID, TRASH_DIR_ID] }
+    })
+    .indexFields(['updated_at'])
+    .sortBy([{ updated_at: 'desc' }])
+    .limitBy(50)
+
 export const buildRecentQuery: QueryBuilder = () => ({
-  definition: () =>
-    Q('io.cozy.files')
-      .where({
-        updated_at: {
-          $gt: null
-        }
-      })
-      .partialIndex({
-        type: 'file',
-        trashed: false,
-        dir_id: { $nin: [SHARED_DRIVES_DIR_ID, TRASH_DIR_ID] }
-      })
-      .indexFields(['updated_at'])
-      .sortBy([{ updated_at: 'desc' }])
-      .limitBy(50),
+  definition: buildRecentsDefinition,
   options: {
     as: 'recent-view-query',
     fetchPolicy: defaultFetchPolicy
@@ -114,21 +112,7 @@ interface BuildRecentsScopedQueryParams {
 export const buildRecentsScopedQuery: QueryBuilder<
   BuildRecentsScopedQueryParams
 > = ({ driveId }) => ({
-  definition: () =>
-    Q('io.cozy.files')
-      .where({
-        updated_at: {
-          $gt: null
-        }
-      })
-      .partialIndex({
-        type: 'file',
-        trashed: false,
-        dir_id: { $nin: [SHARED_DRIVES_DIR_ID, TRASH_DIR_ID] }
-      })
-      .indexFields(['updated_at'])
-      .sortBy([{ updated_at: 'desc' }])
-      .limitBy(50),
+  definition: buildRecentsDefinition,
   options: {
     as: driveId ? `recents-drive-${driveId}` : 'recents-own',
     driveId,

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -107,6 +107,36 @@ export const buildRecentQuery: QueryBuilder = () => ({
   }
 })
 
+interface BuildRecentsScopedQueryParams {
+  driveId?: string
+}
+
+export const buildRecentsScopedQuery = ({
+  driveId
+}: BuildRecentsScopedQueryParams) => ({
+  definition: () =>
+    Q('io.cozy.files')
+      .where({
+        updated_at: {
+          $gt: null
+        }
+      })
+      .partialIndex({
+        type: 'file',
+        trashed: false,
+        dir_id: { $nin: [SHARED_DRIVES_DIR_ID, TRASH_DIR_ID] }
+      })
+      .indexFields(['updated_at'])
+      .sortBy([{ updated_at: 'desc' }])
+      .limitBy(50),
+  options: {
+    as: driveId ? `recents-drive-${driveId}` : 'recents-own',
+    driveId,
+    forceLink: driveId ? 'dataproxy' : undefined,
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
 export const buildParentsByIdsQuery: QueryBuilder<string[]> = ids => ({
   definition: () => Q('io.cozy.files').getByIds(ids),
   options: {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -569,6 +569,35 @@ export const buildSharedDriveFolderQuery: QueryBuilder<
   }
 })
 
+interface buildSharedDriveFolderMangoQueryParams {
+  driveId: string
+  folderId: string
+  sortAttribute: string
+  sortOrder: string
+}
+
+export const buildSharedDriveFolderMangoQuery: QueryBuilder<
+  buildSharedDriveFolderMangoQueryParams
+> = ({ driveId, folderId, sortAttribute, sortOrder }) => ({
+  definition: () =>
+    Q('io.cozy.files')
+      .where({
+        dir_id: folderId,
+        driveId,
+        [sortAttribute]: { $gt: null }
+      })
+      .indexFields(['dir_id', 'driveId', sortAttribute])
+      .sortBy([{ dir_id: sortOrder }, { [sortAttribute]: sortOrder }])
+      .include(['encryption'])
+      .limitBy(100),
+  options: {
+    as: `shareddrive-folder-${driveId}-${folderId}-${sortAttribute}-${sortOrder}`,
+    driveId,
+    forceLink: 'dataproxy',
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
 export const buildSharedDriveIdQuery: QueryBuilder<
   buildSharedDriveIdQueryParams
 > = ({ driveId }) => ({

--- a/src/targets/browser/setupAppContext.js
+++ b/src/targets/browser/setupAppContext.js
@@ -22,7 +22,13 @@ const setupApp = memoize(() => {
   }
 
   const links = [new StackLink({ platform })]
-  if (flag('dataproxy.queries.enabled')) {
+  // cozy-flags is not guaranteed to be populated this early, so the DataProxy
+  // link would be dropped on first load; read the flag from the injected data
+  // blob (always present synchronously) with a cozy-flags fallback.
+  const dataproxyQueriesEnabled =
+    data.flags?.['dataproxy.queries.enabled'] ??
+    flag('dataproxy.queries.enabled')
+  if (dataproxyQueriesEnabled) {
     // DataProxy link will be used for offline data queries
     const dataproxyLink = new DataProxyLink()
     links.push(dataproxyLink)


### PR DESCRIPTION
## Update: reactivity now comes from the data-proxy push, no per-drive websocket

Instead of opening one `CozyRealtime` socket per recipient drive in every Drive tab, the shared worker now pushes shared-drive document changes to Drive. `FilesRealTimeQueries` listens for those pushes on `window` and feeds them into the same buffering and dispatch pipeline, so the store updates the same way, without any Drive-side websocket.

- `FilesRealTimeQueries` no longer constructs `CozyRealtime`; it consumes `{ type: 'DATAPROXYMESSAGE', payload: { kind: 'realtime', event, doctype, driveId, doc } }` messages (origin filtered to the data-proxy) and reuses the existing buffers, `driveIdByFileId`, path resolution and dispatch.
- The worker side (relay on pouch `onSync` + forwarder) is in cozy/cozy-web-data-proxy#63, driven by the data-proxy periodic sync.
- The own-files realtime path is unchanged.
- Latency follows the worker periodic sync; a later change adds realtime inside the worker to bring it back to near-real-time through the same relay.

Original description below.

---

## Summary

Goal: make the Recent view and the shared-drive folder listing update live (trash, rename, move, create) for files inside shared drives, the way they already do for a user's own files.

Approach: shared-drive files are replicated locally by the data-proxy worker under a per-drive doctype. We let any view query them as ordinary reactive `io.cozy.files` documents through cozy-client's store, by adding a `driveId` query option that reads the drive's database while keeping the documents typed `io.cozy.files`. Remote changes flow into the same store slice through one realtime socket per recipient drive.

The work is split across three repositories:
- cozy-client: a `forceLink` query option plus driveId-aware shared-drive reads in cozy-pouch-link (linagora/cozy-client#1691).
- cozy-web-data-proxy: the worker forwards the `driveId` option through to its pouch link (cozy/cozy-web-data-proxy#62).
- this repository: subscribe one realtime socket per recipient shared drive and dispatch the events into the `io.cozy.files` store.

What this PR contains:
- `FilesRealTimeQueries` opens one `CozyRealtime` per recipient shared drive (`owner` is false) and dispatches created, updated and deleted events into the store as `io.cozy.files`, reusing the existing buffering and dispatch pipeline.
- Shared-drive file paths are resolved through the drive-scoped collection so the dispatched documents carry a correct path.
- The own-files realtime path is unchanged; shared-drive support is additive.

Still in progress before this is ready for review:
- Recipient-drive detection filters `owner === false`; confirm the sharings API always returns a boolean `owner`, or widen the filter so no recipient drive is silently skipped.
- Code Health: the dispatch method and its tests carry added complexity and test duplication to revisit.
- The end-to-end check needs the patched libraries linked into the worker build.
- Follow-up PRs will move the Recent view and the shared-drive folder view onto this capability.

