### PR TITLE
feat(file-picker): pick files on double-click

### DIFF
--- a/e2e/pages/FilePickerPage.ts
+++ b/e2e/pages/FilePickerPage.ts
@@ -74,6 +74,10 @@ export class FilePickerPage {
       .waitFor({ state: 'visible', timeout: 10_000 })
   }
 
+  async doubleClickItem(name: string): Promise<void> {
+    await this.getListItemByName(name).getByTestId('listitem-onclick').dblclick()
+  }
+
   // ---------------------------------------------------------------------------
   // Selection (single mode — radio buttons)
   // ---------------------------------------------------------------------------

--- a/e2e/pages/FilePickerPage.ts
+++ b/e2e/pages/FilePickerPage.ts
@@ -75,7 +75,9 @@ export class FilePickerPage {
   }
 
   async doubleClickItem(name: string): Promise<void> {
-    await this.getListItemByName(name).getByTestId('listitem-onclick').dblclick()
+    await this.getListItemByName(name)
+      .getByTestId('listitem-onclick')
+      .dblclick()
   }
 
   // ---------------------------------------------------------------------------

--- a/e2e/tests/file-picker.spec.ts
+++ b/e2e/tests/file-picker.spec.ts
@@ -21,6 +21,7 @@ test.describe('File Picker', () => {
   let parentFolder: string
   let testFileName: string
   let largeFileName: string
+  let linkFreeFileName: string
   let picker: FilePickerPage
 
   const pick = async (name: string, configName?: string): Promise<void> => {
@@ -34,6 +35,7 @@ test.describe('File Picker', () => {
     parentFolder = `picker-${stamp()}`
     testFileName = `picker-${stamp()}.txt`
     largeFileName = `picker-large-${stamp()}.txt`
+    linkFreeFileName = `picker-link-free-${stamp()}.txt`
 
     await alicePage.goto(`${USERS.alice.appUrl}/#/folder?flags`)
     await aliceDrive.createFolder(parentFolder)
@@ -44,15 +46,19 @@ test.describe('File Picker', () => {
 
     const tmpPath = path.join(path.dirname(FIXTURE), testFileName)
     const largeTmpPath = path.join(path.dirname(FIXTURE), largeFileName)
+    const linkFreeTmpPath = path.join(path.dirname(FIXTURE), linkFreeFileName)
     await copyFile(FIXTURE, tmpPath)
     await writeFile(largeTmpPath, 'x'.repeat(2048))
+    await copyFile(FIXTURE, linkFreeTmpPath)
     try {
-      await aliceDrive.uploadFiles([tmpPath, largeTmpPath])
+      await aliceDrive.uploadFiles([tmpPath, largeTmpPath, linkFreeTmpPath])
       await aliceDrive.row(testFileName).waitVisible()
       await aliceDrive.row(largeFileName).waitVisible()
+      await aliceDrive.row(linkFreeFileName).waitVisible()
     } finally {
       await safeUnlink(tmpPath)
       await safeUnlink(largeTmpPath)
+      await safeUnlink(linkFreeTmpPath)
     }
   })
 
@@ -112,7 +118,13 @@ test.describe('File Picker', () => {
     expect(link).toMatch(/^https?:\/\//)
 
     const document = await picker.getResultDocument()
-    const [entry] = document as Array<{ id: string }>
+    const [entry] = document as Array<{
+      id: string
+      sharingLink?: string
+      downloadLink?: string
+    }>
+    expect(entry.sharingLink).toBe(link)
+    expect(entry.downloadLink).toBeUndefined()
     const permission = await findLinkPermission(USERS.alice.instance, entry.id)
     const fileRule = Object.values(
       permission.attributes.permissions ?? {}
@@ -130,6 +142,19 @@ test.describe('File Picker', () => {
     } finally {
       await publicPage.close()
     }
+
+    await picker.closeConfirmation()
+
+    await picker.open()
+    await picker.navigateToFolder(parentFolder)
+    await picker.doubleClickItem(testFileName)
+    await picker.waitForClosed()
+
+    const reusedDocument = await picker.getResultDocument()
+    const reusedEntries = reusedDocument as Array<Record<string, unknown>>
+    expect(reusedEntries).toHaveLength(1)
+    expect(reusedEntries[0].sharingLink).toBe(entry.sharingLink)
+    expect(reusedEntries[0].downloadLink).toBeUndefined()
 
     await picker.closeConfirmation()
   })
@@ -225,13 +250,13 @@ test.describe('File Picker', () => {
     alicePage
   }) => {
     picker = new FilePickerPage(alicePage)
-    await pick(testFileName, 'Download link only')
+    await pick(largeFileName, 'Download link only')
 
     await expect(picker.hasPublicLinkButton()).resolves.toBe(false)
     await expect(picker.hasTemporaryDownloadButton()).resolves.toBe(true)
     await expect(picker.isTemporaryDownloadDisabled()).resolves.toBe(false)
 
-    await picker.clickTemporaryDownloadLink()
+    await picker.doubleClickItem(largeFileName)
     await picker.waitForClosed()
 
     const document = await picker.getResultDocument()
@@ -273,6 +298,9 @@ test.describe('File Picker', () => {
 
     await expect(picker.hasTemporaryDownloadButton()).resolves.toBe(true)
     await expect(picker.isTemporaryDownloadDisabled()).resolves.toBe(true)
+
+    await picker.doubleClickItem(testFileName)
+    await expect(picker.isOpen()).resolves.toBe(true)
   })
 
   test('max-size config disables temporary download for a large file', async ({
@@ -289,19 +317,32 @@ test.describe('File Picker', () => {
     alicePage
   }) => {
     picker = new FilePickerPage(alicePage)
-    await pick(testFileName, 'Default (sharing + download)')
-    await picker.createPublicLinks()
+    await picker.open()
+    await picker.navigateToFolder(parentFolder)
+    await picker.selectItem(linkFreeFileName)
+    await picker.toggleItem(testFileName)
+
+    await picker.doubleClickItem(linkFreeFileName)
+    await expect.poll(() => picker.isLinkAccessOpen()).toBe(true)
+    await expect(
+      picker.hasLinkAccessDocument(linkFreeFileName)
+    ).resolves.toBe(true)
+    await expect(picker.hasLinkAccessDocument(testFileName)).resolves.toBe(
+      false
+    )
+    await picker.confirmPublicLinks()
     await picker.waitForClosed()
 
     const document = await picker.getResultDocument()
     expect(Array.isArray(document)).toBe(true)
-    const [entry] = document as Array<Record<string, unknown>>
-    expect(entry.id).toEqual(expect.any(String))
-    expect(entry.name).toBe(testFileName)
-    expect(entry.size).toEqual(expect.any(Number))
-    expect(entry.mimeType).toEqual(expect.any(String))
-    expect(entry.sharingLink).toMatch(/^https?:\/\//)
-    expect(entry.downloadLink).toBeUndefined()
+    const entries = document as Array<Record<string, unknown>>
+    expect(entries).toHaveLength(1)
+    expect(entries[0].id).toEqual(expect.any(String))
+    expect(entries[0].name).toBe(linkFreeFileName)
+    expect(entries[0].size).toEqual(expect.any(Number))
+    expect(entries[0].mimeType).toEqual(expect.any(String))
+    expect(entries[0].sharingLink).toMatch(/^https?:\/\//)
+    expect(entries[0].downloadLink).toBeUndefined()
 
     await picker.closeConfirmation()
   })
@@ -475,8 +516,9 @@ test.describe('File Picker', () => {
 
       // Picker must stay open with an inline error.
       await expect(picker.isOpen()).resolves.toBe(true)
-      const errorText = await picker.getErrorText()
-      expect(errorText).toBe('The selected file could not be found.')
+      expect(await picker.getErrorText()).toBe(
+        'The selected file could not be found.'
+      )
     })
   })
 })

--- a/e2e/tests/file-picker.spec.ts
+++ b/e2e/tests/file-picker.spec.ts
@@ -324,9 +324,9 @@ test.describe('File Picker', () => {
 
     await picker.doubleClickItem(linkFreeFileName)
     await expect.poll(() => picker.isLinkAccessOpen()).toBe(true)
-    await expect(
-      picker.hasLinkAccessDocument(linkFreeFileName)
-    ).resolves.toBe(true)
+    await expect(picker.hasLinkAccessDocument(linkFreeFileName)).resolves.toBe(
+      true
+    )
     await expect(picker.hasLinkAccessDocument(testFileName)).resolves.toBe(
       false
     )

--- a/src/modules/services/components/FilePicker/FilePickerBody.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerBody.jsx
@@ -28,7 +28,8 @@ const FilePickerBody = ({
   multiple,
   folderSelectable,
   error,
-  onReadyToUse
+  onReadyToUse,
+  onFileDoubleClick
 }) => {
   const { t } = useI18n()
   const selectionContainerRef = useRef(null)
@@ -84,9 +85,11 @@ const FilePickerBody = ({
     item => {
       if (isDirectory(item)) {
         navigateTo(item)
+      } else if (onFileDoubleClick) {
+        onFileDoubleClick(item)
       }
     },
-    [navigateTo]
+    [navigateTo, onFileDoubleClick]
   )
 
   return (
@@ -132,7 +135,8 @@ FilePickerBody.propTypes = {
   multiple: PropTypes.bool,
   folderSelectable: PropTypes.bool,
   error: PropTypes.string,
-  onReadyToUse: PropTypes.func
+  onReadyToUse: PropTypes.func,
+  onFileDoubleClick: PropTypes.func
 }
 
 FilePickerBody.defaultProps = {

--- a/src/modules/services/components/FilePicker/constants.js
+++ b/src/modules/services/components/FilePicker/constants.js
@@ -17,6 +17,16 @@ export const filePickerLinkModes = {
 
 export const filePickerThemes = ['auto', 'light', 'dark']
 
+export const filePickerSharingLinkStatuses = {
+  FOUND: 'found',
+  NOT_FOUND: 'not_found',
+  NO_SHARECODE: 'no_sharecode'
+}
+
+export const filePickerDoubleClickResults = {
+  OPEN_MODAL: 'open-modal'
+}
+
 /**
  * Error codes used by the File Picker internally to track
  * and display error messages in the UI.

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -11,6 +11,7 @@ import FilePickerHeader from './FilePickerHeader'
 import { LinkAccessModal } from './LinkAccessModal'
 import {
   defaultFilePickerConfig,
+  filePickerDoubleClickResults,
   filePickerErrorCodes,
   filePickerLinkModes,
   filePickerThemes
@@ -138,7 +139,7 @@ const FilePicker = ({
         }
 
         const result = await onFileDoubleClick(item)
-        if (result === 'open-modal') {
+        if (result === filePickerDoubleClickResults.OPEN_MODAL) {
           handleOpenLinkAccess()
         } else if (result) {
           setError(result)

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useState, memo, useMemo } from 'react'
+import React, { useState, memo, useMemo, useRef, useCallback } from 'react'
 
 import Box from 'cozy-ui/transpiled/react/Box'
 import Divider from 'cozy-ui/transpiled/react/Divider'
@@ -15,7 +15,7 @@ import {
   filePickerThemes
 } from './constants'
 import { getActionDisabledState } from './constraints'
-import { getCompliantTypes } from './helpers'
+import { getCompliantTypes, isValidFile } from './helpers'
 
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 
@@ -26,13 +26,16 @@ const FilePicker = ({
   accept,
   multiple,
   filePickerConfig,
-  onReadyToUse
+  onReadyToUse,
+  onFileDoubleClick
 }) => {
   const [folderId, setFolderId] = useState(ROOT_DIR_ID)
   const [error, setError] = useState(null)
   const [isLinkAccessOpen, setIsLinkAccessOpen] = useState(false)
-  const { selectedItems, clearSelection } = useSelectionContext()
+  const { selectedItems, clearSelection, setSelectedItems } =
+    useSelectionContext()
   const { showAlert } = useAlert()
+  const isProcessingRef = useRef(false)
   const itemsIdsSelected = useMemo(
     () => selectedItems.map(item => item._id),
     [selectedItems]
@@ -100,6 +103,58 @@ const FilePicker = ({
     ? getActionDisabledState(downloadLinkAction, selectedItems)
     : { disabled: true, reasonKey: null }
 
+  const handleFileDoubleClick = useCallback(
+    async item => {
+      if (!onFileDoubleClick) return
+      if (isProcessingRef.current) return
+
+      if (!isValidFile(item, itemTypesAccepted)) return
+
+      // Sharing takes priority over download
+      const sharingState = publicLinkAction
+        ? getActionDisabledState(publicLinkAction, [item])
+        : { disabled: true }
+      const downloadState = downloadLinkAction
+        ? getActionDisabledState(downloadLinkAction, [item])
+        : { disabled: true }
+      const useDownload = sharingState.disabled && !downloadState.disabled
+      if (sharingState.disabled && downloadState.disabled) return
+
+      isProcessingRef.current = true
+      setSelectedItems({ [item._id]: item })
+
+      try {
+        if (useDownload) {
+          const pickError = await onChange(
+            [item],
+            filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
+          )
+          if (pickError) {
+            setError(pickError)
+          }
+          return
+        }
+
+        const result = await onFileDoubleClick(item)
+        if (result === 'open-modal') {
+          setIsLinkAccessOpen(true)
+        } else if (result) {
+          setError(result)
+        }
+      } finally {
+        isProcessingRef.current = false
+      }
+    },
+    [
+      publicLinkAction,
+      downloadLinkAction,
+      itemTypesAccepted,
+      onFileDoubleClick,
+      onChange,
+      setSelectedItems
+    ]
+  )
+
   return (
     <>
       <div
@@ -127,6 +182,7 @@ const FilePicker = ({
             folderSelectable
             error={error}
             onReadyToUse={onReadyToUse}
+            onFileDoubleClick={handleFileDoubleClick}
           />
         </Box>
         <Divider />
@@ -164,7 +220,8 @@ FilePicker.propTypes = {
     sharingLink: PropTypes.object,
     downloadLink: PropTypes.object
   }),
-  onReadyToUse: PropTypes.func
+  onReadyToUse: PropTypes.func,
+  onFileDoubleClick: PropTypes.func
 }
 
 FilePicker.defaultProps = {

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -11,6 +11,7 @@ import FilePickerHeader from './FilePickerHeader'
 import { LinkAccessModal } from './LinkAccessModal'
 import {
   defaultFilePickerConfig,
+  filePickerErrorCodes,
   filePickerLinkModes,
   filePickerThemes
 } from './constants'
@@ -64,10 +65,10 @@ const FilePicker = ({
     return null
   }
 
-  const handleOpenLinkAccess = () => {
+  const handleOpenLinkAccess = useCallback(() => {
     setError(null)
     setIsLinkAccessOpen(true)
-  }
+  }, [])
 
   const handleLinkAccessConfirm = async sharingLinks => {
     const pickError = await onChange(
@@ -121,6 +122,7 @@ const FilePicker = ({
       if (sharingState.disabled && downloadState.disabled) return
 
       isProcessingRef.current = true
+      setError(null)
       setSelectedItems({ [item._id]: item })
 
       try {
@@ -137,10 +139,16 @@ const FilePicker = ({
 
         const result = await onFileDoubleClick(item)
         if (result === 'open-modal') {
-          setIsLinkAccessOpen(true)
+          handleOpenLinkAccess()
         } else if (result) {
           setError(result)
         }
+      } catch {
+        setError(
+          useDownload
+            ? filePickerErrorCodes.DOWNLOAD_LINK_FAILED
+            : filePickerErrorCodes.SHARING_LINK_FAILED
+        )
       } finally {
         isProcessingRef.current = false
       }
@@ -151,7 +159,8 @@ const FilePicker = ({
       itemTypesAccepted,
       onFileDoubleClick,
       onChange,
-      setSelectedItems
+      setSelectedItems,
+      handleOpenLinkAccess
     ]
   )
 

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -122,23 +122,16 @@ const FilePicker = ({
       const useDownload = sharingState.disabled && !downloadState.disabled
       if (sharingState.disabled && downloadState.disabled) return
 
+      const linkMode = useDownload
+        ? filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
+        : filePickerLinkModes.PUBLIC_LINK
+
       isProcessingRef.current = true
       setError(null)
       setSelectedItems({ [item._id]: item })
 
       try {
-        if (useDownload) {
-          const pickError = await onChange(
-            [item],
-            filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
-          )
-          if (pickError) {
-            setError(pickError)
-          }
-          return
-        }
-
-        const result = await onFileDoubleClick(item)
+        const result = await onFileDoubleClick(item, linkMode)
         if (result === filePickerDoubleClickResults.OPEN_MODAL) {
           handleOpenLinkAccess()
         } else if (result) {
@@ -159,7 +152,6 @@ const FilePicker = ({
       downloadLinkAction,
       itemTypesAccepted,
       onFileDoubleClick,
-      onChange,
       setSelectedItems,
       handleOpenLinkAccess
     ]

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -49,7 +49,7 @@ jest.mock('./FilePickerBody', () => {
     name: 'Folder'
   }
 
-  return ({ folderSelectable, navigateTo }) => {
+  return ({ folderSelectable, navigateTo, onFileDoubleClick, error }) => {
     const { setSelectedItems } = useSelectionContext()
 
     return (
@@ -57,6 +57,7 @@ jest.mock('./FilePickerBody', () => {
         <span data-testid="folder-selectable">
           {folderSelectable ? 'true' : 'false'}
         </span>
+        {error && <div data-testid="file-picker-error">{error}</div>}
         <button
           type="button"
           data-testid="select-file-btn"
@@ -96,6 +97,15 @@ jest.mock('./FilePickerBody', () => {
         >
           Navigate folder
         </button>
+        {onFileDoubleClick && (
+          <button
+            type="button"
+            data-testid="double-click-file-btn"
+            onClick={() => onFileDoubleClick(file)}
+          >
+            Double-click file
+          </button>
+        )}
       </div>
     )
   }
@@ -169,14 +179,22 @@ const FilePickerWrapper = ({ children }) => (
 
 describe('FilePicker', () => {
   const mockOnChange = jest.fn()
+  const mockOnFileDoubleClick = jest.fn()
 
-  const setup = ({ filePickerConfig, multiple = false } = {}) => {
+  const setup = ({
+    filePickerConfig,
+    multiple = false,
+    onFileDoubleClick,
+    accept
+  } = {}) => {
     return render(
       <FilePickerWrapper>
         <FilePicker
           onChange={mockOnChange}
+          onFileDoubleClick={onFileDoubleClick ?? mockOnFileDoubleClick}
           filePickerConfig={filePickerConfig}
           multiple={multiple}
+          accept={accept}
         />
       </FilePickerWrapper>
     )
@@ -328,5 +346,176 @@ describe('FilePicker', () => {
     fireEvent.click(getByTestId('navigate-folder-btn'))
 
     expect(getByTestId('public-link-btn')).toBeDisabled()
+  })
+
+  describe('double-click action', () => {
+    it('should reuse existing single-file sharing link without opening modal', async () => {
+      const { getByTestId, queryByTestId } = setup({
+        filePickerConfig: {
+          sharingLink: { allowFolder: true },
+          downloadLink: null
+        }
+      })
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(mockOnFileDoubleClick).toHaveBeenCalledWith({
+          _id: 'file-id',
+          type: 'file',
+          name: 'file.pdf'
+        })
+      )
+      expect(queryByTestId('link-access-modal')).toBeNull()
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+
+    it('should open LinkAccessModal when onFileDoubleClick returns open-modal', async () => {
+      mockOnFileDoubleClick.mockResolvedValue('open-modal')
+      const { getByTestId } = setup()
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(getByTestId('link-access-modal')).toHaveTextContent('file.pdf')
+      )
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+
+    it('should display error when onFileDoubleClick returns SHARING_LINK_FAILED', async () => {
+      mockOnFileDoubleClick.mockResolvedValue('SHARING_LINK_FAILED')
+      const { getByTestId, queryByTestId } = setup()
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(getByTestId('file-picker-error')).toBeInTheDocument()
+      )
+      expect(queryByTestId('link-access-modal')).toBeNull()
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+
+    it('should generate download link directly when sharing is unavailable', async () => {
+      mockOnChange.mockResolvedValue(null)
+      const { getByTestId, queryByTestId } = setup({
+        filePickerConfig: {
+          sharingLink: null,
+          downloadLink: { allowFolder: false }
+        }
+      })
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(mockOnChange).toHaveBeenCalledWith(
+          [{ _id: 'file-id', type: 'file', name: 'file.pdf' }],
+          filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
+        )
+      )
+      expect(queryByTestId('link-access-modal')).toBeNull()
+      expect(mockOnFileDoubleClick).not.toHaveBeenCalled()
+    })
+
+    it('should do nothing when neither action is configured', () => {
+      const { getByTestId, queryByTestId } = setup({
+        filePickerConfig: {
+          sharingLink: null,
+          downloadLink: null
+        }
+      })
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      expect(mockOnFileDoubleClick).not.toHaveBeenCalled()
+      expect(mockOnChange).not.toHaveBeenCalled()
+      expect(queryByTestId('file-picker-error')).toBeNull()
+    })
+
+    it('should ignore file rejected by accept filter', () => {
+      const { getByTestId } = setup({ accept: 'image/*' })
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      expect(mockOnFileDoubleClick).not.toHaveBeenCalled()
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+
+    it('should block repeated double-clicks during processing', async () => {
+      // First call never resolves — lock stays engaged
+      let resolveFirst
+      mockOnFileDoubleClick.mockReturnValue(
+        new Promise(resolve => {
+          resolveFirst = resolve
+        })
+      )
+      const { getByTestId } = setup()
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+      fireEvent.click(getByTestId('double-click-file-btn'))
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      expect(mockOnFileDoubleClick).toHaveBeenCalledTimes(1)
+
+      resolveFirst('open-modal')
+      await waitFor(() =>
+        expect(getByTestId('link-access-modal')).toBeInTheDocument()
+      )
+    })
+
+    it('should release lock after error so user can retry', async () => {
+      mockOnFileDoubleClick.mockResolvedValueOnce('SHARING_LINK_FAILED')
+      const { getByTestId } = setup()
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(getByTestId('file-picker-error')).toBeInTheDocument()
+      )
+
+      // Second double-click should trigger a new call
+      mockOnFileDoubleClick.mockResolvedValueOnce('open-modal')
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(getByTestId('link-access-modal')).toBeInTheDocument()
+      )
+      expect(mockOnFileDoubleClick).toHaveBeenCalledTimes(2)
+    })
+
+    it('should replace multi-selection with the double-clicked file', async () => {
+      mockOnFileDoubleClick.mockResolvedValue('open-modal')
+      const { getByTestId } = setup({ multiple: true })
+
+      // Create a multi-selection
+      fireEvent.click(getByTestId('select-file-btn'))
+      fireEvent.click(getByTestId('select-second-file-btn'))
+
+      // Double-click a file
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(getByTestId('link-access-modal')).toHaveTextContent('file.pdf')
+      )
+      // The modal should show only the double-clicked file, not the second one
+      expect(getByTestId('link-access-modal')).not.toHaveTextContent(
+        'second-file.pdf'
+      )
+    })
+
+    it('should display download error when onChange returns an error code', async () => {
+      mockOnChange.mockResolvedValue('DOWNLOAD_LINK_FAILED')
+      const { getByTestId } = setup({
+        filePickerConfig: {
+          sharingLink: null,
+          downloadLink: { allowFolder: false }
+        }
+      })
+
+      fireEvent.click(getByTestId('double-click-file-btn'))
+
+      await waitFor(() =>
+        expect(getByTestId('file-picker-error')).toBeInTheDocument()
+      )
+    })
   })
 })

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -382,8 +382,8 @@ describe('FilePicker', () => {
       expect(mockOnChange).not.toHaveBeenCalled()
     })
 
-    it('should display error when onFileDoubleClick returns SHARING_LINK_FAILED', async () => {
-      mockOnFileDoubleClick.mockResolvedValue('SHARING_LINK_FAILED')
+    it('should display error when onFileDoubleClick rejects', async () => {
+      mockOnFileDoubleClick.mockRejectedValue(new Error('sharing failed'))
       const { getByTestId, queryByTestId } = setup()
 
       fireEvent.click(getByTestId('double-click-file-btn'))
@@ -464,7 +464,7 @@ describe('FilePicker', () => {
 
     it('should release lock after error so user can retry', async () => {
       mockOnFileDoubleClick.mockResolvedValueOnce('SHARING_LINK_FAILED')
-      const { getByTestId } = setup()
+      const { getByTestId, queryByTestId } = setup()
 
       fireEvent.click(getByTestId('double-click-file-btn'))
 
@@ -479,6 +479,7 @@ describe('FilePicker', () => {
       await waitFor(() =>
         expect(getByTestId('link-access-modal')).toBeInTheDocument()
       )
+      expect(queryByTestId('file-picker-error')).toBeNull()
       expect(mockOnFileDoubleClick).toHaveBeenCalledTimes(2)
     })
 
@@ -502,8 +503,8 @@ describe('FilePicker', () => {
       )
     })
 
-    it('should display download error when onChange returns an error code', async () => {
-      mockOnChange.mockResolvedValue('DOWNLOAD_LINK_FAILED')
+    it('should display download error when onChange rejects', async () => {
+      mockOnChange.mockRejectedValue(new Error('download failed'))
       const { getByTestId } = setup({
         filePickerConfig: {
           sharingLink: null,

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import React from 'react'
 
-import { filePickerLinkModes } from './constants'
+import { filePickerDoubleClickResults, filePickerLinkModes } from './constants'
 import FilePicker from './index'
 
 import { SelectionProvider } from '@/modules/selection/SelectionProvider'
@@ -371,7 +371,9 @@ describe('FilePicker', () => {
     })
 
     it('should open LinkAccessModal when onFileDoubleClick returns open-modal', async () => {
-      mockOnFileDoubleClick.mockResolvedValue('open-modal')
+      mockOnFileDoubleClick.mockResolvedValue(
+        filePickerDoubleClickResults.OPEN_MODAL
+      )
       const { getByTestId } = setup()
 
       fireEvent.click(getByTestId('double-click-file-btn'))
@@ -456,7 +458,7 @@ describe('FilePicker', () => {
 
       expect(mockOnFileDoubleClick).toHaveBeenCalledTimes(1)
 
-      resolveFirst('open-modal')
+      resolveFirst(filePickerDoubleClickResults.OPEN_MODAL)
       await waitFor(() =>
         expect(getByTestId('link-access-modal')).toBeInTheDocument()
       )
@@ -473,7 +475,9 @@ describe('FilePicker', () => {
       )
 
       // Second double-click should trigger a new call
-      mockOnFileDoubleClick.mockResolvedValueOnce('open-modal')
+      mockOnFileDoubleClick.mockResolvedValueOnce(
+        filePickerDoubleClickResults.OPEN_MODAL
+      )
       fireEvent.click(getByTestId('double-click-file-btn'))
 
       await waitFor(() =>
@@ -484,7 +488,9 @@ describe('FilePicker', () => {
     })
 
     it('should replace multi-selection with the double-clicked file', async () => {
-      mockOnFileDoubleClick.mockResolvedValue('open-modal')
+      mockOnFileDoubleClick.mockResolvedValue(
+        filePickerDoubleClickResults.OPEN_MODAL
+      )
       const { getByTestId } = setup({ multiple: true })
 
       // Create a multi-selection

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -360,11 +360,14 @@ describe('FilePicker', () => {
       fireEvent.click(getByTestId('double-click-file-btn'))
 
       await waitFor(() =>
-        expect(mockOnFileDoubleClick).toHaveBeenCalledWith({
-          _id: 'file-id',
-          type: 'file',
-          name: 'file.pdf'
-        })
+        expect(mockOnFileDoubleClick).toHaveBeenCalledWith(
+          {
+            _id: 'file-id',
+            type: 'file',
+            name: 'file.pdf'
+          },
+          filePickerLinkModes.PUBLIC_LINK
+        )
       )
       expect(queryByTestId('link-access-modal')).toBeNull()
       expect(mockOnChange).not.toHaveBeenCalled()
@@ -397,8 +400,8 @@ describe('FilePicker', () => {
       expect(mockOnChange).not.toHaveBeenCalled()
     })
 
-    it('should generate download link directly when sharing is unavailable', async () => {
-      mockOnChange.mockResolvedValue(null)
+    it('should delegate download link generation when sharing is unavailable', async () => {
+      mockOnFileDoubleClick.mockResolvedValue(null)
       const { getByTestId, queryByTestId } = setup({
         filePickerConfig: {
           sharingLink: null,
@@ -409,13 +412,13 @@ describe('FilePicker', () => {
       fireEvent.click(getByTestId('double-click-file-btn'))
 
       await waitFor(() =>
-        expect(mockOnChange).toHaveBeenCalledWith(
-          [{ _id: 'file-id', type: 'file', name: 'file.pdf' }],
+        expect(mockOnFileDoubleClick).toHaveBeenCalledWith(
+          { _id: 'file-id', type: 'file', name: 'file.pdf' },
           filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
         )
       )
       expect(queryByTestId('link-access-modal')).toBeNull()
-      expect(mockOnFileDoubleClick).not.toHaveBeenCalled()
+      expect(mockOnChange).not.toHaveBeenCalled()
     })
 
     it('should do nothing when neither action is configured', () => {
@@ -509,8 +512,8 @@ describe('FilePicker', () => {
       )
     })
 
-    it('should display download error when onChange rejects', async () => {
-      mockOnChange.mockRejectedValue(new Error('download failed'))
+    it('should display download error when onFileDoubleClick rejects', async () => {
+      mockOnFileDoubleClick.mockRejectedValue(new Error('download failed'))
       const { getByTestId } = setup({
         filePickerConfig: {
           sharingLink: null,

--- a/src/modules/services/components/FilePicker/sharing.js
+++ b/src/modules/services/components/FilePicker/sharing.js
@@ -1,7 +1,7 @@
 import CozyClient, { generateWebLink, models } from 'cozy-client'
 import { makeSharingLink } from 'cozy-client/dist/models/sharing'
 
-import { TEMPORARY_LINK_TTL } from './constants'
+import { filePickerSharingLinkStatuses, TEMPORARY_LINK_TTL } from './constants'
 
 const {
   file: { isFile }
@@ -39,16 +39,16 @@ export async function fetchExistingSharingLink(
   })
 
   if (!existingPermission) {
-    return { status: 'not_found' }
+    return { status: filePickerSharingLinkStatuses.NOT_FOUND }
   }
 
   const sharecode = getShortcode(existingPermission)
   if (!sharecode) {
-    return { status: 'no_sharecode' }
+    return { status: filePickerSharingLinkStatuses.NO_SHARECODE }
   }
 
   return {
-    status: 'found',
+    status: filePickerSharingLinkStatuses.FOUND,
     url: generateWebLink({
       cozyUrl: client.getStackClient().uri,
       searchParams: [['sharecode', sharecode]],
@@ -64,10 +64,10 @@ export async function getOrCreateSharingLink(client, file) {
   try {
     result = await fetchExistingSharingLink(client, file)
   } catch {
-    result = { status: 'not_found' }
+    result = { status: filePickerSharingLinkStatuses.NOT_FOUND }
   }
 
-  return result.status === 'found'
+  return result.status === filePickerSharingLinkStatuses.FOUND
     ? result.url
     : makeSharingLink(client, [getFileId(file)])
 }

--- a/src/modules/services/components/FilePicker/sharing.js
+++ b/src/modules/services/components/FilePicker/sharing.js
@@ -20,65 +20,56 @@ const getShortcode = permission => {
 }
 
 /**
- * Check if a permission is related to a specific file
+ * Fetch a public link for a file without creating or updating permissions.
+ * The strict mode only accepts permissions concerning this file alone.
  */
-const isPermissionRelatedTo = (perm, file) => {
+export async function fetchExistingSharingLink(
+  client,
+  file,
+  { singleFileOnly = false } = {}
+) {
+  const permissionsCol = client.collection('io.cozy.permissions')
+  const result = await permissionsCol.findLinksByDoctype('io.cozy.files')
+  const permissions = result?.data ?? []
   const fileId = getFileId(file)
-  return perm.attributes?.permissions?.files?.values?.includes(fileId)
-}
 
-/**
- * Fetch an existing sharing link for a file, if one exists.
- * This avoids creating duplicate sharing links.
- *
- * @param {object} client - CozyClient instance
- * @param {object} file - File document
- * @returns {Promise<string|null>} - The existing sharing link or null
- */
-const fetchExistingSharingLink = async (client, file) => {
-  try {
-    const permissionsCol = client.collection('io.cozy.permissions')
-    const result = await permissionsCol.findLinksByDoctype('io.cozy.files')
-    const permissions = result?.data ?? []
+  const existingPermission = permissions.find(permission => {
+    const fileIds = permission.attributes?.permissions?.files?.values ?? []
+    return fileIds.includes(fileId) && (!singleFileOnly || fileIds.length === 1)
+  })
 
-    const existingPermission = permissions.find(perm =>
-      isPermissionRelatedTo(perm, file)
-    )
+  if (!existingPermission) {
+    return { status: 'not_found' }
+  }
 
-    if (!existingPermission) {
-      return null
-    }
+  const sharecode = getShortcode(existingPermission)
+  if (!sharecode) {
+    return { status: 'no_sharecode' }
+  }
 
-    const sharecode = getShortcode(existingPermission)
-
-    if (!sharecode) {
-      return null
-    }
-
-    return generateWebLink({
+  return {
+    status: 'found',
+    url: generateWebLink({
       cozyUrl: client.getStackClient().uri,
       searchParams: [['sharecode', sharecode]],
       pathname: '/public',
       slug: 'drive',
       subDomainType: client.capabilities.flat_subdomains ? 'flat' : 'nested'
     })
-  } catch {
-    // Silently fail if we can't fetch existing links — we'll create a new one
-    return null
   }
 }
 
-/**
- * Get an existing sharing link for a file, or create a new one if none exists.
- *
- * @param {object} client - CozyClient instance
- * @param {object} file - File document
- * @returns {Promise<string>} - The sharing link
- */
-export const getOrCreateSharingLink = async (client, file) => {
-  const existingLink = await fetchExistingSharingLink(client, file)
+export async function getOrCreateSharingLink(client, file) {
+  let result
+  try {
+    result = await fetchExistingSharingLink(client, file)
+  } catch {
+    result = { status: 'not_found' }
+  }
 
-  return existingLink || makeSharingLink(client, [getFileId(file)])
+  return result.status === 'found'
+    ? result.url
+    : makeSharingLink(client, [getFileId(file)])
 }
 
 /**

--- a/src/modules/services/components/Picker.jsx
+++ b/src/modules/services/components/Picker.jsx
@@ -5,8 +5,10 @@ import { Q, useClient, fetchPolicies } from 'cozy-client'
 import FilePicker from './FilePicker'
 import { getFilePickerConfig } from './FilePicker/config'
 import {
+  filePickerDoubleClickResults,
   filePickerErrorCodes,
-  filePickerLinkModes
+  filePickerLinkModes,
+  filePickerSharingLinkStatuses
 } from './FilePicker/constants'
 import { makeFilePickerFileEntry } from './FilePicker/payload'
 import {
@@ -119,13 +121,13 @@ const Picker = ({ service, intent, onReadyToUse }) => {
       const result = await fetchExistingSharingLink(client, file, {
         singleFileOnly: true
       })
-      if (result.status === 'found') {
+      if (result.status === filePickerSharingLinkStatuses.FOUND) {
         return handlePick([file], filePickerLinkModes.PUBLIC_LINK, [
           { documentId: getFileId(file), url: result.url }
         ])
       }
-      if (result.status === 'not_found') {
-        return 'open-modal'
+      if (result.status === filePickerSharingLinkStatuses.NOT_FOUND) {
+        return filePickerDoubleClickResults.OPEN_MODAL
       }
       return filePickerErrorCodes.SHARING_LINK_FAILED
     } catch {

--- a/src/modules/services/components/Picker.jsx
+++ b/src/modules/services/components/Picker.jsx
@@ -116,7 +116,11 @@ const Picker = ({ service, intent, onReadyToUse }) => {
     }
   }
 
-  const handleFileDoubleClick = async file => {
+  const handleFileDoubleClick = async (file, linkMode) => {
+    if (linkMode === filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK) {
+      return handlePick([file], linkMode)
+    }
+
     try {
       const result = await fetchExistingSharingLink(client, file, {
         singleFileOnly: true

--- a/src/modules/services/components/Picker.jsx
+++ b/src/modules/services/components/Picker.jsx
@@ -10,6 +10,7 @@ import {
 } from './FilePicker/constants'
 import { makeFilePickerFileEntry } from './FilePicker/payload'
 import {
+  fetchExistingSharingLink,
   getFileId,
   getOrCreateSharingLink,
   makeTemporaryDownloadLinks
@@ -113,9 +114,29 @@ const Picker = ({ service, intent, onReadyToUse }) => {
     }
   }
 
+  const handleFileDoubleClick = async file => {
+    try {
+      const result = await fetchExistingSharingLink(client, file, {
+        singleFileOnly: true
+      })
+      if (result.status === 'found') {
+        return handlePick([file], filePickerLinkModes.PUBLIC_LINK, [
+          { documentId: getFileId(file), url: result.url }
+        ])
+      }
+      if (result.status === 'not_found') {
+        return 'open-modal'
+      }
+      return filePickerErrorCodes.SHARING_LINK_FAILED
+    } catch {
+      return filePickerErrorCodes.SHARING_LINK_FAILED
+    }
+  }
+
   return (
     <FilePicker
       onChange={handlePick}
+      onFileDoubleClick={handleFileDoubleClick}
       filePickerConfig={filePickerConfig}
       onReadyToUse={onReadyToUse}
       multiple={filePickerConfig.multiple}


### PR DESCRIPTION
Only reuse public links scoped to the picked file so a direct action cannot expose additional files. Open link access when no reusable link exists, while preserving download-only configurations.

fixes #3988 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Double-clicking a picker file now reuses an existing public sharing link when available, or opens link options when not found.
  - Supports sharing vs download behavior (including temporary download mode) and preserves previously generated sharing links on reopen.
- **Bug Fixes**
  - Double-click now safely handles invalid/unsupported files, prevents concurrent actions, and improves surfaced inline error messaging.
  - Link results are validated more precisely (sharing URL present; download link undefined when not applicable).
- **Tests**
  - Extended E2E and component test coverage for double-click flows, link reuse, multi-select behavior, and confirmation dialog result fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->