### PR TITLE
Add more File Picker thumbnails

### DIFF
--- a/src/modules/services/components/FilePicker/helpers.js
+++ b/src/modules/services/components/FilePicker/helpers.js
@@ -21,11 +21,14 @@ export const getCompliantTypes = types => {
 
 // Check whether a single mime type matches a single pattern.
 // Patterns may be exact ('image/png'), a subtype wildcard
-// ('image/*'), or the global wildcard ('*/*').
-const matchMimePattern = (mime, pattern) => {
-  if (pattern === '*/*' || pattern === mime) return true
-  const [pType, pSubtype] = pattern.split('/')
-  const [type] = mime.split('/')
+// ('image/*'), or the global wildcard ('*/*'). Matching is
+// case-insensitive, as MIME types are per RFC 2045.
+export const matchMimePattern = (mime, pattern) => {
+  const m = mime.toLowerCase()
+  const p = pattern.toLowerCase()
+  if (p === '*/*' || p === m) return true
+  const [pType, pSubtype] = p.split('/')
+  const [type] = m.split('/')
   return pSubtype === '*' && pType === type
 }
 

--- a/src/modules/services/components/FilePicker/thumbnail.js
+++ b/src/modules/services/components/FilePicker/thumbnail.js
@@ -1,4 +1,4 @@
-import { matchMimeType } from './helpers'
+import { matchMimePattern } from './helpers'
 
 const MIME_TYPE_TO_THUMBNAIL_TYPE = {
   // Audio
@@ -104,10 +104,14 @@ const THUMBNAIL_TYPE_TO_THUMBNAIL_LINK = {
  * @returns {string} - The link of the thumbnail.
  */
 function getThumbnailLinkFromMimeType(mimeType) {
+  if (!mimeType) return THUMBNAIL_TYPE_TO_THUMBNAIL_LINK.default
+
+  const mime = mimeType?.toLowerCase()
+
   const patterns = Object.keys(MIME_TYPE_TO_THUMBNAIL_TYPE)
 
   const matchedPattern = patterns.find(pattern =>
-    matchMimeType(mimeType, [pattern])
+    matchMimePattern(mime, pattern)
   )
 
   const thumbnailType = matchedPattern

--- a/src/modules/services/components/FilePicker/thumbnail.js
+++ b/src/modules/services/components/FilePicker/thumbnail.js
@@ -7,13 +7,75 @@ const MIME_TYPE_TO_THUMBNAIL_TYPE = {
   // Image
   'image/*': 'image',
 
+  // Video
+  'video/*': 'video',
+
   // PDF
   'application/pdf': 'pdf',
+
+  // PowerPoint
+  'application/vnd.ms-powerpoint': 'powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+    'powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.slideshow':
+    'powerpoint',
+
+  // Excel
+  'application/vnd.ms-excel': 'excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'excel',
+  'application/vnd.ms-excel.sheet.macroEnabled.12': 'excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.template':
+    'excel',
 
   // Word
   'application/msword': 'word',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
     'word',
+  'application/vnd.ms-word.document.macroEnabled.12': 'word',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.template':
+    'word',
+
+  // OpenDocument
+  'application/vnd.oasis.opendocument.text': 'odt',
+  'application/vnd.oasis.opendocument.spreadsheet': 'ods',
+  'application/vnd.oasis.opendocument.presentation': 'odp',
+
+  // Archive
+  'application/zip': 'archive',
+  'application/x-zip': 'archive',
+  'application/x-zip-compressed': 'archive',
+  'application/x-rar': 'archive',
+  'application/x-rar-compressed': 'archive',
+  'application/gzip': 'archive',
+  'application/x-gzip': 'archive',
+  'application/x-bzip2': 'archive',
+  'application/x-xz': 'archive',
+  'application/x-tar': 'archive',
+  'application/x-7z-compressed': 'archive',
+
+  // Code
+  'application/x-shellscript': 'code',
+  'application/x-sh': 'code',
+  'application/javascript': 'code',
+  'text/javascript': 'code',
+  'application/json': 'code',
+  'application/x-yaml': 'code',
+  'text/x-yaml': 'code',
+  'text/x-java-source': 'code',
+  'text/x-python': 'code',
+  'text/x-ruby': 'code',
+  'text/x-perl': 'code',
+  'text/x-php': 'code',
+  'text/x-c': 'code',
+  'text/x-c++': 'code',
+  'text/x-objective-c': 'code',
+  'text/x-swift': 'code',
+  'text/x-go': 'code',
+  'text/x-rust': 'code',
+  'text/x-typescript': 'code',
+
+  // Text
+  'text/*': 'text',
 
   // Default
   '*/*': 'default'
@@ -22,8 +84,17 @@ const MIME_TYPE_TO_THUMBNAIL_TYPE = {
 const THUMBNAIL_TYPE_TO_THUMBNAIL_LINK = {
   audio: 'https://files.twake.app/email-assets/file-picker/audio.png',
   image: 'https://files.twake.app/email-assets/file-picker/image.png',
+  video: 'https://files.twake.app/email-assets/file-picker/video.png',
   pdf: 'https://files.twake.app/email-assets/file-picker/pdf.png',
+  powerpoint: 'https://files.twake.app/email-assets/file-picker/powerpoint.png',
+  excel: 'https://files.twake.app/email-assets/file-picker/excel.png',
   word: 'https://files.twake.app/email-assets/file-picker/word.png',
+  odt: 'https://files.twake.app/email-assets/file-picker/odt.png',
+  ods: 'https://files.twake.app/email-assets/file-picker/ods.png',
+  odp: 'https://files.twake.app/email-assets/file-picker/odp.png',
+  archive: 'https://files.twake.app/email-assets/file-picker/archive.png',
+  code: 'https://files.twake.app/email-assets/file-picker/code.png',
+  text: 'https://files.twake.app/email-assets/file-picker/text.png',
   default: 'https://files.twake.app/email-assets/file-picker/default.png'
 }
 

--- a/src/modules/services/components/FilePicker/thumbnail.spec.js
+++ b/src/modules/services/components/FilePicker/thumbnail.spec.js
@@ -43,12 +43,32 @@ describe('makeThumbnail', () => {
     })
   })
 
-  it('should return default thumbnail link for unknown MIME types', () => {
+  it('should return code thumbnail link for JSON MIME type', () => {
     const file = { mime: 'application/json' }
     const result = makeThumbnail(file)
     expect(result).toEqual({
       thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/code.png'
+      }
+    })
+  })
+
+  it('should return default thumbnail link for unknown MIME types', () => {
+    const file = { mime: 'application/x-some-unknown-type' }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
         link: 'https://files.twake.app/email-assets/file-picker/default.png'
+      }
+    })
+  })
+
+  it('should match MIME types case-insensitively', () => {
+    const file = { mime: 'IMAGE/PNG' }
+    const result = makeThumbnail(file)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/image.png'
       }
     })
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added thumbnail support for more file types, including videos, PDFs, Office documents, archives, code, and text files.
  - File type detection now works regardless of capitalization.
  - JSON files now display a code thumbnail.

- **Bug Fixes**
  - Files with missing or unrecognized MIME types consistently use the default thumbnail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->