### PR TITLE
chore(codescene): disable code duplication rule on test files

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,0 +1,67 @@
+{
+  "rule_sets": [
+    {
+      "matching_content_path": "**/*.spec.js",
+      "rules": [
+        {
+          "name": "Code Duplication",
+          "weight": 0.0
+        }
+      ]
+    },
+    {
+      "matching_content_path": "**/*.spec.jsx",
+      "rules": [
+        {
+          "name": "Code Duplication",
+          "weight": 0.0
+        }
+      ]
+    },
+    {
+      "matching_content_path": "**/*.spec.ts",
+      "rules": [
+        {
+          "name": "Code Duplication",
+          "weight": 0.0
+        }
+      ]
+    },
+    {
+      "matching_content_path": "**/*.spec.tsx",
+      "rules": [
+        {
+          "name": "Code Duplication",
+          "weight": 0.0
+        }
+      ]
+    },
+    {
+      "matching_content_path": "e2e/**",
+      "rules": [
+        {
+          "name": "Code Duplication",
+          "weight": 0.0
+        }
+      ]
+    },
+    {
+      "matching_content_path": "jestHelpers/**",
+      "rules": [
+        {
+          "name": "Code Duplication",
+          "weight": 0.0
+        }
+      ]
+    },
+    {
+      "matching_content_path": "test/**",
+      "rules": [
+        {
+          "name": "Code Duplication",
+          "weight": 0.0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `.codescene/code-health-rules.json` setting the `Code Duplication` rule weight to `0.0` for `*.spec.{js,jsx,ts,tsx}` files and for the `e2e/`, `jestHelpers/` and `test/` directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration to exclude test and end-to-end files from code duplication health scoring.
  * Applied the configuration across JavaScript and TypeScript test file patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->