### PR TITLE
Fix nav link for shared drive

### DIFF
--- a/src/modules/navigation/NavItem.jsx
+++ b/src/modules/navigation/NavItem.jsx
@@ -27,6 +27,7 @@ const NavItem = ({
   icon,
   label,
   rx,
+  isActive,
   clickState,
   badgeContent,
   secondary,
@@ -36,7 +37,7 @@ const NavItem = ({
 
   return (
     <UINavItem secondary={secondary}>
-      <NavLink to={to} rx={rx} clickState={clickState}>
+      <NavLink to={to} rx={rx} isActive={isActive} clickState={clickState}>
         <NavContent
           icon={icon}
           label={forcedLabel ?? t(`Nav.item_${label}`)}
@@ -53,6 +54,7 @@ NavItem.propTypes = {
   label: PropTypes.string,
   forcedLabel: PropTypes.string,
   rx: PropTypes.shape(RegExp),
+  isActive: PropTypes.func,
   badgeContent: PropTypes.number
 }
 

--- a/src/modules/navigation/NavLink.jsx
+++ b/src/modules/navigation/NavLink.jsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { NavLink as UINavLink } from 'cozy-ui/transpiled/react/Nav'
@@ -22,6 +22,10 @@ const NavLink = ({
   const location = useLocation()
   const pathname = lastClicked ? lastClicked : location.pathname
   const active = isActive ? isActive(pathname) : navLinkMatch(rx, to, pathname)
+
+  useEffect(() => {
+    setLastClicked(undefined)
+  }, [location.pathname, setLastClicked])
 
   return (
     <a

--- a/src/modules/navigation/NavLink.jsx
+++ b/src/modules/navigation/NavLink.jsx
@@ -16,11 +16,13 @@ const NavLink = ({
   children,
   to,
   rx,
+  isActive,
   clickState: [lastClicked, setLastClicked]
 }) => {
   const location = useLocation()
   const pathname = lastClicked ? lastClicked : location.pathname
-  const isActive = navLinkMatch(rx, to, pathname)
+  const active = isActive ? isActive(pathname) : navLinkMatch(rx, to, pathname)
+
   return (
     <a
       style={{ outline: 'none' }}
@@ -31,7 +33,7 @@ const NavLink = ({
       href={`#${to}`}
       className={cx(
         UINavLink.className,
-        isActive ? UINavLink.activeClassName : null
+        active ? UINavLink.activeClassName : null
       )}
     >
       {children}
@@ -42,7 +44,8 @@ const NavLink = ({
 NavLink.propTypes = {
   children: PropTypes.node.isRequired,
   to: PropTypes.string,
-  rx: PropTypes.shape(RegExp)
+  rx: PropTypes.shape(RegExp),
+  isActive: PropTypes.func
 }
 
 export { NavLink }

--- a/src/modules/navigation/SharedDriveListItem.tsx
+++ b/src/modules/navigation/SharedDriveListItem.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react'
 
 import FileTypeSharedDriveIcon from 'cozy-ui/transpiled/react/Icons/FileTypeSharedDrive'
-import { NavIcon, NavLink, NavItem } from 'cozy-ui/transpiled/react/Nav'
+import { NavIcon, NavItem } from 'cozy-ui/transpiled/react/Nav'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import { FileLink } from './components/FileLink'
+import { NavLink } from './NavLink'
 
 import { useSharedDriveLink } from '@/modules/navigation/hooks/useSharedDriveLink'
 import type { SharedDrive } from '@/modules/shareddrives/helpers'
@@ -16,17 +16,16 @@ interface SharedDriveListItemProps {
 
 const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
   sharing,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  clickState: [lastClicked, setLastClicked]
+  clickState
 }) => {
   const { link } = useSharedDriveLink(sharing)
 
   return (
     <NavItem key={sharing._id}>
-      <FileLink
-        link={link}
-        className={NavLink.className}
-        onClick={(): void => setLastClicked(undefined)}
+      <NavLink
+        to={link.to.pathname}
+        rx={new RegExp(`^\\/shareddrive\\/${sharing._id}(\\/.*|$)`)}
+        clickState={clickState}
       >
         <NavIcon icon={FileTypeSharedDriveIcon} />
         <Typography
@@ -37,7 +36,7 @@ const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
         >
           {sharing.description}
         </Typography>
-      </FileLink>
+      </NavLink>
     </NavItem>
   )
 }

--- a/src/modules/navigation/SharingsNavItem.jsx
+++ b/src/modules/navigation/SharingsNavItem.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { useQuery } from 'cozy-client'
 import { isSharingShortcutNew } from 'cozy-client/dist/models/file'
@@ -7,13 +7,25 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import ShareIcon from 'cozy-ui/transpiled/react/Icons/ShareExternal'
 
 import { NavItem } from '@/modules/navigation/NavItem'
+import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 import { buildSharingsQuery } from '@/queries'
 
 const SharingsNavItem = ({ clickState }) => {
   const { byDocId, allLoaded } = useSharingContext()
+  const { sharedDrives } = useSharedDrives()
   const sharedDocuments = useMemo(
     () => [...new Set(Object.keys(byDocId ?? {}))],
     [byDocId]
+  )
+
+  const orgDriveIds = useMemo(
+    () =>
+      new Set(
+        (sharedDrives || [])
+          .filter(drive => drive.org_drive)
+          .map(drive => drive._id)
+      ),
+    [sharedDrives]
   )
 
   const sharingQuery = useMemo(
@@ -26,12 +38,26 @@ const SharingsNavItem = ({ clickState }) => {
   )
   const sharingResult = useQuery(sharingQuery.definition, sharingQuery.options)
 
+  const isActive = useCallback(
+    pathname => {
+      // For sharing tab
+      if (pathname === '/sharings') return true
+      // For shared folder but not shared drive
+      if (pathname.startsWith('/shareddrive/')) {
+        const driveId = pathname.split('/')[2]
+        return !orgDriveIds.has(driveId)
+      }
+      return false
+    },
+    [orgDriveIds]
+  )
+
   return (
     <NavItem
       to="/sharings"
       icon={<Icon icon={ShareIcon} />}
       label="sharings"
-      rx={/\/sharings(\/.*)?|\/shareddrive(\/.*)?/}
+      isActive={isActive}
       clickState={clickState}
       badgeContent={
         sharingResult.data?.filter(isSharingShortcutNew).length ?? 0


### PR DESCRIPTION
In nav, shared drive (team drive) were not highlighted. Now they are.

https://github.com/user-attachments/assets/fb077308-5dc3-4d33-89c1-dff560b06c72



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved navigation highlighting so the current section stays active more accurately across sharing and shared drive pages.
  * Shared drive items now follow the updated active-link behavior for clearer menu state.

* **Bug Fixes**
  * Fixed cases where navigation could appear active for the wrong shared drive.
  * Cleared stale link state when moving between pages, improving consistency in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->