### PR TITLE
test(e2e): target the password textbox in link sharing

### DIFF
--- a/e2e/pages/ShareByLinkPage.ts
+++ b/e2e/pages/ShareByLinkPage.ts
@@ -72,7 +72,7 @@ export class ShareByLinkPage {
   async enablePassword(password: string): Promise<void> {
     const modal = this.restrictionModal
     await modal.getByText('Limit access with a password').click()
-    await modal.getByLabel('Password').fill(password)
+    await modal.getByRole('textbox', { name: 'Password' }).fill(password)
   }
 
   /** `date` must already be formatted for the current locale (MM/dd/yyyy in


### PR DESCRIPTION
It's a regression after the update of cozy-sharing where I forgot to run all e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password-field selection during link-sharing flows, making automated interactions more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->