### PR TITLE
feat(e2e): Add persistent local E2E runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ $ cd twake-drive
 $ yarn test
 ```
 
+For Playwright end-to-end tests, see [the E2E test guide](docs/e2e.md).
+
 :pushpin: Don't forget to update / create new tests when you contribute to code to keep the app the consistent.
 
 ### Open a Pull-Request

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -1,0 +1,80 @@
+# End-to-end tests
+
+The end-to-end suite runs Playwright against a local Cozy Stack and CouchDB
+started with Docker Compose. It provisions two test instances, Alice and Bob,
+and installs the Drive app in each instance.
+
+## Prerequisites
+
+- Node version from `.nvmrc` and dependencies installed with `yarn install`
+- Docker with the Compose plugin available as `docker compose`
+- The host ports `80`, `5984`, and `6060` available
+- A production build of Drive
+- Playwright Chromium installed
+
+Prepare the environment once:
+
+```sh
+yarn build
+yarn e2e:setup
+```
+
+## Run the suite
+
+```sh
+yarn e2e
+```
+
+The default lifecycle is destructive. It removes the E2E Compose runtime
+before the suite starts and after it finishes. Use it when a clean E2E state
+is wanted.
+
+The suite uses one Playwright worker because its scenarios share Alice and Bob
+fixture state. Do not run two local suites at the same time: they target the
+same Compose project and host ports.
+
+## Reuse a local runtime
+
+Set `E2E_PERSIST=1` to leave the runtime running and reuse it on the next run:
+
+```sh
+yarn e2e:persist
+yarn e2e:persist
+```
+
+`yarn e2e:persist` sets `E2E_PERSIST=1`. Persistent runs do not run Compose
+cleanup and start with `--no-recreate`. Setup is idempotent: existing Alice
+and Bob instances, Drive installations,
+feature flags, and contacts are reused.
+
+`E2E_SKIP_TEARDOWN=1` is kept as a compatibility alias for `E2E_PERSIST=1`.
+Use `E2E_PERSIST` in new commands.
+
+## Reset a persistent runtime
+
+To explicitly discard the current runtime data before running the suite while
+keeping the newly provisioned runtime afterwards:
+
+```sh
+yarn e2e:reset
+```
+
+`yarn e2e:reset` sets both `E2E_PERSIST=1` and `E2E_RESET=1`. `E2E_RESET=1`
+runs `docker compose down --volumes` before startup. Without `E2E_PERSIST=1`,
+the normal teardown also runs after the suite.
+
+To remove the runtime without running tests:
+
+```sh
+docker compose -f docker-compose.e2e.yml down --volumes
+```
+
+## Debugging and reports
+
+```sh
+# Run headed with the Playwright inspector
+yarn e2e:debug
+
+# Open the last HTML report
+yarn e2e:report
+```

--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 
 export const COMPOSE_FILE = 'docker-compose.e2e.yml'
 export const STACK_HOST = 'localhost'
@@ -6,6 +6,9 @@ export const STACK_PORT = 80
 export const STACK_URL = `http://${STACK_HOST}:${STACK_PORT}`
 export const ADMIN_PORT = 6060
 export const ADMIN_URL = `http://${STACK_HOST}:${ADMIN_PORT}`
+export const PERSIST =
+  process.env.E2E_PERSIST === '1' || process.env.E2E_SKIP_TEARDOWN === '1'
+export const RESET = process.env.E2E_RESET === '1'
 export const ADMIN_USER = 'admin'
 export const ADMIN_PASSPHRASE = 'cozy'
 
@@ -43,9 +46,26 @@ export const USERS: Record<UserLabel, User> = {
   }
 }
 
-export function stackExec(cmd: string): string {
-  return execSync(
-    `docker compose -f ${COMPOSE_FILE} exec -T -e COZY_ADMIN_PASSPHRASE=cozy -e COZY_ADMIN_HOST=${STACK_HOST} cozystack cozy-stack ${cmd}`,
+/** Arguments shared by every Docker Compose call for this E2E runtime. */
+export function composeArgs(...args: string[]): string[] {
+  return ['compose', '--file', COMPOSE_FILE, ...args]
+}
+
+/** Execute a cozy-stack command inside the E2E Compose project. */
+export function stackExec(...args: string[]): string {
+  return execFileSync(
+    'docker',
+    composeArgs(
+      'exec',
+      '-T',
+      '-e',
+      `COZY_ADMIN_PASSPHRASE=${ADMIN_PASSPHRASE}`,
+      '-e',
+      `COZY_ADMIN_HOST=${STACK_HOST}`,
+      'cozystack',
+      'cozy-stack',
+      ...args
+    ),
     { encoding: 'utf-8', cwd: process.cwd() }
   ).trim()
 }

--- a/e2e/helpers/flags.ts
+++ b/e2e/helpers/flags.ts
@@ -4,5 +4,5 @@ export function setFlags(
   instance: string,
   flags: Record<string, boolean | string | number>
 ): void {
-  stackExec(`features flags --domain ${instance} '${JSON.stringify(flags)}'`)
+  stackExec('features', 'flags', '--domain', instance, JSON.stringify(flags))
 }

--- a/e2e/helpers/stack.ts
+++ b/e2e/helpers/stack.ts
@@ -24,7 +24,7 @@ interface PermissionDoc {
 
 /** Mint an app token for the drive app, the parent of the link permission. */
 function driveAppToken(instance: string): string {
-  return stackExec(`instances token-app ${instance} drive`)
+  return stackExec('instances', 'token-app', instance, 'drive')
 }
 
 /** Find the share-by-link permission whose rule targets `fileId`. */

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { pbkdf2Sync } from 'crypto'
 
 import { saveAuthState } from '../helpers/auth'
@@ -6,9 +6,11 @@ import {
   ADMIN_PASSPHRASE,
   ADMIN_URL,
   ADMIN_USER,
-  COMPOSE_FILE,
+  composeArgs,
   ORG_DOMAIN,
   ORG_ID,
+  PERSIST,
+  RESET,
   STACK_URL,
   USERS,
   User,
@@ -18,7 +20,31 @@ import { setFlags } from '../helpers/flags'
 
 const ADMIN_AUTH = `Basic ${Buffer.from(`${ADMIN_USER}:${ADMIN_PASSPHRASE}`).toString('base64')}`
 
+function compose(...args: string[]): void {
+  execFileSync('docker', composeArgs(...args), {
+    encoding: 'utf-8',
+    cwd: process.cwd(),
+    stdio: 'inherit'
+  })
+}
+
+async function instanceExists(user: User): Promise<boolean> {
+  const res = await fetch(`${ADMIN_URL}/instances/${user.instance}`, {
+    headers: { Authorization: ADMIN_AUTH, Accept: 'application/json' }
+  })
+  if (res.ok) return true
+  if (res.status === 404) return false
+  throw new Error(
+    `Failed to inspect instance ${user.instance} (${res.status}): ${await res.text()}`
+  )
+}
+
 async function createInstance(user: User): Promise<void> {
+  if (await instanceExists(user)) {
+    console.log(`[e2e] Reusing instance for ${user.label} (${user.instance}).`)
+    return
+  }
+
   const params = new URLSearchParams({
     Domain: user.instance,
     Email: user.email,
@@ -125,14 +151,32 @@ async function getSessionCookie(
   return { name: m[1], value: m[2] }
 }
 
+function isDriveInstalled(user: User): boolean {
+  const apps = stackExec('apps', 'ls', '--domain', user.instance)
+  return apps
+    .split('\n')
+    .some(line => line.trim().split(/\s+/, 1)[0] === 'drive')
+}
+
 async function setupUser(
   user: User
 ): Promise<{ cookieName: string; cookieValue: string }> {
-  console.log(`[e2e] Creating instance for ${user.label} (${user.instance})...`)
+  console.log(`[e2e] Ensuring instance for ${user.label} (${user.instance})...`)
   await createInstance(user)
 
-  console.log(`[e2e] Installing Drive app for ${user.label}...`)
-  stackExec(`apps install drive file:///app/drive --domain ${user.instance}`)
+  if (isDriveInstalled(user)) {
+    console.log(`[e2e] Reusing Drive app for ${user.label}.`)
+  } else {
+    console.log(`[e2e] Installing Drive app for ${user.label}...`)
+    stackExec(
+      'apps',
+      'install',
+      'drive',
+      'file:///app/drive',
+      '--domain',
+      user.instance
+    )
+  }
 
   console.log(`[e2e] Setting feature flags for ${user.label}...`)
   setFlags(user.instance, FEATURE_FLAGS)
@@ -143,19 +187,19 @@ async function setupUser(
 }
 
 // Pre-populate each instance's address book with a contact for every other
-// org member. Without this, the cozy-sharing modal only knows the recipient's
-// email, and `Sharing.SendInvitations` fails over to SMTP. With the contact
-// in place the modal stamps the recipient's instance URL on the share, so
-// cozy-stack does a direct stack-to-stack PUT and the trusted-domain rule on
-// the receiving side fires `auto_accept_trusted`.
+// org member. A deterministic document ID makes this provisioning idempotent.
 async function createContact(hostUser: User, peer: User): Promise<void> {
   const token = stackExec(
-    `instances token-cli ${hostUser.instance} io.cozy.contacts`
+    'instances',
+    'token-cli',
+    hostUser.instance,
+    'io.cozy.contacts'
   )
+  const contactId = `e2e-contact-${hostUser.label}-${peer.label}`
   const res = await fetch(
-    `http://${hostUser.instance}/data/io.cozy.contacts/`,
+    `http://${hostUser.instance}/data/io.cozy.contacts/${contactId}`,
     {
-      method: 'POST',
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json'
@@ -168,6 +212,8 @@ async function createContact(hostUser: User, peer: User): Promise<void> {
       })
     }
   )
+  // A prior persistent run has already created this fixture.
+  if (res.status === 409) return
   if (!res.ok) {
     const body = await res.text()
     throw new Error(
@@ -188,25 +234,21 @@ async function syncContacts(): Promise<void> {
 }
 
 export default async function globalSetup(): Promise<void> {
-  if (process.env.E2E_SKIP_TEARDOWN === '1') {
+  if (RESET || !PERSIST) {
     console.log(
-      '[e2e] E2E_SKIP_TEARDOWN=1 — skipping pre-run cleanup. ' +
-        'Provisioning will fail if state from a previous run conflicts; ' +
-        '`docker compose -f docker-compose.e2e.yml down -v` to reset.'
+      RESET
+        ? '[e2e] E2E_RESET=1 — explicitly removing this runtime and its data.'
+        : '[e2e] Cleaning up previous containers (set E2E_PERSIST=1 to retain them)...'
     )
+    compose('down', '--volumes')
   } else {
-    console.log('[e2e] Cleaning up previous containers...')
-    execSync(`docker compose -f ${COMPOSE_FILE} down -v`, {
-      encoding: 'utf-8',
-      cwd: process.cwd()
-    })
+    console.log(
+      '[e2e] Persistent mode — retaining this runtime and its data.'
+    )
   }
 
   console.log('[e2e] Starting Docker containers...')
-  execSync(`docker compose -f ${COMPOSE_FILE} up -d --wait`, {
-    encoding: 'utf-8',
-    cwd: process.cwd()
-  })
+  compose('up', '--detach', '--wait', ...(PERSIST ? ['--no-recreate'] : []))
 
   console.log('[e2e] Waiting for cozy-stack...')
   await waitForStack(STACK_URL)

--- a/e2e/setup/global-teardown.ts
+++ b/e2e/setup/global-teardown.ts
@@ -1,14 +1,17 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 
-import { COMPOSE_FILE } from '../helpers/config'
+import { composeArgs, PERSIST } from '../helpers/config'
 
-export default async function globalTeardown(): Promise<void> {
-  if (process.env.E2E_SKIP_TEARDOWN === '1') {
-    console.log('[e2e] E2E_SKIP_TEARDOWN=1 — leaving containers up.')
+export default function globalTeardown(): void {
+  if (PERSIST) {
+    console.log(
+      '[e2e] Persistent mode — leaving this runtime and its data up.'
+    )
     return
   }
-  console.log('[e2e] Tearing down Docker containers...')
-  execSync(`docker compose -f ${COMPOSE_FILE} down -v`, {
+
+  console.log('[e2e] Tearing down Docker containers and runtime data...')
+  execFileSync('docker', composeArgs('down', '--volumes'), {
     stdio: 'inherit',
     cwd: process.cwd()
   })

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "lint:js": "eslint --concurrency 4 --cache --cache-strategy=content '{src,test}/**/*.{js,jsx,ts,tsx}'",
     "test": "env NODE_ENV='test' jest",
     "e2e": "playwright test --config e2e/playwright.config.ts",
+    "e2e:persist": "E2E_PERSIST=1 yarn e2e",
+    "e2e:reset": "E2E_PERSIST=1 E2E_RESET=1 yarn e2e",
     "e2e:setup": "playwright install chromium",
     "e2e:debug": "playwright test --config e2e/playwright.config.ts --headed --debug",
     "e2e:report": "playwright show-report playwright-report",


### PR DESCRIPTION
## What
Add persistent local E2E runtime support and document the E2E workflow.

## Why
Avoid rebuilding and reprovisioning the Docker-based E2E environment for every local test run when it is not needed

## How
Allow E2E developers to rerun the suite against the same Docker runtime
without deleting containers or fixture data before or after each run.

Make Alice, Bob, Drive installation, feature flags, and contacts
idempotent so provisioning succeeds on subsequent persistent runs.

Replace stackExec's shell command construction with an argument-based
execFileSync call. This keeps fixture values such as JSON feature flags
intact across command invocation and avoids shell quoting and
interpolation errors.

Keep the historical destructive lifecycle by default: without
E2E_PERSIST=1, setup and teardown both run docker compose down
--volumes. Reserve destructive reset of a persistent runtime for
E2E_RESET=1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive guide for running, debugging, and reporting Playwright end-to-end tests locally.
  - Documented prerequisites, Docker-based setup, required ports, troubleshooting, and runtime cleanup.
  - Added guidance for persistent test environments, resetting test data, and avoiding concurrent local runs.
  - Updated the README to link to the end-to-end testing guide.

- **Tests**
  - Added commands to run end-to-end tests with either persistent or resettable environments.
  - Improved test setup to reuse existing services and installations when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->