### PR TITLE
perf(file-picker): stop loading viewer styles

### DIFF
--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -2,7 +2,6 @@
 
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'cozy-ui/dist/cozy-ui.utils.min.css'
-import 'cozy-viewer/dist/stylesheet.css'
 import 'cozy-sharing/dist/stylesheet.css'
 
 import 'whatwg-fetch'


### PR DESCRIPTION
Keep sharing styles in the intent while removing viewer-only CSS from its startup assets. 

I tested this modification with multiple manual tests and e2e tests. See https://github.com/linagora/twake-drive/pull/3674 for more details

related to #4057 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary stylesheet import to prevent potential styling conflicts in the intent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->