### PR TITLE
feat: classify sharings into with-me/by-me/drives tabs

### DIFF
--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
@@ -288,6 +288,89 @@ describe('useTransformFolderListHasSharedDriveShortcuts', () => {
       })
     })
 
+    it('should stamp org-drive and ownership metadata on recipient drive entries', () => {
+      mockUseSharedDrives.mockReturnValue({
+        sharedDrives: [
+          {
+            id: 'sharing-org',
+            org_drive: true,
+            rules: [{ values: ['folder-org'], title: 'Company Drive' }]
+          },
+          {
+            id: 'sharing-owned',
+            owner: true,
+            rules: [{ values: ['folder-owned'], title: 'My Drive' }]
+          },
+          {
+            id: 'sharing-received',
+            rules: [{ values: ['folder-received'], title: 'Their Drive' }]
+          }
+        ]
+      })
+
+      const { result } = renderHook(() =>
+        useTransformFolderListHasSharedDriveShortcuts([])
+      )
+
+      expect(result.current.sharedDrives).toEqual([
+        expect.objectContaining({
+          driveId: 'sharing-org',
+          orgDrive: true,
+          driveOwner: false
+        }),
+        expect.objectContaining({
+          driveId: 'sharing-owned',
+          orgDrive: false,
+          driveOwner: true
+        }),
+        expect.objectContaining({
+          driveId: 'sharing-received',
+          orgDrive: false,
+          driveOwner: false
+        })
+      ])
+    })
+
+    it('should stamp org-drive and ownership metadata on the owner file entry', () => {
+      mockUseSharedDrives.mockReturnValue({
+        sharedDrives: [
+          {
+            id: 'sharing-1',
+            owner: true,
+            rules: [{ values: ['folder-1'], title: 'My Drive' }]
+          }
+        ]
+      })
+
+      mockUseSharingContext.mockReturnValue({
+        isOwner: jest.fn(() => true)
+      })
+
+      const mockFolderList = [
+        {
+          _id: 'file-1',
+          id: 'file-1',
+          name: 'My Drive',
+          relationships: {
+            referenced_by: {
+              data: [{ id: 'sharing-1' }]
+            }
+          }
+        }
+      ]
+
+      const { result } = renderHook(() =>
+        useTransformFolderListHasSharedDriveShortcuts(mockFolderList)
+      )
+
+      expect(result.current.sharedDrives[0]).toMatchObject({
+        _id: 'file-1',
+        driveId: 'sharing-1',
+        orgDrive: false,
+        driveOwner: true
+      })
+    })
+
     it('should filter out nextcloud shortcuts', () => {
       const mockSharedDrives = [
         {

--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
@@ -82,9 +82,6 @@ const useTransformFolderListHasSharedDriveShortcuts = (
           ...(sharing.rules[0]?.mime ? { mime: sharing.rules[0].mime } : {})
         }
 
-        // org_drive/owner only exist on the sharing doc; stamp them on the
-        // entry so the Sharings view can classify drives into tabs without
-        // refetching the sharings.
         const sharedDriveData = {
           type: isFileDriveRoot ? ('file' as const) : ('directory' as const),
           name: driveName,

--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
@@ -17,10 +17,14 @@ interface SharedDrive {
   id: string
   drive_root_type?: DriveRootType
   rules: SharingRule[]
+  org_drive?: boolean
+  owner?: boolean
 }
 
 interface TransformedSharedDrive extends SharedDriveFile {
   driveId: string
+  orgDrive?: boolean
+  driveOwner?: boolean
 }
 
 interface UseTransformFolderListReturn {
@@ -78,11 +82,16 @@ const useTransformFolderListHasSharedDriveShortcuts = (
           ...(sharing.rules[0]?.mime ? { mime: sharing.rules[0].mime } : {})
         }
 
+        // org_drive/owner only exist on the sharing doc; stamp them on the
+        // entry so the Sharings view can classify drives into tabs without
+        // refetching the sharings.
         const sharedDriveData = {
           type: isFileDriveRoot ? ('file' as const) : ('directory' as const),
           name: driveName,
           dir_id: SHARED_DRIVES_DIR_ID,
           driveId: sharing.id,
+          orgDrive: Boolean(sharing.org_drive),
+          driveOwner: Boolean(sharing.owner),
           ...(isFileDriveRoot
             ? {
                 ...fileMetadata,
@@ -105,6 +114,8 @@ const useTransformFolderListHasSharedDriveShortcuts = (
             {
               ...fileInSharingSection,
               driveId: sharing.id,
+              orgDrive: Boolean(sharing.org_drive),
+              driveOwner: Boolean(sharing.owner),
               ...(isFileDriveRoot
                 ? {
                     ...fileMetadata,

--- a/src/modules/views/Sharings/useFilteredSharings.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.jsx
@@ -1,8 +1,15 @@
 import { useMemo } from 'react'
 
+import { isSharingShortcut } from 'cozy-client/dist/models/file'
 import flag from 'cozy-flags'
+import { useSharingContext } from 'cozy-sharing'
 
-import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
+import {
+  SHARED_DRIVES_DIR_ID,
+  SHARING_TAB_BY_ME,
+  SHARING_TAB_DRIVES,
+  SHARING_TAB_WITH_ME
+} from '@/constants/config'
 import { useTransformFolderListHasSharedDriveShortcuts } from '@/hooks/useTransformFolderListHasSharedDriveShortcuts'
 
 const buildBaseShape = (result, hasIds) => ({
@@ -16,6 +23,19 @@ const isSharedDrivesDirItem = item => item.dir_id === SHARED_DRIVES_DIR_ID
 const shouldReplaceItem = (current, candidate) =>
   isSharedDrivesDirItem(current) && !isSharedDrivesDirItem(candidate)
 
+// The regular Drive row wins deduplication for display, but only the
+// transformed entry carries the driveId/orgDrive/driveOwner attributes the
+// tab classification needs; backfill them onto the surviving row.
+const withDriveMetadata = (kept, dropped) =>
+  !kept.driveId && dropped.driveId
+    ? {
+        ...kept,
+        driveId: dropped.driveId,
+        orgDrive: dropped.orgDrive,
+        driveOwner: dropped.driveOwner
+      }
+    : kept
+
 /**
  * Drops duplicate representations of the same file/folder.
  *
@@ -24,7 +44,8 @@ const shouldReplaceItem = (current, candidate) =>
  * shared-drive entry. The transformed entry has `dir_id` set to the
  * shared-drives magic directory, which renders as `/sharings` in the list.
  * Keep the real Drive entry whenever it is available so the row path matches
- * the stable state after a page reload.
+ * the stable state after a page reload, while retaining the drive
+ * classification metadata of the discarded transformed entry.
  */
 export const deduplicateSharingShortcuts = data => {
   if (!data?.length) return data
@@ -48,12 +69,36 @@ export const deduplicateSharingShortcuts = data => {
     }
 
     hasDuplicates = true
-    if (shouldReplaceItem(deduplicatedData[existingIndex], item)) {
-      deduplicatedData[existingIndex] = item
-    }
+    const existing = deduplicatedData[existingIndex]
+    deduplicatedData[existingIndex] = shouldReplaceItem(existing, item)
+      ? withDriveMetadata(item, existing)
+      : withDriveMetadata(existing, item)
   }
 
   return hasDuplicates ? deduplicatedData : data
+}
+
+/**
+ * Returns the sharings tab a list entry belongs to.
+ *
+ * Shared-drive entries carry `driveId` plus the `orgDrive`/`driveOwner`
+ * flags stamped from the sharing doc by
+ * useTransformFolderListHasSharedDriveShortcuts. Pending invitation
+ * shortcuts must be resolved before `isOwner`: cozy-sharing's `isOwner`
+ * answers true for documents it has no sharing for, which would misfile
+ * them under "shared by me".
+ *
+ * @param {object} entry - File-like entry from the sharings list
+ * @param {(docId: string) => boolean} isOwner - From cozy-sharing's useSharingContext
+ * @returns {string} One of the SHARING_TAB_* constants
+ */
+export const getSharingsTabForEntry = (entry, isOwner) => {
+  if (entry.driveId) {
+    if (entry.orgDrive) return SHARING_TAB_DRIVES
+    return entry.driveOwner ? SHARING_TAB_BY_ME : SHARING_TAB_WITH_ME
+  }
+  if (isSharingShortcut(entry)) return SHARING_TAB_WITH_ME
+  return isOwner(getDocId(entry)) ? SHARING_TAB_BY_ME : SHARING_TAB_WITH_ME
 }
 
 const computeData = ({
@@ -79,9 +124,10 @@ const computeData = ({
  * shared-folder flags are both off, otherwise merges transformed shared-drive
  * shortcuts into the result. Then drops transient duplicate representations of
  * the same document, preferring the real Drive entry over the shared-drives
- * synthetic entry.
+ * synthetic entry. When `tab` is provided, keeps only the entries belonging
+ * to that tab (see getSharingsTabForEntry).
  */
-export const useFilteredSharings = ({ result, sharedDocumentIds }) => {
+export const useFilteredSharings = ({ result, sharedDocumentIds, tab }) => {
   const isEnabledSharedDrive = flag('drive.shared-drive.enabled')
   const isEnabledFederatedSharedFolder = flag(
     'drive.federated-shared-folder.enabled'
@@ -95,21 +141,30 @@ export const useFilteredSharings = ({ result, sharedDocumentIds }) => {
     sharedDrivesLoaded
   } = useTransformFolderListHasSharedDriveShortcuts(result.data)
 
+  const { isOwner } = useSharingContext()
+
   const filteredResult = useMemo(() => {
     const hasIds = sharedDocumentIds?.length > 0
-    const data = computeData({
+    // Filter by tab only after deduplication so each document lands in
+    // exactly one tab.
+    const combined = computeData({
       result,
       withoutSharedDrives,
       transformedSharedDrives,
       nonSharedDriveList
     })
+    const data = tab
+      ? combined.filter(entry => getSharingsTabForEntry(entry, isOwner) === tab)
+      : combined
     return { ...buildBaseShape(result, hasIds), data, count: data.length }
   }, [
     withoutSharedDrives,
     transformedSharedDrives,
     nonSharedDriveList,
     result,
-    sharedDocumentIds?.length
+    sharedDocumentIds?.length,
+    tab,
+    isOwner
   ])
 
   // When shared drives are disabled the view ignores the transformed list,

--- a/src/modules/views/Sharings/useFilteredSharings.spec.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.spec.jsx
@@ -2,8 +2,15 @@ import { renderHook } from '@testing-library/react'
 
 import {
   deduplicateSharingShortcuts,
+  getSharingsTabForEntry,
   useFilteredSharings
 } from './useFilteredSharings'
+
+import {
+  SHARING_TAB_BY_ME,
+  SHARING_TAB_DRIVES,
+  SHARING_TAB_WITH_ME
+} from '@/constants/config'
 
 jest.mock('cozy-sharing', () => ({
   useSharingContext: jest.fn()
@@ -19,6 +26,7 @@ jest.mock('@/hooks/useTransformFolderListHasSharedDriveShortcuts', () => ({
 }))
 
 const mockFlag = require('cozy-flags').default
+const mockUseSharingContext = require('cozy-sharing').useSharingContext
 
 const mockUseTransform =
   require('@/hooks/useTransformFolderListHasSharedDriveShortcuts').useTransformFolderListHasSharedDriveShortcuts
@@ -53,6 +61,87 @@ const anotherFolder = {
   path: '/Archives/Photos'
 }
 
+const ownedFolder = {
+  _id: 'folder-owned',
+  id: 'folder-owned',
+  name: 'Specs',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.root-dir',
+  path: '/Specs'
+}
+
+const receivedFolder = {
+  _id: 'folder-received',
+  id: 'folder-received',
+  name: 'Recipes',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.root-dir',
+  path: '/Recipes'
+}
+
+// A pending sharing invitation materialized as a shortcut file.
+const invitationShortcut = {
+  _id: 'file-invitation',
+  id: 'file-invitation',
+  name: 'Contracts.url',
+  class: 'shortcut',
+  type: 'file',
+  dir_id: 'io.cozy.files.root-dir',
+  metadata: { sharing: { status: 'new' } }
+}
+
+// Drive entries as shaped by useTransformFolderListHasSharedDriveShortcuts,
+// which stamps driveId plus the orgDrive/driveOwner classification metadata.
+const orgDrive = {
+  _id: 'drive-org-root',
+  id: 'drive-org-root',
+  name: 'Company drive',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.shared-drives-dir',
+  driveId: 'sharing-org',
+  orgDrive: true,
+  driveOwner: false
+}
+
+const ownedFederatedDrive = {
+  _id: 'drive-owned-root',
+  id: 'drive-owned-root',
+  name: 'My federated folder',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.shared-drives-dir',
+  driveId: 'sharing-fed-owned',
+  orgDrive: false,
+  driveOwner: true
+}
+
+const receivedFederatedDrive = {
+  _id: 'drive-received-root',
+  id: 'drive-received-root',
+  name: 'Partner federated folder',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.shared-drives-dir',
+  driveId: 'sharing-fed-received',
+  orgDrive: false,
+  driveOwner: false
+}
+
+// The same organizational drive as a regular Drive row, as it can show up
+// alongside the transformed entry during transient sharing updates.
+const orgDriveRegularRow = {
+  _id: 'drive-org-root',
+  id: 'drive-org-root',
+  name: 'Company drive',
+  class: 'directory',
+  type: 'directory',
+  dir_id: 'io.cozy.files.root-dir',
+  path: '/Company drive'
+}
+
 describe('deduplicateSharingShortcuts', () => {
   it('returns the same list when data is empty', () => {
     expect(deduplicateSharingShortcuts([])).toEqual([])
@@ -75,9 +164,72 @@ describe('deduplicateSharingShortcuts', () => {
       sharedDrivesFolder
     ])
   })
+
+  it('backfills drive classification metadata onto the winning regular entry, whatever the order', () => {
+    const merged = {
+      ...orgDriveRegularRow,
+      driveId: orgDrive.driveId,
+      orgDrive: true,
+      driveOwner: false
+    }
+
+    expect(deduplicateSharingShortcuts([orgDrive, orgDriveRegularRow])).toEqual(
+      [merged]
+    )
+    expect(deduplicateSharingShortcuts([orgDriveRegularRow, orgDrive])).toEqual(
+      [merged]
+    )
+  })
+})
+
+describe('getSharingsTabForEntry', () => {
+  it('classifies a document the user owns (including link-only shares) as shared by me', () => {
+    // A share by link has permissions but no sharing doc; cozy-sharing's
+    // isOwner also answers true for it.
+    expect(getSharingsTabForEntry(ownedFolder, () => true)).toBe(
+      SHARING_TAB_BY_ME
+    )
+  })
+
+  it('classifies a document shared by someone else as shared with me', () => {
+    expect(getSharingsTabForEntry(receivedFolder, () => false)).toBe(
+      SHARING_TAB_WITH_ME
+    )
+  })
+
+  it('classifies a pending invitation shortcut as shared with me even when isOwner reports true', () => {
+    // isOwner defaults to true for docs the sharing context does not know,
+    // which is the case for not-yet-accepted invitation shortcuts.
+    expect(getSharingsTabForEntry(invitationShortcut, () => true)).toBe(
+      SHARING_TAB_WITH_ME
+    )
+  })
+
+  it('classifies an organizational drive as a team drive regardless of ownership', () => {
+    expect(
+      getSharingsTabForEntry({ ...orgDrive, driveOwner: true }, () => false)
+    ).toBe(SHARING_TAB_DRIVES)
+  })
+
+  it('classifies a federated drive created by the user as shared by me', () => {
+    // Drive ownership comes from the sharing doc attribute, not from isOwner.
+    expect(getSharingsTabForEntry(ownedFederatedDrive, () => false)).toBe(
+      SHARING_TAB_BY_ME
+    )
+  })
+
+  it('classifies a federated drive received from someone else as shared with me', () => {
+    expect(getSharingsTabForEntry(receivedFederatedDrive, () => true)).toBe(
+      SHARING_TAB_WITH_ME
+    )
+  })
 })
 
 describe('useFilteredSharings', () => {
+  beforeEach(() => {
+    mockUseSharingContext.mockReturnValue({ isOwner: () => false })
+  })
+
   const setupMocks = ({ flags = {} } = {}) => {
     mockFlag.mockImplementation(name => Boolean(flags[name]))
     mockUseTransform.mockReturnValue({
@@ -132,5 +284,164 @@ describe('useFilteredSharings', () => {
 
     expect(hook.current.filteredResult.data).toEqual([rootFolder])
     expect(hook.current.filteredResult.count).toBe(1)
+  })
+
+  describe('tab filtering', () => {
+    const driveEntries = [orgDrive, ownedFederatedDrive, receivedFederatedDrive]
+    const classicShares = [ownedFolder, receivedFolder, invitationShortcut]
+
+    const setupTabMocks = ({ drivesEnabled = true } = {}) => {
+      mockFlag.mockImplementation(
+        name => drivesEnabled && name === 'drive.shared-drive.enabled'
+      )
+      mockUseTransform.mockReturnValue({
+        sharedDrives: drivesEnabled ? driveEntries : [],
+        nonSharedDriveList: classicShares,
+        sharedDrivesLoaded: true
+      })
+      mockUseSharingContext.mockReturnValue({
+        isOwner: id => id === ownedFolder._id
+      })
+    }
+
+    const renderFiltered = tab => {
+      const { result: hook } = renderHook(() =>
+        useFilteredSharings({
+          result: {
+            data: [...classicShares, orgDrive],
+            fetchStatus: 'loaded',
+            lastFetch: Date.now()
+          },
+          sharedDocumentIds: [ownedFolder._id, receivedFolder._id],
+          tab
+        })
+      )
+      return hook.current.filteredResult
+    }
+
+    it('keeps only entries shared with the user on the with-me tab', () => {
+      setupTabMocks()
+
+      const { data, count } = renderFiltered(SHARING_TAB_WITH_ME)
+
+      expect(data).toEqual([
+        receivedFederatedDrive,
+        receivedFolder,
+        invitationShortcut
+      ])
+      expect(count).toBe(3)
+    })
+
+    it('keeps only entries shared by the user on the by-me tab', () => {
+      setupTabMocks()
+
+      const { data } = renderFiltered(SHARING_TAB_BY_ME)
+
+      expect(data).toEqual([ownedFederatedDrive, ownedFolder])
+    })
+
+    it('keeps only organizational drives on the drives tab', () => {
+      setupTabMocks()
+
+      const { data } = renderFiltered(SHARING_TAB_DRIVES)
+
+      expect(data).toEqual([orgDrive])
+    })
+
+    it('returns the full combined list when no tab is given', () => {
+      setupTabMocks()
+
+      const { data } = renderFiltered(undefined)
+
+      expect(data).toEqual([...driveEntries, ...classicShares])
+    })
+
+    it('partitions the combined list across the three tabs', () => {
+      setupTabMocks()
+
+      const all = renderFiltered(undefined).data
+      const partition = [
+        ...renderFiltered(SHARING_TAB_DRIVES).data,
+        ...renderFiltered(SHARING_TAB_BY_ME).data,
+        ...renderFiltered(SHARING_TAB_WITH_ME).data
+      ]
+
+      expect(partition).toHaveLength(all.length)
+      expect(new Set(partition)).toEqual(new Set(all))
+    })
+
+    it('shows no drive entries on any tab when shared drives are disabled', () => {
+      setupTabMocks({ drivesEnabled: false })
+
+      expect(renderFiltered(SHARING_TAB_DRIVES).data).toEqual([])
+      expect(renderFiltered(SHARING_TAB_BY_ME).data).toEqual([ownedFolder])
+      expect(renderFiltered(SHARING_TAB_WITH_ME).data).toEqual([
+        receivedFolder,
+        invitationShortcut
+      ])
+    })
+
+    it('classifies an owner-side drive root as shared by me when shared drives are disabled', () => {
+      // With the flags off the transform output is ignored, so an
+      // owner-side drive root reaches classification as a plain folder
+      // (regular dir_id, no stamped drive metadata) and lands on the
+      // by-me tab via isOwner — same tab it gets with the flags on.
+      setupTabMocks({ drivesEnabled: false })
+      mockUseSharingContext.mockReturnValue({
+        isOwner: id => [ownedFolder._id, orgDriveRegularRow._id].includes(id)
+      })
+
+      const renderTab = tab =>
+        renderHook(() =>
+          useFilteredSharings({
+            result: {
+              data: [...classicShares, orgDriveRegularRow],
+              fetchStatus: 'loaded',
+              lastFetch: Date.now()
+            },
+            sharedDocumentIds: [ownedFolder._id, orgDriveRegularRow._id],
+            tab
+          })
+        ).result.current.filteredResult.data
+
+      expect(renderTab(SHARING_TAB_BY_ME)).toEqual([
+        ownedFolder,
+        orgDriveRegularRow
+      ])
+      expect(renderTab(SHARING_TAB_DRIVES)).toEqual([])
+    })
+
+    it('keeps an organizational drive on the drives tab when a regular duplicate wins deduplication', () => {
+      mockFlag.mockImplementation(name => name === 'drive.shared-drive.enabled')
+      mockUseTransform.mockReturnValue({
+        sharedDrives: [orgDrive],
+        nonSharedDriveList: [orgDriveRegularRow],
+        sharedDrivesLoaded: true
+      })
+
+      const renderTab = tab =>
+        renderHook(() =>
+          useFilteredSharings({
+            result: {
+              data: [orgDriveRegularRow],
+              fetchStatus: 'loaded',
+              lastFetch: Date.now()
+            },
+            sharedDocumentIds: [orgDriveRegularRow._id],
+            tab
+          })
+        ).result.current.filteredResult.data
+
+      expect(renderTab(SHARING_TAB_DRIVES)).toEqual([
+        {
+          ...orgDriveRegularRow,
+          driveId: orgDrive.driveId,
+          orgDrive: true,
+          driveOwner: false
+        }
+      ])
+      expect(renderTab(SHARING_TAB_WITH_ME)).toEqual([])
+      expect(renderTab(SHARING_TAB_BY_ME)).toEqual([])
+    })
   })
 })


### PR DESCRIPTION
## What

Second subtask of #3975 (Sharings tabs). Adds the client-side classification layer that decides which tab — **Shared with me**, **Shared by me**, or **Team drives** — each entry of the Sharings view belongs to. No visible change yet: the view call-site is untouched; the tab control (#4039) and view wiring (#4040) build on this.

## How

- `useTransformFolderListHasSharedDriveShortcuts` stamps `orgDrive`/`driveOwner` (from the sharing doc's `org_drive`/`owner` attributes) onto transformed drive entries, on both the owner-file and the recipient-synthetic branch — the sharing attributes aren't available downstream otherwise, and this avoids refetching sharings in the view.

Part of #3975
Closes #4038


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tab-based filtering and classification for sharings, including shortcut and shared-drive categories.
  * Shared-drive entries now expose organization and ownership flags to improve accurate tab placement.

* **Bug Fixes**
  * Improved deduplication so the selected (“regular”) row retains drive classification metadata.
  * Corrected tab classification for pending invitations, link-only shares, and shared-drive entries (including owner scenarios).

* **Tests**
  * Expanded unit tests for shared-drive metadata transformation, shortcut deduplication, and per-tab filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->