### PR TITLE
perf(file-picker): Prefetch the file picker’s root folder while the intent handshake is pending.

### DIFF
--- a/src/modules/services/components/IntentHandler.jsx
+++ b/src/modules/services/components/IntentHandler.jsx
@@ -9,6 +9,18 @@ import Picker from './Picker'
 
 import { ROOT_DIR_ID } from '@/constants/config'
 
+async function initPicker(client) {
+  const rootFolderQuery = buildContentFolderQuery(ROOT_DIR_ID)
+
+  try {
+    await client.query(rootFolderQuery.definition(), rootFolderQuery.options)
+  } catch (error) {
+    logger.warn('File Picker root prefetch failed', error)
+  }
+
+  return Picker
+}
+
 const IntentHandler = ({ intentId }) => {
   const client = useClient()
 
@@ -22,33 +34,22 @@ const IntentHandler = ({ intentId }) => {
 
   useEffect(() => {
     const startService = async () => {
-      let component
       let service
-      let intent
       try {
         const intents = new Intents({ client })
+        // createService exposes the intent only after the handshake, so fetch it separately to start prefetching earlier
         const intentPromise = intents.request.get(intentId)
         const servicePromise = intents.createService(intentId, window)
         const pendingIntent = await intentPromise
-        let rootFolderPrefetch = null
-
-        if (
+        const pickerInitialization =
           pendingIntent.attributes.action === 'PICK' &&
           pendingIntent.attributes.type === 'io.cozy.files'
-        ) {
-          component = Picker
-          const rootFolderQuery = buildContentFolderQuery(ROOT_DIR_ID)
-          rootFolderPrefetch = client
-            .query(rootFolderQuery.definition(), rootFolderQuery.options)
-            .catch(error => {
-              logger.warn('File Picker root prefetch failed', error)
-              return null
-            })
-        }
+            ? initPicker(client)
+            : null
 
         service = await servicePromise
-        intent = service.getIntent()
-        await rootFolderPrefetch
+        const intent = service.getIntent()
+        const component = await pickerInitialization
 
         setState({
           component,

--- a/src/modules/services/components/IntentHandler.jsx
+++ b/src/modules/services/components/IntentHandler.jsx
@@ -26,25 +26,29 @@ const IntentHandler = ({ intentId }) => {
       let service
       let intent
       try {
-        const rootFolderQuery = buildContentFolderQuery(ROOT_DIR_ID)
-        const rootFolderPrefetch = client
-          .query(rootFolderQuery.definition(), rootFolderQuery.options)
-          .catch(error => {
-            logger.warn('File Picker root prefetch failed', error)
-            return null
-          })
-
         const intents = new Intents({ client })
-        service = await intents.createService(intentId, window)
-        intent = service.getIntent()
+        const intentPromise = intents.request.get(intentId)
+        const servicePromise = intents.createService(intentId, window)
+        const pendingIntent = await intentPromise
+        let rootFolderPrefetch = null
 
         if (
-          intent.attributes.action === 'PICK' &&
-          intent.attributes.type === 'io.cozy.files'
+          pendingIntent.attributes.action === 'PICK' &&
+          pendingIntent.attributes.type === 'io.cozy.files'
         ) {
-          await rootFolderPrefetch
           component = Picker
+          const rootFolderQuery = buildContentFolderQuery(ROOT_DIR_ID)
+          rootFolderPrefetch = client
+            .query(rootFolderQuery.definition(), rootFolderQuery.options)
+            .catch(error => {
+              logger.warn('File Picker root prefetch failed', error)
+              return null
+            })
         }
+
+        service = await servicePromise
+        intent = service.getIntent()
+        await rootFolderPrefetch
 
         setState({
           component,

--- a/src/modules/services/components/IntentHandler.jsx
+++ b/src/modules/services/components/IntentHandler.jsx
@@ -4,7 +4,10 @@ import { useClient } from 'cozy-client'
 import Intents from 'cozy-interapp'
 import logger from 'cozy-logger'
 
+import { buildContentFolderQuery } from './FilePicker/queries'
 import Picker from './Picker'
+
+import { ROOT_DIR_ID } from '@/constants/config'
 
 const IntentHandler = ({ intentId }) => {
   const client = useClient()
@@ -23,6 +26,14 @@ const IntentHandler = ({ intentId }) => {
       let service
       let intent
       try {
+        const rootFolderQuery = buildContentFolderQuery(ROOT_DIR_ID)
+        const rootFolderPrefetch = client
+          .query(rootFolderQuery.definition(), rootFolderQuery.options)
+          .catch(error => {
+            logger.warn('File Picker root prefetch failed', error)
+            return null
+          })
+
         const intents = new Intents({ client })
         service = await intents.createService(intentId, window)
         intent = service.getIntent()
@@ -31,6 +42,7 @@ const IntentHandler = ({ intentId }) => {
           intent.attributes.action === 'PICK' &&
           intent.attributes.type === 'io.cozy.files'
         ) {
+          await rootFolderPrefetch
           component = Picker
         }
 

--- a/src/modules/services/components/IntentHandler.spec.jsx
+++ b/src/modules/services/components/IntentHandler.spec.jsx
@@ -1,0 +1,102 @@
+import { act, render, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import { buildContentFolderQuery } from './FilePicker/queries'
+import IntentHandler from './IntentHandler'
+
+const mockClient = { query: jest.fn() }
+const mockCreateService = jest.fn()
+const mockRootFolderDefinition = { doctype: 'io.cozy.files' }
+const mockRootFolderOptions = {
+  as: 'buildContentFolderQuery-io.cozy.files.root-dir',
+  fetchPolicy: jest.fn()
+}
+
+jest.mock('cozy-client', () => ({
+  useClient: () => mockClient
+}))
+
+jest.mock('cozy-interapp', () =>
+  jest.fn().mockImplementation(() => ({ createService: mockCreateService }))
+)
+
+jest.mock('./FilePicker/queries', () => ({
+  buildContentFolderQuery: jest.fn()
+}))
+
+jest.mock('cozy-logger', () => ({
+  error: jest.fn(),
+  warn: jest.fn()
+}))
+
+jest.mock('./Picker', () => () => <div data-testid="picker" />)
+
+function makeDeferredPromise() {
+  let resolvePromise
+  const promise = new Promise(resolve => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}
+
+describe('IntentHandler', () => {
+  beforeEach(() => {
+    buildContentFolderQuery.mockReturnValue({
+      definition: () => mockRootFolderDefinition,
+      options: mockRootFolderOptions
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('prefetches the root folder while the intent handshake is pending', async () => {
+    const handshake = makeDeferredPromise()
+    const rootFolderPrefetch = makeDeferredPromise()
+    mockCreateService.mockReturnValue(handshake.promise)
+    mockClient.query.mockReturnValue(rootFolderPrefetch.promise)
+
+    const { getByTestId, queryByTestId } = render(
+      <IntentHandler intentId="intent-id" />
+    )
+
+    expect(buildContentFolderQuery).toHaveBeenCalledWith(
+      'io.cozy.files.root-dir'
+    )
+    expect(mockClient.query).toHaveBeenCalledWith(
+      mockRootFolderDefinition,
+      mockRootFolderOptions
+    )
+    expect(mockCreateService).toHaveBeenCalledWith('intent-id', window)
+
+    const service = {
+      getIntent: () => ({
+        attributes: { action: 'PICK', type: 'io.cozy.files' }
+      })
+    }
+    await act(async () => {
+      handshake.resolve(service)
+    })
+
+    expect(queryByTestId('picker')).toBe(null)
+
+    rootFolderPrefetch.resolve({ data: [] })
+
+    await waitFor(() => expect(getByTestId('picker')).toBeInTheDocument())
+    expect(mockClient.query).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the picker when the root folder prefetch fails', async () => {
+    mockClient.query.mockRejectedValue(new Error('prefetch failed'))
+    mockCreateService.mockResolvedValue({
+      getIntent: () => ({
+        attributes: { action: 'PICK', type: 'io.cozy.files' }
+      })
+    })
+
+    const { getByTestId } = render(<IntentHandler intentId="intent-id" />)
+
+    await waitFor(() => expect(getByTestId('picker')).toBeInTheDocument())
+  })
+})

--- a/src/modules/services/components/IntentHandler.spec.jsx
+++ b/src/modules/services/components/IntentHandler.spec.jsx
@@ -1,11 +1,14 @@
 import { act, render, waitFor } from '@testing-library/react'
 import React from 'react'
 
+import logger from 'cozy-logger'
+
 import { buildContentFolderQuery } from './FilePicker/queries'
 import IntentHandler from './IntentHandler'
 
 const mockClient = { query: jest.fn() }
 const mockCreateService = jest.fn()
+const mockGetIntent = jest.fn()
 const mockRootFolderDefinition = { doctype: 'io.cozy.files' }
 const mockRootFolderOptions = {
   as: 'buildContentFolderQuery-io.cozy.files.root-dir',
@@ -17,7 +20,10 @@ jest.mock('cozy-client', () => ({
 }))
 
 jest.mock('cozy-interapp', () =>
-  jest.fn().mockImplementation(() => ({ createService: mockCreateService }))
+  jest.fn().mockImplementation(() => ({
+    createService: mockCreateService,
+    request: { get: mockGetIntent }
+  }))
 )
 
 jest.mock('./FilePicker/queries', () => ({
@@ -41,6 +47,9 @@ function makeDeferredPromise() {
 
 describe('IntentHandler', () => {
   beforeEach(() => {
+    mockGetIntent.mockResolvedValue({
+      attributes: { action: 'PICK', type: 'io.cozy.files' }
+    })
     buildContentFolderQuery.mockReturnValue({
       definition: () => mockRootFolderDefinition,
       options: mockRootFolderOptions
@@ -61,14 +70,16 @@ describe('IntentHandler', () => {
       <IntentHandler intentId="intent-id" />
     )
 
-    expect(buildContentFolderQuery).toHaveBeenCalledWith(
-      'io.cozy.files.root-dir'
+    expect(mockCreateService).toHaveBeenCalledWith('intent-id', window)
+    await waitFor(() =>
+      expect(buildContentFolderQuery).toHaveBeenCalledWith(
+        'io.cozy.files.root-dir'
+      )
     )
     expect(mockClient.query).toHaveBeenCalledWith(
       mockRootFolderDefinition,
       mockRootFolderOptions
     )
-    expect(mockCreateService).toHaveBeenCalledWith('intent-id', window)
 
     const service = {
       getIntent: () => ({
@@ -98,5 +109,21 @@ describe('IntentHandler', () => {
     const { getByTestId } = render(<IntentHandler intentId="intent-id" />)
 
     await waitFor(() => expect(getByTestId('picker')).toBeInTheDocument())
+  })
+
+  it('does not prefetch the root folder for unrelated intents', async () => {
+    const intent = {
+      attributes: { action: 'OPEN', type: 'io.cozy.files' }
+    }
+    const getIntent = jest.fn(() => intent)
+    mockGetIntent.mockResolvedValue(intent)
+    mockCreateService.mockResolvedValue({ getIntent })
+
+    render(<IntentHandler intentId="intent-id" />)
+
+    await waitFor(() => expect(getIntent).toHaveBeenCalled())
+    expect(buildContentFolderQuery).not.toHaveBeenCalled()
+    expect(mockClient.query).not.toHaveBeenCalled()
+    expect(logger.warn).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
 Why

 Reduce the time needed to display the file picker after receiving an intent.

 How

 - Build and start the root-folder query before completing the intent handshake.
 - Wait for the prefetch before rendering the picker.
 - Log prefetch failures and continue rendering normally.

 Testing

 Added tests covering concurrent prefetching and graceful handling of prefetch failures.

I tested this modification with multiple manual tests and e2e tests. See https://github.com/linagora/twake-drive/pull/3674 for more details

related to #4057 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved picker startup by preloading the root content folder before rendering the picker for compatible `PICK` intents.
  * Picker now waits for the preload attempt when applicable, and still renders if the preload fails.
  * Faster service readiness by fetching intent details and creating the service concurrently.

* **Tests**
  * Added/updated Jest + React Testing Library tests for preload success, preload failure resilience, and ignoring non-`PICK` intents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->