### PR TITLE
feat:  Remove encrypted-file support

### DIFF
--- a/src/components/FolderPicker/FolderPicker.spec.jsx
+++ b/src/components/FolderPicker/FolderPicker.spec.jsx
@@ -8,10 +8,6 @@ import AppLike from 'test/components/AppLike'
 
 import { FolderPicker } from '@/components/FolderPicker/FolderPicker'
 
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
-
 jest.mock('cozy-sharing', () => ({
   ...jest.requireActual('cozy-sharing'),
   useSharingContext: jest.fn(),

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -182,10 +182,6 @@ declare module 'cozy-ui/transpiled/react/Typography' {
   export default Typography
 }
 
-declare module 'cozy-keys-lib' {
-  export const useVaultClient: () => object
-}
-
 declare module '*.styl' {
   const content: Record<string, string>
   export default content

--- a/src/hooks/useMoreMenuActions.jsx
+++ b/src/hooks/useMoreMenuActions.jsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { useClient } from 'cozy-client'
 import { fetchBlobFileById, isFile } from 'cozy-client/dist/models/file'
 import { useWebviewIntent } from 'cozy-intent'
-import { useVaultClient } from 'cozy-keys-lib'
 import {
   useSharingContext,
   useNativeFileSharing,
@@ -37,7 +36,6 @@ export const useMoreMenuActions = (
 ) => {
   const [isPrintAvailable, setIsPrintAvailable] = useState(false)
   const client = useClient()
-  const vaultClient = useVaultClient()
   const webviewIntent = useWebviewIntent()
   const { t, lang } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -79,7 +77,6 @@ export const useMoreMenuActions = (
       client,
       t,
       lang,
-      vaultClient,
       pushModal,
       popModal,
       refresh: () => navigate('..'),

--- a/src/hooks/useMoreMenuActions.spec.jsx
+++ b/src/hooks/useMoreMenuActions.spec.jsx
@@ -6,9 +6,6 @@ import { createMockClient } from 'cozy-client'
 import { useMoreMenuActions } from './useMoreMenuActions'
 import AppLike from 'test/components/AppLike'
 
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
 jest.mock('cozy-intent', () => ({
   useWebviewIntent: jest.fn()
 }))

--- a/src/lib/DriveProvider.jsx
+++ b/src/lib/DriveProvider.jsx
@@ -3,11 +3,6 @@ import React from 'react'
 
 import { CozyProvider } from 'cozy-client'
 import { DataProxyProvider } from 'cozy-dataproxy-lib'
-import {
-  VaultUnlockProvider,
-  VaultProvider,
-  VaultUnlockPlaceholder
-} from 'cozy-keys-lib'
 import SharingProvider, { NativeFileSharingProvider } from 'cozy-sharing'
 import AlertProvider from 'cozy-ui/transpiled/react/providers/Alert'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -26,28 +21,23 @@ const DriveProvider = ({ client, lang, polyglot, dictRequire, children }) => {
     <I18n lang={lang} polyglot={polyglot} dictRequire={dictRequire}>
       <CozyProvider client={client}>
         <DataProxyWrapper isPublic={isPublic}>
-          <VaultProvider cozyClient={client}>
-            <VaultUnlockProvider>
-              <SharingProvider
-                doctype="io.cozy.files"
-                documentType="Files"
-                isPublic={isPublic}
-              >
-                <NativeFileSharingProvider>
-                  <CozyTheme ignoreCozySettings={isPublic} className="u-w-100">
-                    <BreakpointsProvider>
-                      <AlertProvider>
-                        <VaultUnlockPlaceholder />
-                        <FabProvider>
-                          <RightClickProvider>{children}</RightClickProvider>
-                        </FabProvider>
-                      </AlertProvider>
-                    </BreakpointsProvider>
-                  </CozyTheme>
-                </NativeFileSharingProvider>
-              </SharingProvider>
-            </VaultUnlockProvider>
-          </VaultProvider>
+          <SharingProvider
+            doctype="io.cozy.files"
+            documentType="Files"
+            isPublic={isPublic}
+          >
+            <NativeFileSharingProvider>
+              <CozyTheme ignoreCozySettings={isPublic} className="u-w-100">
+                <BreakpointsProvider>
+                  <AlertProvider>
+                    <FabProvider>
+                      <RightClickProvider>{children}</RightClickProvider>
+                    </FabProvider>
+                  </AlertProvider>
+                </BreakpointsProvider>
+              </CozyTheme>
+            </NativeFileSharingProvider>
+          </SharingProvider>
         </DataProxyWrapper>
       </CozyProvider>
     </I18n>

--- a/src/lib/doctypes.js
+++ b/src/lib/doctypes.js
@@ -4,7 +4,6 @@ import { Contact, Group } from '@/models'
 export const DOCTYPE_FILES = 'io.cozy.files'
 export const DOCTYPE_FILES_SETTINGS = 'io.cozy.files.settings'
 export const DOCTYPE_DRIVE_SETTINGS = 'io.cozy.drive.settings'
-export const DOCTYPE_FILES_ENCRYPTION = 'io.cozy.files.encryption'
 export const DOCTYPE_FILES_SHORTCUT = 'io.cozy.files.shortcuts'
 export const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 export const DOCTYPE_PHOTOS_SETTINGS = 'io.cozy.photos.settings'
@@ -24,10 +23,6 @@ export const schema = {
       old_versions: {
         type: 'has-many',
         doctype: 'io.cozy.files.versions'
-      },
-      encryption: {
-        type: 'io.cozy.files:has-many',
-        doctype: DOCTYPE_FILES_ENCRYPTION
       }
     }
   },

--- a/src/modules/actions/types.ts
+++ b/src/modules/actions/types.ts
@@ -59,7 +59,6 @@ export interface ActionContext {
   client?: unknown
   t?: (key: string, options?: Record<string, unknown>) => string
   lang?: string
-  vaultClient?: unknown
   pushModal?: (modal: React.ReactNode) => void
   popModal?: () => void
   refresh?: () => void

--- a/src/modules/drive/AddMenu/AddMenuContent.spec.jsx
+++ b/src/modules/drive/AddMenu/AddMenuContent.spec.jsx
@@ -11,9 +11,6 @@ import { setupFolderContent, mockCozyClientRequestQuery } from 'test/setup'
 import { ScannerProvider } from '@/modules/drive/Toolbar/components/Scanner/ScannerProvider'
 
 jest.mock('cozy-client/dist/hooks/useAppLinkWithStoreFallback', () => jest.fn())
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
 jest.mock('cozy-flags')
 mockCozyClientRequestQuery()
 

--- a/src/modules/filelist/AddFolder.spec.jsx
+++ b/src/modules/filelist/AddFolder.spec.jsx
@@ -14,12 +14,6 @@ jest.mock('lib/logger', () => ({
 }))
 
 jest.mock('cozy-flags', () => jest.fn())
-jest.mock('cozy-keys-lib', () => ({
-  withVaultClient: jest.fn().mockReturnValue({}),
-  useVaultClient: jest.fn(),
-  WebVaultClient: jest.fn().mockReturnValue({})
-}))
-
 describe('AddFolder', () => {
   const setup = () => {
     const { client, store } = setupStoreAndClient({})

--- a/src/modules/filelist/virtualized/cells/columns/TempDirectoryCell.jsx
+++ b/src/modules/filelist/virtualized/cells/columns/TempDirectoryCell.jsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { useVaultClient } from 'cozy-keys-lib'
-
 import AddFolder from '@/modules/filelist/AddFolder'
 
 /**
@@ -15,11 +13,9 @@ const TempDirectoryCell = ({
   refreshFolderContent,
   driveId
 }) => {
-  const vaultClient = useVaultClient()
   if (column.id === 'name') {
     return (
       <AddFolder
-        vaultClient={vaultClient}
         currentFolderId={currentFolderId}
         refreshFolderContent={refreshFolderContent}
         driveId={driveId}

--- a/src/modules/folder/components/FolderBody.jsx
+++ b/src/modules/folder/components/FolderBody.jsx
@@ -1,7 +1,6 @@
 import cx from 'classnames'
 import React, { useCallback } from 'react'
 
-import { useVaultClient } from 'cozy-keys-lib'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import styles from '@/styles/folder-view.styl'
@@ -52,7 +51,6 @@ const FolderBody = ({
   canInteractWith,
   driveId
 }) => {
-  const vaultClient = useVaultClient()
   const { isDesktop } = useBreakpoints()
 
   useScrollToTop(folderId)
@@ -104,7 +102,6 @@ const FolderBody = ({
               )}
             >
               <AddFolder
-                vaultClient={vaultClient}
                 refreshFolderContent={refreshFolderContent}
                 currentFolderId={folderId}
                 driveId={driveId}
@@ -124,7 +121,6 @@ const FolderBody = ({
               )}
             >
               <AddFolder
-                vaultClient={vaultClient}
                 refreshFolderContent={refreshFolderContent}
                 currentFolderId={folderId}
                 driveId={driveId}

--- a/src/modules/navigation/Index.spec.js
+++ b/src/modules/navigation/Index.spec.js
@@ -6,10 +6,6 @@ import { SHAREDWITHME_DIR_ID } from '@/constants/config'
 
 const mockFileModels = require('cozy-client/dist/models/file')
 
-jest.mock('cozy-keys-lib', () => ({
-  withVaultClient: jest.fn().mockReturnValue({}),
-  useVaultClient: jest.fn()
-}))
 const client = createMockClient({})
 const navigate = jest.fn()
 const setSharingsValue = jest.fn()

--- a/src/modules/public/LightFileViewer.spec.jsx
+++ b/src/modules/public/LightFileViewer.spec.jsx
@@ -8,10 +8,6 @@ import I18n from 'twake-i18n'
 import LightFileViewer from './LightFileViewer'
 import AppLike from 'test/components/AppLike'
 
-jest.mock('cozy-keys-lib', () => ({
-  ...jest.requireActual('cozy-keys-lib'),
-  useVaultClient: jest.fn()
-}))
 jest.mock('cozy-intent', () => ({
   WebviewIntentProvider: ({ children }) => children,
   useWebviewIntent: () => ({ call: () => {} })

--- a/src/modules/public/PublicToolbarByLink.jsx
+++ b/src/modules/public/PublicToolbarByLink.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { useClient } from 'cozy-client'
-import { useVaultClient } from 'cozy-keys-lib'
 import { createCozySharingLink, useSharingInfos } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
@@ -29,7 +28,6 @@ const PublicToolbarByLink = ({
   const { t } = useI18n()
   const { showAlert } = useAlert()
   const client = useClient()
-  const vaultClient = useVaultClient()
   const { createCozyLink } = useSharingInfos()
 
   const isMoreMenuDisplayed = files.length > 1
@@ -46,7 +44,6 @@ const PublicToolbarByLink = ({
       t,
       showAlert,
       client,
-      vaultClient,
       showSelectionBar,
       createCozyLink,
       hasWriteAccess

--- a/src/modules/public/PublicToolbarCozyToCozy.jsx
+++ b/src/modules/public/PublicToolbarCozyToCozy.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { useClient } from 'cozy-client'
-import { useVaultClient } from 'cozy-keys-lib'
 import {
   addToCozySharingLink,
   syncToCozySharingLink,
@@ -34,7 +33,6 @@ const PublicToolbarCozyToCozy = ({ sharingInfos, files }) => {
   const { showAlert } = useAlert()
   const client = useClient()
   const { showSelectionBar } = useSelectionContext()
-  const vaultClient = useVaultClient()
   const currentFolderId = useCurrentFolderId()
   // Sharing can be a folder or a file
   const itemId = currentFolderId ?? files[0]?._id
@@ -54,7 +52,6 @@ const PublicToolbarCozyToCozy = ({ sharingInfos, files }) => {
       t,
       showAlert,
       client,
-      vaultClient,
       showSelectionBar,
       isSharingShortcutCreated,
       addSharingLink,

--- a/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
+++ b/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
@@ -3,7 +3,6 @@ import { useDispatch } from 'react-redux'
 import { useNavigate, useLocation, useParams } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
-import { useVaultClient } from 'cozy-keys-lib'
 import { useSharingContext } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
@@ -32,7 +31,6 @@ const SharedDriveFolderBody = ({
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const client = useClient()
-  const vaultClient = useVaultClient()
   const { driveId } = useParams()
   const { t } = useI18n()
   const { isOwner, byDocId, hasWriteAccess, refresh } = useSharingContext()
@@ -46,7 +44,6 @@ const SharedDriveFolderBody = ({
   const actionsOptions = {
     client,
     t,
-    vaultClient,
     pathname,
     isOwner,
     isMobile,

--- a/src/modules/viewer/FilesViewer.spec.jsx
+++ b/src/modules/viewer/FilesViewer.spec.jsx
@@ -10,10 +10,6 @@ import { generateFile } from 'test/generate'
 import { useCurrentFileId } from '@/hooks'
 
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
-
 jest.mock('lib/logger', () => ({
   error: jest.fn()
 }))

--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 
 import flag from 'cozy-flags'
-import { useVaultClient } from 'cozy-keys-lib'
 import {
   useSharingContext,
   useNativeFileSharing,
@@ -64,7 +63,6 @@ const DriveFolderView = () => {
   const { allLoaded, hasWriteAccess, refresh, isOwner, byDocId } =
     sharingContext
   const nativeSharing = useNativeFileSharing()
-  const vaultClient = useVaultClient()
   const { hasClipboardData } = useClipboardContext()
 
   const { displayedFolder, isNotFound } = useDisplayedFolder()
@@ -106,7 +104,6 @@ const DriveFolderView = () => {
   const actionsOptions = {
     ...base,
     ...nativeSharing,
-    vaultClient,
     refresh,
     hasWriteAccess: canWriteToCurrentFolder,
     canMove: true,

--- a/src/modules/views/Drive/DriveFolderView.spec.jsx
+++ b/src/modules/views/Drive/DriveFolderView.spec.jsx
@@ -39,10 +39,6 @@ jest.mock('modules/shareddrives/hooks/useSharedDrives', () => ({
   useSharedDrives: jest.fn().mockReturnValue([])
 }))
 
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
-
 jest.mock('components/useHead', () => jest.fn())
 
 jest.mock('@/modules/shareddrives/hooks/useSharedDriveFolder', () => ({

--- a/src/modules/views/Folder/virtualized/AddFolderWrapper.jsx
+++ b/src/modules/views/Folder/virtualized/AddFolderWrapper.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { useVaultClient } from 'cozy-keys-lib'
 import Table from 'cozy-ui/transpiled/react/Table'
 import TableBody from 'cozy-ui/transpiled/react/TableBody'
 import TableCell from 'cozy-ui/transpiled/react/TableCell'
@@ -18,14 +17,12 @@ const AddFolderWrapper = ({
   refreshFolderContent,
   driveId
 }) => {
-  const vaultClient = useVaultClient()
   const { viewType } = useViewSwitcherContext()
 
   if (viewType === 'grid') {
     return (
       <div className={styles['fil-folder-body-grid']}>
         <AddFolder
-          vaultClient={vaultClient}
           currentFolderId={currentFolderId}
           refreshFolderContent={refreshFolderContent}
           driveId={driveId}
@@ -52,7 +49,6 @@ const AddFolderWrapper = ({
         <TableRow>
           <TableCell className="u-pl-1">
             <AddFolder
-              vaultClient={vaultClient}
               currentFolderId={currentFolderId}
               refreshFolderContent={refreshFolderContent}
               driveId={driveId}

--- a/src/modules/views/Folder/virtualized/Grid.jsx
+++ b/src/modules/views/Folder/virtualized/Grid.jsx
@@ -7,7 +7,6 @@ import React, {
   useState
 } from 'react'
 
-import { useVaultClient } from 'cozy-keys-lib'
 import VirtualizedGridList from 'cozy-ui/transpiled/react/GridList/Virtualized'
 import virtuosoComponents from 'cozy-ui/transpiled/react/GridList/Virtualized/Dnd/virtuosoComponents'
 import CustomDragLayer from 'cozy-ui/transpiled/react/utils/Dnd/CustomDrag/CustomDragLayer'
@@ -69,7 +68,6 @@ const Grid = forwardRef(
     },
     ref
   ) => {
-    const vaultClient = useVaultClient()
     const internalVirtuosoRef = useRef(null)
     const virtuosoRef = parentVirtuosoRef || internalVirtuosoRef
     const [itemsInDropProcess, setItemsInDropProcess] = useState([])
@@ -106,7 +104,6 @@ const Grid = forwardRef(
             </RightClickFileMenu>
           ) : (
             <AddFolder
-              vaultClient={vaultClient}
               currentFolderId={currentFolderId}
               refreshFolderContent={refreshFolderContent}
               driveId={driveId}
@@ -123,7 +120,6 @@ const Grid = forwardRef(
         isReferencedByShareInSharingContext,
         sharingsValue,
         onInteractWithFile,
-        vaultClient,
         currentFolderId,
         driveId
       ]

--- a/src/modules/views/Public/PublicFolderView.spec.jsx
+++ b/src/modules/views/Public/PublicFolderView.spec.jsx
@@ -78,9 +78,6 @@ jest.mock('./usePublicFilesQuery', () => {
   return jest.fn()
 })
 jest.mock('./usePublicWritePermissions', () => jest.fn().mockReturnValue(false))
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
 jest.mock('components/pushClient', () => ({
   isMacOS: jest.fn(() => false),
   isIOS: jest.fn(() => false),

--- a/src/modules/views/Recent/index.loading.spec.jsx
+++ b/src/modules/views/Recent/index.loading.spec.jsx
@@ -26,9 +26,6 @@ jest.mock('cozy-client/dist/hooks/useQuery', () =>
     data: []
   }))
 )
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
 jest.mock('components/useHead', () => jest.fn())
 jest.mock('cozy-sharing', () => ({
   __esModule: true,

--- a/src/modules/views/Recent/index.spec.jsx
+++ b/src/modules/views/Recent/index.spec.jsx
@@ -32,10 +32,6 @@ jest.mock('cozy-client/dist/hooks/useQuery', () =>
     data: []
   }))
 )
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
-
 jest.mock('components/useHead', () => jest.fn())
 jest.mock('cozy-sharing', () => ({
   __esModule: true,

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -4,7 +4,6 @@ import { Outlet, useParams, useNavigate, useLocation } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
 import flag from 'cozy-flags'
-import { useVaultClient } from 'cozy-keys-lib'
 import { useSharingContext } from 'cozy-sharing'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
@@ -59,7 +58,6 @@ const SharedDriveFolderView = () => {
   const { t } = useI18n()
   const { showAlert } = useAlert()
   const dispatch = useDispatch()
-  const vaultClient = useVaultClient()
   const isInRootOfSharedDrive = displayedFolder?.dir_id === SHARED_DRIVES_DIR_ID
   const { isFabDisplayed, setIsFabDisplayed } = useContext(FabContext)
   const { isSelectionBarVisible } = useSelectionContext()
@@ -109,7 +107,6 @@ const SharedDriveFolderView = () => {
     () => ({
       client,
       t,
-      vaultClient,
       pathname,
       isOwner,
       isMobile,
@@ -129,7 +126,6 @@ const SharedDriveFolderView = () => {
     [
       client,
       t,
-      vaultClient,
       pathname,
       isOwner,
       isMobile,

--- a/src/modules/views/Sharings/index.spec.jsx
+++ b/src/modules/views/Sharings/index.spec.jsx
@@ -38,9 +38,6 @@ jest.mock('cozy-client/dist/hooks/useQuery', () =>
     data: []
   }))
 )
-jest.mock('cozy-keys-lib', () => ({
-  useVaultClient: jest.fn()
-}))
 jest.mock('cozy-flags', () => ({
   __esModule: true,
   default: jest.fn(() => false)

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -76,7 +76,6 @@ export const buildDriveQuery: QueryBuilder<buildDriveQueryParams> = ({
         { type: sortOrder },
         { [sortAttribute]: sortOrder }
       ])
-      .include(['encryption'])
       .limitBy(100)
   },
   options: {
@@ -204,7 +203,6 @@ export const buildSharedDriveQuery: QueryBuilder<
         { type: sortOrder },
         { [sortAttribute]: sortOrder }
       ])
-      .include(['encryption'])
       .limitBy(100),
   options: {
     as: formatFolderQueryId(

--- a/test/generate.js
+++ b/test/generate.js
@@ -5,8 +5,7 @@ export const generateFile = ({
   ext,
   path = '/',
   dir_id = 'io.cozy.files.root-dir',
-  updated_at = '',
-  encrypted = false
+  updated_at = ''
 } = {}) => {
   let extension = ext
   if (extension === undefined) {
@@ -38,7 +37,6 @@ export const generateFile = ({
     path: `${path === '/' ? '' : path}/${prefix}${i}${extension}`,
     type,
     _type: 'io.cozy.files',
-    encrypted,
     ...optional
   }
 }

--- a/test/setup.jsx
+++ b/test/setup.jsx
@@ -12,25 +12,6 @@ import configureStore from '../src/store/configureStore'
 import AppLike from 'test/components/AppLike'
 import FolderContent from 'test/components/FolderContent'
 
-jest.mock('cozy-keys-lib', () => ({
-  withVaultClient: BaseComponent => {
-    const Component = props => (
-      <>
-        {({ vaultClient }) => (
-          <BaseComponent vaultClient={vaultClient} {...props} />
-        )}
-      </>
-    )
-
-    Component.displayName = `withVaultClient(${
-      BaseComponent.displayName || BaseComponent.name
-    })`
-
-    return Component
-  },
-  useVaultClient: jest.fn()
-}))
-
 configure({ testIdAttribute: 'data-testid' })
 
 export const mockCozyClientRequestQuery = dir_id => {


### PR DESCRIPTION
 Why

 The encrypted-file integration is no longer supported and its related code is obsolete.

 How

 - Remove cozy-keys-lib usage and mocks.
 - Remove vault providers from DriveProvider.
 - Remove encryption doctypes, schema entries, and action context fields.
 - Remove vault client props from file and sharing components.
 - Update affected tests and test setup.

 Testing

 Tests were updated to remove encrypted-file mocks and dependencies.

I tested this modification with multiple manual tests and e2e tests. See https://github.com/linagora/twake-drive/pull/3674 for more details

related to #4057 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified file and folder actions by removing reliance on legacy vault-specific services.
  * Streamlined provider setup and action configuration across drive, folder, sharing, and public views.
  * Removed obsolete file encryption metadata and encryption-related query includes.

* **Tests**
  * Updated test setup and mocks to reflect the simplified service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->