### PR TITLE
docs: Propose thumbnail in File Picker intent

### DIFF
--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -191,6 +191,9 @@ interface FilePickerEntry {
   mimeType: string | null
   sharingLink?: string
   downloadLink?: string
+  thumbnail?: {
+    link: string
+  }
 }
 ```
 
@@ -206,13 +209,20 @@ Example:
       "name": "invoice.pdf",
       "size": 123456,
       "mimeType": "application/pdf",
-      "downloadLink": "https://alice.example/files/download/..."
+      "downloadLink": "https://alice.example/files/download/...",
+      "thumbnail": {
+        "link": "https://cdn.example.com/files/pdf.jpg"
+      }
     }
   ]
 }
 ```
 
 For folders, `size` is `0` and `mimeType` is `null`.
+
+### Thumbnails
+
+The File Picker may provide a thumbnail (an illustration or a preview) that may be used by the caller. The thumbnail link is public and has an unlimited lifetime.
 
 ## Error handling
 


### PR DESCRIPTION
## Context

When using the File Picker to share by link, we want to display nicely links in the email. So we want to display these beautiful cards for the sender on tmail but also for the recipient on whatever email client he uses. So these beautiful cards must be inline HTML. The question is about the illustration of these cards.

<img width="400" alt="Screenshot 2026-07-08 at 09 37 54" src="https://github.com/user-attachments/assets/2cdfafad-aac0-4a2b-8303-35008bfdb049" />

## Plan

It makes sense that the File Picker return a thumbnail to keep consistency between all apps calling the File Picker. Also, even if today we only talk about illustration, we may return real thumbnail in the future and only the File Picker can return a real thumbnail easily.

According to tmail team, it is not possible to use base64 images as they won't be rendered by some clients. So we propose here the following plan:

1. On a public CDN on our side, we upload some illustrations like _https://cdn.twake.app/files/pdf.jpg_, _https://cdn.twake.app/files/image.jpg_, _https://cdn.twake.app/files/default.jpg_
⚠️ this CDN does not exist yet
2. File Picker map the type of the picked file to the list of illustrations available in the CDN or to the default one





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated File Picker response details to include an optional thumbnail link for selected files.
  * Expanded the example payload to show thumbnail data alongside existing link fields.
  * Added guidance explaining that thumbnails are public, intended as previews, and do not expire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->