### PR TITLE
perf(file-picker): remove broad cozy force splitting

### DIFF
--- a/rsbuild.config.mjs
+++ b/rsbuild.config.mjs
@@ -31,6 +31,18 @@ const templates = {
 
 config.environments = {
   web: {
+    performance: {
+      chunkSplit: {
+        // The inherited config forces every cozy-* dependency into one broad
+        // chunk, so the intent downloads unrelated Drive capabilities.
+        forceSplitting: {},
+        override: {
+          cacheGroups: {
+            cozy: false
+          }
+        }
+      }
+    },
     html: {
       template: ({ entryName }) => templates[entryName]
     },


### PR DESCRIPTION
This will significantly reduce bundle size for file picker intent.
I did not apply it to global rsbuild config because I am not sure of the consequences on other apps.

I tested this modification with multiple manual tests and e2e tests. See https://github.com/linagora/twake-drive/pull/3674 for more details

related to #4057 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved web build chunking to produce more consistent dependency bundles.
  * Updated asset splitting behavior to support more efficient delivery and loading of web application resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->