### PR TITLE
fix: drop redundant hardcoded fonts.css link from app templates

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -24,7 +24,6 @@
       name="viewport"
       content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover"
     />
-    <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
     {{.CozyFonts}}
     <% htmlPlugin.files.css.forEach(function(file) { %>
       <link rel="stylesheet" href="<%- file %>" />

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -20,7 +20,6 @@
     <meta name="theme-color" content="#ffffff" />
     <meta name="color-scheme" content="light dark" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
     {{.CozyFonts}}
     <% htmlPlugin.files.css.forEach(function(file) { %>
       <link rel="stylesheet" href="<%- file %>" />

--- a/src/targets/public/index.ejs
+++ b/src/targets/public/index.ejs
@@ -21,7 +21,6 @@
     <meta name="color-scheme" content="light dark" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex, nofollow, noimageindex" />
-    <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
     {{.CozyFonts}}
     <% htmlPlugin.files.css.forEach(function(file) { %>
       <link rel="stylesheet" href="<%- file %>" />


### PR DESCRIPTION
## Summary

- Remove the hardcoded `//{{.Domain}}/assets/fonts/fonts.css` link from the browser, intents and public `index.ejs`.
- `{{.CozyFonts}}`, already present right below it, injects a fingerprinted, context-aware link to the same Inter `fonts.css` from the same origin.
- The hardcoded link loaded a second, unfingerprinted copy of the same font family and added a 304 revalidation round-trip on every page load.
- Its `@font-face` was overridden by the following `{{.CozyFonts}}` one, so removing it changes nothing in rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font loading across browser, intents, and public pages.
  * Font styles are now injected dynamically alongside the page’s other styles, helping ensure consistent typography and theme integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->