### PR TITLE
feat: sharings tab across navigation and in the viewer

### DIFF
--- a/src/modules/navigation/hooks/helpers.spec.js
+++ b/src/modules/navigation/hooks/helpers.spec.js
@@ -1,4 +1,9 @@
-import { computeFileType, computeApp, computePath } from './helpers'
+import {
+  computeFileType,
+  computeApp,
+  computePath,
+  getSharingsTabSearch
+} from './helpers'
 
 import { TRASH_DIR_ID, SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { DRIVE_ROOT_TYPE } from '@/modules/shareddrives/types'
@@ -743,5 +748,24 @@ describe('computePath', () => {
         pathname: '/sharings'
       })
     ).toBe('folder-1')
+  })
+})
+
+describe('getSharingsTabSearch', () => {
+  it('returns the tab param when navigating within the sharings section', () => {
+    expect(getSharingsTabSearch('/sharings', '?tab=by-me')).toBe('?tab=by-me')
+    expect(
+      getSharingsTabSearch('/sharings/folder-1', '?foo=bar&tab=drives')
+    ).toBe('?tab=drives')
+  })
+
+  it('returns an empty search outside the sharings section', () => {
+    expect(getSharingsTabSearch('/folder/dir-1', '?tab=by-me')).toBe('')
+    expect(getSharingsTabSearch('/favorites', '?tab=by-me')).toBe('')
+  })
+
+  it('returns an empty search when no tab is set', () => {
+    expect(getSharingsTabSearch('/sharings', '')).toBe('')
+    expect(getSharingsTabSearch('/sharings', '?foo=bar')).toBe('')
   })
 })

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -139,6 +139,24 @@ export const computeFileType = (
   }
 }
 
+/**
+ * Search string preserving the active Sharings tab across in-section
+ * navigations.
+ *
+ * The `?tab=` query param is the only storage of the active tab (see
+ * useSharingsTab), so any navigation staying under /sharings must carry it
+ * over. Outside the section it returns an empty search, so other views
+ * never inherit the param.
+ */
+export const getSharingsTabSearch = (
+  pathname: string,
+  search: string
+): string => {
+  if (!pathname.startsWith('/sharings')) return ''
+  const tab = new URLSearchParams(search).get('tab')
+  return tab ? `?${new URLSearchParams({ tab }).toString()}` : ''
+}
+
 export const computeApp = (type: string): string => {
   switch (type) {
     case 'nextcloud-file':

--- a/src/modules/navigation/hooks/useFileLink.tsx
+++ b/src/modules/navigation/hooks/useFileLink.tsx
@@ -11,7 +11,8 @@ import { joinPath } from '@/lib/path'
 import {
   computeFileType,
   computeApp,
-  computePath
+  computePath,
+  getSharingsTabSearch
 } from '@/modules/navigation/hooks/helpers'
 import { usePublicContext } from '@/modules/public/PublicProvider'
 import { getFolderPath } from '@/modules/routeUtils'
@@ -83,7 +84,7 @@ const useFileLink = (
   { forceFolderPath }: { forceFolderPath?: boolean } = {}
 ): UseFileLinkResult => {
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
   const client = useClient()
   const { isDesktop } = useBreakpoints()
   const isOfficeEnabled = computeOfficeEnabled(isDesktop)
@@ -141,6 +142,15 @@ const useFileLink = (
         (type === 'directory' ? '/folder' : getFolderPath(file.dir_id)) +
         to.pathname
     }
+  }
+
+  // The active sharings tab lives in ?tab= only: carry it over when the
+  // in-app navigation stays under /sharings. Owner docs resolve to
+  // /folder/... routes and deliberately leave the section, so they never
+  // inherit it; a search already carried by the computed path wins.
+  const tabSearch = getSharingsTabSearch(pathname, search)
+  if (tabSearch && to.pathname.startsWith('/sharings') && !to.search) {
+    to = { ...to, search: tabSearch }
   }
 
   // we need to merge the searchParams of the current url and the new one created in computed path

--- a/src/modules/views/Folder/FolderViewBreadcrumb.jsx
+++ b/src/modules/views/Folder/FolderViewBreadcrumb.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import BreadcrumbSkeleton from '@/modules/breadcrumb/components/BreadcrumbSkeleton'
 import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
 import { useBreadcrumbPath } from '@/modules/breadcrumb/hooks/useBreadcrumbPath.jsx'
+import { getSharingsTabSearch } from '@/modules/navigation/hooks/helpers'
 
 const FolderViewBreadcrumb = ({
   currentFolderId,
@@ -12,6 +13,7 @@ const FolderViewBreadcrumb = ({
   sharedDocumentIds
 }) => {
   const navigate = useNavigate()
+  const { pathname, search } = useLocation()
   const path = useBreadcrumbPath({
     currentFolderId,
     rootBreadcrumbPath,
@@ -20,11 +22,17 @@ const FolderViewBreadcrumb = ({
 
   const onBreadcrumbClick = useCallback(
     ({ id }) => {
-      navigate(id ? `../${id}` : '..', {
-        relative: 'path'
-      })
+      navigate(
+        {
+          pathname: id ? `../${id}` : '..',
+          // The active sharings tab lives in ?tab= only: keep it when
+          // navigating back within the section (empty search elsewhere).
+          search: getSharingsTabSearch(pathname, search)
+        },
+        { relative: 'path' }
+      )
     },
-    [navigate]
+    [navigate, pathname, search]
   )
 
   return path && path.length > 0 ? (

--- a/src/modules/views/Folder/FolderViewBreadcrumb.spec.jsx
+++ b/src/modules/views/Folder/FolderViewBreadcrumb.spec.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import React from 'react'
 
 import FolderViewBreadcrumb from './FolderViewBreadcrumb'
@@ -9,22 +9,36 @@ import {
 
 import { useBreadcrumbPath } from '@/modules/breadcrumb/hooks/useBreadcrumbPath'
 
+const mockNavigate = jest.fn()
+const mockLocation = jest.fn()
+
 jest.mock('modules/breadcrumb/hooks/useBreadcrumbPath')
 jest.mock('modules/breadcrumb/components/MobileAwareBreadcrumb', () => ({
-  MobileAwareBreadcrumb: ({ path, opening }) => (
+  MobileAwareBreadcrumb: ({ path, opening, onBreadcrumbClick }) => (
     <div
       data-testid="MobileAwareBreadcrumb"
       data-path={path}
       data-opening={opening ? 'true' : 'false'}
-    />
+    >
+      {path.map(item => (
+        <button key={item.name} onClick={() => onBreadcrumbClick(item)}>
+          {item.name}
+        </button>
+      ))}
+    </div>
   )
 }))
 jest.mock('react-router-dom', () => ({
-  useNavigate: jest.fn()
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation()
 }))
 
 describe('FolderViewBreadcrumb', () => {
   const rootBreadcrumbPath = dummyRootBreadcrumbPath()
+
+  beforeEach(() => {
+    mockLocation.mockReturnValue({ pathname: '/folder/folder-1', search: '' })
+  })
 
   it('should use breadcrumb path', () => {
     // Given
@@ -102,5 +116,68 @@ describe('FolderViewBreadcrumb', () => {
     // Then
     expect(getByTestId('breadcrumb-skeleton')).toBeTruthy()
     expect(queryByTestId('MobileAwareBreadcrumb')).toBeNull()
+  })
+
+  describe('navigation', () => {
+    beforeEach(() => {
+      useBreadcrumbPath.mockReturnValue([
+        { name: 'Sharings' },
+        { id: 'parent-1', name: 'Parent' },
+        { id: 'folder-1', name: 'Current' }
+      ])
+    })
+
+    const setup = () =>
+      render(
+        <FolderViewBreadcrumb
+          currentFolderId="folder-1"
+          rootBreadcrumbPath={{ name: 'Sharings' }}
+        />
+      )
+
+    it('keeps the sharings tab when navigating back to the section root', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/sharings/folder-1',
+        search: '?tab=by-me'
+      })
+      const { getByText } = setup()
+
+      fireEvent.click(getByText('Sharings'))
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        { pathname: '..', search: '?tab=by-me' },
+        { relative: 'path' }
+      )
+    })
+
+    it('keeps the sharings tab when navigating to a parent folder', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/sharings/folder-1',
+        search: '?tab=by-me'
+      })
+      const { getByText } = setup()
+
+      fireEvent.click(getByText('Parent'))
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        { pathname: '../parent-1', search: '?tab=by-me' },
+        { relative: 'path' }
+      )
+    })
+
+    it('does not carry search params outside the sharings section', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/folder/folder-1',
+        search: '?foo=bar'
+      })
+      const { getByText } = setup()
+
+      fireEvent.click(getByText('Parent'))
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        { pathname: '../parent-1', search: '' },
+        { relative: 'path' }
+      )
+    })
   })
 })

--- a/src/modules/views/Sharings/FilesViewerSharings.jsx
+++ b/src/modules/views/Sharings/FilesViewerSharings.jsx
@@ -1,8 +1,11 @@
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useQuery } from 'cozy-client'
+import { useSharingContext } from 'cozy-sharing'
 
+import { getSharingsTabForEntry } from './useFilteredSharings'
+import { useSharingsTab } from './useSharingsTab'
 import withSharedDocumentIds from './withSharedDocumentIds'
 
 import { FilesViewerLoading } from '@/components/FilesViewerLoading'
@@ -15,9 +18,23 @@ const FilesViewerSharing = ({ sharedDocumentIds }) => {
   const filesQuery = buildSharingsQuery({ ids: sharedDocumentIds })
   const results = useQuery(filesQuery.definition, filesQuery.options)
   const navigate = useNavigate()
+  // The active tab only lives in ?tab= (see useSharingsTab): navigations
+  // must carry the current search over or the tab resets to the default.
+  const { search } = useLocation()
+  const [tab] = useSharingsTab()
+  const { isOwner } = useSharingContext()
 
   if (results.data) {
-    const viewableFiles = results.data.filter(f => f.type !== 'directory')
+    // At the sharings root, next/previous must not leak into files that
+    // belong to another tab. Inside a shared folder the whole content
+    // belongs to the folder's tab and nested files are unknown to the
+    // sharing context (isOwner would misclassify them), so the tab filter
+    // only applies at the root.
+    const viewableFiles = results.data.filter(
+      f =>
+        f.type !== 'directory' &&
+        (currentFolderId || getSharingsTabForEntry(f, isOwner) === tab)
+    )
     const basePath = currentFolderId
       ? `/sharings/${currentFolderId}`
       : '/sharings'
@@ -25,8 +42,10 @@ const FilesViewerSharing = ({ sharedDocumentIds }) => {
       <FilesViewer
         files={viewableFiles}
         filesQuery={results}
-        onClose={() => navigate(basePath)}
-        onChange={fileId => navigate(`${basePath}/file/${fileId}`)}
+        onClose={() => navigate({ pathname: basePath, search })}
+        onChange={fileId =>
+          navigate({ pathname: `${basePath}/file/${fileId}`, search })
+        }
       />
     )
   } else {

--- a/src/modules/views/Sharings/FilesViewerSharings.spec.jsx
+++ b/src/modules/views/Sharings/FilesViewerSharings.spec.jsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+import { useQuery } from 'cozy-client'
+import { useSharingContext } from 'cozy-sharing'
+
+import FilesViewerSharings from './FilesViewerSharings'
+
+const mockNavigate = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate
+}))
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+jest.mock('cozy-sharing', () => ({
+  useSharingContext: jest.fn()
+}))
+jest.mock('./withSharedDocumentIds', () => Component => {
+  const React = require('react')
+  const WithSharedDocumentIds = props =>
+    React.createElement(Component, {
+      ...props,
+      sharedDocumentIds: ['file-owned', 'file-received']
+    })
+  return WithSharedDocumentIds
+})
+jest.mock('@/modules/viewer/FilesViewer', () => {
+  const React = require('react')
+  const FilesViewer = ({ files, onClose, onChange }) =>
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(
+        'div',
+        { 'data-testid': 'viewer-files' },
+        files.map(f => f._id).join(',')
+      ),
+      React.createElement(
+        'button',
+        { onClick: () => onClose() },
+        'close-viewer'
+      ),
+      React.createElement(
+        'button',
+        { onClick: () => onChange('file-owned') },
+        'change-file'
+      )
+    )
+  return FilesViewer
+})
+
+const ownedFile = { _id: 'file-owned', id: 'file-owned', type: 'file' }
+const receivedFile = { _id: 'file-received', id: 'file-received', type: 'file' }
+const someDirectory = { _id: 'dir-1', id: 'dir-1', type: 'directory' }
+
+const setup = ({
+  route = `/sharings/file/${receivedFile._id}?tab=with-me`,
+  path = '/sharings/file/:fileId'
+} = {}) =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path={path} element={<FilesViewerSharings />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('FilesViewerSharings', () => {
+  beforeEach(() => {
+    useQuery.mockReturnValue({
+      data: [ownedFile, receivedFile, someDirectory]
+    })
+    useSharingContext.mockReturnValue({
+      isOwner: id => id === ownedFile._id
+    })
+  })
+
+  it('pages only through the files of the active tab at the sharings root', () => {
+    setup({ route: `/sharings/file/${receivedFile._id}?tab=with-me` })
+
+    expect(screen.getByTestId('viewer-files').textContent).toBe(
+      receivedFile._id
+    )
+  })
+
+  it('pages only through owned files on the by-me tab', () => {
+    setup({ route: `/sharings/file/${ownedFile._id}?tab=by-me` })
+
+    expect(screen.getByTestId('viewer-files').textContent).toBe(ownedFile._id)
+  })
+
+  it('keeps the tab in the URL when closing the viewer', () => {
+    setup({ route: `/sharings/file/${receivedFile._id}?tab=with-me` })
+
+    fireEvent.click(screen.getByText('close-viewer'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/sharings',
+      search: '?tab=with-me'
+    })
+  })
+
+  it('keeps the tab in the URL when the viewer changes file', () => {
+    setup({ route: `/sharings/file/${receivedFile._id}?tab=with-me` })
+
+    fireEvent.click(screen.getByText('change-file'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: `/sharings/file/${ownedFile._id}`,
+      search: '?tab=with-me'
+    })
+  })
+
+  it('does not tab-filter the viewer inside a shared folder', () => {
+    // A folder belongs wholly to one tab, and its nested files are unknown
+    // to the sharing context (isOwner would misclassify them), so the tab
+    // filter only applies at the sharings root.
+    setup({
+      route: `/sharings/folder-1/file/${receivedFile._id}?tab=with-me`,
+      path: '/sharings/:folderId/file/:fileId'
+    })
+
+    expect(screen.getByTestId('viewer-files').textContent).toBe(
+      `${ownedFile._id},${receivedFile._id}`
+    )
+
+    fireEvent.click(screen.getByText('close-viewer'))
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/sharings/folder-1',
+      search: '?tab=with-me'
+    })
+  })
+})


### PR DESCRIPTION
> Rebased onto master — #4051 (the tabs UI + filtering this builds on) is merged.

## What

Fifth subtask of #3975 (Sharings tabs): the active tab survives all in-section navigation, and the viewer stops leaking across tabs. With URL-only tab state (#4037, no storage fallback), any navigation that drops the query string resets the tab — and `FilesViewerSharings` paged through **every** shared file, so next/previous could cross from one tab's files into another's.

Part of #3975
Closes #4041



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserved the selected Sharings tab during navigation across breadcrumbs, file links, and the sharings viewer.
  - Applied tab-based filtering to file lists at the Sharings root (and avoided applying it to nested shared content).

- **Bug Fixes**
  - Prevented `?tab=...` from carrying into non-sharings routes.
  - Ensured closing/changing files in the viewer retains the active tab query parameter.

- **Tests**
  - Expanded unit tests for tab extraction/preservation, breadcrumb navigation behavior, and viewer filtering/navigation transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->