### PR TITLE
chore: bump version to 1.106.0

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -2,7 +2,7 @@
   "name": "Drive",
   "name_prefix": "Twake",
   "slug": "drive",
-  "version": "1.105.0",
+  "version": "1.106.0",
   "type": "webapp",
   "licence": "AGPL-3.0",
   "icon": "assets/app-icon.svg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-drive",
-  "version": "1.105.0",
+  "version": "1.106.0",
   "main": "src/main.jsx",
   "engines": {
     "node": "~24"


### PR DESCRIPTION
## Summary

- Set the package and webapp manifest versions to 1.106.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the application version to 1.106.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->