### PR TITLE
fix(sharings): preserve tab around share dialog

### DIFF
--- a/src/modules/actions/helpers.js
+++ b/src/modules/actions/helpers.js
@@ -1,10 +1,22 @@
 import { joinPath } from '@/lib/path'
+import { makeSharingsTabLocation } from '@/modules/navigation/sharingsTabNavigation'
 
-export const navigateToModal = ({ navigate, pathname, files, path }) => {
+export const navigateToModal = ({
+  navigate,
+  pathname,
+  files,
+  path,
+  location
+}) => {
   const file = Array.isArray(files) ? files[0] : files
+  const targetPathname = pathname
+    ? joinPath(pathname, `file/${file.id}/${path}`)
+    : `v/${path}`
 
   return navigate(
-    pathname ? joinPath(pathname, `file/${file.id}/${path}`) : `v/${path}`
+    location
+      ? makeSharingsTabLocation({ currentLocation: location, targetPathname })
+      : targetPathname
   )
 }
 

--- a/src/modules/actions/helpers.spec.js
+++ b/src/modules/actions/helpers.spec.js
@@ -50,6 +50,26 @@ describe('actions helpers', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith('/folder/456/file/file-1/edit')
     })
+
+    it('should preserve the active Sharings tab', () => {
+      const params = {
+        navigate: mockNavigate,
+        pathname: '/sharings',
+        location: {
+          pathname: '/sharings',
+          search: '?foo=bar&tab=by-me'
+        },
+        files: { id: 'file-123', name: 'test.pdf' },
+        path: 'share'
+      }
+
+      navigateToModal(params)
+
+      expect(mockNavigate).toHaveBeenCalledWith({
+        pathname: '/sharings/file/file-123/share',
+        search: '?tab=by-me'
+      })
+    })
   })
 
   describe('navigateToModalWithMultipleFile', () => {

--- a/src/modules/actions/share.jsx
+++ b/src/modules/actions/share.jsx
@@ -16,6 +16,7 @@ const share = ({
   hasWriteAccess,
   navigate,
   pathname,
+  location,
   allLoaded
 }) => {
   const label = t('Files.share.cta')
@@ -41,7 +42,7 @@ const share = ({
       )
     },
     action: files =>
-      navigateToModal({ navigate, pathname, files, path: 'share' }),
+      navigateToModal({ navigate, pathname, files, path: 'share', location }),
     Component: forwardRef(function ShareMenuItemInMenu(props, ref) {
       const { isMobile } = useBreakpoints()
 

--- a/src/modules/drive/Toolbar/share/ShareButton.jsx
+++ b/src/modules/drive/Toolbar/share/ShareButton.jsx
@@ -5,16 +5,16 @@ import { ShareButton } from 'cozy-sharing'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { useDisplayedFolder } from '@/hooks'
-import { getPathToShareDisplayedFolder } from '@/modules/drive/Toolbar/share/helpers'
+import { makeDisplayedFolderShareLocation } from '@/modules/drive/Toolbar/share/helpers'
 
 const ShareButtonWithProps = ({ isDisabled, className, useShortLabel }) => {
   const { displayedFolder } = useDisplayedFolder()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const location = useLocation()
   const { isMobile } = useBreakpoints()
 
   const share = () => {
-    navigate(getPathToShareDisplayedFolder(pathname))
+    navigate(makeDisplayedFolderShareLocation({ location }))
   }
 
   if (!displayedFolder) return null

--- a/src/modules/drive/Toolbar/share/ShareItem.jsx
+++ b/src/modules/drive/Toolbar/share/ShareItem.jsx
@@ -9,15 +9,15 @@ import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useI18n } from 'twake-i18n'
 
-import { getPathToShareDisplayedFolder } from '@/modules/drive/Toolbar/share/helpers'
+import { makeDisplayedFolderShareLocation } from '@/modules/drive/Toolbar/share/helpers'
 
 const ShareItem = ({ displayedFolder }) => {
   const { t } = useI18n()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const location = useLocation()
 
   const share = () => {
-    navigate(getPathToShareDisplayedFolder(pathname))
+    navigate(makeDisplayedFolderShareLocation({ location }))
   }
 
   return (

--- a/src/modules/drive/Toolbar/share/SharedRecipients.jsx
+++ b/src/modules/drive/Toolbar/share/SharedRecipients.jsx
@@ -4,15 +4,15 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { SharedRecipients } from 'cozy-sharing'
 
 import { useDisplayedFolder } from '@/hooks'
-import { getPathToShareDisplayedFolder } from '@/modules/drive/Toolbar/share/helpers'
+import { makeDisplayedFolderShareLocation } from '@/modules/drive/Toolbar/share/helpers'
 
 const SharedRecipientsComponent = () => {
   const { displayedFolder } = useDisplayedFolder()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const location = useLocation()
 
   const share = () => {
-    navigate(getPathToShareDisplayedFolder(pathname))
+    navigate(makeDisplayedFolderShareLocation({ location }))
   }
 
   return (

--- a/src/modules/drive/Toolbar/share/helpers.js
+++ b/src/modules/drive/Toolbar/share/helpers.js
@@ -1,4 +1,5 @@
 import { joinPath } from '@/lib/path'
+import { makeSharingsTabLocation } from '@/modules/navigation/sharingsTabNavigation'
 
 /**
  * Get the path to share the displayed folder
@@ -7,4 +8,11 @@ import { joinPath } from '@/lib/path'
  */
 export function getPathToShareDisplayedFolder(pathname) {
   return joinPath(pathname, 'share')
+}
+
+export function makeDisplayedFolderShareLocation({ location }) {
+  return makeSharingsTabLocation({
+    currentLocation: location,
+    targetPathname: getPathToShareDisplayedFolder(location.pathname)
+  })
 }

--- a/src/modules/drive/Toolbar/share/helpers.spec.js
+++ b/src/modules/drive/Toolbar/share/helpers.spec.js
@@ -1,4 +1,7 @@
-import { getPathToShareDisplayedFolder } from '@/modules/drive/Toolbar/share/helpers'
+import {
+  getPathToShareDisplayedFolder,
+  makeDisplayedFolderShareLocation
+} from '@/modules/drive/Toolbar/share/helpers'
 
 describe('getPathToShareDisplayedFolder', () => {
   it('should return path to displayed folder share modal', () => {
@@ -11,5 +14,21 @@ describe('getPathToShareDisplayedFolder', () => {
     expect(getPathToShareDisplayedFolder('/path/to/folder/123/')).toBe(
       '/path/to/folder/123/share'
     )
+  })
+})
+
+describe('makeDisplayedFolderShareLocation', () => {
+  it('preserves the active Sharings tab', () => {
+    expect(
+      makeDisplayedFolderShareLocation({
+        location: {
+          pathname: '/sharings/shareddrive/drive-id/folder-id',
+          search: '?tab=drives'
+        }
+      })
+    ).toEqual({
+      pathname: '/sharings/shareddrive/drive-id/folder-id/share',
+      search: '?tab=drives'
+    })
   })
 })

--- a/src/modules/filelist/sharePath.js
+++ b/src/modules/filelist/sharePath.js
@@ -1,4 +1,5 @@
 import { joinPath } from '@/lib/path'
+import { makeSharingsTabLocation } from '@/modules/navigation/sharingsTabNavigation'
 import { isSharedDriveDoc } from '@/modules/shareddrives/helpers'
 import {
   getFileRootSharePath,
@@ -27,4 +28,14 @@ export const makeFileSharePath = ({ file, pathname }) => {
   // itself: the route's `:folderId` segment and the share modal's `:fileId`
   // segment reference the same doc. Use one resolved id for both.
   return `/shareddrive/${file.driveId}/${fileId}/file/${fileId}/share`
+}
+
+export function makeFileShareLocation({ file, location }) {
+  return makeSharingsTabLocation({
+    currentLocation: location,
+    targetPathname: makeFileSharePath({
+      file,
+      pathname: location.pathname
+    })
+  })
 }

--- a/src/modules/filelist/sharePath.spec.js
+++ b/src/modules/filelist/sharePath.spec.js
@@ -1,4 +1,4 @@
-import { makeFileSharePath } from './sharePath'
+import { makeFileShareLocation, makeFileSharePath } from './sharePath'
 
 import { DRIVE_ROOT_TYPE } from '@/modules/shareddrives/types'
 
@@ -22,5 +22,22 @@ describe('makeFileSharePath', () => {
     ${'folder-root shared drive outside sharings'}     | ${{ _id: 'folder-1', id: 'folder-1', driveId: 'drive-1' }}                                    | ${'/shareddrive/drive-1/folder-1'}             | ${'/shareddrive/drive-1/folder-1/file/folder-1/share'}
   `('builds $label share path', ({ file, pathname, expectedPath }) => {
     expectSharePath({ file, pathname, expectedPath })
+  })
+})
+
+describe('makeFileShareLocation', () => {
+  it('preserves the active Sharings tab', () => {
+    expect(
+      makeFileShareLocation({
+        file: { id: 'file-1' },
+        location: {
+          pathname: '/sharings',
+          search: '?tab=by-me'
+        }
+      })
+    ).toEqual({
+      pathname: '/sharings/file/file-1/share',
+      search: '?tab=by-me'
+    })
   })
 })

--- a/src/modules/filelist/useFileShareNavigate.js
+++ b/src/modules/filelist/useFileShareNavigate.js
@@ -1,10 +1,10 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 
-import { makeFileSharePath } from '@/modules/filelist/sharePath'
+import { makeFileShareLocation } from '@/modules/filelist/sharePath'
 
 export const useFileShareNavigate = ({ file, disabled }) => {
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const location = useLocation()
 
   return e => {
     // Avoid triggering row click from FileOpener.
@@ -12,7 +12,7 @@ export const useFileShareNavigate = ({ file, disabled }) => {
     e.stopPropagation()
 
     if (!disabled) {
-      navigate(makeFileSharePath({ file, pathname }))
+      navigate(makeFileShareLocation({ file, location }))
     }
   }
 }

--- a/src/modules/filelist/useFileShareNavigate.spec.jsx
+++ b/src/modules/filelist/useFileShareNavigate.spec.jsx
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react'
+
+import { useFileShareNavigate } from './useFileShareNavigate'
+
+const mockNavigate = jest.fn()
+const mockUseLocation = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => mockUseLocation(),
+  useNavigate: () => mockNavigate
+}))
+
+describe('useFileShareNavigate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseLocation.mockReturnValue({
+      pathname: '/sharings',
+      search: '?tab=by-me'
+    })
+  })
+
+  it('preserves the active Sharings tab when opening the dialog', () => {
+    const event = {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn()
+    }
+    const { result } = renderHook(() =>
+      useFileShareNavigate({ file: { id: 'file-1' }, disabled: false })
+    )
+
+    result.current(event)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/sharings/file/file-1/share',
+      search: '?tab=by-me'
+    })
+  })
+})

--- a/src/modules/navigation/sharingsTabNavigation.js
+++ b/src/modules/navigation/sharingsTabNavigation.js
@@ -1,0 +1,26 @@
+import {
+  DEFAULT_SHARINGS_VIEW_ROUTE,
+  SHARINGS_VIEW_ROUTE
+} from '@/constants/config'
+import { getSharingsTabSearch } from '@/modules/navigation/hooks/helpers'
+
+function makeSharingsTabLocation({ currentLocation, targetPathname }) {
+  return {
+    pathname: targetPathname,
+    search: getSharingsTabSearch(
+      currentLocation.pathname,
+      currentLocation.search
+    )
+  }
+}
+
+function makeSharingsViewLocation({ currentLocation }) {
+  const location = makeSharingsTabLocation({
+    currentLocation,
+    targetPathname: SHARINGS_VIEW_ROUTE
+  })
+
+  return location.search ? location : DEFAULT_SHARINGS_VIEW_ROUTE
+}
+
+export { makeSharingsTabLocation, makeSharingsViewLocation }

--- a/src/modules/navigation/sharingsTabNavigation.spec.js
+++ b/src/modules/navigation/sharingsTabNavigation.spec.js
@@ -1,0 +1,60 @@
+import {
+  makeSharingsTabLocation,
+  makeSharingsViewLocation
+} from './sharingsTabNavigation'
+
+import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
+
+describe('sharingsTabNavigation', () => {
+  it('preserves the active tab for a target inside Sharings', () => {
+    expect(
+      makeSharingsTabLocation({
+        currentLocation: {
+          pathname: '/sharings',
+          search: '?foo=bar&tab=by-me'
+        },
+        targetPathname: '/sharings/file/file-1/share'
+      })
+    ).toEqual({
+      pathname: '/sharings/file/file-1/share',
+      search: '?tab=by-me'
+    })
+  })
+
+  it('does not carry the tab outside Sharings', () => {
+    expect(
+      makeSharingsTabLocation({
+        currentLocation: {
+          pathname: '/recent',
+          search: '?tab=by-me'
+        },
+        targetPathname: '/recent/file/file-1/share'
+      })
+    ).toEqual({
+      pathname: '/recent/file/file-1/share',
+      search: ''
+    })
+  })
+
+  it('returns the active tab when leaving a Sharings modal', () => {
+    expect(
+      makeSharingsViewLocation({
+        currentLocation: {
+          pathname: '/sharings/file/file-1/share',
+          search: '?tab=drives'
+        }
+      })
+    ).toEqual({ pathname: '/sharings', search: '?tab=drives' })
+  })
+
+  it('uses the default Sharings route outside the section', () => {
+    expect(
+      makeSharingsViewLocation({
+        currentLocation: {
+          pathname: '/folder/folder-1/file/file-1/share',
+          search: ''
+        }
+      })
+    ).toBe(DEFAULT_SHARINGS_VIEW_ROUTE)
+  })
+})

--- a/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.js
@@ -5,7 +5,7 @@ import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuIte
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
-import { makeFileSharePath } from '@/modules/filelist/sharePath'
+import { makeFileShareLocation } from '@/modules/filelist/sharePath'
 import { isFileRootSharedDrive } from '@/modules/shareddrives/rootFileNavigation'
 
 // Only for sharing tabs. Mutually exclusive with `shareSharedDrive`: that one
@@ -14,7 +14,7 @@ export const shareFileRootSharedDrive = ({
   navigate,
   t,
   isOwner,
-  pathname
+  location
 }) => {
   const label = t('Files.share.cta')
   const icon = Share
@@ -33,7 +33,7 @@ export const shareFileRootSharedDrive = ({
     // Same route the avatars build, so the share button layers the modal over
     // the sharings list instead of navigating into the shared-drive view.
     action: docs => {
-      navigate(makeFileSharePath({ file: docs[0], pathname }))
+      navigate(makeFileShareLocation({ file: docs[0], location }))
     },
     Component: forwardRef(function ShareFileRootSharedDrive(props, ref) {
       return (

--- a/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.spec.js
+++ b/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.spec.js
@@ -6,8 +6,10 @@ describe('shareFileRootSharedDrive', () => {
   const t = key => key
   const navigate = jest.fn()
 
-  const makeAction = ({ isOwner = () => true, pathname = '/sharings' } = {}) =>
-    shareFileRootSharedDrive({ navigate, t, isOwner, pathname })
+  const makeAction = ({
+    isOwner = () => true,
+    location = { pathname: '/sharings', search: '?tab=drives' }
+  } = {}) => shareFileRootSharedDrive({ navigate, t, isOwner, location })
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -25,7 +27,7 @@ describe('shareFileRootSharedDrive', () => {
   })
 
   it('layers the share modal over the sharings list', () => {
-    makeAction({ pathname: '/sharings' }).action([
+    makeAction().action([
       {
         _id: 'file-id',
         driveId: 'drive-id',
@@ -33,13 +35,16 @@ describe('shareFileRootSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/sharings/shareddrive/drive-id/file-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/sharings/shareddrive/drive-id/file-id/share',
+      search: '?tab=drives'
+    })
   })
 
   it('navigates to the direct share route when pathname is outside /sharings', () => {
-    makeAction({ pathname: '/recent' }).action([
+    makeAction({
+      location: { pathname: '/recent', search: '?tab=by-me' }
+    }).action([
       {
         _id: 'file-id',
         driveId: 'drive-id',
@@ -47,8 +52,9 @@ describe('shareFileRootSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/shareddrive/drive-id/file/file-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/shareddrive/drive-id/file/file-id/share',
+      search: ''
+    })
   })
 })

--- a/src/modules/shareddrives/components/actions/shareSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/shareSharedDrive.js
@@ -5,7 +5,7 @@ import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuIte
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
-import { makeFileSharePath } from '@/modules/filelist/sharePath'
+import { makeFileShareLocation } from '@/modules/filelist/sharePath'
 import { isSharedDriveDoc } from '@/modules/shareddrives/helpers'
 import { isFileRootSharedDrive } from '@/modules/shareddrives/rootFileNavigation'
 
@@ -13,7 +13,7 @@ import { isFileRootSharedDrive } from '@/modules/shareddrives/rootFileNavigation
 // drives are handled by `shareFileRootSharedDrive`. The two are mutually
 // exclusive: this one hides itself when the doc is a file-root, and the
 // file-root one only shows for file-roots.
-export const shareSharedDrive = ({ navigate, t, pathname }) => {
+export const shareSharedDrive = ({ navigate, t, location }) => {
   const label = t('Files.share.cta')
   const icon = Share
 
@@ -33,7 +33,7 @@ export const shareSharedDrive = ({ navigate, t, pathname }) => {
     // Same route the avatars build, so the share button layers the modal over
     // the sharings list instead of navigating into the shared-drive view.
     action: docs => {
-      navigate(makeFileSharePath({ file: docs[0], pathname }))
+      navigate(makeFileShareLocation({ file: docs[0], location }))
     },
     Component: forwardRef(function ShareSharedDrive(props, ref) {
       return (

--- a/src/modules/shareddrives/components/actions/shareSharedDrive.spec.js
+++ b/src/modules/shareddrives/components/actions/shareSharedDrive.spec.js
@@ -6,8 +6,10 @@ describe('shareSharedDrive', () => {
   const t = key => key
   const navigate = jest.fn()
 
-  const makeAction = ({ isOwner, pathname = '/sharings' } = {}) =>
-    shareSharedDrive({ navigate, t, isOwner, pathname })
+  const makeAction = ({
+    isOwner,
+    location = { pathname: '/sharings', search: '?tab=drives' }
+  } = {}) => shareSharedDrive({ navigate, t, isOwner, location })
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -43,7 +45,7 @@ describe('shareSharedDrive', () => {
   })
 
   it('layers the share modal over the sharings list', () => {
-    makeAction({ pathname: '/sharings' }).action([
+    makeAction().action([
       {
         _id: 'folder-id',
         id: 'folder-id',
@@ -51,13 +53,19 @@ describe('shareSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/sharings/shareddrive/drive-id/folder-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/sharings/shareddrive/drive-id/folder-id/share',
+      search: '?tab=drives'
+    })
   })
 
   it('opens the folder view share modal when outside /sharings', () => {
-    makeAction({ pathname: '/shareddrive/drive-id/folder-id' }).action([
+    makeAction({
+      location: {
+        pathname: '/shareddrive/drive-id/folder-id',
+        search: '?tab=by-me'
+      }
+    }).action([
       {
         _id: 'folder-id',
         id: 'folder-id',
@@ -65,8 +73,9 @@ describe('shareSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/shareddrive/drive-id/folder-id/file/folder-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/shareddrive/drive-id/folder-id/file/folder-id/share',
+      search: ''
+    })
   })
 })

--- a/src/modules/viewer/FilesViewer.jsx
+++ b/src/modules/viewer/FilesViewer.jsx
@@ -222,7 +222,8 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange, viewerProps }) => {
                       navigate,
                       pathname: '',
                       files,
-                      path: 'share'
+                      path: 'share',
+                      location
                     })
                   }
                 />

--- a/src/modules/views/Folder/hooks/useFolderViewBase.js
+++ b/src/modules/views/Folder/hooks/useFolderViewBase.js
@@ -18,7 +18,8 @@ import { useSelectionContext } from '@/modules/selection/SelectionProvider'
  */
 export const useFolderViewBase = () => {
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const location = useLocation()
+  const { pathname } = location
   const { isMobile } = useBreakpoints()
   const { t, lang } = useI18n()
   const client = useClient()
@@ -30,6 +31,7 @@ export const useFolderViewBase = () => {
 
   return {
     navigate,
+    location,
     pathname,
     isMobile,
     t,

--- a/src/modules/views/Modal/ShareDisplayedFolderView.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.jsx
@@ -1,23 +1,35 @@
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import flag from 'cozy-flags'
 import { ShareModal } from 'cozy-sharing'
 
-import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
+import {
+  makeSharingsTabLocation,
+  makeSharingsViewLocation
+} from '@/modules/navigation/sharingsTabNavigation'
 
 const ShareDisplayedFolderView = () => {
   const { displayedFolder } = useDisplayedFolder()
+  const location = useLocation()
   const navigate = useNavigate()
 
   if (displayedFolder) {
-    const onClose = () => {
-      navigate('..', { replace: true })
+    const handleClose = () => {
+      navigate(
+        makeSharingsTabLocation({
+          currentLocation: location,
+          targetPathname: '..'
+        }),
+        { replace: true }
+      )
     }
 
-    const onRevokeSuccess = () => {
-      navigate(DEFAULT_SHARINGS_VIEW_ROUTE, { replace: true })
+    const handleRevokeSuccess = () => {
+      navigate(makeSharingsViewLocation({ currentLocation: location }), {
+        replace: true
+      })
     }
 
     return (
@@ -25,8 +37,8 @@ const ShareDisplayedFolderView = () => {
         document={displayedFolder}
         documentType="Files"
         sharingDesc={displayedFolder.name}
-        onClose={onClose}
-        onRevokeSuccess={onRevokeSuccess}
+        onClose={handleClose}
+        onRevokeSuccess={handleRevokeSuccess}
         autoOpenShareRestriction={flag('sharing.auto-open-settings.enabled')}
         showGenerateLinkButton={flag('sharing.generate-link-button.enabled')}
       />

--- a/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
@@ -5,13 +5,19 @@ import { ShareModal } from 'cozy-sharing'
 
 import { ShareDisplayedFolderView } from './ShareDisplayedFolderView'
 
-import { SHARING_TAB_WITH_ME } from '@/constants/config'
+import {
+  DEFAULT_SHARINGS_VIEW_ROUTE,
+  SHARING_TAB_BY_ME,
+  SHARING_TAB_DRIVES
+} from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
 
 const mockNavigate = jest.fn()
+const mockUseLocation = jest.fn()
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
+  useLocation: () => mockUseLocation(),
   useNavigate: () => mockNavigate
 }))
 
@@ -30,29 +36,40 @@ jest.mock('@/hooks', () => ({
 describe('ShareDisplayedFolderView', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseLocation.mockReturnValue({
+      pathname: '/sharings/folder/folder-id/share',
+      search: `?tab=${SHARING_TAB_BY_ME}`
+    })
   })
 
-  it('should redirect to the with-me tab after leaving a shared drive', () => {
+  it('should preserve the drives tab after leaving a shared drive', () => {
     useDisplayedFolder.mockReturnValue({
       displayedFolder: {
         driveId: 'drive-id',
         name: 'Shared folder'
       }
     })
+    mockUseLocation.mockReturnValue({
+      pathname: '/sharings/shareddrive/drive-id/folder-id/share',
+      search: `?tab=${SHARING_TAB_DRIVES}`
+    })
 
     render(<ShareDisplayedFolderView />)
 
     fireEvent.click(screen.getByText('Revoke self'))
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
+      {
+        pathname: '/sharings',
+        search: `?tab=${SHARING_TAB_DRIVES}`
+      },
       {
         replace: true
       }
     )
   })
 
-  it('should redirect to the sharings section after leaving a regular sharing', () => {
+  it('should preserve the by-me tab after leaving a regular sharing', () => {
     useDisplayedFolder.mockReturnValue({
       displayedFolder: {
         name: 'Shared folder'
@@ -64,7 +81,10 @@ describe('ShareDisplayedFolderView', () => {
     fireEvent.click(screen.getByText('Revoke self'))
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
+      {
+        pathname: '/sharings',
+        search: `?tab=${SHARING_TAB_BY_ME}`
+      },
       { replace: true }
     )
   })
@@ -80,6 +100,29 @@ describe('ShareDisplayedFolderView', () => {
 
     ShareModal.mock.calls[0][0].onClose()
 
-    expect(mockNavigate).toHaveBeenCalledWith('..', { replace: true })
+    expect(mockNavigate).toHaveBeenCalledWith(
+      { pathname: '..', search: `?tab=${SHARING_TAB_BY_ME}` },
+      { replace: true }
+    )
+  })
+
+  it('should use the default Sharings route outside the section', () => {
+    useDisplayedFolder.mockReturnValue({
+      displayedFolder: {
+        name: 'Shared folder'
+      }
+    })
+    mockUseLocation.mockReturnValue({
+      pathname: '/folder/folder-id/share',
+      search: ''
+    })
+
+    render(<ShareDisplayedFolderView />)
+
+    fireEvent.click(screen.getByText('Revoke self'))
+
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_SHARINGS_VIEW_ROUTE, {
+      replace: true
+    })
   })
 })

--- a/src/modules/views/Modal/ShareFileView.jsx
+++ b/src/modules/views/Modal/ShareFileView.jsx
@@ -1,18 +1,22 @@
 import React from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
 import flag from 'cozy-flags'
 import { ShareModal } from 'cozy-sharing'
 
 import { LoaderModal } from '@/components/LoaderModal'
-import { DEFAULT_SHARINGS_VIEW_ROUTE } from '@/constants/config'
+import {
+  makeSharingsTabLocation,
+  makeSharingsViewLocation
+} from '@/modules/navigation/sharingsTabNavigation'
 import {
   buildFileOrFolderByIdQuery,
   buildSharedDriveFileOrFolderByIdQuery
 } from '@/queries'
 
 const ShareFileView = () => {
+  const location = useLocation()
   const navigate = useNavigate()
   const { fileId, driveId } = useParams()
 
@@ -22,11 +26,19 @@ const ShareFileView = () => {
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
 
   const handleExit = () => {
-    navigate('..', { replace: true })
+    navigate(
+      makeSharingsTabLocation({
+        currentLocation: location,
+        targetPathname: '..'
+      }),
+      { replace: true }
+    )
   }
 
   const handleRevokeSuccess = () => {
-    navigate(DEFAULT_SHARINGS_VIEW_ROUTE, { replace: true })
+    navigate(makeSharingsViewLocation({ currentLocation: location }), {
+      replace: true
+    })
   }
 
   if (hasQueryBeenLoaded(fileResult) && fileResult.data) {

--- a/src/modules/views/Modal/ShareFileView.spec.jsx
+++ b/src/modules/views/Modal/ShareFileView.spec.jsx
@@ -2,16 +2,23 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
+import { ShareModal } from 'cozy-sharing'
 
 import { ShareFileView } from './ShareFileView'
 
-import { SHARING_TAB_WITH_ME } from '@/constants/config'
+import {
+  DEFAULT_SHARINGS_VIEW_ROUTE,
+  SHARING_TAB_BY_ME,
+  SHARING_TAB_DRIVES
+} from '@/constants/config'
 
 const mockNavigate = jest.fn()
+const mockUseLocation = jest.fn()
 const mockUseParams = jest.fn()
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
+  useLocation: () => mockUseLocation(),
   useNavigate: () => mockNavigate,
   useParams: () => mockUseParams()
 }))
@@ -49,6 +56,10 @@ jest.mock('@/queries', () => ({
 describe('ShareFileView', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseLocation.mockReturnValue({
+      pathname: '/sharings/file/file-id/share',
+      search: `?tab=${SHARING_TAB_BY_ME}`
+    })
     hasQueryBeenLoaded.mockReturnValue(true)
     useQuery.mockReturnValue({
       data: {
@@ -59,22 +70,29 @@ describe('ShareFileView', () => {
     })
   })
 
-  it('should redirect to the with-me tab after leaving a shared drive file', () => {
+  it('should preserve the drives tab after leaving a shared drive file', () => {
     mockUseParams.mockReturnValue({ driveId: 'drive-id', fileId: 'file-id' })
+    mockUseLocation.mockReturnValue({
+      pathname: '/sharings/shareddrive/drive-id/file-id/share',
+      search: `?tab=${SHARING_TAB_DRIVES}`
+    })
 
     render(<ShareFileView />)
 
     fireEvent.click(screen.getByText('Revoke self'))
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
+      {
+        pathname: '/sharings',
+        search: `?tab=${SHARING_TAB_DRIVES}`
+      },
       {
         replace: true
       }
     )
   })
 
-  it('should redirect to the sharings section after leaving a regular sharing', () => {
+  it('should preserve the by-me tab after leaving a regular sharing', () => {
     mockUseParams.mockReturnValue({ fileId: 'file-id' })
 
     render(<ShareFileView />)
@@ -82,8 +100,41 @@ describe('ShareFileView', () => {
     fireEvent.click(screen.getByText('Revoke self'))
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/sharings?tab=${SHARING_TAB_WITH_ME}`,
+      {
+        pathname: '/sharings',
+        search: `?tab=${SHARING_TAB_BY_ME}`
+      },
       { replace: true }
     )
+  })
+
+  it('should preserve the active tab when closing the modal', () => {
+    mockUseParams.mockReturnValue({ fileId: 'file-id' })
+
+    render(<ShareFileView />)
+
+    const shareModalProps = ShareModal.mock.calls[0][0]
+    shareModalProps.onClose()
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      { pathname: '..', search: `?tab=${SHARING_TAB_BY_ME}` },
+      { replace: true }
+    )
+  })
+
+  it('should use the default Sharings route outside the section', () => {
+    mockUseParams.mockReturnValue({ fileId: 'file-id' })
+    mockUseLocation.mockReturnValue({
+      pathname: '/folder/folder-id/file/file-id/share',
+      search: ''
+    })
+
+    render(<ShareFileView />)
+
+    fireEvent.click(screen.getByText('Revoke self'))
+
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_SHARINGS_VIEW_ROUTE, {
+      replace: true
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Preserve the active Sharings tab when opening and closing file and folder share dialogs.
- Return to the same tab after revoking a sharing while keeping the default redirect outside Sharings.
- Add regression coverage for share entry points and modal redirects.
