### PR TITLE
fix(file-picker): render content in caller dialog

### DIFF
--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 import React, { useState, memo, useMemo } from 'react'
 
-import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Box from 'cozy-ui/transpiled/react/Box'
+import Divider from 'cozy-ui/transpiled/react/Divider'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 
 import FilePickerBody from './FilePickerBody'
@@ -11,14 +12,12 @@ import { LinkAccessModal } from './LinkAccessModal'
 import { defaultFilePickerConfig, filePickerLinkModes } from './constants'
 import { getActionDisabledState } from './constraints'
 import { getCompliantTypes } from './helpers'
-import styles from './styles.styl'
 
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 
 export const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 
 const FilePicker = ({
-  onClose,
   onChange,
   accept,
   multiple,
@@ -38,11 +37,6 @@ const FilePicker = ({
   const config = filePickerConfig || defaultFilePickerConfig
   const publicLinkAction = config.sharingLink ?? null
   const downloadLinkAction = config.downloadLink ?? null
-
-  const handleClose = () => {
-    clearSelection()
-    onClose()
-  }
 
   const navigateTo = folder => {
     setError(null)
@@ -104,23 +98,23 @@ const FilePicker = ({
 
   return (
     <>
-      <FixedDialog
-        open
-        disableGutters
-        onClose={handleClose}
-        size="large"
-        disableTitleAutoPadding
-        classes={{ paper: `${styles.filePickerDialogPaper} u-h-100` }}
-        componentsProps={{
-          dialogTitle: {
-            className: 'u-pl-1-half'
-          },
-          dialogContent: {
-            className: 'u-pos-relative'
-          }
-        }}
-        title={<FilePickerHeader />}
-        content={
+      <div
+        className="u-h-100 u-w-100 u-flex u-flex-column"
+        data-testid="file-picker"
+      >
+        <header
+          className="u-pv-1-half u-pl-1-half u-pr-2"
+          data-testid="file-picker-header-wrapper"
+        >
+          <FilePickerHeader />
+        </header>
+        <Divider />
+        <Box
+          flex={1}
+          minHeight={0}
+          className="u-pos-relative"
+          data-testid="file-picker-body-wrapper"
+        >
           <FilePickerBody
             navigateTo={navigateTo}
             folderId={folderId}
@@ -130,8 +124,9 @@ const FilePicker = ({
             error={error}
             onReadyToUse={onReadyToUse}
           />
-        }
-        actions={
+        </Box>
+        <Divider />
+        <footer className="u-mv-1 u-mh-2" data-testid="file-picker-footer">
           <FilePickerFooter
             onConfirm={handleFooterConfirm}
             publicLinkState={publicLinkState}
@@ -139,8 +134,8 @@ const FilePicker = ({
             publicLinkAction={publicLinkAction}
             downloadLinkAction={downloadLinkAction}
           />
-        }
-      />
+        </footer>
+      </div>
 
       {isLinkAccessOpen && (
         <LinkAccessModal
@@ -154,7 +149,6 @@ const FilePicker = ({
 }
 
 FilePicker.propTypes = {
-  onClose: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   accept: PropTypes.string,
   multiple: PropTypes.bool,

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -21,17 +21,9 @@ jest.mock('cozy-ui/transpiled/react/providers/Alert', () => ({
   useAlert: () => ({ showAlert: mockShowAlert })
 }))
 
-jest.mock('cozy-ui/transpiled/react/CozyDialogs', () => ({
-  FixedDialog: ({ title, content, actions }) => (
-    <div>
-      <div data-testid="dialog-title">{title}</div>
-      <div data-testid="dialog-content">{content}</div>
-      <div data-testid="dialog-actions">{actions}</div>
-    </div>
-  )
-}))
-
-jest.mock('./FilePickerHeader', () => () => <div>Header</div>)
+jest.mock('./FilePickerHeader', () => () => (
+  <div data-testid="file-picker-header-inner">Header</div>
+))
 
 jest.mock('./FilePickerBody', () => {
   const {
@@ -177,14 +169,12 @@ const FilePickerWrapper = ({ children }) => (
 
 describe('FilePicker', () => {
   const mockOnChange = jest.fn()
-  const mockOnClose = jest.fn()
 
   const setup = ({ filePickerConfig, multiple = false } = {}) => {
     return render(
       <FilePickerWrapper>
         <FilePicker
           onChange={mockOnChange}
-          onClose={mockOnClose}
           filePickerConfig={filePickerConfig}
           multiple={multiple}
         />
@@ -194,6 +184,14 @@ describe('FilePicker', () => {
 
   afterEach(() => {
     jest.clearAllMocks()
+  })
+
+  it('should render the header, content and footer', () => {
+    const { getByTestId } = setup()
+
+    expect(getByTestId('file-picker-header-inner')).toBeInTheDocument()
+    expect(getByTestId('file-picker-body-wrapper')).toBeInTheDocument()
+    expect(getByTestId('file-picker-footer')).toBeInTheDocument()
   })
 
   it('should render both action buttons by default', () => {

--- a/src/modules/services/components/FilePicker/styles.styl
+++ b/src/modules/services/components/FilePicker/styles.styl
@@ -1,8 +1,3 @@
-.filePickerDialogPaper
-    [class*='DialogBackButton'],
-    [class*='DialogCloseButton']
-        display none
-
 .filePickerBreadcrumb-previousPath
     color var(--actionColorActive)
     cursor pointer

--- a/src/modules/services/components/Picker.jsx
+++ b/src/modules/services/components/Picker.jsx
@@ -47,10 +47,6 @@ const Picker = ({ service, intent, onReadyToUse }) => {
   const serviceData = service.getData?.()
   const filePickerConfig = getFilePickerConfig(intent, serviceData)
 
-  const handleClose = () => {
-    service.cancel()
-  }
-
   const handlePick = async (fileIds, linkMode, generatedSharingLinks) => {
     const selectedFiles = Array.isArray(fileIds) ? fileIds : [fileIds]
     const selectedFileIds = selectedFiles.map(file =>
@@ -120,7 +116,6 @@ const Picker = ({ service, intent, onReadyToUse }) => {
   return (
     <FilePicker
       onChange={handlePick}
-      onClose={handleClose}
       filePickerConfig={filePickerConfig}
       onReadyToUse={onReadyToUse}
       multiple

--- a/src/modules/services/components/Picker.spec.jsx
+++ b/src/modules/services/components/Picker.spec.jsx
@@ -56,113 +56,100 @@ jest.mock('cozy-client/dist/models/sharing', () => ({
   makeSharingLink: jest.fn()
 }))
 
-jest.mock(
-  './FilePicker',
-  () =>
-    ({ onChange, onClose, filePickerConfig, multiple }) => {
-      const React = jest.requireActual('react')
-      const [error, setError] = React.useState(null)
+jest.mock('./FilePicker', () => ({ onChange, filePickerConfig, multiple }) => {
+  const React = jest.requireActual('react')
+  const [error, setError] = React.useState(null)
 
-      // Expose the received config so tests can assert on the transit.
-      return (
-        <div>
-          <div data-testid="received-config">
-            {JSON.stringify(filePickerConfig)}
-          </div>
-          <div data-testid="received-multiple">
-            {multiple ? 'true' : 'false'}
-          </div>
-          {error && <div data-testid="error-message">{error}</div>}
-          <button
-            type="button"
-            data-testid="close-picker-btn"
-            onClick={onClose}
-          >
-            Close picker
-          </button>
-          <button
-            type="button"
-            data-testid="public-link-btn"
-            onClick={async () => {
-              const pickError = await onChange(
-                'file-id',
-                filePickerLinkModes.PUBLIC_LINK
-              )
-              if (pickError) setError(pickError)
-            }}
-          >
-            Public link
-          </button>
-          <button
-            type="button"
-            data-testid="generated-public-links-btn"
-            onClick={async () => {
-              const pickError = await onChange(
-                [
-                  {
-                    _id: 'file-id',
-                    type: 'file',
-                    name: 'invoice.pdf',
-                    size: '42',
-                    mime: 'application/pdf'
-                  }
-                ],
-                filePickerLinkModes.PUBLIC_LINK,
-                [
-                  {
-                    documentId: 'file-id',
-                    url: 'https://drive.example/public?sharecode=abc'
-                  }
-                ]
-              )
-              if (pickError) setError(pickError)
-            }}
-          >
-            Generated public links
-          </button>
-          <button
-            type="button"
-            data-testid="temporary-download-link-btn"
-            onClick={async () => {
-              const pickError = await onChange(
-                'file-id',
-                filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
-              )
-              if (pickError) setError(pickError)
-            }}
-          >
-            Temporary link
-          </button>
-          <button
-            type="button"
-            data-testid="multiple-public-link-btn"
-            onClick={async () => {
-              const pickError = await onChange(
-                ['file-id', 'second-file-id'],
-                filePickerLinkModes.PUBLIC_LINK
-              )
-              if (pickError) setError(pickError)
-            }}
-          >
-            Multiple public link
-          </button>
-          <button
-            type="button"
-            data-testid="multiple-temporary-download-link-btn"
-            onClick={async () => {
-              const pickError = await onChange(
-                ['file-id', 'second-file-id'],
-                filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
-              )
-              if (pickError) setError(pickError)
-            }}
-          >
-            Multiple temporary link
-          </button>
-        </div>
-      )
-    }
-)
+  // Expose the received config so tests can assert on the transit.
+  return (
+    <div>
+      <div data-testid="received-config">
+        {JSON.stringify(filePickerConfig)}
+      </div>
+      <div data-testid="received-multiple">{multiple ? 'true' : 'false'}</div>
+      {error && <div data-testid="error-message">{error}</div>}
+      <button
+        type="button"
+        data-testid="public-link-btn"
+        onClick={async () => {
+          const pickError = await onChange(
+            'file-id',
+            filePickerLinkModes.PUBLIC_LINK
+          )
+          if (pickError) setError(pickError)
+        }}
+      >
+        Public link
+      </button>
+      <button
+        type="button"
+        data-testid="generated-public-links-btn"
+        onClick={async () => {
+          const pickError = await onChange(
+            [
+              {
+                _id: 'file-id',
+                type: 'file',
+                name: 'invoice.pdf',
+                size: '42',
+                mime: 'application/pdf'
+              }
+            ],
+            filePickerLinkModes.PUBLIC_LINK,
+            [
+              {
+                documentId: 'file-id',
+                url: 'https://drive.example/public?sharecode=abc'
+              }
+            ]
+          )
+          if (pickError) setError(pickError)
+        }}
+      >
+        Generated public links
+      </button>
+      <button
+        type="button"
+        data-testid="temporary-download-link-btn"
+        onClick={async () => {
+          const pickError = await onChange(
+            'file-id',
+            filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
+          )
+          if (pickError) setError(pickError)
+        }}
+      >
+        Temporary link
+      </button>
+      <button
+        type="button"
+        data-testid="multiple-public-link-btn"
+        onClick={async () => {
+          const pickError = await onChange(
+            ['file-id', 'second-file-id'],
+            filePickerLinkModes.PUBLIC_LINK
+          )
+          if (pickError) setError(pickError)
+        }}
+      >
+        Multiple public link
+      </button>
+      <button
+        type="button"
+        data-testid="multiple-temporary-download-link-btn"
+        onClick={async () => {
+          const pickError = await onChange(
+            ['file-id', 'second-file-id'],
+            filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
+          )
+          if (pickError) setError(pickError)
+        }}
+      >
+        Multiple temporary link
+      </button>
+    </div>
+  )
+})
 
 const mockFile = {
   _id: 'file-id',
@@ -182,7 +169,6 @@ const mockSecondFile = {
 
 const setup = ({ intent = null } = {}) => {
   const service = {
-    cancel: jest.fn(),
     terminate: jest.fn(),
     throw: jest.fn()
   }
@@ -204,16 +190,6 @@ describe('Picker', () => {
 
   afterEach(() => {
     jest.clearAllMocks()
-  })
-
-  it('should cancel the intent when the picker is closed', () => {
-    const { service, getByTestId } = setup()
-
-    fireEvent.click(getByTestId('close-picker-btn'))
-
-    expect(service.cancel).toHaveBeenCalled()
-    expect(service.terminate).not.toHaveBeenCalled()
-    expect(service.throw).not.toHaveBeenCalled()
   })
 
   it('should pass the default filePickerConfig when the intent carries no data', () => {


### PR DESCRIPTION
## What

Remove the FilePicker's internal dialog and render its content directly inside
the dialog provided by the calling application.

## Why

`IntentDialogOpener` already owns the modal containing the intent iframe. The
additional `FixedDialog` created nested dialogs with competing sizing and
closing behavior.

## How

- Replace `FixedDialog` with a full-size flex layout for the header, content,
  and footer.
- Preserve the previous dialog spacing and dividers.
- Remove the internal `onClose` and `service.cancel()` flow.
- Keep `LinkAccessModal` as a secondary modal over the picker.
- Update tests for the new component structure and ownership model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the file picker to use a simpler layout with distinct header, body, and footer regions.
  * Adjusted component structure and rendering to match the new layout.
* **Bug Fixes**
  * Removed outdated close controls and related styling from the file picker.
  * Closing the picker no longer triggers service cancellation.
  * Preserved existing file selection and link-generation/termination behavior.
* **Tests**
  * Updated tests and mocks to use the new file picker test IDs.
  * Added assertions for header, body, and footer rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->