### PR TITLE
fix(file-picker): preserve content height in wide dialogs

### DIFF
--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -74,7 +74,7 @@ const FilePicker = ({
       onClose={handleClose}
       size="large"
       disableTitleAutoPadding
-      classes={{ paper: styles.filePickerDialogPaper }}
+      classes={{ paper: `${styles.filePickerDialogPaper} u-h-100` }}
       componentsProps={{
         dialogTitle: {
           className: 'u-pl-1-half'


### PR DESCRIPTION
Wide intent dialogs render the picker outside fullscreen mode. Give the inner dialog an explicit height so its absolutely positioned body and virtualized table do not collapse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the file picker dialog layout so it consistently fills the available height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->