### PR TITLE
feat(file-picker): Support intent themes

### DIFF
--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -30,6 +30,7 @@ It is not a top-level `actions` field.
   "type": "io.cozy.files",
   "permissions": ["GET"],
   "data": {
+    "theme": { "type": "dark" },
     "multiple": false,
     "sharingLink": { "label": "Share as link" },
     "downloadLink": {
@@ -45,6 +46,12 @@ It is not a top-level `actions` field.
 
 ```ts
 interface FilePickerConfig {
+  /**
+   * Theme used to render the File Picker.
+   * Defaults to { type: "auto" }.
+   */
+  theme?: { type: 'light' | 'dark' | 'auto' }
+
   /**
    * Whether several files or folders can be selected.
    * Defaults to true. When false, modifier-key selection shortcuts are disabled.
@@ -112,11 +119,32 @@ When no config is provided, Drive uses:
 
 ```js
 {
+  theme: { type: 'auto' },
   multiple: true,
   sharingLink: { allowFolder: true },
   downloadLink: { allowFolder: false }
 }
 ```
+
+### Theme
+
+Use `theme.type` with `light` or `dark` to force the File Picker theme. The
+theme is fixed when the intent is created and does not change while it remains
+open.
+
+`auto`, an invalid value or an omitted value preserves the existing behavior:
+the iframe follows the Cozy instance theme, with the system color scheme as a
+fallback. For `auto`, omit `theme` from the options passed to
+`IntentDialogOpener`, which only accepts explicit `light` or `dark` values.
+`IntentDialogOpener` and `IntentIframe` from `cozy-ui-plus >= 12.2.0` apply an
+explicit theme to their dialog, close button and loading surface.
+Older versions still pass the option to Drive, so the iframe is themed but the
+calling application's surrounding UI keeps its own theme.
+
+Custom intent containers remain responsible for styling their own UI. For raw
+intents, pass the `theme` object in `attributes.data` like the other File Picker
+options. The option never changes Cozy settings, local storage or the caller's
+global theme.
 
 Default labels:
 

--- a/e2e/pages/FilePickerPage.ts
+++ b/e2e/pages/FilePickerPage.ts
@@ -21,13 +21,16 @@ export class FilePickerPage {
   }
 
   /** Navigate to Drive and open the file picker dialog. */
-  async open(configName?: string): Promise<void> {
+  async open(configName?: string, themeName?: string): Promise<void> {
     await this.page.goto(`${USERS.alice.appUrl}/#/folder`)
     await this.page.getByRole('button', { name: /pick a file/i }).waitFor({
       state: 'visible'
     })
     if (configName) {
       await this.page.getByRole('radio', { name: configName }).check()
+    }
+    if (themeName) {
+      await this.page.getByRole('radio', { name: themeName }).check()
     }
     await this.page.getByRole('button', { name: /pick a file/i }).click()
     // The picker is loaded inside an iframe inside a MUI/Dialog — wait for it.
@@ -202,12 +205,6 @@ export class FilePickerPage {
   // ---------------------------------------------------------------------------
   // Error display (inside the picker iframe)
   // ---------------------------------------------------------------------------
-
-  /** Whether the inline error alert is visible inside the picker. */
-  async isErrorVisible(): Promise<boolean> {
-    const frame = this.getFrameLocator()
-    return frame.getByTestId('file-picker-error').isVisible()
-  }
 
   /** Get the error text displayed inside the picker. */
   async getErrorText(): Promise<string> {

--- a/e2e/tests/file-picker.spec.ts
+++ b/e2e/tests/file-picker.spec.ts
@@ -61,6 +61,34 @@ test.describe('File Picker', () => {
     await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
   })
 
+  test('forces the dark theme without relying on caller layout utilities', async ({
+    alicePage
+  }) => {
+    await alicePage.setViewportSize({ width: 1920, height: 958 })
+    await alicePage.emulateMedia({ colorScheme: 'light' })
+    await alicePage.addInitScript(() => {
+      const style = document.createElement('style')
+      style.textContent = '.u-dc { display: block !important; }'
+      document.documentElement.appendChild(style)
+    })
+    picker = new FilePickerPage(alicePage)
+    await picker.open(undefined, 'Theme: Dark')
+
+    const dialog = alicePage.getByRole('dialog')
+    const frame = alicePage.frameLocator('iframe[src*="intents"]')
+    const filePicker = frame.getByTestId('file-picker')
+    await expect(alicePage.locator('.TwakeTheme--light').first()).toHaveClass(
+      /TwakeTheme--light/
+    )
+    await expect(
+      alicePage.locator('.TwakeTheme--dark').filter({ has: dialog })
+    ).toHaveCount(1)
+    await expect(
+      frame.locator('.TwakeTheme--dark').filter({ has: filePicker })
+    ).toHaveCount(1)
+    expect(await filePicker.boundingBox()).toEqual(await dialog.boundingBox())
+  })
+
   // ---------------------------------------------------------------------------
   // 1. Pick a file → public sharing link
   // ---------------------------------------------------------------------------
@@ -447,7 +475,6 @@ test.describe('File Picker', () => {
 
       // Picker must stay open with an inline error.
       await expect(picker.isOpen()).resolves.toBe(true)
-      await expect(picker.isErrorVisible()).resolves.toBe(true)
       const errorText = await picker.getErrorText()
       expect(errorText).toBe('The selected file could not be found.')
     })

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "cozy-sharing": "^37.2.3",
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^140.5.2",
-    "cozy-ui-plus": "^12.1.3",
+    "cozy-ui-plus": "^12.3.0",
     "cozy-viewer": "^30.0.19",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",

--- a/src/modules/navigation/components/FilePickerButton.jsx
+++ b/src/modules/navigation/components/FilePickerButton.jsx
@@ -10,6 +10,7 @@ import IntentDialogOpener from 'cozy-ui-plus/dist/Intent/IntentDialogOpener'
 import { useI18n } from 'twake-i18n'
 
 import logger from '@/lib/logger'
+import { filePickerThemes } from '@/modules/services/components/FilePicker/constants'
 
 const PICKER_CONFIGS = [
   {
@@ -90,10 +91,14 @@ export const FilePickerButton = () => {
   const { t } = useI18n()
   const [modalData, setModalData] = useState(null)
   const [configId, setConfigId] = useState(PICKER_CONFIGS[0].id)
+  const [themeType, setThemeType] = useState(filePickerThemes[0])
 
   const filePickerOptions = useMemo(
-    () => buildFilePickerOptions(configId, t),
-    [configId, t]
+    () => ({
+      ...buildFilePickerOptions(configId, t),
+      ...(themeType === 'auto' ? {} : { theme: { type: themeType } })
+    }),
+    [configId, t, themeType]
   )
 
   const handleComplete = res => {
@@ -130,6 +135,20 @@ export const FilePickerButton = () => {
             value={config.id}
             control={<Radios />}
             label={config.label}
+          />
+        ))}
+      </RadioGroup>
+      <RadioGroup
+        name="file-picker-theme"
+        value={themeType}
+        onChange={event => setThemeType(event.target.value)}
+      >
+        {filePickerThemes.map(themeOption => (
+          <FormControlLabel
+            key={themeOption}
+            value={themeOption}
+            control={<Radios />}
+            label={`Theme: ${themeOption[0].toUpperCase()}${themeOption.slice(1)}`}
           />
         ))}
       </RadioGroup>

--- a/src/modules/services/components/FilePicker/config.js
+++ b/src/modules/services/components/FilePicker/config.js
@@ -1,4 +1,4 @@
-import { defaultFilePickerConfig } from './constants'
+import { defaultFilePickerConfig, filePickerThemes } from './constants'
 
 /**
  * Read the FilePickerConfig carried in the intent data and merge it
@@ -18,6 +18,7 @@ import { defaultFilePickerConfig } from './constants'
  * @param {object|null|undefined} intent - The intent object returned
  *   by `service.getIntent()`. Null-safe.
  * @returns {{
+ *   theme: { type: 'auto'|'light'|'dark' },
  *   multiple: boolean,
  *   sharingLink: object|null,
  *   downloadLink: object|null
@@ -40,7 +41,14 @@ export const getFilePickerConfig = (intent, serviceData = null) => {
     return { ...defaultAction, ...clientAction }
   }
 
+  const themeType = data.theme?.type
+
   return {
+    theme: {
+      type: filePickerThemes.includes(themeType)
+        ? themeType
+        : defaultFilePickerConfig.theme.type
+    },
     multiple: data.multiple ?? defaultFilePickerConfig.multiple,
     sharingLink: resolveActionConfig(
       data.sharingLink,

--- a/src/modules/services/components/FilePicker/config.spec.js
+++ b/src/modules/services/components/FilePicker/config.spec.js
@@ -18,6 +18,32 @@ describe('FilePicker config', () => {
       )
     })
 
+    it('uses the automatic theme by default', () => {
+      expect(getFilePickerConfig(null).theme.type).toBe('auto')
+    })
+
+    it.each(['auto', 'light', 'dark'])('preserves the %s theme', theme => {
+      const intent = {
+        attributes: { data: { theme: { type: theme } } }
+      }
+
+      expect(getFilePickerConfig(intent).theme.type).toBe(theme)
+    })
+
+    it.each([null, 'sepia'])('falls back to auto for the %s theme', theme => {
+      const intent = {
+        attributes: { data: { theme: { type: theme } } }
+      }
+
+      expect(getFilePickerConfig(intent).theme.type).toBe('auto')
+    })
+
+    it('reads the theme from service data', () => {
+      expect(
+        getFilePickerConfig(null, { theme: { type: 'dark' } }).theme.type
+      ).toBe('dark')
+    })
+
     it('preserves multiple selection by default', () => {
       expect(getFilePickerConfig(null).multiple).toBe(true)
     })

--- a/src/modules/services/components/FilePicker/constants.js
+++ b/src/modules/services/components/FilePicker/constants.js
@@ -15,6 +15,8 @@ export const filePickerLinkModes = {
   TEMPORARY_DOWNLOAD_LINK: 'temporary-download-link'
 }
 
+export const filePickerThemes = ['auto', 'light', 'dark']
+
 /**
  * Error codes used by the File Picker internally to track
  * and display error messages in the UI.
@@ -39,6 +41,7 @@ export const filePickerErrorCodes = {
  */
 // TODO: enforce maxFileCount and availableSize on the downloadLink action.
 export const defaultFilePickerConfig = {
+  theme: { type: 'auto' },
   multiple: true,
   sharingLink: { allowFolder: true },
   downloadLink: { allowFolder: false }

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -9,7 +9,11 @@ import FilePickerBody from './FilePickerBody'
 import FilePickerFooter from './FilePickerFooter'
 import FilePickerHeader from './FilePickerHeader'
 import { LinkAccessModal } from './LinkAccessModal'
-import { defaultFilePickerConfig, filePickerLinkModes } from './constants'
+import {
+  defaultFilePickerConfig,
+  filePickerLinkModes,
+  filePickerThemes
+} from './constants'
 import { getActionDisabledState } from './constraints'
 import { getCompliantTypes } from './helpers'
 
@@ -153,6 +157,9 @@ FilePicker.propTypes = {
   accept: PropTypes.string,
   multiple: PropTypes.bool,
   filePickerConfig: PropTypes.shape({
+    theme: PropTypes.shape({
+      type: PropTypes.oneOf(filePickerThemes)
+    }),
     multiple: PropTypes.bool,
     sharingLink: PropTypes.object,
     downloadLink: PropTypes.object

--- a/src/modules/services/components/IntentHandler.jsx
+++ b/src/modules/services/components/IntentHandler.jsx
@@ -3,11 +3,21 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useClient } from 'cozy-client'
 import Intents from 'cozy-interapp'
 import logger from 'cozy-logger'
+import Box from 'cozy-ui/transpiled/react/Box'
+import CozyTheme from 'cozy-ui-plus/dist/providers/CozyTheme'
 
+import { getFilePickerConfig } from './FilePicker/config'
 import { buildContentFolderQuery } from './FilePicker/queries'
 import Picker from './Picker'
 
 import { ROOT_DIR_ID } from '@/constants/config'
+
+function isFilePickerIntent(intent) {
+  return (
+    intent?.attributes?.action === 'PICK' &&
+    intent?.attributes?.type === 'io.cozy.files'
+  )
+}
 
 async function initPicker(client) {
   const rootFolderQuery = buildContentFolderQuery(ROOT_DIR_ID)
@@ -48,11 +58,13 @@ const IntentHandler = ({ intentId }) => {
         const intentPromise = intents.request.get(intentId, { tryDOM: true })
         const servicePromise = intents.createService(intentId, window)
         const pendingIntent = await intentPromise
-        const pickerInitialization =
-          pendingIntent.attributes.action === 'PICK' &&
-          pendingIntent.attributes.type === 'io.cozy.files'
-            ? initPicker(client)
-            : null
+        setState(currentState => ({
+          ...currentState,
+          intent: pendingIntent
+        }))
+        const pickerInitialization = isFilePickerIntent(pendingIntent)
+          ? initPicker(client)
+          : null
 
         service = await servicePromise
         const intent = service.getIntent()
@@ -72,14 +84,35 @@ const IntentHandler = ({ intentId }) => {
     startService()
   }, [client, intentId])
 
-  return ServiceComponent ? (
+  const content = ServiceComponent ? (
     <ServiceComponent
       service={state.service}
       intent={state.intent}
       onReadyToUse={handleReadyToUse}
     />
   ) : (
-    <div className="u-w-100 u-bg-charcoalGrey" />
+    <Box className="u-h-100 u-w-100" bgcolor="background.paper" />
+  )
+
+  if (!isFilePickerIntent(state.intent)) return content
+
+  const serviceData = state.service?.getData?.()
+  const { type: themeType } = getFilePickerConfig(
+    state.intent,
+    serviceData
+  ).theme
+
+  return themeType === 'auto' ? (
+    content
+  ) : (
+    <CozyTheme
+      type={themeType}
+      ignoreCozySettings
+      ignoreItself={false}
+      className="u-h-100 u-w-100"
+    >
+      {content}
+    </CozyTheme>
   )
 }
 

--- a/src/modules/services/components/IntentHandler.spec.jsx
+++ b/src/modules/services/components/IntentHandler.spec.jsx
@@ -35,6 +35,20 @@ jest.mock('cozy-logger', () => ({
   warn: jest.fn()
 }))
 
+jest.mock(
+  'cozy-ui-plus/dist/providers/CozyTheme',
+  () =>
+    ({ children, ignoreItself, type }) => (
+      <div
+        data-testid="intent-theme"
+        data-theme={type}
+        data-ignore-itself={ignoreItself}
+      >
+        {children}
+      </div>
+    )
+)
+
 jest.mock('./Picker', () => () => <div data-testid="picker" />)
 
 function makeDeferredPromise() {
@@ -59,6 +73,34 @@ describe('IntentHandler', () => {
   afterEach(() => {
     jest.clearAllMocks()
   })
+
+  it.each(['light', 'dark'])(
+    'forces the %s theme while the picker initializes',
+    async theme => {
+      mockGetIntent.mockResolvedValue({
+        attributes: {
+          action: 'PICK',
+          type: 'io.cozy.files',
+          data: { theme: { type: theme } }
+        }
+      })
+      mockCreateService.mockReturnValue(new Promise(() => {}))
+      mockClient.query.mockReturnValue(new Promise(() => {}))
+
+      const { getByTestId, queryByTestId } = render(
+        <IntentHandler intentId="intent-id" />
+      )
+
+      await waitFor(() =>
+        expect(getByTestId('intent-theme')).toHaveAttribute('data-theme', theme)
+      )
+      expect(getByTestId('intent-theme')).toHaveAttribute(
+        'data-ignore-itself',
+        'false'
+      )
+      expect(queryByTestId('picker')).toBe(null)
+    }
+  )
 
   it('prefetches the root folder while the intent handshake is pending', async () => {
     const handshake = makeDeferredPromise()

--- a/yarn.lock
+++ b/yarn.lock
@@ -11696,7 +11696,7 @@ __metadata:
     cozy-stack-client: "npm:^60.28.0"
     cozy-tsconfig: "npm:^1.8.1"
     cozy-ui: "npm:^140.5.2"
-    cozy-ui-plus: "npm:^12.1.3"
+    cozy-ui-plus: "npm:^12.3.0"
     cozy-viewer: "npm:^30.0.19"
     css-mediaquery: "npm:0.1.2"
     date-fns: "npm:2.30.0"
@@ -12108,9 +12108,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-ui-plus@npm:^12.1.3":
-  version: 12.1.3
-  resolution: "cozy-ui-plus@npm:12.1.3"
+"cozy-ui-plus@npm:^12.3.0":
+  version: 12.3.0
+  resolution: "cozy-ui-plus@npm:12.3.0"
   dependencies:
     classnames: "npm:^2.5.1"
     filesize: "npm:8.0.7"
@@ -12134,7 +12134,7 @@ __metadata:
     react: ^16 || ^17 || ^18
     react-dom: ^16 || ^17 || ^18
     twake-i18n: ">=0.3.0"
-  checksum: 10/297738e42a85e109feb9b73f7fb3a2a5c4bfd5bef0aa1c911b9ad9cc6598cc75c765e581ecdcc2b8b44a05eeaf296f7887695cb2d660b0c65da41f34dd9d89ba
+  checksum: 10/63a6c18404e8035a54d856f8e6bc122c81f949e385253818dcdfcfd6403315a80179f777c6bd46e3a028922e1f56a5dc8d524e9e42c62b399aa52c4afab7c100
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Expose light and dark  through the File Picker intent config. cozy-ui-plus uses the caller's single options.theme value for the host dialog, close button and spinner, then forwards it to the service.

Drive must apply that forwarded value again inside the service document because React context and CSS do not cross the iframe boundary. This keeps the API to one option while theming both sides without changing the instance preference.


[Capture vidéo du 2026-07-28 11-43-16.webm](https://github.com/user-attachments/assets/dd72fcc5-69d1-42e2-b348-d31cbb667e7d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added File Picker theme selection with `auto`, `light`, and `dark`.
  * File Picker dialogs and embedded picker content now render with the chosen theme consistently.
* **Documentation**
  * Updated File Picker theming documentation, including `theme` options, defaults, and how `auto` behaves.
* **Bug Fixes**
  * Improved reliability of the “selected file missing” error UI validation by asserting the exact error text.
* **Tests**
  * Added end-to-end coverage for dark-theme rendering and iframe/dialog alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->