### PR TITLE
feat: hide the team drives tab while it has no content

### DIFF
--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -22,6 +22,7 @@ import { useFolderViewBase } from '../Folder/hooks/useFolderViewBase'
 import FolderViewBodyVz from '../Folder/virtualized/FolderViewBody'
 
 import useHead from '@/components/useHead'
+import { SHARING_TAB_DRIVES } from '@/constants/config'
 import { useFolderSort } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import {
@@ -53,7 +54,6 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   useHead({ title: base.t('breadcrumb.title_sharings') })
   const [sortOrder, setSortOrder, isSettingsLoaded] = useFolderSort('sharings')
   const [tab, setTab] = useSharingsTab()
-  const showDrives = areDrivesAvailable()
 
   const query = useMemo(
     () =>
@@ -65,11 +65,19 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   )
   const result = useQuery(query.definition, query.options)
 
-  const { filteredResult, sharedDrivesLoaded } = useFilteredSharings({
-    result,
-    sharedDocumentIds,
-    tab
-  })
+  const { filteredResult, sharedDrivesLoaded, hasDrives } = useFilteredSharings(
+    {
+      result,
+      sharedDocumentIds,
+      tab
+    }
+  )
+
+  // The Team drives tab only shows while it has content; it stays rendered
+  // when it is the active tab so a ?tab=drives deep link keeps a visible,
+  // consistent control (the list then shows the empty state).
+  const showDrives =
+    areDrivesAvailable() && (hasDrives || tab === SHARING_TAB_DRIVES)
 
   useKeyboardShortcuts({
     onPaste: () => refresh(),

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -52,6 +52,18 @@ import { buildSharingsQuery } from '@/queries'
 const shouldShowDrivesTab = ({ hasDrives, tab }) =>
   areDrivesAvailable() && (hasDrives || tab === SHARING_TAB_DRIVES)
 
+const useSharingsQueryResult = (sharedDocumentIds, allLoaded) => {
+  const query = useMemo(
+    () =>
+      buildSharingsQuery({
+        ids: sharedDocumentIds,
+        enabled: allLoaded && sharedDocumentIds?.length > 0
+      }),
+    [sharedDocumentIds, allLoaded]
+  )
+  return useQuery(query.definition, query.options)
+}
+
 export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const base = useFolderViewBase()
   const sharingContext = useSharingContext()
@@ -61,15 +73,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const [sortOrder, setSortOrder, isSettingsLoaded] = useFolderSort('sharings')
   const [tab, setTab] = useSharingsTab()
 
-  const query = useMemo(
-    () =>
-      buildSharingsQuery({
-        ids: sharedDocumentIds,
-        enabled: allLoaded && sharedDocumentIds?.length > 0
-      }),
-    [sharedDocumentIds, allLoaded]
-  )
-  const result = useQuery(query.definition, query.options)
+  const result = useSharingsQueryResult(sharedDocumentIds, allLoaded)
 
   const { filteredResult, sharedDrivesLoaded, hasDrives } = useFilteredSharings(
     {

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -46,6 +46,12 @@ import { shareFileRootSharedDrive } from '@/modules/shareddrives/components/acti
 import { shareSharedDrive } from '@/modules/shareddrives/components/actions/shareSharedDrive'
 import { buildSharingsQuery } from '@/queries'
 
+// The Team drives tab only shows while it has content; it stays rendered
+// when it is the active tab so a ?tab=drives deep link keeps a visible,
+// consistent control (the list then shows the empty state).
+const shouldShowDrivesTab = ({ hasDrives, tab }) =>
+  areDrivesAvailable() && (hasDrives || tab === SHARING_TAB_DRIVES)
+
 export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const base = useFolderViewBase()
   const sharingContext = useSharingContext()
@@ -73,11 +79,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
     }
   )
 
-  // The Team drives tab only shows while it has content; it stays rendered
-  // when it is the active tab so a ?tab=drives deep link keeps a visible,
-  // consistent control (the list then shows the empty state).
-  const showDrives =
-    areDrivesAvailable() && (hasDrives || tab === SHARING_TAB_DRIVES)
+  const showDrives = shouldShowDrivesTab({ hasDrives, tab })
 
   useKeyboardShortcuts({
     onPaste: () => refresh(),

--- a/src/modules/views/Sharings/index.spec.jsx
+++ b/src/modules/views/Sharings/index.spec.jsx
@@ -2,6 +2,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import { useQuery } from 'cozy-client'
+import flag from 'cozy-flags'
 
 import { SharingsView } from './index'
 import {
@@ -40,13 +41,17 @@ jest.mock('cozy-client/dist/hooks/useQuery', () =>
 jest.mock('cozy-keys-lib', () => ({
   useVaultClient: jest.fn()
 }))
+jest.mock('cozy-flags', () => ({
+  __esModule: true,
+  default: jest.fn(() => false)
+}))
 jest.mock('cozy-client/dist/utils', () => ({
   ...jest.requireActual('cozy-client/dist/utils'),
   hasQueryBeenLoaded: jest.fn().mockReturnValue(true)
 }))
 jest.mock('components/useHead', () => jest.fn())
 
-const setup = () => {
+const setup = ({ sharedDrives = [] } = {}) => {
   const { store, client } = setupStoreAndClient()
 
   client.plugins.realtime = {
@@ -56,7 +61,11 @@ const setup = () => {
   client.query = jest.fn().mockReturnValue({ data: [] })
   client.stackClient.fetchJSON = jest
     .fn()
-    .mockReturnValue({ data: [], rows: [] })
+    .mockImplementation((method, route) =>
+      route === '/sharings/drives'
+        ? { data: sharedDrives }
+        : { data: [], rows: [] }
+    )
 
   const rendered = render(
     <AppLike client={client} store={store}>
@@ -94,6 +103,7 @@ describe('Sharings View', () => {
   })
 
   beforeEach(() => {
+    flag.mockImplementation(() => false)
     // isOwner is consumed by useFilteredSharings to classify entries into
     // tabs; false files every fixture under the default with-me tab.
     mockSharingContext.mockReturnValue({
@@ -206,5 +216,56 @@ describe('Sharings View', () => {
       expect(getByText('foobar0')).toBeInTheDocument()
     })
     expect(queryByText('foobar1')).toBeNull()
+  })
+
+  describe('team drives tab visibility', () => {
+    const orgDriveSharing = {
+      id: 'sharing-org',
+      _id: 'sharing-org',
+      org_drive: true,
+      rules: [{ title: 'Org Drive', values: ['folder-org'] }]
+    }
+
+    beforeEach(() => {
+      flag.mockImplementation(name => name === 'drive.shared-drive.enabled')
+    })
+
+    it('hides the team drives tab when there are no org drives', async () => {
+      useQuery.mockReturnValue(filesFixtureWithPath)
+
+      const { getByRole, queryByRole } = setup()
+
+      await waitFor(() => {
+        expect(getByRole('tab', { name: 'With me' })).toBeInTheDocument()
+      })
+      expect(queryByRole('tab', { name: 'Team drives' })).toBeNull()
+    })
+
+    it('shows the team drives tab once an org drive exists', async () => {
+      useQuery.mockReturnValue(filesFixtureWithPath)
+
+      const { getByRole } = setup({ sharedDrives: [orgDriveSharing] })
+
+      await waitFor(() => {
+        expect(getByRole('tab', { name: 'Team drives' })).toBeInTheDocument()
+      })
+    })
+
+    it('renders the drives tab when deep-linked even without drives', async () => {
+      // The ?tab= URL contract is kept: a deep link opens the tab and the
+      // active pill renders even while the tab has no content.
+      window.location.hash = '#/sharings?tab=drives'
+      useQuery.mockReturnValue(filesFixtureWithPath)
+
+      const { getByRole } = setup()
+
+      await waitFor(() => {
+        expect(getByRole('tab', { name: 'Team drives' })).toBeInTheDocument()
+      })
+      expect(getByRole('tab', { name: 'Team drives' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
   })
 })

--- a/src/modules/views/Sharings/useFilteredSharings.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.jsx
@@ -126,6 +126,10 @@ const computeData = ({
  * the same document, preferring the real Drive entry over the shared-drives
  * synthetic entry. When `tab` is provided, keeps only the entries belonging
  * to that tab (see getSharingsTabForEntry).
+ *
+ * Also exposes `hasDrives`: whether any entry classifies onto the drives
+ * tab, computed from the same deduplicated list regardless of the active
+ * tab, so the view can hide the Team drives tab while it has no content.
  */
 export const useFilteredSharings = ({ result, sharedDocumentIds, tab }) => {
   const isEnabledSharedDrive = flag('drive.shared-drive.enabled')
@@ -143,7 +147,7 @@ export const useFilteredSharings = ({ result, sharedDocumentIds, tab }) => {
 
   const { isOwner } = useSharingContext()
 
-  const filteredResult = useMemo(() => {
+  const { filteredResult, hasDrives } = useMemo(() => {
     const hasIds = sharedDocumentIds?.length > 0
     // Filter by tab only after deduplication so each document lands in
     // exactly one tab.
@@ -156,7 +160,16 @@ export const useFilteredSharings = ({ result, sharedDocumentIds, tab }) => {
     const data = tab
       ? combined.filter(entry => getSharingsTabForEntry(entry, isOwner) === tab)
       : combined
-    return { ...buildBaseShape(result, hasIds), data, count: data.length }
+    return {
+      filteredResult: {
+        ...buildBaseShape(result, hasIds),
+        data,
+        count: data.length
+      },
+      hasDrives: combined.some(
+        entry => getSharingsTabForEntry(entry, isOwner) === SHARING_TAB_DRIVES
+      )
+    }
   }, [
     withoutSharedDrives,
     transformedSharedDrives,
@@ -171,6 +184,7 @@ export const useFilteredSharings = ({ result, sharedDocumentIds, tab }) => {
   // so don't block the page on that hook's load state.
   return {
     filteredResult,
+    hasDrives,
     sharedDrivesLoaded: withoutSharedDrives || sharedDrivesLoaded
   }
 }

--- a/src/modules/views/Sharings/useFilteredSharings.spec.jsx
+++ b/src/modules/views/Sharings/useFilteredSharings.spec.jsx
@@ -443,5 +443,65 @@ describe('useFilteredSharings', () => {
       expect(renderTab(SHARING_TAB_WITH_ME)).toEqual([])
       expect(renderTab(SHARING_TAB_BY_ME)).toEqual([])
     })
+
+    it('exposes hasDrives when an org drive is present, whatever the active tab', () => {
+      setupTabMocks()
+
+      const { result: hook } = renderHook(() =>
+        useFilteredSharings({
+          result: {
+            data: [...classicShares, orgDrive],
+            fetchStatus: 'loaded',
+            lastFetch: Date.now()
+          },
+          sharedDocumentIds: [ownedFolder._id],
+          tab: SHARING_TAB_WITH_ME
+        })
+      )
+
+      expect(hook.current.hasDrives).toBe(true)
+    })
+
+    it('reports no drives content when only non-org federated drives exist', () => {
+      // Federated drives classify onto with-me/by-me, so they must not
+      // make the drives tab appear.
+      mockFlag.mockImplementation(name => name === 'drive.shared-drive.enabled')
+      mockUseTransform.mockReturnValue({
+        sharedDrives: [ownedFederatedDrive, receivedFederatedDrive],
+        nonSharedDriveList: classicShares,
+        sharedDrivesLoaded: true
+      })
+
+      const { result: hook } = renderHook(() =>
+        useFilteredSharings({
+          result: {
+            data: classicShares,
+            fetchStatus: 'loaded',
+            lastFetch: Date.now()
+          },
+          sharedDocumentIds: [ownedFolder._id],
+          tab: SHARING_TAB_WITH_ME
+        })
+      )
+
+      expect(hook.current.hasDrives).toBe(false)
+    })
+
+    it('reports no drives content when shared drives are disabled', () => {
+      setupTabMocks({ drivesEnabled: false })
+
+      const { result: hook } = renderHook(() =>
+        useFilteredSharings({
+          result: {
+            data: [...classicShares, orgDrive],
+            fetchStatus: 'loaded',
+            lastFetch: Date.now()
+          },
+          sharedDocumentIds: [ownedFolder._id]
+        })
+      )
+
+      expect(hook.current.hasDrives).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
## What

UX improvement on the Sharings tabs (#3975): the **Team drives** tab is now shown only while it actually has content. Previously it was purely flag-gated, so instances with the shared-drive flags on but no org drive showed a tab opening onto an empty state.

> Deliberate design change: this supersedes #4039's "visible (with empty content) when flags are on and no org drive exists yet" acceptance criterion.

## How

- `useFilteredSharings` exposes `hasDrives`, computed inside its existing memo with the same classifier (`getSharingsTabForEntry`) over the same deduplicated pre-tab-filter list the drives tab renders — so "empty" can never drift from what the tab would show, and there is no duplicate `useSharedDrives` fetch.

Part of #3975


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab visibility for shared/organization drives based on actual drive availability and filtering results.
  * Kept the drives tab accessible via direct deep links (e.g., `?tab=drives`), even when the current list is empty.

* **Tests**
  * Expanded automated coverage for team drives and drives-tab visibility across scenarios: drives available, unavailable, and disabled via flags.
  * Added assertions for correct behavior when deep-linking to the drives tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->