### PR TITLE
test(e2e): isolate e2e environment on custom local ports

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -5,7 +5,7 @@ services:
       COUCHDB_USER: admin
       COUCHDB_PASSWORD: password
     ports:
-      - "5984:5984"
+      - "127.0.0.1:${COZY_E2E_COUCHDB_PORT:-15984}:5984"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:5984/ || exit 1"]
       interval: 5s
@@ -23,14 +23,15 @@ services:
       COZY_COUCHDB_URL: http://admin:password@couchdb:5984/
       COZY_FS_URL: file:///var/lib/cozy/storage
       COZY_HOST: 0.0.0.0
-      COZY_PORT: "80"
+      COZY_PORT: "${COZY_E2E_STACK_PORT:-18080}"
       COZY_ADMIN_HOST: 0.0.0.0
-      COZY_ADMIN_PORT: "6060"
+      COZY_ADMIN_PORT: "${COZY_E2E_ADMIN_PORT:-16060}"
+      COZY_CONTEXTS_DEFAULT_SHARING_TRUSTED_DOMAINS: "cozy.localhost,cozy.localhost:${COZY_E2E_STACK_PORT:-18080}"
       COZY_SUBDOMAINS: flat
     command: ["cozy-stack", "serve", "--dev"]
     volumes:
       - ./build:/app/drive
       - ./e2e/cozy.yml:/etc/cozy/cozy.yml
     ports:
-      - "80:80"
-      - "6060:6060"
+      - "127.0.0.1:${COZY_E2E_STACK_PORT:-18080}:${COZY_E2E_STACK_PORT:-18080}"
+      - "127.0.0.1:${COZY_E2E_ADMIN_PORT:-16060}:${COZY_E2E_ADMIN_PORT:-16060}"

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -69,6 +69,16 @@ To remove the runtime without running tests:
 docker compose -f docker-compose.e2e.yml down --volumes
 ```
 
+## Isolate a test runtime
+
+By default, the E2E suite uses the default Docker Compose project name. If you need to isolate a test run from an existing persistent runtime, use `E2E_PROJECT_NAME`:
+
+```sh
+E2E_PROJECT_NAME=custom-harness yarn e2e
+```
+
+The harness will apply this explicit Compose identity to all startup, lifecycle, and teardown commands. To run concurrent suites, combine `E2E_PROJECT_NAME` with custom port overrides (`COZY_E2E_STACK_PORT`, etc.) to prevent port collisions.
+
 ## Debugging and reports
 
 ```sh

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -8,7 +8,7 @@ and installs the Drive app in each instance.
 
 - Node version from `.nvmrc` and dependencies installed with `yarn install`
 - Docker with the Compose plugin available as `docker compose`
-- The host ports `80`, `5984`, and `6060` available
+- The host ports `18080`, `15984`, and `16060` available (can be configured via `COZY_E2E_STACK_PORT`, `COZY_E2E_COUCHDB_PORT`, `COZY_E2E_ADMIN_PORT`)
 - A production build of Drive
 - Playwright Chromium installed
 

--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -48,9 +48,17 @@ export const USERS: Record<UserLabel, User> = {
   }
 }
 
+export const PROJECT_NAME = process.env.E2E_PROJECT_NAME
+
 /** Arguments shared by every Docker Compose call for this E2E runtime. */
 export function composeArgs(...args: string[]): string[] {
-  return ['compose', '--file', COMPOSE_FILE, ...args]
+  return [
+    'compose',
+    '--file',
+    COMPOSE_FILE,
+    ...(PROJECT_NAME ? ['--project-name', PROJECT_NAME] : []),
+    ...args
+  ]
 }
 
 /** Execute a cozy-stack command inside the E2E Compose project. */

--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -2,9 +2,9 @@ import { execFileSync } from 'child_process'
 
 export const COMPOSE_FILE = 'docker-compose.e2e.yml'
 export const STACK_HOST = 'localhost'
-export const STACK_PORT = 80
+export const STACK_PORT = parseInt(process.env.COZY_E2E_STACK_PORT || '18080', 10)
 export const STACK_URL = `http://${STACK_HOST}:${STACK_PORT}`
-export const ADMIN_PORT = 6060
+export const ADMIN_PORT = parseInt(process.env.COZY_E2E_ADMIN_PORT || '16060', 10)
 export const ADMIN_URL = `http://${STACK_HOST}:${ADMIN_PORT}`
 export const PERSIST =
   process.env.E2E_PERSIST === '1' || process.env.E2E_SKIP_TEARDOWN === '1'
@@ -29,18 +29,20 @@ export interface User {
   passphrase: string
 }
 
+const instancePortSuffix = STACK_PORT === 80 ? '' : `:${STACK_PORT}`
+
 export const USERS: Record<UserLabel, User> = {
   alice: {
     label: 'alice',
-    instance: 'alice.cozy.localhost',
-    appUrl: 'http://alice-drive.cozy.localhost',
+    instance: `alice.cozy.localhost${instancePortSuffix}`,
+    appUrl: `http://alice-drive.cozy.localhost${instancePortSuffix}`,
     email: 'alice@cozy.localhost',
     passphrase: 'alice1234'
   },
   bob: {
     label: 'bob',
-    instance: 'bob.cozy.localhost',
-    appUrl: 'http://bob-drive.cozy.localhost',
+    instance: `bob.cozy.localhost${instancePortSuffix}`,
+    appUrl: `http://bob-drive.cozy.localhost${instancePortSuffix}`,
     email: 'bob@cozy.localhost',
     passphrase: 'bob1234'
   }

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -111,7 +111,7 @@ async function getSessionCookie(
   user: User
 ): Promise<{ name: string; value: string }> {
   const { instance, passphrase } = user
-  const loginPageRes = await fetch(`http://${instance}:80/auth/login`)
+  const loginPageRes = await fetch(`http://${instance}/auth/login`)
   if (!loginPageRes.ok) {
     throw new Error(
       `GET /auth/login on ${instance} failed (${loginPageRes.status}): ${await loginPageRes.text()}`
@@ -126,7 +126,7 @@ async function getSessionCookie(
   const hashed = pbkdf2Sync(Uint8Array.from(master), passphrase, 1, 32, 'sha256')
 
   const initialCookies = loginPageRes.headers.getSetCookie?.() ?? []
-  const res = await fetch(`http://${instance}:80/auth/login`, {
+  const res = await fetch(`http://${instance}/auth/login`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## What
Make the local E2E environment use configurable, non-privileged ports and support an explicit Docker Compose project name.

## Why
Avoid collisions with local Cozy Stack services and allow isolated E2E runtimes.

## How
- Default E2E ports to `18080`, `15984`, and `16060`, with environment-variable overrides.
- Bind exposed Docker ports to localhost.
- Include the stack port in instance URLs and trusted sharing domains.
- Pass `E2E_PROJECT_NAME` to every Docker Compose command.
- Document custom ports and isolated runtime usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * End-to-end test environments now use safer localhost-only port bindings by default.
  * Local service ports can be customized through environment variables, making it easier to avoid conflicts.
  * Test runs can be isolated with a custom project name and separate ports, enabling concurrent test suites.
  * Test setup now reuses existing Drive installations and handles previously created contacts without failing.
* **Documentation**
  * Updated end-to-end testing prerequisites and added guidance for isolated and concurrent test runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->