### PR TITLE
More intent bundle size optimization

### DIFF
--- a/src/lib/IntentProvider.jsx
+++ b/src/lib/IntentProvider.jsx
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { CozyProvider } from 'cozy-client'
+import SharingProvider from 'cozy-sharing'
+import AlertProvider from 'cozy-ui/transpiled/react/providers/Alert'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import CozyTheme from 'cozy-ui-plus/dist/providers/CozyTheme'
+import { I18n } from 'twake-i18n'
+
+import { usePublicContext } from '@/modules/public/PublicProvider'
+
+const IntentProvider = ({ client, lang, polyglot, dictRequire, children }) => {
+  const { isPublic } = usePublicContext()
+
+  return (
+    <I18n lang={lang} polyglot={polyglot} dictRequire={dictRequire}>
+      <CozyProvider client={client}>
+        <SharingProvider
+          doctype="io.cozy.files"
+          documentType="Files"
+          isPublic={isPublic}
+        >
+          <CozyTheme ignoreCozySettings={isPublic} className="u-w-100">
+            <BreakpointsProvider>
+              <AlertProvider>{children}</AlertProvider>
+            </BreakpointsProvider>
+          </CozyTheme>
+        </SharingProvider>
+      </CozyProvider>
+    </I18n>
+  )
+}
+
+IntentProvider.propTypes = {
+  client: PropTypes.object.isRequired,
+  lang: PropTypes.string.isRequired,
+  polyglot: PropTypes.object,
+  dictRequire: PropTypes.func
+}
+
+export default IntentProvider

--- a/src/lib/IntentProvider.jsx
+++ b/src/lib/IntentProvider.jsx
@@ -8,20 +8,12 @@ import { BreakpointsProvider } from 'cozy-ui/transpiled/react/providers/Breakpoi
 import CozyTheme from 'cozy-ui-plus/dist/providers/CozyTheme'
 import { I18n } from 'twake-i18n'
 
-import { usePublicContext } from '@/modules/public/PublicProvider'
-
 const IntentProvider = ({ client, lang, polyglot, dictRequire, children }) => {
-  const { isPublic } = usePublicContext()
-
   return (
     <I18n lang={lang} polyglot={polyglot} dictRequire={dictRequire}>
       <CozyProvider client={client}>
-        <SharingProvider
-          doctype="io.cozy.files"
-          documentType="Files"
-          isPublic={isPublic}
-        >
-          <CozyTheme ignoreCozySettings={isPublic} className="u-w-100">
+        <SharingProvider doctype="io.cozy.files" documentType="Files">
+          <CozyTheme className="u-w-100">
             <BreakpointsProvider>
               <AlertProvider>{children}</AlertProvider>
             </BreakpointsProvider>

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -1,5 +1,13 @@
 import PropTypes from 'prop-types'
-import React, { useState, memo, useMemo, useRef, useCallback } from 'react'
+import React, {
+  useState,
+  memo,
+  useMemo,
+  useRef,
+  useCallback,
+  lazy,
+  Suspense
+} from 'react'
 
 import Box from 'cozy-ui/transpiled/react/Box'
 import Divider from 'cozy-ui/transpiled/react/Divider'
@@ -8,7 +16,6 @@ import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import FilePickerBody from './FilePickerBody'
 import FilePickerFooter from './FilePickerFooter'
 import FilePickerHeader from './FilePickerHeader'
-import { LinkAccessModal } from './LinkAccessModal'
 import {
   defaultFilePickerConfig,
   filePickerDoubleClickResults,
@@ -20,6 +27,10 @@ import { getActionDisabledState } from './constraints'
 import { getCompliantTypes, isValidFile } from './helpers'
 
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+
+const LinkAccessModal = lazy(() =>
+  import('./LinkAccessModal').then(m => ({ default: m.LinkAccessModal }))
+)
 
 export const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 
@@ -200,11 +211,13 @@ const FilePicker = ({
       </div>
 
       {isLinkAccessOpen && (
-        <LinkAccessModal
-          selectedItems={selectedItems}
-          onCancel={() => setIsLinkAccessOpen(false)}
-          onConfirm={handleLinkAccessConfirm}
-        />
+        <Suspense fallback={null}>
+          <LinkAccessModal
+            selectedItems={selectedItems}
+            onCancel={() => setIsLinkAccessOpen(false)}
+            onConfirm={handleLinkAccessConfirm}
+          />
+        </Suspense>
       )}
     </>
   )

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -238,7 +238,7 @@ describe('FilePicker', () => {
   })
 
   it('should collect link access before confirming a public link', async () => {
-    const { getByTestId } = setup()
+    const { getByTestId, findByTestId } = setup()
 
     expect(getByTestId('public-link-btn')).toBeDisabled()
     expect(getByTestId('temporary-download-link-btn')).toBeDisabled()
@@ -251,7 +251,9 @@ describe('FilePicker', () => {
 
     fireEvent.click(getByTestId('public-link-btn'))
 
-    expect(getByTestId('link-access-modal')).toHaveTextContent('file.pdf')
+    expect(await findByTestId('link-access-modal')).toHaveTextContent(
+      'file.pdf'
+    )
     expect(mockOnChange).not.toHaveBeenCalled()
 
     fireEvent.click(getByTestId('confirm-link-access-btn'))
@@ -273,19 +275,20 @@ describe('FilePicker', () => {
 
   it('should keep link access open when link generation fails', async () => {
     mockOnChange.mockResolvedValueOnce('SHARING_LINK_FAILED')
-    const { getByTestId } = setup()
+    const { getByTestId, findByTestId } = setup()
 
     fireEvent.click(getByTestId('select-file-btn'))
     fireEvent.click(getByTestId('public-link-btn'))
+
+    await findByTestId('link-access-modal')
     fireEvent.click(getByTestId('confirm-link-access-btn'))
 
     await waitFor(() =>
-      expect(getByTestId('link-access-modal')).toBeInTheDocument()
+      expect(mockShowAlert).toHaveBeenCalledWith({
+        message: 'SHARING_LINK_FAILED',
+        severity: 'error'
+      })
     )
-    expect(mockShowAlert).toHaveBeenCalledWith({
-      message: 'SHARING_LINK_FAILED',
-      severity: 'error'
-    })
   })
 
   it('should disable temporary download link when a folder is selected', () => {
@@ -298,11 +301,13 @@ describe('FilePicker', () => {
   })
 
   it('should preserve multiple selected file ids while collecting link access', async () => {
-    const { getByTestId } = setup({ multiple: true })
+    const { getByTestId, findByTestId } = setup({ multiple: true })
 
     fireEvent.click(getByTestId('select-file-btn'))
     fireEvent.click(getByTestId('select-second-file-btn'))
     fireEvent.click(getByTestId('public-link-btn'))
+
+    await findByTestId('link-access-modal')
     fireEvent.click(getByTestId('confirm-link-access-btn'))
 
     await waitFor(() =>

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -11,7 +11,7 @@ import { createRoot } from 'react-dom/client'
 
 import CozyClient from 'cozy-client'
 
-import DriveProvider from '@/lib/DriveProvider'
+import IntentProvider from '@/lib/IntentProvider'
 import appMetadata from '@/lib/appMetadata'
 import { schema } from '@/lib/doctypes'
 import registerClientPlugins from '@/lib/registerClientPlugins'
@@ -43,10 +43,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   const dictRequire = await loadIntentLocales(data.locale)
 
   createRoot(root).render(
-    <DriveProvider client={client} lang={data.locale} dictRequire={dictRequire}>
+    <IntentProvider
+      client={client}
+      lang={data.locale}
+      dictRequire={dictRequire}
+    >
       <SelectionProvider clearOnLocationChange={false}>
         <IntentHandler intentId={intent} />
       </SelectionProvider>
-    </DriveProvider>
+    </IntentProvider>
   )
 })


### PR DESCRIPTION
Intent bundle size: 4.07MB -> 3.39MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared provider setup for intent pages, including localization, theming, sharing, and Cozy client context.
  * Intent pages now render through the new provider wrapper while keeping selection and intent handling intact.
* **Performance Improvements**
  * Link access dialogs in the FilePicker are now loaded on demand (lazy-loaded) when opened.
* **Tests**
  * Updated FilePicker tests to handle the modal’s async appearance before performing assertions and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->