### PR TITLE
fix(gridview): distribute grid column spacing

### DIFF
--- a/src/styles/folder-view.styl
+++ b/src/styles/folder-view.styl
@@ -1,5 +1,6 @@
 .fil-folder-body-grid
     display grid
     grid-template-columns repeat(auto-fill, 8.4rem)
+    justify-content space-between
     padding .5rem
     gap .8rem // @stylint ignore


### PR DESCRIPTION
This will avoid to have large empty column on the right in some cases while keeping the first grid column aligned with the left edge.

fixes #4011