### PR TITLE
fix: Use same style that rest of navbar

### DIFF
--- a/src/modules/navigation/FavoriteListItem.tsx
+++ b/src/modules/navigation/FavoriteListItem.tsx
@@ -61,7 +61,7 @@ const FavoriteListItem: FC<FavoriteListItemProps> = ({
         <NavIcon icon={ItemIcon} />
         <Typography
           className="u-fz-small"
-          variant="inherit"
+          variant="button"
           color="inherit"
           noWrap
         >

--- a/src/modules/navigation/SharedDriveListItem.tsx
+++ b/src/modules/navigation/SharedDriveListItem.tsx
@@ -30,7 +30,7 @@ const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
         <NavIcon icon={FileTypeSharedDriveIcon} />
         <Typography
           className="u-fz-small"
-          variant="inherit"
+          variant="button"
           color="inherit"
           noWrap
         >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of items in the navigation list so filenames and shared-drive descriptions now display with a button-like text style for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->