### PR TITLE
fix: use editor author for onlyoffice shared folder username

### DIFF
--- a/src/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/modules/views/OnlyOffice/Editor.spec.jsx
@@ -23,6 +23,10 @@ jest.mock('modules/views/OnlyOffice/helpers', () => ({
   isOfficeEnabled: jest.fn()
 }))
 
+jest.mock('@/modules/views/editor/useEditorAuthor', () => ({
+  useEditorAuthor: jest.fn(() => ({ author: 'Bob', isLoading: false }))
+}))
+
 jest.mock('cozy-ui/transpiled/react/providers/Breakpoints', () => ({
   ...jest.requireActual('cozy-ui/transpiled/react/providers/Breakpoints'),
   __esModule: true,

--- a/src/modules/views/OnlyOffice/helpers.js
+++ b/src/modules/views/OnlyOffice/helpers.js
@@ -186,16 +186,3 @@ export const showSharingBanner = ({
     (isInSharedFolder ? window.history.length <= 1 : window.history.length <= 2)
   )
 }
-
-/**
- * Make username to use in the Only office editor in order to show the name
- * when adding comment or moving the cursor for example
- * @param {object} params - Params
- * @param {boolean} params.isPublic - Whether the route is public (like /public)
- * @param {boolean} params.isFromSharing - Whether the doc is shared from cozy to cozy
- * @param {string} params.username - The name of the sharing recipient
- * @param {string} params.public_name - The name of the owner
- * @returns {string|undefined}
- */
-export const makeName = ({ isPublic, isFromSharing, username, public_name }) =>
-  isPublic && !isFromSharing ? undefined : username ? username : public_name

--- a/src/modules/views/OnlyOffice/helpers.spec.js
+++ b/src/modules/views/OnlyOffice/helpers.spec.js
@@ -1,6 +1,5 @@
 import {
   showSharingBanner,
-  makeName,
   shouldBeOpenedOnOtherInstance
 } from '@/modules/views/OnlyOffice/helpers'
 
@@ -78,110 +77,6 @@ describe('shouldBeOpenedOnOtherInstance', () => {
         'http://alice.cozy.localhost'
       )
     ).toBe(false)
-  })
-})
-
-describe('makeName', () => {
-  describe('for public route', () => {
-    it('should return undefined if it is not an accepted document from cozy to cozy sharing', () => {
-      expect(
-        makeName({
-          isPublic: true,
-          isFromSharing: false,
-          username: 'bob',
-          public_name: 'alice'
-        })
-      ).toBe(undefined)
-      expect(
-        makeName({
-          isPublic: true,
-          isFromSharing: false,
-          username: undefined,
-          public_name: 'alice'
-        })
-      ).toBe(undefined)
-      expect(
-        makeName({
-          isPublic: true,
-          isFromSharing: false,
-          username: 'bob',
-          public_name: undefined
-        })
-      ).toBe(undefined)
-      expect(
-        makeName({
-          isPublic: true,
-          isFromSharing: false,
-          username: undefined,
-          public_name: undefined
-        })
-      ).toBe(undefined)
-    })
-
-    it('should return the name of the sharing recipient for a document shared from cozy to cozy', () => {
-      expect(
-        makeName({
-          isPublic: true,
-          isFromSharing: true,
-          username: 'bob',
-          public_name: 'alice'
-        })
-      ).toBe('bob')
-      expect(
-        makeName({
-          isPublic: true,
-          isFromSharing: true,
-          username: 'bob',
-          public_name: undefined
-        })
-      ).toBe('bob')
-      expect(
-        makeName({
-          isPublic: true,
-          isFromSharing: true,
-          username: undefined,
-          public_name: undefined
-        })
-      ).toBe(undefined)
-    })
-  })
-
-  it('should return the public name if no sharing recipient', () => {
-    expect(
-      makeName({
-        isPublic: false,
-        isFromSharing: false,
-        username: undefined,
-        public_name: undefined
-      })
-    ).toBe(undefined)
-    expect(
-      makeName({
-        isPublic: false,
-        isFromSharing: false,
-        username: undefined,
-        public_name: 'alice'
-      })
-    ).toBe('alice')
-  })
-
-  it('should return the name of the sharing recipient if present', () => {
-    expect(
-      makeName({
-        isPublic: false,
-        isFromSharing: false,
-        username: 'bob',
-        public_name: 'alice'
-      })
-    ).toBe('bob')
-    expect(
-      makeName({
-        isPublic: false,
-        isFromSharing: false,
-        username: 'bob',
-        public_name: undefined
-      })
-    ).toBe('bob')
   })
 })
 

--- a/src/modules/views/OnlyOffice/useConfig.jsx
+++ b/src/modules/views/OnlyOffice/useConfig.jsx
@@ -8,9 +8,9 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useOnlyOfficeContext } from '@/modules/views/OnlyOffice/OnlyOfficeProvider'
 import {
   shouldBeOpenedOnOtherInstance,
-  isOfficeEnabled,
-  makeName
+  isOfficeEnabled
 } from '@/modules/views/OnlyOffice/helpers'
+import { useEditorAuthor } from '@/modules/views/editor/useEditorAuthor'
 
 const useConfig = () => {
   const {
@@ -18,8 +18,6 @@ const useConfig = () => {
     driveId,
     setIsEditorReady,
     isPublic,
-    username,
-    isFromSharing,
     editorMode,
     isEditorModeView,
     setOfficeKey
@@ -27,6 +25,7 @@ const useConfig = () => {
   const client = useClient()
   const instanceUri = client.getStackClient().uri
   const [currentSearchParams] = useSearchParams()
+  const { author, isLoading: isAuthorLoading } = useEditorAuthor({ isPublic })
 
   const [config, setConfig] = useState()
   const [status, setStatus] = useState('loading')
@@ -81,14 +80,11 @@ const useConfig = () => {
 
         window.location = link
       } else if (isOfficeEnabled(isDesktop)) {
+        // The editor reads the author from its config at mount, so wait for it.
+        if (isAuthorLoading) return
+
         const { attributes } = data.data
-        const { onlyoffice, public_name } = attributes
-        const name = makeName({
-          isPublic,
-          isFromSharing,
-          username,
-          public_name
-        })
+        const { onlyoffice } = attributes
 
         setOfficeKey(onlyoffice.document.key)
 
@@ -104,7 +100,7 @@ const useConfig = () => {
               'edit'
                 ? editorMode
                 : 'view',
-            user: { name },
+            user: { name: author },
             customization: {
               reviewDisplay: 'markup'
             }
@@ -130,8 +126,8 @@ const useConfig = () => {
     setConfig,
     setIsEditorReady,
     isPublic,
-    username,
-    isFromSharing,
+    author,
+    isAuthorLoading,
     instanceUri,
     isDesktop,
     currentSearchParams,

--- a/src/modules/views/OnlyOffice/useConfig.spec.jsx
+++ b/src/modules/views/OnlyOffice/useConfig.spec.jsx
@@ -1,0 +1,96 @@
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { useClient } from 'cozy-client'
+import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+
+import { officeDoc } from 'test/data'
+
+import { useOnlyOfficeContext } from '@/modules/views/OnlyOffice/OnlyOfficeProvider'
+import useConfig from '@/modules/views/OnlyOffice/useConfig'
+import { useEditorAuthor } from '@/modules/views/editor/useEditorAuthor'
+
+jest.mock('cozy-client', () => ({
+  useClient: jest.fn(),
+  isQueryLoading: jest.fn(() => false),
+  generateWebLink: jest.fn()
+}))
+jest.mock('cozy-client/dist/hooks/useFetchJSON', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+jest.mock('cozy-ui/transpiled/react/providers/Breakpoints', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+jest.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams()]
+}))
+jest.mock('@/modules/views/OnlyOffice/OnlyOfficeProvider', () => ({
+  useOnlyOfficeContext: jest.fn()
+}))
+jest.mock('@/modules/views/editor/useEditorAuthor', () => ({
+  useEditorAuthor: jest.fn()
+}))
+jest.mock('@/modules/views/OnlyOffice/helpers', () => ({
+  ...jest.requireActual('@/modules/views/OnlyOffice/helpers'),
+  isOfficeEnabled: jest.fn(() => true)
+}))
+jest.mock('cozy-flags')
+
+// Same instance as the client so the doc is opened locally (no redirect branch).
+const officeDocWithoutPublicName = {
+  data: {
+    ...officeDoc,
+    attributes: { ...officeDoc.attributes, public_name: undefined }
+  }
+}
+
+const setup = ({
+  data = officeDocWithoutPublicName,
+  author = 'Bob',
+  isAuthorLoading = false,
+  isPublic = false
+} = {}) => {
+  useClient.mockReturnValue({
+    getStackClient: () => ({ uri: 'https://bob.cozy.example' })
+  })
+  useBreakpoints.mockReturnValue({ isDesktop: true })
+  useFetchJSON.mockReturnValue({ data, fetchStatus: 'loaded' })
+  useEditorAuthor.mockReturnValue({ author, isLoading: isAuthorLoading })
+  useOnlyOfficeContext.mockReturnValue({
+    fileId: '123',
+    driveId: undefined,
+    setIsEditorReady: jest.fn(),
+    isPublic,
+    username: undefined,
+    isFromSharing: false,
+    editorMode: 'edit',
+    isEditorModeView: false,
+    setOfficeKey: jest.fn()
+  })
+
+  return renderHook(() => useConfig())
+}
+
+describe('useConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('sets the OnlyOffice username from the resolved editor author, even when the office open response has no public_name', async () => {
+    const { result } = setup({ author: 'Bob' })
+
+    await waitFor(() => expect(result.current.config).toBeDefined())
+
+    expect(result.current.config.docEditorConfig.editorConfig.user.name).toBe(
+      'Bob'
+    )
+  })
+
+  it('does not build the config until the editor author is resolved', () => {
+    const { result } = setup({ isAuthorLoading: true })
+
+    expect(result.current.config).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Resolve the OnlyOffice editor username through `useEditorAuthor`, the shared source already used by the PDF and Excalidraw editors, instead of the `public_name` from the `/office/:id/open` response. That value is empty for a file inside a shared folder, so the editor prompted the user to type a name.
- Wait for the author to resolve before building the editor config, since OnlyOffice reads it at mount.
- Remove the now unused `makeName` helper.

Fixes #3831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OnlyOffice now shows the correct editor author name, even when public profile details are missing.
  * Editor configuration now waits for author information to finish loading before opening.
  * Adjusted sharing banner display behavior to better match navigation context.
* **Tests**
  * Added/updated test coverage to ensure author-loading gating and correct username mapping in OnlyOffice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->