### PR TITLE
fix: Open OO file on other instance in shared drive

### DIFF
--- a/src/modules/views/OnlyOffice/helpers.js
+++ b/src/modules/views/OnlyOffice/helpers.js
@@ -133,7 +133,10 @@ export const makeOnlyOfficeFileRoute = (
  * @returns {boolean}
  */
 export const shouldBeOpenedOnOtherInstance = ({ data }, instanceUri) => {
-  return !!instanceUri && !instanceUri.includes(data.attributes.instance)
+  if (!instanceUri) return false
+  const docHost = data.attributes.instance.split(':')[0]
+  const currentHost = new URL(instanceUri).hostname
+  return docHost !== currentHost
 }
 
 export const makeOnlyOfficeIconByClass = fileClass => {

--- a/src/modules/views/OnlyOffice/helpers.spec.js
+++ b/src/modules/views/OnlyOffice/helpers.spec.js
@@ -20,6 +20,36 @@ describe('shouldBeOpenedOnOtherInstance', () => {
     ).toBe(true)
   })
 
+  it('should return true if current instance is different from document instance without port', () => {
+    expect(
+      shouldBeOpenedOnOtherInstance(
+        {
+          data: {
+            attributes: {
+              instance: 'alice.cozy.localhost'
+            }
+          }
+        },
+        'http://bob.cozy.localhost'
+      )
+    ).toBe(true)
+  })
+
+  it('should return true if current instance is different from document instance with org instance', () => {
+    expect(
+      shouldBeOpenedOnOtherInstance(
+        {
+          data: {
+            attributes: {
+              instance: 'myorgc81729.example.com:8080'
+            }
+          }
+        },
+        ' http://myusermyorgc81729.example.com:8080'
+      )
+    ).toBe(true)
+  })
+
   it('should return false if current instance is equal to document instance', () => {
     expect(
       shouldBeOpenedOnOtherInstance(
@@ -31,6 +61,21 @@ describe('shouldBeOpenedOnOtherInstance', () => {
           }
         },
         'http://alice.cozy.localhost:8080'
+      )
+    ).toBe(false)
+  })
+
+  it('should return false if current instance is equal to document instance without port', () => {
+    expect(
+      shouldBeOpenedOnOtherInstance(
+        {
+          data: {
+            attributes: {
+              instance: 'alice.cozy.localhost'
+            }
+          }
+        },
+        'http://alice.cozy.localhost'
       )
     ).toBe(false)
   })


### PR DESCRIPTION
Due to the org B2B instance name ending like user B2B instance name, it was opened in same instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of whether documents should open in another instance.
  * Correctly handles missing instance URLs and compares hostnames from document and current instance data (including cases without explicit ports and organization-based hosts).
  * Avoids unnecessary redirects when instance hosts match.

* **Tests**
  * Extended test coverage for matching and differing instance hostnames across supported URL formats, including edge-case URL formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->