### PR TITLE
feat: Return thumbnail link in File Picker

### DIFF
--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -199,6 +199,9 @@ interface FilePickerEntry {
   mimeType: string | null
   sharingLink?: string
   downloadLink?: string
+  thumbnail?: {
+    link: string
+  }
 }
 ```
 
@@ -214,13 +217,20 @@ Example:
       "name": "invoice.pdf",
       "size": 123456,
       "mimeType": "application/pdf",
-      "downloadLink": "https://alice.example/files/download/..."
+      "downloadLink": "https://alice.example/files/download/...",
+      "thumbnail": {
+        "link": "https://cdn.example.com/files/pdf.jpg"
+      }
     }
   ]
 }
 ```
 
 For folders, `size` is `0` and `mimeType` is `null`.
+
+### Thumbnails
+
+The File Picker may provide a thumbnail (an illustration or a preview) that may be used by the caller. The thumbnail link is public and has an unlimited lifetime. It is currently a 80x80 png image.
 
 ## Error handling
 

--- a/src/modules/services/components/FilePicker/payload.js
+++ b/src/modules/services/components/FilePicker/payload.js
@@ -2,6 +2,8 @@ import { models } from 'cozy-client'
 
 const { file: fileModel } = models
 
+import { makeThumbnail } from './thumbnail'
+
 /**
  * Build a single file entry of the File Picker payload from a
  * Cozy file/folder document and the links generated for it.
@@ -25,5 +27,6 @@ export const makeFilePickerFileEntry = (
   size: fileModel.isFile(file) ? parseInt(file.size, 10) || 0 : 0,
   mimeType: fileModel.isFile(file) ? file.mime : null,
   ...(sharingLink ? { sharingLink } : {}),
-  ...(downloadLink ? { downloadLink } : {})
+  ...(downloadLink ? { downloadLink } : {}),
+  ...makeThumbnail(file)
 })

--- a/src/modules/services/components/FilePicker/payload.spec.js
+++ b/src/modules/services/components/FilePicker/payload.spec.js
@@ -18,7 +18,10 @@ describe('FilePicker payload', () => {
         name: 'invoice.pdf',
         size: 1024,
         mimeType: 'application/pdf',
-        sharingLink: 'https://x'
+        sharingLink: 'https://x',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       })
     })
 

--- a/src/modules/services/components/FilePicker/thumbnail.js
+++ b/src/modules/services/components/FilePicker/thumbnail.js
@@ -1,0 +1,59 @@
+import { matchMimeType } from './helpers'
+
+const MIME_TYPE_TO_THUMBNAIL_TYPE = {
+  // Audio
+  'audio/*': 'audio',
+
+  // Image
+  'image/*': 'image',
+
+  // PDF
+  'application/pdf': 'pdf',
+
+  // Word
+  'application/msword': 'word',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    'word',
+
+  // Default
+  '*/*': 'default'
+}
+
+const THUMBNAIL_TYPE_TO_THUMBNAIL_LINK = {
+  audio: 'https://files.twake.app/email-assets/file-picker/audio.png',
+  image: 'https://files.twake.app/email-assets/file-picker/image.png',
+  pdf: 'https://files.twake.app/email-assets/file-picker/pdf.png',
+  word: 'https://files.twake.app/email-assets/file-picker/word.png',
+  default: 'https://files.twake.app/email-assets/file-picker/default.png'
+}
+
+/**
+ * Maps a MIME type to its corresponding thumbnail link.
+ * @param {string} mimeType - The MIME type to map.
+ * @returns {string} - The link of the thumbnail.
+ */
+function getThumbnailLinkFromMimeType(mimeType) {
+  const patterns = Object.keys(MIME_TYPE_TO_THUMBNAIL_TYPE)
+
+  const matchedPattern = patterns.find(pattern =>
+    matchMimeType(mimeType, [pattern])
+  )
+
+  const thumbnailType = matchedPattern
+    ? MIME_TYPE_TO_THUMBNAIL_TYPE[matchedPattern]
+    : 'default'
+
+  return THUMBNAIL_TYPE_TO_THUMBNAIL_LINK[thumbnailType]
+}
+
+export const makeThumbnail = file => {
+  try {
+    return {
+      thumbnail: {
+        link: getThumbnailLinkFromMimeType(file.mime)
+      }
+    }
+  } catch {
+    return {}
+  }
+}

--- a/src/modules/services/components/FilePicker/thumbnail.spec.js
+++ b/src/modules/services/components/FilePicker/thumbnail.spec.js
@@ -1,0 +1,75 @@
+import { makeThumbnail } from './thumbnail'
+
+describe('makeThumbnail', () => {
+  it('should return audio thumbnail link for audio MIME types', () => {
+    const file = { mime: 'audio/mpeg' }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/audio.png'
+      }
+    })
+  })
+
+  it('should return image thumbnail link for image MIME types', () => {
+    const file = { mime: 'image/png' }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/image.png'
+      }
+    })
+  })
+
+  it('should return pdf thumbnail link for PDF MIME type', () => {
+    const file = { mime: 'application/pdf' }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+      }
+    })
+  })
+
+  it('should return word thumbnail link for Word MIME types', () => {
+    const file = {
+      mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/word.png'
+      }
+    })
+  })
+
+  it('should return default thumbnail link for unknown MIME types', () => {
+    const file = { mime: 'application/json' }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/default.png'
+      }
+    })
+  })
+
+  it('should return default thumbnail link when file has no mime property', () => {
+    const file = { name: 'test.txt' }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/default.png'
+      }
+    })
+  })
+
+  it('should return empty object when file is undefined', () => {
+    const result = makeThumbnail(undefined)
+    expect(result).toEqual({})
+  })
+
+  it('should return empty object when file is null', () => {
+    const result = makeThumbnail(null)
+    expect(result).toEqual({})
+  })
+})

--- a/src/modules/services/components/Picker.spec.jsx
+++ b/src/modules/services/components/Picker.spec.jsx
@@ -266,7 +266,10 @@ describe('Picker', () => {
         name: 'updated-invoice.pdf',
         size: 84,
         mimeType: 'application/pdf',
-        sharingLink: 'https://drive.example/public?sharecode=abc'
+        sharingLink: 'https://drive.example/public?sharecode=abc',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       }
     ])
   })
@@ -290,7 +293,10 @@ describe('Picker', () => {
         name: 'invoice.pdf',
         size: 42,
         mimeType: 'application/pdf',
-        sharingLink: 'https://drive.example/public?sharecode=abc'
+        sharingLink: 'https://drive.example/public?sharecode=abc',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       }
     ])
   })
@@ -321,14 +327,20 @@ describe('Picker', () => {
         name: 'invoice.pdf',
         size: 42,
         mimeType: 'application/pdf',
-        sharingLink: 'https://drive.example/public?sharecode=abc'
+        sharingLink: 'https://drive.example/public?sharecode=abc',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       },
       {
         id: 'second-file-id',
         name: 'receipt.pdf',
         size: 84,
         mimeType: 'application/pdf',
-        sharingLink: 'https://drive.example/public?sharecode=def'
+        sharingLink: 'https://drive.example/public?sharecode=def',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       }
     ])
   })
@@ -369,7 +381,10 @@ describe('Picker', () => {
         size: 42,
         mimeType: 'application/pdf',
         downloadLink:
-          'https://alice.example/files/downloads/123/invoice.pdf?Dl=1'
+          'https://alice.example/files/downloads/123/invoice.pdf?Dl=1',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       }
     ])
   })
@@ -421,7 +436,10 @@ describe('Picker', () => {
         size: 42,
         mimeType: 'application/pdf',
         downloadLink:
-          'https://alice.example/files/downloads/123/invoice.pdf?Dl=1'
+          'https://alice.example/files/downloads/123/invoice.pdf?Dl=1',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       },
       {
         id: 'second-file-id',
@@ -429,7 +447,10 @@ describe('Picker', () => {
         size: 84,
         mimeType: 'application/pdf',
         downloadLink:
-          'https://alice.example/files/downloads/456/receipt.pdf?Dl=1'
+          'https://alice.example/files/downloads/456/receipt.pdf?Dl=1',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       }
     ])
   })
@@ -480,7 +501,10 @@ describe('Picker', () => {
         name: 'invoice.pdf',
         size: 42,
         mimeType: 'application/pdf',
-        sharingLink: 'https://drive.example/public?sharecode=existing-code'
+        sharingLink: 'https://drive.example/public?sharecode=existing-code',
+        thumbnail: {
+          link: 'https://files.twake.app/email-assets/file-picker/pdf.png'
+        }
       }
     ])
   })


### PR DESCRIPTION
Not every types have been implemented. It is a first step to ensure it works well on the client side.

Note that files.twake.app links are temporary and will be replaced in the future by new CDN links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File Picker results now optionally include a `thumbnail` object with a public `link` for supported file types.
  * Thumbnails are selected automatically based on the file’s MIME type, with a default thumbnail for unknown or missing MIME types.
* **Documentation**
  * Updated File Picker documentation and examples to describe the new `thumbnail` field and its characteristics (public, unlimited lifetime, current preview format/size).
* **Tests**
  * Added and updated test coverage for thumbnail link generation and File Picker termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->