### PR TITLE
feat: add sharings tabs with per-tab filtering

### DIFF
--- a/e2e/helpers/sharing.ts
+++ b/e2e/helpers/sharing.ts
@@ -43,16 +43,23 @@ export async function createAndShareFolderWithBob(
   await modal.share()
 }
 
+/** The Sharings list is split into tabs (?tab= in the URL): rows shared
+ * WITH the user live on `with-me` (the default), the user's own shares on
+ * `by-me`, organizational drives on `drives`. */
+export type SharingsTab = 'with-me' | 'by-me' | 'drives'
+
 /** Sharing propagates asynchronously across instances — reload the user's
- * Sharings tab until the row shows up. */
+ * Sharings tab until the row shows up. Recipients find their rows on the
+ * default `with-me` tab; pass `by-me` when asserting the OWNER's side. */
 export async function waitForSharingRow(
   page: Page,
   user: User,
   drive: DrivePage,
-  name: string
+  name: string,
+  tab: SharingsTab = 'with-me'
 ): Promise<void> {
   await expect(async () => {
-    await page.goto(`${user.appUrl}/#/sharings`)
+    await page.goto(`${user.appUrl}/#/sharings?tab=${tab}`)
     await drive.row(name).waitVisible({ timeout: 5_000 })
   }).toPass({ timeout: 30_000 })
 }

--- a/e2e/tests/z-share-modal-surfaces.spec.ts
+++ b/e2e/tests/z-share-modal-surfaces.spec.ts
@@ -50,7 +50,14 @@ test.describe.serial('Share modal surfaces (shared drives)', () => {
     alicePage,
     aliceDrive
   }) => {
-    await waitForSharingRow(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+    // Alice owns the drive, so her row lives on the by-me tab.
+    await waitForSharingRow(
+      alicePage,
+      USERS.alice,
+      aliceDrive,
+      DRIVE_NAME,
+      'by-me'
+    )
 
     const modal = await aliceDrive.row(DRIVE_NAME).share()
 
@@ -62,7 +69,8 @@ test.describe.serial('Share modal surfaces (shared drives)', () => {
     await expect(alicePage.getByTestId('fil-content-body')).toBeVisible()
 
     await modal.close()
-    await expect(alicePage).toHaveURL(/#\/sharings$/)
+    // The list canonicalizes its URL with the active tab param.
+    await expect(alicePage).toHaveURL(/#\/sharings(\?tab=[a-z-]+)?$/)
   })
 
   test('Share from the shared-drive file viewer renders the modal', async ({

--- a/e2e/tests/z-shared-drive-browse.spec.ts
+++ b/e2e/tests/z-shared-drive-browse.spec.ts
@@ -40,7 +40,14 @@ test.describe.serial('Shared drive browsing (recipient)', () => {
       await safeUnlink(filePath)
     }
 
-    await waitForSharingRow(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+    // Alice owns the drive, so her row lives on the by-me tab.
+    await waitForSharingRow(
+      alicePage,
+      USERS.alice,
+      aliceDrive,
+      DRIVE_NAME,
+      'by-me'
+    )
   })
 
   test('the share auto-accepts as a proxied drive Bob can browse', async ({

--- a/e2e/tests/z-shared-drive-members.spec.ts
+++ b/e2e/tests/z-shared-drive-members.spec.ts
@@ -66,7 +66,14 @@ test.describe.serial('Shared drive members & permissions', () => {
     // The owner manages members through the share modal, reachable from the
     // Sharings-list row without entering the drive (the owner's in-drive view
     // is the regular /folder route, not the proxied /shareddrive one).
-    await waitForSharingRow(alicePage, USERS.alice, aliceDrive, VIEWER_DRIVE)
+    // Alice owns the drive, so her row lives on the by-me tab.
+    await waitForSharingRow(
+      alicePage,
+      USERS.alice,
+      aliceDrive,
+      VIEWER_DRIVE,
+      'by-me'
+    )
     const modal = await aliceDrive.row(VIEWER_DRIVE).share()
     await expect(modal.memberItem('bob')).toContainText(/viewer/i)
     await modal.close()
@@ -78,7 +85,13 @@ test.describe.serial('Shared drive members & permissions', () => {
     bobPage,
     bobDrive
   }) => {
-    await waitForSharingRow(alicePage, USERS.alice, aliceDrive, VIEWER_DRIVE)
+    await waitForSharingRow(
+      alicePage,
+      USERS.alice,
+      aliceDrive,
+      VIEWER_DRIVE,
+      'by-me'
+    )
     const modal = await aliceDrive.row(VIEWER_DRIVE).share()
     await modal.removeMember('bob')
     await modal.close()

--- a/e2e/tests/z-shared-folder-browse.spec.ts
+++ b/e2e/tests/z-shared-folder-browse.spec.ts
@@ -23,7 +23,8 @@ test.describe.serial('Shared folder browsing', () => {
     await shareModal.addMember(USERS.bob.email)
     await shareModal.share()
 
-    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings`)
+    // Alice owns the share, so her row lives on the by-me tab.
+    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings?tab=by-me`)
     await expect(aliceDrive.row(SHARED_FOLDER_NAME).cell).toBeVisible({
       timeout: 15_000
     })
@@ -47,7 +48,7 @@ test.describe.serial('Shared folder browsing', () => {
     bobPage,
     bobDrive
   }) => {
-    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings`)
+    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings?tab=by-me`)
     await aliceDrive.row(SHARED_FOLDER_NAME).open()
     await expect(alicePage.getByText(SHARED_FOLDER_NAME).first()).toBeVisible()
     await aliceDrive.createFolder(FOLDER_INSIDE)

--- a/e2e/tests/z-viewer-sharing-access.spec.ts
+++ b/e2e/tests/z-viewer-sharing-access.spec.ts
@@ -41,7 +41,14 @@ test.describe('Viewer sharing access panel', () => {
       await safeUnlink(filePath)
     }
 
-    await waitForSharingRow(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
+    // Alice owns the drive, so her row lives on the by-me tab.
+    await waitForSharingRow(
+      alicePage,
+      USERS.alice,
+      aliceDrive,
+      DRIVE_NAME,
+      'by-me'
+    )
     await openOwnerFolder(alicePage, USERS.alice, aliceDrive, DRIVE_NAME)
     await aliceDrive.row(SUBFOLDER).open()
     await aliceDrive.row(FILE_NAME).waitVisible({ timeout: 10_000 })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,8 +75,10 @@
     "select_all_mobile": "all",
     "clear_selection": "Clear Selection",
     "clear_selection_mobile": "Clear",
-    "sharings_tab_all": "All",
-    "sharings_tab_drives": "Drives"
+    "sharings_tabs": "Sharings tabs",
+    "sharings_tab_with_me": "With me",
+    "sharings_tab_by_me": "By me",
+    "sharings_tab_drives": "Team drives"
   },
   "Share": {
     "create-cozy": "Create my Twake"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -75,8 +75,10 @@
     "select_all_mobile": "Tout",
     "clear_selection": "Effacer la sélection",
     "clear_selection_mobile": "Annuler",
-    "sharings_tab_all": "Tout",
-    "sharings_tab_drives": "Drives"
+    "sharings_tabs": "Onglets des partages",
+    "sharings_tab_with_me": "Avec moi",
+    "sharings_tab_by_me": "Par moi",
+    "sharings_tab_drives": "Drives d'équipe"
   },
   "Share": {
     "create-cozy": "Créer mon Twake"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -73,8 +73,10 @@
     "select_all_mobile": "все",
     "clear_selection": "Очистить выбор",
     "clear_selection_mobile": "отмена",
-    "sharings_tab_all": "Всё",
-    "sharings_tab_drives": "Диски"
+    "sharings_tabs": "Общий доступ",
+    "sharings_tab_with_me": "Со мной",
+    "sharings_tab_by_me": "От меня",
+    "sharings_tab_drives": "Командные диски"
   },
   "Share": {
     "create-cozy": "Создать Twake Drive"

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -73,8 +73,10 @@
     "select_all_mobile": "Tất cả",
     "clear_selection": "Xóa lựa chọn",
     "clear_selection_mobile": "Hủy",
-    "sharings_tab_all": "Tất cả",
-    "sharings_tab_drives": "Ổ đĩa"
+    "sharings_tabs": "Các thẻ chia sẻ",
+    "sharings_tab_with_me": "Với tôi",
+    "sharings_tab_by_me": "Do tôi",
+    "sharings_tab_drives": "Ổ đĩa nhóm"
   },
   "Share": {
     "create-cozy": "Tạo Twake của tôi"

--- a/src/modules/selection/SelectionProvider.spec.jsx
+++ b/src/modules/selection/SelectionProvider.spec.jsx
@@ -46,6 +46,7 @@ const SelectionConsumer = ({ items }) => {
   return (
     <>
       {pathname === '/' && <Link to="/other">Change route</Link>}
+      {pathname === '/' && <Link to="/?tab=by-me">Change tab</Link>}
       {isSelectionBarVisible && (
         <button onClick={hideSelectionBar}>Hide selection bar</button>
       )}
@@ -128,6 +129,24 @@ describe('SelectionProvider', () => {
     expect(screen.getByText('Item file-foobar1')).toBeInTheDocument()
     expect(screen.getByText('Item file-foobar2')).toBeInTheDocument()
     expect(screen.queryByText('Hide selection bar')).toBeNull()
+  })
+
+  it('should deselect items when only the search params change (tab switch)', async () => {
+    setup()
+
+    // selecting an item
+    fireEvent.click(screen.getByText('Item file-foobar1'))
+    expect(screen.getByText('Item file-foobar1 selected')).toBeInTheDocument()
+    expect(screen.getByText('Hide selection bar')).toBeInTheDocument()
+
+    // navigate to the same pathname with different search params, which is
+    // what a Sharings tab switch does (tab state lives in ?tab=)
+    fireEvent.click(screen.getByText('Change tab'))
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Item file-foobar1')).toBeInTheDocument()
+      expect(screen.queryByText('Hide selection bar')).toBeNull()
+    })
   })
 
   it('should deselects items when location changed', async () => {

--- a/src/modules/views/Sharings/SharingsHeader.jsx
+++ b/src/modules/views/Sharings/SharingsHeader.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import SharingsTabs from './SharingsTabs'
+import FolderViewHeader from '../Folder/FolderViewHeader'
+
+import styles from '@/styles/topbar.styl'
+
+import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
+import Toolbar from '@/modules/drive/Toolbar'
+
+/**
+ * Sharings view header: title, tabs and toolbar.
+ *
+ * The tabs live inside the header row on desktop (next to the title, per
+ * the mockup) and below the header on mobile, where the header itself is
+ * hidden.
+ *
+ * @param {object} props - Component props
+ * @param {string} props.title - Page title shown as the single breadcrumb
+ * @param {boolean} props.isMobile - Current breakpoint
+ * @param {string} props.tab - Active SHARING_TAB_* slug
+ * @param {(tab: string) => void} props.onChange - Called with the tab slug
+ * @param {boolean} props.showDrives - Whether to render the Team drives tab
+ * @returns {JSX.Element} The rendered component
+ */
+const SharingsHeader = ({ title, isMobile, tab, onChange, showDrives }) => (
+  <>
+    <FolderViewHeader>
+      {/* Keeps the title at its content width so the tabs sit right next
+          to it, as in the mockup (see topbar.styl). */}
+      <div className={styles['fil-sharings-title']}>
+        <Breadcrumb path={[{ name: title }]} />
+      </div>
+      {!isMobile && (
+        <SharingsTabs
+          tab={tab}
+          onChange={onChange}
+          showDrives={showDrives}
+          className="u-ml-2"
+        />
+      )}
+      <Toolbar canUpload={false} canCreateFolder={false} />
+    </FolderViewHeader>
+    {isMobile && (
+      <SharingsTabs tab={tab} onChange={onChange} showDrives={showDrives} />
+    )}
+  </>
+)
+
+export default SharingsHeader

--- a/src/modules/views/Sharings/SharingsTabs.jsx
+++ b/src/modules/views/Sharings/SharingsTabs.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+
+import Tab from 'cozy-ui/transpiled/react/Tab'
+import Tabs from 'cozy-ui/transpiled/react/Tabs'
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'twake-i18n'
+
+import {
+  SHARING_TAB_BY_ME,
+  SHARING_TAB_DRIVES,
+  SHARING_TAB_WITH_ME
+} from '@/constants/config'
+
+const TAB_ITEMS = [
+  { value: SHARING_TAB_WITH_ME, labelKey: 'toolbar.sharings_tab_with_me' },
+  { value: SHARING_TAB_BY_ME, labelKey: 'toolbar.sharings_tab_by_me' },
+  { value: SHARING_TAB_DRIVES, labelKey: 'toolbar.sharings_tab_drives' }
+]
+
+/**
+ * Segmented control switching between the Sharings tabs.
+ *
+ * Fully controlled: the active tab and changes flow through props; tab
+ * values are the SHARING_TAB_* slugs. The Team drives tab presence is
+ * decided by the parent through `showDrives` (flag-driven, never
+ * data-driven, so an async drives list cannot cause layout shift).
+ *
+ * Desktop renders the theme's `segmented` pill track (per the Figma
+ * mockup, text-only, meant for the header row next to the title). The
+ * mobile design is not specified yet, so mobile keeps interim full-width
+ * tabs, placed below the header which is hidden on mobile. The segmented
+ * variant must not receive textColor/indicatorColor: the theme styles the
+ * indicator as the sliding active pill.
+ *
+ * @param {object} props - Component props
+ * @param {string} props.tab - Active SHARING_TAB_* slug
+ * @param {(tab: string) => void} props.onChange - Called with the tab slug
+ * @param {boolean} props.showDrives - Whether to render the Team drives tab
+ * @param {string} [props.className] - Extra class for the Tabs root
+ * @returns {JSX.Element} The rendered component
+ */
+const SharingsTabs = ({ tab, onChange, showDrives = false, className }) => {
+  const { isMobile } = useBreakpoints()
+  const { t } = useI18n()
+
+  const items = showDrives
+    ? TAB_ITEMS
+    : TAB_ITEMS.filter(item => item.value !== SHARING_TAB_DRIVES)
+
+  // MUI emits null when re-clicking the active button of an exclusive
+  // group and re-fires onChange for the active Tab.
+  const handleChange = (_, value) => {
+    if (value !== null && value !== tab) {
+      onChange(value)
+    }
+  }
+
+  const variantProps = isMobile
+    ? { narrowed: true, textColor: 'primary', indicatorColor: 'primary' }
+    : { segmented: true }
+
+  return (
+    <Tabs
+      value={tab}
+      onChange={handleChange}
+      aria-label={t('toolbar.sharings_tabs')}
+      className={className}
+      {...variantProps}
+    >
+      {items.map(({ value, labelKey }) => (
+        <Tab key={value} value={value} label={t(labelKey)} />
+      ))}
+    </Tabs>
+  )
+}
+
+export default SharingsTabs

--- a/src/modules/views/Sharings/SharingsTabs.spec.jsx
+++ b/src/modules/views/Sharings/SharingsTabs.spec.jsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'twake-i18n'
+
+import SharingsTabs from './SharingsTabs'
+
+import {
+  SHARING_TAB_BY_ME,
+  SHARING_TAB_DRIVES,
+  SHARING_TAB_WITH_ME
+} from '@/constants/config'
+
+jest.mock('twake-i18n')
+jest.mock('cozy-ui/transpiled/react/providers/Breakpoints', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+const mockUseBreakpoints = useBreakpoints
+
+const renderTabs = (props = {}) =>
+  render(
+    <SharingsTabs
+      tab={SHARING_TAB_WITH_ME}
+      onChange={jest.fn()}
+      showDrives
+      {...props}
+    />
+  )
+
+describe('SharingsTabs', () => {
+  beforeEach(() => {
+    useI18n.mockReturnValue({ t: key => key })
+  })
+
+  // The two breakpoints share the whole behavior; only the variant of the
+  // underlying Tabs differs (asserted separately below).
+  describe.each([
+    ['desktop', false],
+    ['mobile', true]
+  ])('on %s', (_, isMobile) => {
+    beforeEach(() => {
+      mockUseBreakpoints.mockReturnValue({ isMobile })
+    })
+
+    it('renders the three tabs when drives are shown', () => {
+      renderTabs()
+
+      expect(screen.getAllByRole('tab')).toHaveLength(3)
+      expect(
+        screen.getByRole('tab', { name: 'toolbar.sharings_tab_with_me' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('tab', { name: 'toolbar.sharings_tab_by_me' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('tab', { name: 'toolbar.sharings_tab_drives' })
+      ).toBeInTheDocument()
+    })
+
+    it('hides the drives tab when showDrives is false', () => {
+      renderTabs({ showDrives: false })
+
+      expect(screen.getAllByRole('tab')).toHaveLength(2)
+      expect(
+        screen.queryByRole('tab', { name: 'toolbar.sharings_tab_drives' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('marks the active tab as selected', () => {
+      renderTabs({ tab: SHARING_TAB_BY_ME })
+
+      expect(
+        screen.getByRole('tab', { name: 'toolbar.sharings_tab_by_me' })
+      ).toHaveAttribute('aria-selected', 'true')
+      expect(
+        screen.getByRole('tab', { name: 'toolbar.sharings_tab_with_me' })
+      ).toHaveAttribute('aria-selected', 'false')
+    })
+
+    it('calls onChange with the tab slug when activating another tab', () => {
+      const onChange = jest.fn()
+      renderTabs({ onChange })
+
+      fireEvent.click(
+        screen.getByRole('tab', { name: 'toolbar.sharings_tab_drives' })
+      )
+
+      expect(onChange).toHaveBeenCalledWith(SHARING_TAB_DRIVES)
+    })
+
+    it('does not call onChange when re-activating the active tab', () => {
+      const onChange = jest.fn()
+      renderTabs({ onChange })
+
+      fireEvent.click(
+        screen.getByRole('tab', { name: 'toolbar.sharings_tab_with_me' })
+      )
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+
+  it('renders the segmented pill variant on desktop only', () => {
+    mockUseBreakpoints.mockReturnValue({ isMobile: false })
+    const { container: desktop } = renderTabs()
+    // The theme's segmented variant is the Figma pill track.
+    expect(desktop.querySelector('.MuiTabs-root.segmented')).toBeTruthy()
+
+    mockUseBreakpoints.mockReturnValue({ isMobile: true })
+    const { container: mobile } = renderTabs()
+    // Interim mobile design keeps the plain full-width tabs.
+    expect(mobile.querySelector('.MuiTabs-root.segmented')).toBeNull()
+  })
+})

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -11,12 +11,13 @@ import {
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
 
+import SharingsHeader from './SharingsHeader'
 import { buildSharingsActionsOptions } from './helpers'
 import { useFilteredSharings } from './useFilteredSharings'
+import { areDrivesAvailable, useSharingsTab } from './useSharingsTab'
 import withSharedDocumentIds from './withSharedDocumentIds'
 import FolderView from '../Folder/FolderView'
 import FolderViewBody from '../Folder/FolderViewBody'
-import FolderViewHeader from '../Folder/FolderViewHeader'
 import { useFolderViewBase } from '../Folder/hooks/useFolderViewBase'
 import FolderViewBodyVz from '../Folder/virtualized/FolderViewBody'
 
@@ -36,10 +37,8 @@ import {
 import { addToFavorites } from '@/modules/actions/components/addToFavorites'
 import { moveTo } from '@/modules/actions/components/moveTo'
 import { removeFromFavorites } from '@/modules/actions/components/removeFromFavorites'
-import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
-import Toolbar from '@/modules/drive/Toolbar'
 import FileListRowsPlaceholder from '@/modules/filelist/FileListRowsPlaceholder'
 import { leaveSharedDrive } from '@/modules/shareddrives/components/actions/leaveSharedDrive'
 import { shareFileRootSharedDrive } from '@/modules/shareddrives/components/actions/shareFileRootSharedDrive'
@@ -53,6 +52,8 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const nativeSharing = useNativeFileSharing()
   useHead({ title: base.t('breadcrumb.title_sharings') })
   const [sortOrder, setSortOrder, isSettingsLoaded] = useFolderSort('sharings')
+  const [tab, setTab] = useSharingsTab()
+  const showDrives = areDrivesAvailable()
 
   const query = useMemo(
     () =>
@@ -66,7 +67,8 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
 
   const { filteredResult, sharedDrivesLoaded } = useFilteredSharings({
     result,
-    sharedDocumentIds
+    sharedDocumentIds,
+    tab
   })
 
   useKeyboardShortcuts({
@@ -113,10 +115,13 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   return (
     <FolderView>
       <Content className={base.isMobile ? '' : 'u-pt-1'}>
-        <FolderViewHeader>
-          <Breadcrumb path={[{ name: base.t('breadcrumb.title_sharings') }]} />
-          <Toolbar canUpload={false} canCreateFolder={false} />
-        </FolderViewHeader>
+        <SharingsHeader
+          title={base.t('breadcrumb.title_sharings')}
+          isMobile={base.isMobile}
+          tab={tab}
+          onChange={setTab}
+          showDrives={showDrives}
+        />
         {!allLoaded ||
         !sharedDrivesLoaded ||
         !hasQueryBeenLoaded(filteredResult) ? (

--- a/src/modules/views/Sharings/index.spec.jsx
+++ b/src/modules/views/Sharings/index.spec.jsx
@@ -93,12 +93,32 @@ describe('Sharings View', () => {
     jest.spyOn(console, 'error').mockImplementation()
   })
 
+  beforeEach(() => {
+    // isOwner is consumed by useFilteredSharings to classify entries into
+    // tabs; false files every fixture under the default with-me tab.
+    mockSharingContext.mockReturnValue({
+      byDocId: [],
+      allLoaded: true,
+      isOwner: () => false
+    })
+  })
+
+  afterEach(() => {
+    // useSharingsTab writes ?tab= into the hash-router URL; reset it so
+    // a tab switched in one test does not leak into the next.
+    window.location.hash = ''
+  })
+
   afterAll(() => {
     jest.clearAllMocks()
   })
 
   it('should display placeholder when all files are not loaded', async () => {
-    mockSharingContext.mockReturnValue({ byDocId: [], allLoaded: false })
+    mockSharingContext.mockReturnValue({
+      byDocId: [],
+      allLoaded: false,
+      isOwner: () => false
+    })
     const { container } = setup()
 
     await waitFor(() => {
@@ -109,7 +129,6 @@ describe('Sharings View', () => {
   })
 
   it('should not display placeholder when all files are loaded', async () => {
-    mockSharingContext.mockReturnValue({ byDocId: [], allLoaded: true })
     useQuery.mockReturnValue(filesFixtureWithPath)
 
     const { container } = setup()
@@ -162,5 +181,30 @@ describe('Sharings View', () => {
     })
 
     expect(mockNavigate).toHaveBeenCalledWith('/file/file-foobar0/revision')
+  })
+
+  it('filters the list by the active tab and swaps it on tab switch', async () => {
+    useQuery.mockReturnValue(filesFixtureWithPath)
+    mockSharingContext.mockReturnValue({
+      byDocId: [],
+      allLoaded: true,
+      isOwner: id => id === 'file-foobar0'
+    })
+
+    const { getByText, queryByText, getByRole } = setup()
+
+    // Default with-me tab: only the file shared by someone else is listed.
+    await waitFor(() => {
+      expect(getByText('foobar1')).toBeInTheDocument()
+    })
+    expect(queryByText('foobar0')).toBeNull()
+
+    // Switching to the by-me tab swaps the list to the owned file.
+    fireEvent.click(getByRole('tab', { name: 'By me' }))
+
+    await waitFor(() => {
+      expect(getByText('foobar0')).toBeInTheDocument()
+    })
+    expect(queryByText('foobar1')).toBeNull()
   })
 })

--- a/src/modules/views/Sharings/useSharingsTab.ts
+++ b/src/modules/views/Sharings/useSharingsTab.ts
@@ -33,7 +33,7 @@ const isAvailableTab = (
 ): value is SharingsTab =>
   isSharingsTab(value) && (value !== SHARING_TAB_DRIVES || drivesAvailable)
 
-const areDrivesAvailable = (): boolean =>
+export const areDrivesAvailable = (): boolean =>
   Boolean(flag('drive.shared-drive.enabled')) ||
   Boolean(flag('drive.federated-shared-folder.enabled'))
 

--- a/src/styles/topbar.styl
+++ b/src/styles/topbar.styl
@@ -32,3 +32,17 @@
 
         path
             fill: var(--shadow7)
+
+// Boxes the breadcrumb so the Sharings header can place the tabs right
+// after the title: the breadcrumb root stretches over all free header
+// space (flex 1 1 auto / width 1% in breadcrumb.styl), which pushes any
+// sibling to the far edge and collapses the title once boxed. The inner
+// override targets the breadcrumb's <nav> root by element because the
+// module-hashed fil-path-backdrop class cannot be referenced from here.
+.fil-sharings-title
+    flex 0 1 auto
+    min-width 0
+
+    > nav
+        flex none
+        width auto


### PR DESCRIPTION
## What

Third and fourth subtasks of #3975 (Sharings tabs): the visible **With me / By me / Team drives** control, wired to per-tab filtering so the feature is fully functional. The Sharings view now shows a segmented pill control next to the page title on desktop and full-width tabs below the header on mobile; switching tabs filters the list client-side (classification landed in #4047) and persists in the URL (#4043).

**Design check against Figma** (`Cozy new UI`, node 33267-55389): token-level match on track color, typography and labels. 
Known deviations left as is for now: control height (Figma 32px vs cozy-ui theme's 40px `minHeight`), inactive label color (`text/disabled` vs MUI default) and the active-pill shadow — all theme-level in cozy-ui, worth a design-system alignment rather than local overrides. The filters row in the mockup is a separate feature outside #3975.


Part of #3975
Closes #4039
Closes #4040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Sharings navigation to use separate **“With me”** and **“By me”** tabs (including new grouping label support).
  * Added/labelled the **“Team drives”** tab when drives are available.
  * Refreshed the Sharings header with responsive tab placement and tab-driven file filtering.
* **Bug Fixes**
  * Tab switching via URL parameters now updates query state without disrupting other routing, and correctly clears selection/hides the selection bar.
* **Localization**
  * Updated Sharings tab labels across supported languages (including “Team drives” wording).
* **Tests**
  * Expanded Sharings tab and filtering coverage (desktop/mobile) and updated related e2e helpers/assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->