### PR TITLE
perf(file-picker): Split intent locale loading into a dedicated asynchronous loader

### DIFF
--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -17,12 +17,13 @@ import appMetadata from '@/lib/appMetadata'
 import { schema } from '@/lib/doctypes'
 import registerClientPlugins from '@/lib/registerClientPlugins'
 import IntentHandler from '@/modules/services'
+import { loadIntentLocales } from '@/targets/intents/loadIntentLocales'
 import { SelectionProvider } from '@/modules/selection/SelectionProvider'
 
 // ambient styles
 import styles from '@/styles/main.styl' // eslint-disable-line no-unused-vars
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const root = document.getElementById('main')
   const data = JSON.parse(root.dataset.cozy)
 
@@ -40,12 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   registerClientPlugins(client)
 
+  const dictRequire = await loadIntentLocales(data.locale)
+
   createRoot(root).render(
-    <DriveProvider
-      client={client}
-      lang={data.locale}
-      dictRequire={lang => require(`@/locales/${lang}`)}
-    >
+    <DriveProvider client={client} lang={data.locale} dictRequire={dictRequire}>
       <SelectionProvider clearOnLocationChange={false}>
         <IntentHandler intentId={intent} />
       </SelectionProvider>

--- a/src/targets/intents/loadIntentLocales.js
+++ b/src/targets/intents/loadIntentLocales.js
@@ -1,0 +1,26 @@
+const FALLBACK_LOCALE = 'en'
+
+async function loadLocale(locale) {
+  // Keep intent locale modules separate from the synchronous locale context
+  // used by the full app, otherwise chunk optimization merges every locale.
+  const localeModule = await import(`@/locales/${locale}.json?intent`)
+  return localeModule.default ?? localeModule
+}
+
+export async function loadIntentLocales(locale, loadDictionary = loadLocale) {
+  const fallbackDictionaryPromise = loadDictionary(FALLBACK_LOCALE)
+  if (locale === FALLBACK_LOCALE) {
+    const fallbackDictionary = await fallbackDictionaryPromise
+    return () => fallbackDictionary
+  }
+
+  const [fallbackDictionary, currentDictionary] = await Promise.all([
+    fallbackDictionaryPromise,
+    loadDictionary(locale).catch(() => null)
+  ])
+
+  return requestedLocale =>
+    requestedLocale === locale
+      ? (currentDictionary ?? fallbackDictionary)
+      : fallbackDictionary
+}

--- a/src/targets/intents/loadIntentLocales.spec.js
+++ b/src/targets/intents/loadIntentLocales.spec.js
@@ -1,0 +1,78 @@
+import { initTranslation } from 'twake-i18n'
+
+import { loadIntentLocales } from './loadIntentLocales'
+
+const supportedLocales = [
+  'ar',
+  'de',
+  'en',
+  'es',
+  'fr',
+  'it',
+  'ja',
+  'ko',
+  'nl',
+  'nl_NL',
+  'pl',
+  'ru',
+  'vi',
+  'zh_CN',
+  'zh_TW'
+]
+
+const dictionaries = {
+  en: { greeting: 'Hello' },
+  fr: { greeting: 'Bonjour' }
+}
+
+function makeLocaleLoader() {
+  return jest.fn(locale => Promise.resolve(dictionaries[locale]))
+}
+
+describe('loadIntentLocales', () => {
+  it('loads only the current locale and the English fallback', async () => {
+    const loadLocale = makeLocaleLoader()
+
+    const requireLocale = await loadIntentLocales('fr', loadLocale)
+
+    expect(loadLocale).toHaveBeenCalledTimes(2)
+    expect(loadLocale).toHaveBeenNthCalledWith(1, 'en')
+    expect(loadLocale).toHaveBeenNthCalledWith(2, 'fr')
+    expect(requireLocale('fr')).toEqual(dictionaries.fr)
+    expect(requireLocale('en')).toEqual(dictionaries.en)
+  })
+
+  it.each(supportedLocales)(
+    'renders the %s locale with English fallback',
+    async locale => {
+      const loadLocale = localeCode =>
+        Promise.resolve(require(`@/locales/${localeCode}.json`))
+      const requireLocale = await loadIntentLocales(locale, loadLocale)
+      const translation = initTranslation(locale, requireLocale)
+
+      expect(translation.t('Nav.item_drive')).not.toBe('Nav.item_drive')
+    }
+  )
+
+  it('uses English when the current locale cannot be loaded', async () => {
+    const loadLocale = jest.fn(locale =>
+      locale === 'en'
+        ? Promise.resolve(dictionaries.en)
+        : Promise.reject(new Error('locale unavailable'))
+    )
+
+    const requireLocale = await loadIntentLocales('fr', loadLocale)
+
+    expect(requireLocale('fr')).toEqual(dictionaries.en)
+  })
+
+  it('loads English only once when it is the current locale', async () => {
+    const loadLocale = makeLocaleLoader()
+
+    const requireLocale = await loadIntentLocales('en', loadLocale)
+
+    expect(loadLocale).toHaveBeenCalledTimes(1)
+    expect(loadLocale).toHaveBeenCalledWith('en')
+    expect(requireLocale('en')).toEqual(dictionaries.en)
+  })
+})


### PR DESCRIPTION
 Why

 Prevent all locale bundles from being merged into the intent chunk while preserving English fallback behavior.

 How

 - Dynamically load English and the requested locale.
 - Fall back to English if the requested locale is unavailable.
 - Load locales before rendering the intent handler.
 - Add coverage for supported locales and fallback cases.

We could also apply this to other targets but this will be the object of other PRs

I tested this modification with multiple manual tests and e2e tests. See https://github.com/linagora/twake-drive/pull/3674 for more details

related to #4057 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intent translations now load before the interface renders.
  * Added fallback to English when the selected language cannot be loaded.

* **Bug Fixes**
  * Improved reliability of localized intent experiences across supported languages.

* **Tests**
  * Added coverage for locale loading, fallback behavior, and supported translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->