### PR TITLE
fix(sharings): default to the with-me tab

### DIFF
--- a/src/components/EditorToolbar/Sharing.jsx
+++ b/src/components/EditorToolbar/Sharing.jsx
@@ -7,7 +7,7 @@ import { ShareButton, ShareModal, SharedRecipients } from 'cozy-sharing'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
-import { makeRevokeSuccessRedirectPath } from '@/modules/views/Modal/revokeSuccessRedirect'
+import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
 
 const Sharing = ({ file }) => {
   const [showShareModal, setShowShareModal] = useState(false)
@@ -19,8 +19,8 @@ const Sharing = ({ file }) => {
     [setShowShareModal]
   )
 
-  const handleRevokeSuccess = document => {
-    navigate(makeRevokeSuccessRedirectPath({ document }), { replace: true })
+  const handleRevokeSuccess = () => {
+    navigate(DEFAULT_SHARINGS_VIEW_ROUTE, { replace: true })
   }
 
   return (

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -21,5 +21,6 @@ export const MAX_UPLOAD_FILE_COUNT = 500
 export const SHARING_TAB_WITH_ME = 'with-me'
 export const SHARING_TAB_BY_ME = 'by-me'
 export const SHARING_TAB_DRIVES = 'drives'
-export const DEFAULT_UPLOAD_PROGRESS_HIDE_DELAY = 5000
 export const SHARINGS_VIEW_ROUTE = '/sharings'
+export const DEFAULT_SHARINGS_VIEW_ROUTE = `${SHARINGS_VIEW_ROUTE}?tab=${SHARING_TAB_WITH_ME}`
+export const DEFAULT_UPLOAD_PROGRESS_HIDE_DELAY = 5000

--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -27,10 +27,10 @@ import TrashFolderView from '../views/Trash/TrashFolderView'
 
 import FileHistory from '@/components/FileHistory'
 import {
+  DEFAULT_SHARINGS_VIEW_ROUTE,
   ROOT_DIR_ID,
-  TRASH_DIR_ID,
   SHARED_DRIVES_DIR_ID,
-  SHARING_TAB_DRIVES
+  TRASH_DIR_ID
 } from '@/constants/config'
 import { SentryRoutes } from '@/lib/sentry'
 import { UploaderComponent } from '@/modules//views/Upload/UploaderComponent'
@@ -71,7 +71,7 @@ const FilesRedirect = () => {
 }
 
 const SharedDrivesRedirect = () => {
-  return <Navigate to={`/sharings?tab=${SHARING_TAB_DRIVES}`} replace={true} />
+  return <Navigate to={DEFAULT_SHARINGS_VIEW_ROUTE} replace={true} />
 }
 
 const OutletWrapper = ({ Component }) => (

--- a/src/modules/navigation/SharingsNavItem.jsx
+++ b/src/modules/navigation/SharingsNavItem.jsx
@@ -5,6 +5,7 @@ import { useQuery } from 'cozy-client'
 import { isSharingShortcutNew } from 'cozy-client/dist/models/file'
 import { useSharingContext } from 'cozy-sharing'
 
+import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
 import { NavItem } from '@/modules/navigation/NavItem'
 import { useSharedDrives } from '@/modules/shareddrives/hooks/useSharedDrives'
 import { buildSharingsQuery } from '@/queries'
@@ -53,7 +54,7 @@ const SharingsNavItem = ({ clickState }) => {
 
   return (
     <NavItem
-      to="/sharings"
+      to={DEFAULT_SHARINGS_VIEW_ROUTE}
       icon={<Icon icon={ShareExternal} />}
       label="sharings"
       isActive={isActive}

--- a/src/modules/views/Modal/ShareDisplayedFolderView.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.jsx
@@ -4,8 +4,8 @@ import { useNavigate } from 'react-router-dom'
 import flag from 'cozy-flags'
 import { ShareModal } from 'cozy-sharing'
 
+import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
-import { makeRevokeSuccessRedirectPath } from '@/modules/views/Modal/revokeSuccessRedirect'
 
 const ShareDisplayedFolderView = () => {
   const { displayedFolder } = useDisplayedFolder()
@@ -17,9 +17,7 @@ const ShareDisplayedFolderView = () => {
     }
 
     const onRevokeSuccess = () => {
-      navigate(makeRevokeSuccessRedirectPath({ document: displayedFolder }), {
-        replace: true
-      })
+      navigate(DEFAULT_SHARINGS_VIEW_ROUTE, { replace: true })
     }
 
     return (

--- a/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
@@ -5,7 +5,7 @@ import { ShareModal } from 'cozy-sharing'
 
 import { ShareDisplayedFolderView } from './ShareDisplayedFolderView'
 
-import { SHARING_TAB_DRIVES } from '@/constants/config'
+import { SHARING_TAB_WITH_ME } from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
 
 const mockNavigate = jest.fn()
@@ -32,7 +32,7 @@ describe('ShareDisplayedFolderView', () => {
     jest.clearAllMocks()
   })
 
-  it('should redirect to the drives sharing tab after leaving a shared drive', () => {
+  it('should redirect to the with-me tab after leaving a shared drive', () => {
     useDisplayedFolder.mockReturnValue({
       displayedFolder: {
         driveId: 'drive-id',
@@ -45,7 +45,7 @@ describe('ShareDisplayedFolderView', () => {
     fireEvent.click(screen.getByText('Revoke self'))
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/sharings?tab=${SHARING_TAB_DRIVES}`,
+      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
       {
         replace: true
       }
@@ -63,7 +63,10 @@ describe('ShareDisplayedFolderView', () => {
 
     fireEvent.click(screen.getByText('Revoke self'))
 
-    expect(mockNavigate).toHaveBeenCalledWith('/sharings', { replace: true })
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
+      { replace: true }
+    )
   })
 
   it('should keep passing onClose to the share modal', () => {

--- a/src/modules/views/Modal/ShareFileView.jsx
+++ b/src/modules/views/Modal/ShareFileView.jsx
@@ -6,7 +6,7 @@ import flag from 'cozy-flags'
 import { ShareModal } from 'cozy-sharing'
 
 import { LoaderModal } from '@/components/LoaderModal'
-import { makeRevokeSuccessRedirectPath } from '@/modules/views/Modal/revokeSuccessRedirect'
+import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
 import {
   buildFileOrFolderByIdQuery,
   buildSharedDriveFileOrFolderByIdQuery
@@ -25,10 +25,8 @@ const ShareFileView = () => {
     navigate('..', { replace: true })
   }
 
-  const handleRevokeSuccess = document => {
-    navigate(makeRevokeSuccessRedirectPath({ document, driveId }), {
-      replace: true
-    })
+  const handleRevokeSuccess = () => {
+    navigate(DEFAULT_SHARINGS_VIEW_ROUTE, { replace: true })
   }
 
   if (hasQueryBeenLoaded(fileResult) && fileResult.data) {

--- a/src/modules/views/Modal/ShareFileView.spec.jsx
+++ b/src/modules/views/Modal/ShareFileView.spec.jsx
@@ -5,7 +5,7 @@ import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
 
 import { ShareFileView } from './ShareFileView'
 
-import { SHARING_TAB_DRIVES } from '@/constants/config'
+import { SHARING_TAB_WITH_ME } from '@/constants/config'
 
 const mockNavigate = jest.fn()
 const mockUseParams = jest.fn()
@@ -59,7 +59,7 @@ describe('ShareFileView', () => {
     })
   })
 
-  it('should redirect to the drives sharing tab after leaving a shared drive file', () => {
+  it('should redirect to the with-me tab after leaving a shared drive file', () => {
     mockUseParams.mockReturnValue({ driveId: 'drive-id', fileId: 'file-id' })
 
     render(<ShareFileView />)
@@ -67,7 +67,7 @@ describe('ShareFileView', () => {
     fireEvent.click(screen.getByText('Revoke self'))
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/sharings?tab=${SHARING_TAB_DRIVES}`,
+      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
       {
         replace: true
       }
@@ -81,6 +81,9 @@ describe('ShareFileView', () => {
 
     fireEvent.click(screen.getByText('Revoke self'))
 
-    expect(mockNavigate).toHaveBeenCalledWith('/sharings', { replace: true })
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
+      { replace: true }
+    )
   })
 })

--- a/src/modules/views/Modal/revokeSuccessRedirect.js
+++ b/src/modules/views/Modal/revokeSuccessRedirect.js
@@ -1,5 +1,0 @@
-import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
-
-const makeRevokeSuccessRedirectPath = () => DEFAULT_SHARINGS_VIEW_ROUTE
-
-export { makeRevokeSuccessRedirectPath }

--- a/src/modules/views/Modal/revokeSuccessRedirect.js
+++ b/src/modules/views/Modal/revokeSuccessRedirect.js
@@ -1,11 +1,5 @@
-import { SHARINGS_VIEW_ROUTE, SHARING_TAB_DRIVES } from '@/constants/config'
+import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
 
-function makeRevokeSuccessRedirectPath({ document, driveId } = {}) {
-  if (driveId || document?.driveId) {
-    return `${SHARINGS_VIEW_ROUTE}?tab=${SHARING_TAB_DRIVES}`
-  }
-
-  return SHARINGS_VIEW_ROUTE
-}
+const makeRevokeSuccessRedirectPath = () => DEFAULT_SHARINGS_VIEW_ROUTE
 
 export { makeRevokeSuccessRedirectPath }

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -62,6 +62,21 @@ const useSharingsQueryResult = (sharedDocumentIds, allLoaded) => {
   return useQuery(query.definition, query.options)
 }
 
+function useCanonicalizeUnavailableDrivesTab({
+  setTab,
+  sharedDrivesLoaded,
+  showDrives,
+  tab
+}) {
+  useEffect(() => {
+    if (!sharedDrivesLoaded) return
+    if (tab !== SHARING_TAB_DRIVES) return
+    if (showDrives) return
+
+    setTab(SHARING_TAB_WITH_ME, { replace: true })
+  }, [setTab, sharedDrivesLoaded, showDrives, tab])
+}
+
 export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const base = useFolderViewBase()
   const sharingContext = useSharingContext()
@@ -83,11 +98,12 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
 
   const showDrives = shouldShowDrivesTab({ hasDrives })
 
-  useEffect(() => {
-    if (sharedDrivesLoaded && tab === SHARING_TAB_DRIVES && !showDrives) {
-      setTab(SHARING_TAB_WITH_ME, { replace: true })
-    }
-  }, [setTab, sharedDrivesLoaded, showDrives, tab])
+  useCanonicalizeUnavailableDrivesTab({
+    setTab,
+    sharedDrivesLoaded,
+    showDrives,
+    tab
+  })
 
   useKeyboardShortcuts({
     onPaste: () => refresh(),

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
@@ -22,7 +22,7 @@ import { useFolderViewBase } from '../Folder/hooks/useFolderViewBase'
 import FolderViewBodyVz from '../Folder/virtualized/FolderViewBody'
 
 import useHead from '@/components/useHead'
-import { SHARING_TAB_DRIVES } from '@/constants/config'
+import { SHARING_TAB_DRIVES, SHARING_TAB_WITH_ME } from '@/constants/config'
 import { useFolderSort } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import {
@@ -46,11 +46,9 @@ import { shareFileRootSharedDrive } from '@/modules/shareddrives/components/acti
 import { shareSharedDrive } from '@/modules/shareddrives/components/actions/shareSharedDrive'
 import { buildSharingsQuery } from '@/queries'
 
-// The Team drives tab only shows while it has content; it stays rendered
-// when it is the active tab so a ?tab=drives deep link keeps a visible,
-// consistent control (the list then shows the empty state).
-const shouldShowDrivesTab = ({ hasDrives, tab }) =>
-  areDrivesAvailable() && (hasDrives || tab === SHARING_TAB_DRIVES)
+// The Team drives tab only exists while the feature is enabled and at least
+// one organizational drive can be displayed in it.
+const shouldShowDrivesTab = ({ hasDrives }) => areDrivesAvailable() && hasDrives
 
 const useSharingsQueryResult = (sharedDocumentIds, allLoaded) => {
   const query = useMemo(
@@ -83,7 +81,13 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
     }
   )
 
-  const showDrives = shouldShowDrivesTab({ hasDrives, tab })
+  const showDrives = shouldShowDrivesTab({ hasDrives })
+
+  useEffect(() => {
+    if (sharedDrivesLoaded && tab === SHARING_TAB_DRIVES && !showDrives) {
+      setTab(SHARING_TAB_WITH_ME, { replace: true })
+    }
+  }, [setTab, sharedDrivesLoaded, showDrives, tab])
 
   useKeyboardShortcuts({
     onPaste: () => refresh(),

--- a/src/modules/views/Sharings/index.spec.jsx
+++ b/src/modules/views/Sharings/index.spec.jsx
@@ -248,21 +248,20 @@ describe('Sharings View', () => {
       })
     })
 
-    it('renders the drives tab when deep-linked even without drives', async () => {
-      // The ?tab= URL contract is kept: a deep link opens the tab and the
-      // active pill renders even while the tab has no content.
+    it('canonicalizes an empty drives deep link to the with-me tab', async () => {
       window.location.hash = '#/sharings?tab=drives'
       useQuery.mockReturnValue(filesFixtureWithPath)
 
-      const { getByRole } = setup()
+      const { getByRole, queryByRole } = setup()
 
       await waitFor(() => {
-        expect(getByRole('tab', { name: 'Team drives' })).toBeInTheDocument()
+        expect(getByRole('tab', { name: 'With me' })).toHaveAttribute(
+          'aria-selected',
+          'true'
+        )
       })
-      expect(getByRole('tab', { name: 'Team drives' })).toHaveAttribute(
-        'aria-selected',
-        'true'
-      )
+      expect(queryByRole('tab', { name: 'Team drives' })).toBeNull()
+      expect(window.location.hash).toContain('tab=with-me')
     })
   })
 })

--- a/src/modules/views/Sharings/useSharingsTab.spec.tsx
+++ b/src/modules/views/Sharings/useSharingsTab.spec.tsx
@@ -45,6 +45,11 @@ const TabProbe = (): JSX.Element => {
         go-drives
       </button>
       <button onClick={(): void => setTab(SHARING_TAB_BY_ME)}>go-by-me</button>
+      <button
+        onClick={(): void => setTab(SHARING_TAB_WITH_ME, { replace: true })}
+      >
+        replace-with-me
+      </button>
       <button onClick={(): void => navigate(-1)}>go-back</button>
     </>
   )
@@ -149,6 +154,17 @@ describe('useSharingsTab', () => {
     fireEvent.click(screen.getByText('go-back'))
     expect(getTab()).toBe(SHARING_TAB_BY_ME)
     expect(getSearch()).toBe(`?tab=${SHARING_TAB_BY_ME}`)
+  })
+
+  it('can replace the current history entry when canonicalizing a tab', () => {
+    renderWithSearch(`?tab=${SHARING_TAB_BY_ME}`)
+
+    fireEvent.click(screen.getByText('replace-with-me'))
+    expect(getTab()).toBe(SHARING_TAB_WITH_ME)
+
+    fireEvent.click(screen.getByText('go-back'))
+    expect(getTab()).toBe(SHARING_TAB_WITH_ME)
+    expect(getSearch()).toBe(`?tab=${SHARING_TAB_WITH_ME}`)
   })
 
   it('returns to the canonicalized entry when going back after a tab switch', () => {

--- a/src/modules/views/Sharings/useSharingsTab.ts
+++ b/src/modules/views/Sharings/useSharingsTab.ts
@@ -17,6 +17,8 @@ const SHARINGS_TABS = [
 ] as const
 
 export type SharingsTab = (typeof SHARINGS_TABS)[number]
+type SetTabOptions = { replace?: boolean }
+type SetSharingsTab = (tab: SharingsTab, options?: SetTabOptions) => void
 
 const TAB_SEARCH_PARAM = 'tab'
 
@@ -51,9 +53,10 @@ const withTab = (prev: URLSearchParams, tab: SharingsTab): URLSearchParams => {
  * unrecognized (including the legacy numeric `?tab=1`) or unavailable values
  * resolve to the default "With me" tab, and the URL is canonicalized with a
  * `replace` navigation so the back button is never trapped. User tab switches
- * push a history entry so browser back/forward moves between visited tabs.
+ * push a history entry by default; callers can request `replace` for later
+ * canonicalization once asynchronously loaded tab availability is known.
  */
-export const useSharingsTab = (): [SharingsTab, (tab: SharingsTab) => void] => {
+export const useSharingsTab = (): [SharingsTab, SetSharingsTab] => {
   const [searchParams, setSearchParams] = useSearchParams()
   const drivesAvailable = areDrivesAvailable()
 
@@ -71,7 +74,7 @@ export const useSharingsTab = (): [SharingsTab, (tab: SharingsTab) => void] => {
   }, [paramValue, tab, setSearchParams])
 
   const setTab = useCallback(
-    (nextTab: SharingsTab): void => {
+    (nextTab: SharingsTab, options: SetTabOptions = {}): void => {
       if (!isAvailableTab(nextTab, drivesAvailable)) {
         logger.warn(
           `useSharingsTab: ignoring unknown or unavailable tab value "${String(
@@ -87,9 +90,11 @@ export const useSharingsTab = (): [SharingsTab, (tab: SharingsTab) => void] => {
       if (nextTab === tab) {
         return
       }
-      // A user tab switch pushes a history entry so back/forward moves
-      // between visited tabs; unrelated params (future filters) are kept.
-      setSearchParams(prev => withTab(prev, nextTab))
+      // User tab switches push by default so back/forward moves between tabs;
+      // canonicalization callers can replace. Unrelated params are kept.
+      setSearchParams(prev => withTab(prev, nextTab), {
+        replace: options.replace
+      })
     },
     [drivesAvailable, setSearchParams, tab]
   )


### PR DESCRIPTION
## Summary

- Route sharing navigation and revoke redirects to the With me tab.
- Hide the Team drives tab when no organizational drives are available.
- Canonicalize unavailable Team drives deep links without adding browser history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sharing and revoke-success redirects now consistently return users to the canonical **“With me”** sharing tab.
  - Deep-linked **“Team drives”** URLs are automatically rewritten to **“With me”** when team drives aren’t available.
  - Canonicalization uses history replacement to avoid stale or stuck tab states.

- **Navigation**
  - Sharing links and routes now use a shared default destination that includes the correct `tab` query parameter.
  - Tab switching supports optional history replacement to preserve canonical behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->