### PR TITLE
feat(file-picker): Add mobile support

### DIFF
--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,6 +1,12 @@
 import { unlink } from 'fs/promises'
+
 import { test as base, expect } from '@playwright/test'
-import type { Page, TestInfo } from '@playwright/test'
+import type {
+  Browser,
+  BrowserContextOptions,
+  Page,
+  TestInfo
+} from '@playwright/test'
 
 import { authenticate } from './auth'
 import { DrivePage } from '../pages/DrivePage'
@@ -10,6 +16,11 @@ type AuthedFixtures = {
   bobPage: Page
   aliceDrive: DrivePage
   bobDrive: DrivePage
+}
+
+type ContextFixtures = {
+  browser: Browser
+  contextOptions: BrowserContextOptions
 }
 
 // Console messages we never want to fail on — benign in the test stack
@@ -33,11 +44,11 @@ const attachIfAny = async (
 const userPageFixture =
   (user: 'alice' | 'bob') =>
   async (
-    { browser }: { browser: import('@playwright/test').Browser },
+    { browser, contextOptions }: ContextFixtures,
     use: (page: Page) => Promise<void>,
     testInfo: TestInfo
   ): Promise<void> => {
-    const ctx = await browser.newContext()
+    const ctx = await browser.newContext(contextOptions)
     const consoleErrors: string[] = []
     const pageErrors: string[] = []
     try {

--- a/e2e/pages/FilePickerPage.ts
+++ b/e2e/pages/FilePickerPage.ts
@@ -37,6 +37,15 @@ export class FilePickerPage {
     await this.waitForPicker()
   }
 
+  /** Navigate to the mobile demo route and open the picker with a tap. */
+  async openMobile(): Promise<void> {
+    await this.page.goto(`${USERS.alice.appUrl}/#/file-picker-demo`)
+    const button = this.page.getByRole('button', { name: /pick a file/i })
+    await button.waitFor({ state: 'visible' })
+    await button.tap()
+    await this.waitForPicker()
+  }
+
   /** Wait until the picker iframe is present and loaded. */
   async waitForPicker(): Promise<void> {
     const frameLocator = this.getFrameLocator()
@@ -78,6 +87,42 @@ export class FilePickerPage {
     await this.getListItemByName(name)
       .getByTestId('listitem-onclick')
       .dblclick()
+  }
+
+  async tapItem(name: string): Promise<void> {
+    await this.getListItemByName(name).getByTestId('listitem-onclick').tap()
+  }
+
+  async navigateToFolderOnMobile(name: string): Promise<void> {
+    await this.tapItem(name)
+    await this.getFrameLocator()
+      .getByTestId('file-picker-breadcrumb')
+      .getByText(name, { exact: true })
+      .waitFor({ state: 'visible', timeout: 10_000 })
+  }
+
+  async navigateBackOnMobile(parentName: string): Promise<void> {
+    const frame = this.getFrameLocator()
+    await frame.getByRole('button', { name: 'Back' }).tap()
+    await frame
+      .getByTestId('file-picker-breadcrumb')
+      .getByText(parentName, { exact: true })
+      .waitFor({ state: 'visible', timeout: 10_000 })
+  }
+
+  async longPressItem(name: string): Promise<void> {
+    const row = this.getListItemByName(name)
+    await row.dispatchEvent('touchstart')
+    await this.page.waitForTimeout(300)
+    await row.dispatchEvent('touchend')
+  }
+
+  async getCheckboxCount(): Promise<number> {
+    return this.getFrameLocator().getByRole('checkbox').count()
+  }
+
+  async isItemChecked(name: string): Promise<boolean> {
+    return this.getListItemByName(name).getByRole('checkbox').isChecked()
   }
 
   // ---------------------------------------------------------------------------

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests',
@@ -24,9 +24,18 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testIgnore: /file-picker\.mobile\.spec\.ts/,
       use: {
         browserName: 'chromium',
         viewport: { width: 1280, height: 720 }
+      }
+    },
+    {
+      name: 'mobile',
+      testMatch: /file-picker\.mobile\.spec\.ts/,
+      use: {
+        ...devices['Pixel 5'],
+        browserName: 'chromium'
       }
     }
   ]

--- a/e2e/tests/file-picker.mobile.spec.ts
+++ b/e2e/tests/file-picker.mobile.spec.ts
@@ -1,0 +1,79 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { authenticate } from '../helpers/auth'
+import { USERS } from '../helpers/config'
+import { test, expect, safeUnlink, stamp } from '../helpers/fixtures'
+import { DrivePage } from '../pages/DrivePage'
+import { FilePickerPage } from '../pages/FilePickerPage'
+
+const FIXTURE = path.resolve(__dirname, '..', 'fixtures', 'sample.txt')
+
+test.describe('File Picker mobile', () => {
+  let parentFolder: string
+  let fileName: string
+  let folderName: string
+
+  test.beforeAll(async ({ browser }) => {
+    parentFolder = `000-picker-mobile-${stamp()}`
+    fileName = `picker-mobile-${stamp()}.txt`
+    folderName = `picker-mobile-folder-${stamp()}`
+
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 720 }
+    })
+    const page = await context.newPage()
+    const drive = new DrivePage(page)
+    const tmpPath = path.join(path.dirname(FIXTURE), fileName)
+
+    try {
+      await authenticate(page, 'alice')
+      await page.goto(`${USERS.alice.appUrl}/#/folder?flags`)
+      await drive.createFolder(parentFolder)
+      await drive.row(parentFolder).open()
+      await page.waitForURL(/\/folder\/[^/]+$/)
+      await drive.createFolder(folderName)
+      await copyFile(FIXTURE, tmpPath)
+      await drive.uploadFiles(tmpPath)
+      await drive.row(fileName).waitVisible()
+    } finally {
+      await safeUnlink(tmpPath)
+      await context.close()
+    }
+  })
+
+  test('supports the focused touch flow in a full-screen intent', async ({
+    alicePage
+  }) => {
+    const picker = new FilePickerPage(alicePage)
+    await picker.openMobile()
+
+    const viewport = alicePage.viewportSize()
+    if (!viewport) throw new Error('Mobile project requires a viewport')
+    expect(viewport.width).toBeLessThan(600)
+    expect(
+      await alicePage.evaluate(() => navigator.maxTouchPoints)
+    ).toBeGreaterThan(0)
+    expect(await alicePage.getByRole('dialog').boundingBox()).toEqual({
+      x: 0,
+      y: 0,
+      width: viewport.width,
+      height: viewport.height
+    })
+
+    await picker.navigateToFolderOnMobile(parentFolder)
+    await picker.tapItem(fileName)
+    await expect.poll(() => picker.getCheckboxCount()).toBe(0)
+    await expect(picker.isTemporaryDownloadDisabled()).resolves.toBe(true)
+    await expect(picker.isPublicLinkDisabled()).resolves.toBe(true)
+
+    await picker.navigateToFolderOnMobile(folderName)
+    await picker.navigateBackOnMobile(parentFolder)
+    await picker.longPressItem(folderName)
+
+    await expect.poll(() => picker.getCheckboxCount()).toBe(2)
+    await expect(picker.isItemChecked(folderName)).resolves.toBe(true)
+    await expect(picker.isTemporaryDownloadDisabled()).resolves.toBe(true)
+    await expect(picker.isPublicLinkDisabled()).resolves.toBe(false)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "cozy-search": "^2.0.2",
     "cozy-sharing": "^37.2.12",
     "cozy-stack-client": "^60.28.0",
-    "cozy-ui": "^140.5.2",
+    "cozy-ui": "^141.0.0",
     "cozy-ui-plus": "^12.3.0",
     "cozy-viewer": "^30.0.19",
     "date-fns": "2.30.0",

--- a/src/components/FolderPicker/FolderPickerListItem.tsx
+++ b/src/components/FolderPicker/FolderPickerListItem.tsx
@@ -12,7 +12,10 @@ import { useI18n } from 'twake-i18n'
 import styles from '@/styles/folder-picker.styl'
 
 import type { File } from '@/components/FolderPicker/types'
-import { getFileNameAndExtension } from '@/modules/filelist/helpers'
+import {
+  getFileNameAndExtension,
+  makeFileMetadata
+} from '@/modules/filelist/helpers'
 import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
 
 interface FolderPickerListItemProps {
@@ -44,7 +47,7 @@ const FolderPickerListItem: FC<FolderPickerListItemProps> = ({
     ? filesize(file.size, { base: 10 })
     : undefined
   const secondaryText = !isDirectory(file)
-    ? `${formattedUpdatedAt}${formattedSize ? ` - ${formattedSize}` : ''}`
+    ? makeFileMetadata(formattedUpdatedAt, formattedSize)
     : undefined
 
   const { title } = getFileNameAndExtension(file, t)

--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -127,11 +127,17 @@ export const makeMobileHandlers = ({
     }, 250)
   }
 
+  const cancelPress = () => {
+    clearTimeout(timerId.current)
+    isLongPress.current = false
+  }
+
   return {
     // first event triggered on Mobile when taping an item
     onTouchStart: startPressTimer,
     // second event triggered on Mobile when dragging an item
     onTouchMove: () => clearTimeout(timerId.current),
+    onTouchCancel: cancelPress,
     // third event triggered on Mobile when taping an item
     onTouchEnd: () => clearTimeout(timerId.current),
     // fourth event triggered on Mobile

--- a/src/modules/filelist/cells/FileName.jsx
+++ b/src/modules/filelist/cells/FileName.jsx
@@ -13,6 +13,7 @@ import { useViewSwitcherContext } from '@/lib/ViewSwitcherContext'
 import RenameInput from '@/modules/drive/RenameInput'
 import {
   getFileNameAndExtension,
+  makeFileMetadata,
   makeParentFolderPath
 } from '@/modules/filelist/helpers'
 import { getSharingsRootRoute } from '@/modules/views/Sharings/routes'
@@ -93,9 +94,7 @@ const FileName = ({
           {!withFilePath &&
             (isDirectory(attributes) || (
               <div className={styles['fil-file-infos']}>
-                {`${formattedUpdatedAt}${
-                  formattedSize ? ` - ${formattedSize}` : ''
-                }`}
+                {makeFileMetadata(formattedUpdatedAt, formattedSize)}
               </div>
             ))}
         </div>

--- a/src/modules/filelist/helpers.ts
+++ b/src/modules/filelist/helpers.ts
@@ -12,6 +12,11 @@ import { isNextcloudShortcut } from '@/modules/nextcloud/helpers'
 
 export const isDriveBackedFile = (file: File): boolean => !!file.driveId
 
+export const makeFileMetadata = (
+  formattedUpdatedAt?: string,
+  formattedSize?: string
+): string => [formattedUpdatedAt, formattedSize].filter(Boolean).join(' - ')
+
 export const makeParentFolderPath = (file: File): string => {
   if (file.dir_id === SHARED_DRIVES_DIR_ID) {
     return SHARINGS_VIEW_ROUTE

--- a/src/modules/filelist/virtualized/cells/FileNamePath.jsx
+++ b/src/modules/filelist/virtualized/cells/FileNamePath.jsx
@@ -7,7 +7,10 @@ import { useI18n } from 'twake-i18n'
 
 import styles from '@/styles/filelist.styl'
 
-import { getFileNameAndExtension } from '@/modules/filelist/helpers'
+import {
+  getFileNameAndExtension,
+  makeFileMetadata
+} from '@/modules/filelist/helpers'
 import { getFolderPath } from '@/modules/routeUtils'
 import { getSharingsRootRoute } from '@/modules/views/Sharings/routes'
 
@@ -26,7 +29,7 @@ const FileNamePath = ({
   if (!withFilePath) {
     return (
       <div className={styles['fil-file-infos']}>
-        {`${formattedUpdatedAt}${formattedSize ? ` - ${formattedSize}` : ''}`}
+        {makeFileMetadata(formattedUpdatedAt, formattedSize)}
       </div>
     )
   }

--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -12,6 +12,7 @@ import AssistantLayout from '../views/Assistant/AssistantLayout'
 import { DriveFolderView } from '../views/Drive/DriveFolderView'
 import FilesViewerDrive from '../views/Drive/FilesViewerDrive'
 import { getExcalidrawRoutes } from '../views/Excalidraw/routes'
+import { FilePickerDemoView } from '../views/FilePickerDemo/FilePickerDemoView'
 import OnlyOfficePaywallView from '../views/OnlyOffice/OnlyOfficePaywallView'
 import { getOnlyOfficeRoutes } from '../views/OnlyOffice/routes'
 import { getPdfRoutes } from '../views/Pdf/routes'
@@ -202,6 +203,9 @@ const AppRoutes = ({ sharedDrivesEnabled }) => (
 
     <Route element={<Layout />}>
       <Route path="upload" element={<UploaderComponent />} />
+      {flag('drive.file-picker-demo.enabled') && (
+        <Route path="file-picker-demo" element={<FilePickerDemoView />} />
+      )}
       <Route path="/files/:folderId" element={<FilesRedirect />} />
       <Route path="/" element={<Index />} />
 

--- a/src/modules/navigation/components/FilePickerButton.jsx
+++ b/src/modules/navigation/components/FilePickerButton.jsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radios from 'cozy-ui/transpiled/react/Radios'
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import IntentDialogOpener from 'cozy-ui-plus/dist/Intent/IntentDialogOpener'
 import { useI18n } from 'twake-i18n'
 
@@ -89,6 +90,7 @@ const buildFilePickerOptions = (configId, t) => {
 
 export const FilePickerButton = () => {
   const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
   const [modalData, setModalData] = useState(null)
   const [configId, setConfigId] = useState(PICKER_CONFIGS[0].id)
   const [themeType, setThemeType] = useState(filePickerThemes[0])
@@ -157,6 +159,7 @@ export const FilePickerButton = () => {
         doctype="io.cozy.files"
         options={filePickerOptions}
         classes={{ paper: 'u-h-100' }}
+        fullScreen={isMobile}
         fullWidth
         maxWidth="md"
         iframeProps={{ spinnerProps: { middle: true } }}

--- a/src/modules/navigation/components/FilePickerButton.spec.jsx
+++ b/src/modules/navigation/components/FilePickerButton.spec.jsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient } from 'cozy-client'
+import IntentDialogOpener from 'cozy-ui-plus/dist/Intent/IntentDialogOpener'
+
+import { FilePickerButton } from './FilePickerButton'
+import AppLike from 'test/components/AppLike'
+
+jest.mock('cozy-ui-plus/dist/Intent/IntentDialogOpener', () => ({
+  __esModule: true,
+  default: jest.fn(({ children }) => children)
+}))
+
+const client = createMockClient()
+
+describe('FilePickerButton', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it.each([true, false])('sets full-screen dialog to %s', isMobile => {
+    window.innerWidth = isMobile ? 500 : 1024
+
+    render(
+      <AppLike client={client}>
+        <FilePickerButton />
+      </AppLike>
+    )
+
+    expect(IntentDialogOpener).toHaveBeenCalledWith(
+      expect.objectContaining({ fullScreen: isMobile }),
+      expect.anything()
+    )
+  })
+})

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -127,13 +127,19 @@ function getVisibleText(element) {
   return element.textContent.replaceAll('\u200e', '')
 }
 
-function setup({ accept, isMobile = true, multiple = false } = {}) {
+function setup({
+  accept,
+  filePickerConfig,
+  isMobile = true,
+  multiple = false
+} = {}) {
   window.innerWidth = isMobile ? 500 : 1024
 
   return render(
     <AppLike client={mockClient}>
       <FilePicker
         accept={accept}
+        filePickerConfig={filePickerConfig}
         multiple={multiple}
         onChange={mockOnChange}
         onFileDoubleClick={mockOnFileDoubleClick}
@@ -155,10 +161,55 @@ function longPress(row) {
   fireEvent.click(row)
 }
 
-describe('FilePicker mobile navigation and list', () => {
+describe('FilePicker mobile navigation, list and actions', () => {
   afterEach(() => {
     jest.clearAllMocks()
     jest.useRealTimers()
+  })
+
+  it('gives a single mobile action the available width', () => {
+    const { getByTestId } = setup({
+      filePickerConfig: {
+        sharingLink: { allowFolder: true },
+        downloadLink: null
+      }
+    })
+
+    expect(getByTestId('public-link-btn')).toHaveClass('u-flex-grow-1')
+  })
+
+  it('uses equal-width iconless mobile action variants', () => {
+    const { getByTestId } = setup()
+    const downloadButton = getByTestId('temporary-download-link-btn')
+    const publicButton = getByTestId('public-link-btn')
+
+    expect(downloadButton).toHaveClass('u-flex-grow-1')
+    expect(publicButton).toHaveClass('u-flex-grow-1')
+    expect(downloadButton).toHaveClass('MuiButton-outlined')
+    expect(publicButton).toHaveClass('MuiButton-contained')
+    expect(downloadButton.querySelector('svg')).toBe(null)
+    expect(publicButton.querySelector('svg')).toBe(null)
+  })
+
+  it('evaluates each action against the complete selection', () => {
+    jest.useFakeTimers()
+    const { getAllByTestId, getByTestId, queryByRole, queryByText } = setup({
+      multiple: true
+    })
+    const rows = getAllByTestId('list-item')
+    const folderRow = rows.find(row => row.dataset.fileId === mockFolder.id)
+    const fileRow = rows.find(row => row.dataset.fileId === mockFile.id)
+
+    longPress(fileRow)
+    tap(folderRow)
+
+    expect(getByTestId('public-link-btn')).not.toBeDisabled()
+    expect(getByTestId('temporary-download-link-btn')).toBeDisabled()
+    expect(queryByRole('button', { name: 'Clear Selection' })).toBe(null)
+    expect(queryByText(/item selected/)).toBe(null)
+    expect(
+      queryByText('FilePicker.constraints.disabledReasons.folderNotAllowed')
+    ).toBe(null)
   })
 
   it('starts selection on long press and ignores the following click', () => {
@@ -248,7 +299,7 @@ describe('FilePicker mobile navigation and list', () => {
 
   it('replaces and clears selection in single selection mode', () => {
     jest.useFakeTimers()
-    const { getAllByTestId, queryAllByRole } = setup()
+    const { getAllByTestId, getByTestId, queryAllByRole } = setup()
     const rows = getAllByTestId('list-item')
     const folderRow = rows.find(row => row.dataset.fileId === mockFolder.id)
     const fileRow = rows.find(row => row.dataset.fileId === mockFile.id)
@@ -262,6 +313,8 @@ describe('FilePicker mobile navigation and list', () => {
     tap(folderRow)
 
     expect(queryAllByRole('checkbox')).toHaveLength(0)
+    expect(getByTestId('public-link-btn')).toBeDisabled()
+    expect(getByTestId('temporary-download-link-btn')).toBeDisabled()
   })
 
   it('allows selection of files outside the accepted action types', () => {
@@ -317,6 +370,16 @@ describe('FilePicker mobile navigation and list', () => {
     expect(queryByRole('columnheader', { name: 'Size' })).toBeInTheDocument()
     fireEvent.click(fileRow)
     expect(getByTestId('public-link-btn')).not.toBeDisabled()
+    expect(getByTestId('temporary-download-link-btn')).toHaveClass(
+      'MuiButton-contained'
+    )
+    expect(getByTestId('public-link-btn')).toHaveClass('MuiButton-contained')
+    expect(
+      getByTestId('temporary-download-link-btn').querySelector('svg')
+    ).toBeInTheDocument()
+    expect(
+      getByTestId('public-link-btn').querySelector('svg')
+    ).toBeInTheDocument()
 
     fireEvent.doubleClick(folderRow)
     expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -1,0 +1,155 @@
+import { render, within } from '@testing-library/react'
+import React from 'react'
+
+import { Q, createMockClient } from 'cozy-client'
+
+import FilePicker from './index'
+import { buildContentFolderQuery } from './queries'
+import AppLike from 'test/components/AppLike'
+
+const mockRootId = 'io.cozy.files.root-dir'
+const mockFolder = {
+  _id: 'folder-id',
+  id: 'folder-id',
+  dir_id: mockRootId,
+  type: 'directory',
+  name: 'Photos'
+}
+const mockEmptyFile = {
+  _id: 'empty-file-id',
+  id: 'empty-file-id',
+  dir_id: mockRootId,
+  type: 'file',
+  name: 'empty.txt',
+  updated_at: '2025-01-02T10:00:00.000Z',
+  size: 0
+}
+const mockFile = {
+  _id: 'file-id',
+  id: 'file-id',
+  dir_id: mockRootId,
+  type: 'file',
+  name: 'report.pdf',
+  updated_at: '2025-01-02T10:00:00.000Z',
+  size: 1500
+}
+const mockItems = [mockFolder, mockEmptyFile, mockFile]
+const mockClient = createMockClient({
+  queries: {
+    [`buildContentFolderQuery-${mockRootId}`]: {
+      definition: buildContentFolderQuery(mockRootId).definition(),
+      doctype: 'io.cozy.files',
+      data: mockItems
+    },
+    [`io.cozy.files/${mockRootId}`]: {
+      definition: Q('io.cozy.files').getById(mockRootId),
+      doctype: 'io.cozy.files',
+      data: [
+        {
+          _id: mockRootId,
+          id: mockRootId,
+          dir_id: null,
+          type: 'directory',
+          name: 'My Drive'
+        }
+      ]
+    }
+  }
+})
+
+jest.mock('cozy-ui/transpiled/react/Table/Virtualized', () => {
+  const React = require('react')
+  const VirtualizedTable = React.forwardRef(
+    (
+      { rows, columns, context, components, componentsProps, isSelectedItem },
+      ref
+    ) => {
+      const TableHead = components.TableHead
+      const TableRow = components.TableRow
+
+      return (
+        <table ref={ref}>
+          <TableHead>
+            <tr>
+              {columns.map(column => (
+                <th key={column.id}>{column.label}</th>
+              ))}
+            </tr>
+          </TableHead>
+          <tbody>
+            {rows.map(row => (
+              <TableRow
+                key={row._id}
+                item={row}
+                context={{ ...context, isSelectedItem }}
+              >
+                {columns.map(column => (
+                  <td key={column.id}>
+                    {React.cloneElement(componentsProps.rowContent.children, {
+                      column,
+                      row
+                    })}
+                  </td>
+                ))}
+              </TableRow>
+            ))}
+          </tbody>
+        </table>
+      )
+    }
+  )
+  VirtualizedTable.displayName = 'VirtualizedTable'
+
+  return { __esModule: true, default: VirtualizedTable }
+})
+
+const mockOnChange = jest.fn()
+const mockOnFileDoubleClick = jest.fn()
+
+function getVisibleText(element) {
+  return element.textContent.replaceAll('\u200e', '')
+}
+
+function setup() {
+  window.innerWidth = 500
+
+  return render(
+    <AppLike client={mockClient}>
+      <FilePicker
+        onChange={mockOnChange}
+        onFileDoubleClick={mockOnFileDoubleClick}
+      />
+    </AppLike>
+  )
+}
+
+describe('FilePicker mobile list', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders compact rows without column headers', () => {
+    const { getAllByTestId, queryAllByRole } = setup()
+    const folderRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFolder.id
+    )
+    const emptyFileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockEmptyFile.id
+    )
+    const fileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFile.id
+    )
+
+    expect(queryAllByRole('columnheader')).toHaveLength(0)
+    expect(getVisibleText(folderRow)).toContain('Photos')
+    expect(folderRow).not.toHaveTextContent('Jan 2, 2025')
+    expect(folderRow).not.toHaveTextContent('1.5 kB')
+    expect(getVisibleText(fileRow)).toContain('report.pdf')
+    expect(
+      within(fileRow).getByText('Jan 2, 2025 - 1.5 kB')
+    ).toBeInTheDocument()
+    expect(
+      within(emptyFileRow).getByText('Jan 2, 2025 - 0 B')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -1,4 +1,4 @@
-import { render, within } from '@testing-library/react'
+import { fireEvent, render, within } from '@testing-library/react'
 import React from 'react'
 
 import { Q, createMockClient } from 'cozy-client'
@@ -41,6 +41,11 @@ const mockClient = createMockClient({
       doctype: 'io.cozy.files',
       data: mockItems
     },
+    'buildContentFolderQuery-folder-id': {
+      definition: buildContentFolderQuery(mockFolder.id).definition(),
+      doctype: 'io.cozy.files',
+      data: mockItems
+    },
     [`io.cozy.files/${mockRootId}`]: {
       definition: Q('io.cozy.files').getById(mockRootId),
       doctype: 'io.cozy.files',
@@ -53,6 +58,11 @@ const mockClient = createMockClient({
           name: 'My Drive'
         }
       ]
+    },
+    'io.cozy.files/folder-id': {
+      definition: Q('io.cozy.files').getById(mockFolder.id),
+      doctype: 'io.cozy.files',
+      data: [mockFolder]
     }
   }
 })
@@ -110,8 +120,8 @@ function getVisibleText(element) {
   return element.textContent.replaceAll('\u200e', '')
 }
 
-function setup() {
-  window.innerWidth = 500
+function setup({ isMobile = true } = {}) {
+  window.innerWidth = isMobile ? 500 : 1024
 
   return render(
     <AppLike client={mockClient}>
@@ -123,9 +133,51 @@ function setup() {
   )
 }
 
-describe('FilePicker mobile list', () => {
+describe('FilePicker mobile navigation and list', () => {
   afterEach(() => {
     jest.clearAllMocks()
+  })
+
+  it('preserves desktop columns, selection and folder double-click navigation', () => {
+    const { getAllByTestId, getByTestId, queryByRole } = setup({
+      isMobile: false
+    })
+    const rows = getAllByTestId('list-item')
+    const folderRow = rows.find(row => row.dataset.fileId === mockFolder.id)
+    const fileRow = rows.find(row => row.dataset.fileId === mockFile.id)
+
+    expect(queryByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+    expect(
+      queryByRole('columnheader', { name: 'Last update' })
+    ).toBeInTheDocument()
+    expect(queryByRole('columnheader', { name: 'Size' })).toBeInTheDocument()
+    fireEvent.click(fileRow)
+    expect(getByTestId('public-link-btn')).not.toBeDisabled()
+
+    fireEvent.doubleClick(folderRow)
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('Photos')
+    expect(queryByRole('button', { name: 'Back' })).toBe(null)
+  })
+
+  it('leaves files unselected and gives double taps no extra behavior', () => {
+    const { getAllByTestId, getByTestId } = setup()
+    const rows = getAllByTestId('list-item')
+    const folderRow = rows.find(row => row.dataset.fileId === mockFolder.id)
+    const fileRow = rows.find(row => row.dataset.fileId === mockFile.id)
+
+    fireEvent.click(fileRow)
+    fireEvent.click(fileRow)
+    fireEvent.doubleClick(fileRow)
+
+    expect(getByTestId('public-link-btn')).toBeDisabled()
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
+
+    fireEvent.click(folderRow)
+
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('Photos')
+    expect(mockOnFileDoubleClick).not.toHaveBeenCalled()
+    expect(mockOnChange).not.toHaveBeenCalled()
   })
 
   it('renders compact rows without column headers', () => {
@@ -151,5 +203,24 @@ describe('FilePicker mobile list', () => {
     expect(
       within(emptyFileRow).getByText('Jan 2, 2025 - 0 B')
     ).toBeInTheDocument()
+  })
+
+  it('opens a folder on tap and shows only its name with a back control', () => {
+    const { getByTestId, getByRole, getAllByTestId, queryByRole } = setup()
+    const folderRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFolder.id
+    )
+
+    fireEvent.click(folderRow)
+
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('Photos')
+    expect(getByTestId('file-picker-breadcrumb')).not.toHaveTextContent(
+      'My Drive'
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Back' }))
+
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
+    expect(queryByRole('button', { name: 'Back' })).toBe(null)
   })
 })

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from '@testing-library/react'
+import { act, fireEvent, render, within } from '@testing-library/react'
 import React from 'react'
 
 import { Q, createMockClient } from 'cozy-client'
@@ -33,6 +33,13 @@ const mockFile = {
   updated_at: '2025-01-02T10:00:00.000Z',
   size: 1500
 }
+const mockChildFile = {
+  ...mockFile,
+  _id: 'child-file-id',
+  id: 'child-file-id',
+  dir_id: mockFolder.id,
+  name: 'child-report.pdf'
+}
 const mockItems = [mockFolder, mockEmptyFile, mockFile]
 const mockClient = createMockClient({
   queries: {
@@ -44,7 +51,7 @@ const mockClient = createMockClient({
     'buildContentFolderQuery-folder-id': {
       definition: buildContentFolderQuery(mockFolder.id).definition(),
       doctype: 'io.cozy.files',
-      data: mockItems
+      data: [mockChildFile]
     },
     [`io.cozy.files/${mockRootId}`]: {
       definition: Q('io.cozy.files').getById(mockRootId),
@@ -120,12 +127,14 @@ function getVisibleText(element) {
   return element.textContent.replaceAll('\u200e', '')
 }
 
-function setup({ isMobile = true } = {}) {
+function setup({ accept, isMobile = true, multiple = false } = {}) {
   window.innerWidth = isMobile ? 500 : 1024
 
   return render(
     <AppLike client={mockClient}>
       <FilePicker
+        accept={accept}
+        multiple={multiple}
         onChange={mockOnChange}
         onFileDoubleClick={mockOnFileDoubleClick}
       />
@@ -133,9 +142,164 @@ function setup({ isMobile = true } = {}) {
   )
 }
 
+function tap(row) {
+  fireEvent.touchStart(row)
+  fireEvent.touchEnd(row)
+  fireEvent.click(row)
+}
+
+function longPress(row) {
+  fireEvent.touchStart(row)
+  act(() => jest.advanceTimersByTime(250))
+  fireEvent.touchEnd(row)
+  fireEvent.click(row)
+}
+
 describe('FilePicker mobile navigation and list', () => {
   afterEach(() => {
     jest.clearAllMocks()
+    jest.useRealTimers()
+  })
+
+  it('starts selection on long press and ignores the following click', () => {
+    jest.useFakeTimers()
+    const { getAllByRole, getAllByTestId, getByTestId, queryAllByRole } =
+      setup()
+    const fileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFile.id
+    )
+
+    expect(queryAllByRole('checkbox')).toHaveLength(0)
+
+    longPress(fileRow)
+
+    expect(getAllByRole('checkbox')).toHaveLength(mockItems.length)
+    expect(within(fileRow).getByRole('checkbox')).toBeChecked()
+    expect(getByTestId('public-link-btn')).not.toBeDisabled()
+  })
+
+  it('selects folders by long press without navigating', () => {
+    jest.useFakeTimers()
+    const { getAllByTestId, getByTestId } = setup()
+    const folderRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFolder.id
+    )
+
+    longPress(folderRow)
+
+    expect(within(folderRow).getByRole('checkbox')).toBeChecked()
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
+  })
+
+  it('cancels pending selection when touch movement starts', () => {
+    jest.useFakeTimers()
+    const { getAllByTestId, getByTestId, queryAllByRole } = setup()
+    const fileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFile.id
+    )
+
+    fireEvent.touchStart(fileRow)
+    fireEvent.touchMove(fileRow)
+    act(() => jest.advanceTimersByTime(300))
+    fireEvent.touchEnd(fileRow)
+
+    expect(queryAllByRole('checkbox')).toHaveLength(0)
+    expect(getByTestId('public-link-btn')).toBeDisabled()
+  })
+
+  it('cancels pending selection when the touch is cancelled', () => {
+    jest.useFakeTimers()
+    const { getAllByTestId, getByTestId, queryAllByRole } = setup()
+    const fileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFile.id
+    )
+
+    fireEvent.touchStart(fileRow)
+    fireEvent.touchCancel(fileRow)
+    act(() => jest.advanceTimersByTime(300))
+
+    expect(queryAllByRole('checkbox')).toHaveLength(0)
+    expect(getByTestId('public-link-btn')).toBeDisabled()
+  })
+
+  it('toggles only the tapped item in multiple selection mode', () => {
+    jest.useFakeTimers()
+    const { getAllByRole, getAllByTestId } = setup({ multiple: true })
+    const rows = getAllByTestId('list-item')
+    const folderRow = rows.find(row => row.dataset.fileId === mockFolder.id)
+    const emptyFileRow = rows.find(
+      row => row.dataset.fileId === mockEmptyFile.id
+    )
+    const fileRow = rows.find(row => row.dataset.fileId === mockFile.id)
+
+    longPress(fileRow)
+    expect(getAllByRole('checkbox')).toHaveLength(mockItems.length)
+    tap(folderRow)
+    expect(within(folderRow).getByRole('checkbox')).toBeChecked()
+    tap(emptyFileRow)
+    expect(within(emptyFileRow).getByRole('checkbox')).toBeChecked()
+    tap(fileRow)
+
+    expect(getAllByRole('checkbox')).toHaveLength(mockItems.length)
+    expect(within(folderRow).getByRole('checkbox')).toBeChecked()
+    expect(within(emptyFileRow).getByRole('checkbox')).toBeChecked()
+    expect(within(fileRow).getByRole('checkbox')).not.toBeChecked()
+  })
+
+  it('replaces and clears selection in single selection mode', () => {
+    jest.useFakeTimers()
+    const { getAllByTestId, queryAllByRole } = setup()
+    const rows = getAllByTestId('list-item')
+    const folderRow = rows.find(row => row.dataset.fileId === mockFolder.id)
+    const fileRow = rows.find(row => row.dataset.fileId === mockFile.id)
+
+    longPress(fileRow)
+    tap(folderRow)
+
+    expect(within(folderRow).getByRole('checkbox')).toBeChecked()
+    expect(within(fileRow).getByRole('checkbox')).not.toBeChecked()
+
+    tap(folderRow)
+
+    expect(queryAllByRole('checkbox')).toHaveLength(0)
+  })
+
+  it('allows selection of files outside the accepted action types', () => {
+    jest.useFakeTimers()
+    const { getAllByTestId } = setup({ accept: 'application/pdf' })
+    const incompatibleFileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockEmptyFile.id
+    )
+
+    longPress(incompatibleFileRow)
+
+    expect(within(incompatibleFileRow).getByRole('checkbox')).toBeChecked()
+  })
+
+  it('clears selection when navigating back to the parent folder', () => {
+    jest.useFakeTimers()
+    const {
+      getAllByTestId,
+      getByRole,
+      getByTestId,
+      queryAllByRole,
+      queryByRole
+    } = setup()
+    const folderRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFolder.id
+    )
+
+    fireEvent.click(folderRow)
+    const childFileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockChildFile.id
+    )
+    longPress(childFileRow)
+    fireEvent.click(getByRole('button', { name: 'Back' }))
+
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
+    expect(queryByRole('button', { name: 'Back' })).toBe(null)
+    expect(queryAllByRole('checkbox')).toHaveLength(0)
+    expect(getByTestId('public-link-btn')).toBeDisabled()
   })
 
   it('preserves desktop columns, selection and folder double-click navigation', () => {

--- a/src/modules/services/components/FilePicker/FilePickerBody.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerBody.jsx
@@ -74,14 +74,15 @@ const FilePickerBody = ({
     })
   }, [])
 
-  const { handleItemClick, selectedItemIds } = useFilePickerSelection({
-    items,
-    canSelectItem,
-    multiple,
-    selectionContainerRef,
-    scrollElement,
-    scrollToIndex
-  })
+  const { handleItemClick, handleMobileToggleSelect, selectedItemIds } =
+    useFilePickerSelection({
+      items,
+      canSelectItem,
+      multiple,
+      selectionContainerRef,
+      scrollElement,
+      scrollToIndex
+    })
 
   const handleListItemDoubleClick = useCallback(
     item => {
@@ -128,6 +129,7 @@ const FilePickerBody = ({
         items={items}
         itemsIdsSelected={selectedItemIds}
         onItemClick={isMobile ? handleMobileItemClick : handleItemClick}
+        onItemToggle={isMobile ? handleMobileToggleSelect : null}
         onItemDoubleClick={isMobile ? null : handleListItemDoubleClick}
         fetchMore={hasMore ? fetchMore : undefined}
         scrollerRef={setScrollElement}

--- a/src/modules/services/components/FilePicker/FilePickerBody.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerBody.jsx
@@ -5,6 +5,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { models, useQuery } from 'cozy-client'
 import Alert from 'cozy-ui/transpiled/react/Alert'
 import Box from 'cozy-ui/transpiled/react/Box'
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
 import FilePickerBreadcrumb from './FilePickerBreadcrumb'
@@ -32,6 +33,7 @@ const FilePickerBody = ({
   onFileDoubleClick
 }) => {
   const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
   const selectionContainerRef = useRef(null)
   const virtuosoRef = useRef(null)
   const [scrollElement, setScrollElement] = useState(null)
@@ -92,6 +94,13 @@ const FilePickerBody = ({
     [navigateTo, onFileDoubleClick]
   )
 
+  const handleMobileItemClick = useCallback(
+    item => {
+      if (isDirectory(item)) navigateTo(item)
+    },
+    [navigateTo]
+  )
+
   return (
     <Box
       ref={selectionContainerRef}
@@ -118,8 +127,8 @@ const FilePickerBody = ({
       <FilePickerTable
         items={items}
         itemsIdsSelected={selectedItemIds}
-        onItemClick={handleItemClick}
-        onItemDoubleClick={handleListItemDoubleClick}
+        onItemClick={isMobile ? handleMobileItemClick : handleItemClick}
+        onItemDoubleClick={isMobile ? null : handleListItemDoubleClick}
         fetchMore={hasMore ? fetchMore : undefined}
         scrollerRef={setScrollElement}
         virtuosoRef={virtuosoRef}

--- a/src/modules/services/components/FilePicker/FilePickerBreadcrumb.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerBreadcrumb.jsx
@@ -3,16 +3,23 @@ import PropTypes from 'prop-types'
 import React, { Fragment, useCallback, memo } from 'react'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import styles from './styles.styl'
 
+import { BackButton } from '@/components/Button/BackButton'
+
 const FilePickerBreadcrumb = ({ path, onBreadcrumbClick }) => {
+  const { isMobile } = useBreakpoints()
   const hasPath = path && path.length > 0
 
   const navigateTo = useCallback(
     folder => () => onBreadcrumbClick(folder),
     [onBreadcrumbClick]
   )
+  const navigateBack = useCallback(() => {
+    onBreadcrumbClick(path[path.length - 2])
+  }, [onBreadcrumbClick, path])
 
   return (
     <Typography
@@ -20,7 +27,13 @@ const FilePickerBreadcrumb = ({ path, onBreadcrumbClick }) => {
       data-testid="file-picker-breadcrumb"
       className="u-flex u-flex-items-center u-fw-bold"
     >
-      {hasPath &&
+      {isMobile && hasPath ? (
+        <>
+          {path.length > 1 && <BackButton onClick={navigateBack} />}
+          <span>{path[path.length - 1].name}</span>
+        </>
+      ) : (
+        hasPath &&
         path.map((folder, idx) => {
           if (idx < path.length - 1) {
             return (
@@ -40,7 +53,8 @@ const FilePickerBreadcrumb = ({ path, onBreadcrumbClick }) => {
           } else {
             return <span key={idx}>{folder.name}</span>
           }
-        })}
+        })
+      )}
     </Typography>
   )
 }

--- a/src/modules/services/components/FilePicker/FilePickerFooter.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerFooter.jsx
@@ -8,6 +8,7 @@ import Button from 'cozy-ui/transpiled/react/Buttons'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Tooltip from 'cozy-ui/transpiled/react/Tooltip'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
 import { filePickerLinkModes } from './constants'
@@ -30,6 +31,7 @@ const FilePickerFooter = ({
   downloadLinkAction
 }) => {
   const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
   const { selectedItems, clearSelection } = useSelectionContext()
   const selectedCount = selectedItems.length
 
@@ -47,74 +49,102 @@ const FilePickerFooter = ({
     actionConfig,
     onClick,
     testId,
-    IconComponent
+    IconComponent,
+    mobileVariant,
+    hasLeftMargin = false
   ) => {
     if (!label) return null
 
+    const mobileMarginClass =
+      hasLeftMargin && (downloadLinkLabel || !isMobile) ? 'u-ml-1' : ''
     const button = (
       <Button
+        className={isMobile ? `u-flex-grow-1 ${mobileMarginClass}` : null}
         data-testid={testId}
         label={
-          <span className="u-flex u-flex-items-center">
-            <Icon icon={IconComponent} size={16} />
-            <span className="u-ml-half">{label}</span>
-          </span>
+          isMobile ? (
+            label
+          ) : (
+            <span className="u-flex u-flex-items-center">
+              <Icon icon={IconComponent} size={16} />
+              <span className="u-ml-half">{label}</span>
+            </span>
+          )
         }
-        variant="primary"
+        variant={isMobile ? mobileVariant : 'primary'}
         onClick={onClick}
         disabled={state.disabled}
       />
     )
 
-    if (!state.disabled || !state.reasonKey) {
-      return <span>{button}</span>
-    }
+    if (isMobile) return button
 
-    const tooltipTitle = getTooltipTitle(t, state.reasonKey, actionConfig)
-    return (
-      <Tooltip title={tooltipTitle} placement="top">
-        <span>{button}</span>
-      </Tooltip>
-    )
+    const action =
+      !state.disabled || !state.reasonKey ? (
+        button
+      ) : (
+        <Tooltip
+          title={getTooltipTitle(t, state.reasonKey, actionConfig)}
+          placement="top"
+        >
+          <span>{button}</span>
+        </Tooltip>
+      )
+
+    return <span className={hasLeftMargin ? 'u-ml-1' : null}>{action}</span>
   }
 
   return (
-    <Box className="u-flex u-flex-items-center u-flex-justify-between u-w-100">
-      {selectedCount > 0 ? (
-        <Box className="u-flex u-flex-items-center">
-          <IconButton
-            onClick={clearSelection}
-            size="small"
-            aria-label={t('toolbar.clear_selection')}
-          >
-            <Icon icon={Cross} size={16} />
-          </IconButton>
-          <Typography variant="body1" className="u-ml-half">
-            {selectedCount} {t('SelectionBar.selected_count', selectedCount)}
-          </Typography>
-        </Box>
-      ) : (
-        <span />
-      )}
-      <Box className="u-flex u-flex-items-center">
+    <Box
+      className={
+        isMobile
+          ? 'u-flex u-flex-items-center u-w-100'
+          : 'u-flex u-flex-items-center u-flex-justify-between u-w-100'
+      }
+    >
+      {!isMobile &&
+        (selectedCount > 0 ? (
+          <Box className="u-flex u-flex-items-center">
+            <IconButton
+              onClick={clearSelection}
+              size="small"
+              aria-label={t('toolbar.clear_selection')}
+            >
+              <Icon icon={Cross} size={16} />
+            </IconButton>
+            <Typography variant="body1" className="u-ml-half">
+              {selectedCount} {t('SelectionBar.selected_count', selectedCount)}
+            </Typography>
+          </Box>
+        ) : (
+          <span />
+        ))}
+      <Box
+        className={
+          isMobile
+            ? 'u-flex u-flex-items-center u-w-100'
+            : 'u-flex u-flex-items-center'
+        }
+      >
         {renderAction(
           downloadLinkLabel,
           downloadLinkState,
           downloadLinkAction,
           () => onConfirm(filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK),
           'temporary-download-link-btn',
-          Attachment
+          Attachment,
+          'secondary'
         )}
-        <span className="u-ml-1">
-          {renderAction(
-            publicLinkLabel,
-            publicLinkState,
-            publicLinkAction,
-            () => onConfirm(filePickerLinkModes.PUBLIC_LINK),
-            'public-link-btn',
-            Link
-          )}
-        </span>
+        {renderAction(
+          publicLinkLabel,
+          publicLinkState,
+          publicLinkAction,
+          () => onConfirm(filePickerLinkModes.PUBLIC_LINK),
+          'public-link-btn',
+          Link,
+          'primary',
+          true
+        )}
       </Box>
     </Box>
   )

--- a/src/modules/services/components/FilePicker/FilePickerTable.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerTable.jsx
@@ -6,6 +6,7 @@ import Box from 'cozy-ui/transpiled/react/Box'
 import VirtualizedTable from 'cozy-ui/transpiled/react/Table/Virtualized'
 import virtuosoComponents from 'cozy-ui/transpiled/react/Table/Virtualized/virtuosoComponents'
 import TableRow from 'cozy-ui/transpiled/react/TableRow'
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
 import { FilePickerTableCell } from './FilePickerTableCell'
@@ -40,7 +41,7 @@ const FilePickerTableRow = forwardRef(
     }
 
     const handleDoubleClick = event => {
-      context.onItemDoubleClick(row, event)
+      context.onItemDoubleClick?.(row, event)
     }
 
     return (
@@ -66,16 +67,25 @@ FilePickerTableRow.propTypes = {
     data: PropTypes.array,
     isSelectedItem: PropTypes.func.isRequired,
     onItemClick: PropTypes.func.isRequired,
-    onItemDoubleClick: PropTypes.func.isRequired
+    onItemDoubleClick: PropTypes.func
   }).isRequired,
   className: PropTypes.string
 }
 
 const FilePickerTableRowMemo = memo(FilePickerTableRow)
 
+const MobileTableHead = forwardRef(function MobileTableHead(_props, ref) {
+  return <thead ref={ref} />
+})
+
 const tableComponents = {
   ...virtuosoComponents,
   TableRow: FilePickerTableRowMemo
+}
+
+const mobileTableComponents = {
+  ...tableComponents,
+  TableHead: MobileTableHead
 }
 
 const tableComponentsProps = {
@@ -95,7 +105,11 @@ export const FilePickerTable = memo(
     virtuosoRef
   }) => {
     const { t } = useI18n()
-    const columns = useMemo(() => makeFilePickerColumns(t), [t])
+    const { isMobile } = useBreakpoints()
+    const columns = useMemo(() => {
+      const filePickerColumns = makeFilePickerColumns(t)
+      return isMobile ? filePickerColumns.slice(0, 1) : filePickerColumns
+    }, [isMobile, t])
 
     const selectedItems = useMemo(
       () => items.filter(item => itemsIdsSelected.includes(item._id)),
@@ -120,7 +134,7 @@ export const FilePickerTable = memo(
         <VirtualizedTable
           ref={virtuosoRef}
           context={tableContext}
-          components={tableComponents}
+          components={isMobile ? mobileTableComponents : tableComponents}
           rows={items}
           columns={columns}
           endReached={fetchMore}
@@ -139,7 +153,7 @@ FilePickerTable.propTypes = {
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   itemsIdsSelected: PropTypes.arrayOf(PropTypes.string).isRequired,
   onItemClick: PropTypes.func.isRequired,
-  onItemDoubleClick: PropTypes.func.isRequired,
+  onItemDoubleClick: PropTypes.func,
   fetchMore: PropTypes.func,
   scrollerRef: PropTypes.func,
   virtuosoRef: PropTypes.object

--- a/src/modules/services/components/FilePicker/FilePickerTable.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerTable.jsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { forwardRef, memo, useMemo } from 'react'
+import React, { forwardRef, memo, useMemo, useRef } from 'react'
 
 import Box from 'cozy-ui/transpiled/react/Box'
 import VirtualizedTable from 'cozy-ui/transpiled/react/Table/Virtualized'
@@ -10,6 +10,8 @@ import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
 import { FilePickerTableCell } from './FilePickerTableCell'
+
+import { makeMobileHandlers } from '@/hooks/useOnLongPress/helpers'
 
 const makeFilePickerColumns = t => [
   {
@@ -35,13 +37,33 @@ const makeFilePickerColumns = t => [
 const FilePickerTableRow = forwardRef(
   ({ item, context, className, ...props }, ref) => {
     const row = item
+    const timerId = useRef()
+    const isLongPress = useRef(false)
 
     const handleClick = event => {
       context.onItemClick(row, event)
     }
 
+    const handleToggle = event => {
+      context.onItemToggle(row, event)
+    }
+
     const handleDoubleClick = event => {
       context.onItemDoubleClick?.(row, event)
+    }
+
+    let handlers = { onClick: handleClick, onDoubleClick: handleDoubleClick }
+    if (context.isMobile) {
+      // eslint-disable-next-line react-hooks/refs
+      handlers = makeMobileHandlers({
+        timerId,
+        disabled: false,
+        selectionModeActive: context.selectionModeActive,
+        isRenaming: false,
+        isLongPress,
+        openLink: handleClick,
+        toggle: handleToggle
+      })
     }
 
     return (
@@ -52,8 +74,7 @@ const FilePickerTableRow = forwardRef(
         data-file-id={row?._id}
         className={cx(className, 'virtualized', 'u-c-pointer')}
         selected={context.isSelectedItem(row)}
-        onClick={handleClick}
-        onDoubleClick={handleDoubleClick}
+        {...handlers}
         hover
       />
     )
@@ -66,7 +87,10 @@ FilePickerTableRow.propTypes = {
   context: PropTypes.shape({
     data: PropTypes.array,
     isSelectedItem: PropTypes.func.isRequired,
+    isMobile: PropTypes.bool.isRequired,
+    selectionModeActive: PropTypes.bool.isRequired,
     onItemClick: PropTypes.func.isRequired,
+    onItemToggle: PropTypes.func,
     onItemDoubleClick: PropTypes.func
   }).isRequired,
   className: PropTypes.string
@@ -88,17 +112,12 @@ const mobileTableComponents = {
   TableHead: MobileTableHead
 }
 
-const tableComponentsProps = {
-  rowContent: {
-    children: <FilePickerTableCell />
-  }
-}
-
 export const FilePickerTable = memo(
   ({
     items,
     itemsIdsSelected,
     onItemClick,
+    onItemToggle,
     onItemDoubleClick,
     fetchMore,
     scrollerRef,
@@ -111,9 +130,20 @@ export const FilePickerTable = memo(
       return isMobile ? filePickerColumns.slice(0, 1) : filePickerColumns
     }, [isMobile, t])
 
+    const selectionModeActive = itemsIdsSelected.length > 0
     const selectedItems = useMemo(
       () => items.filter(item => itemsIdsSelected.includes(item._id)),
       [items, itemsIdsSelected]
+    )
+    const tableComponentsProps = useMemo(
+      () => ({
+        rowContent: {
+          children: (
+            <FilePickerTableCell selectionModeActive={selectionModeActive} />
+          )
+        }
+      }),
+      [selectionModeActive]
     )
 
     const isSelectedItem = item => {
@@ -123,10 +153,20 @@ export const FilePickerTable = memo(
     const tableContext = useMemo(
       () => ({
         data: items,
+        isMobile,
+        selectionModeActive,
         onItemClick,
+        onItemToggle,
         onItemDoubleClick
       }),
-      [items, onItemClick, onItemDoubleClick]
+      [
+        isMobile,
+        items,
+        selectionModeActive,
+        onItemClick,
+        onItemDoubleClick,
+        onItemToggle
+      ]
     )
 
     return (
@@ -153,6 +193,7 @@ FilePickerTable.propTypes = {
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   itemsIdsSelected: PropTypes.arrayOf(PropTypes.string).isRequired,
   onItemClick: PropTypes.func.isRequired,
+  onItemToggle: PropTypes.func,
   onItemDoubleClick: PropTypes.func,
   fetchMore: PropTypes.func,
   scrollerRef: PropTypes.func,

--- a/src/modules/services/components/FilePicker/FilePickerTableCell.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerTableCell.jsx
@@ -8,7 +8,10 @@ import Filename from 'cozy-ui/transpiled/react/Filename'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
-import { getFileNameAndExtension } from '@/modules/filelist/helpers'
+import {
+  getFileNameAndExtension,
+  makeFileMetadata
+} from '@/modules/filelist/helpers'
 import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
 import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
 import SizeCell from '@/modules/filelist/virtualized/cells/columns/SizeCell'
@@ -30,7 +33,7 @@ const FilePickerNameCell = ({ row, selectionModeActive }) => {
       : null
   const metadata =
     isMobile && !isFolder
-      ? `${formattedUpdatedAt ?? '—'} - ${formattedSize ?? '—'}`
+      ? makeFileMetadata(formattedUpdatedAt ?? '—', formattedSize ?? '—')
       : null
 
   return (

--- a/src/modules/services/components/FilePicker/FilePickerTableCell.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerTableCell.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { isDirectory } from 'cozy-client/dist/models/file'
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
 import Filename from 'cozy-ui/transpiled/react/Filename'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
@@ -12,10 +13,12 @@ import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
 import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
 import SizeCell from '@/modules/filelist/virtualized/cells/columns/SizeCell'
 import UpdatedAtCell from '@/modules/filelist/virtualized/cells/columns/UpdatedAtCell'
+import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 
-const FilePickerNameCell = ({ row }) => {
+const FilePickerNameCell = ({ row, selectionModeActive }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
+  const { isItemSelected } = useSelectionContext()
   const { title, filename, extension } = getFileNameAndExtension(row, t)
   const isFolder = isDirectory(row)
   const formattedUpdatedAt = useFormattedUpdatedAt(
@@ -36,6 +39,13 @@ const FilePickerNameCell = ({ row }) => {
       className="u-flex u-flex-items-center"
       title={title}
     >
+      {isMobile && selectionModeActive && (
+        <Checkbox
+          checked={isItemSelected(row._id)}
+          size="medium"
+          onChange={() => {}}
+        />
+      )}
       <div
         data-testid="choice-onclick"
         className="u-flex u-flex-items-center u-flex-shrink-0 u-mr-1"
@@ -55,13 +65,18 @@ const FilePickerNameCell = ({ row }) => {
 }
 
 FilePickerNameCell.propTypes = {
-  row: PropTypes.object.isRequired
+  row: PropTypes.object.isRequired,
+  selectionModeActive: PropTypes.bool.isRequired
 }
 
-export const FilePickerTableCell = ({ column, row }) => {
+export const FilePickerTableCell = ({ column, row, selectionModeActive }) => {
   if (!column || !row) return null
 
-  if (column.id === 'name') return <FilePickerNameCell row={row} />
+  if (column.id === 'name') {
+    return (
+      <FilePickerNameCell row={row} selectionModeActive={selectionModeActive} />
+    )
+  }
   if (column.id === 'updated_at') {
     return <UpdatedAtCell row={row} cell={row.updated_at || row.created_at} />
   }
@@ -76,5 +91,6 @@ FilePickerTableCell.propTypes = {
   column: PropTypes.shape({
     id: PropTypes.string.isRequired
   }),
-  row: PropTypes.object
+  row: PropTypes.object,
+  selectionModeActive: PropTypes.bool
 }

--- a/src/modules/services/components/FilePicker/FilePickerTableCell.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerTableCell.jsx
@@ -1,17 +1,34 @@
+import { filesize } from 'filesize'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { isDirectory } from 'cozy-client/dist/models/file'
 import Filename from 'cozy-ui/transpiled/react/Filename'
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
 import { getFileNameAndExtension } from '@/modules/filelist/helpers'
 import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
+import { useFormattedUpdatedAt } from '@/modules/filelist/useFormattedUpdatedAt'
 import SizeCell from '@/modules/filelist/virtualized/cells/columns/SizeCell'
 import UpdatedAtCell from '@/modules/filelist/virtualized/cells/columns/UpdatedAtCell'
 
 const FilePickerNameCell = ({ row }) => {
   const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
   const { title, filename, extension } = getFileNameAndExtension(row, t)
+  const isFolder = isDirectory(row)
+  const formattedUpdatedAt = useFormattedUpdatedAt(
+    row.updated_at || row.created_at
+  )
+  const formattedSize =
+    !isFolder && row.size !== null && row.size !== undefined
+      ? filesize(row.size, { base: 10 })
+      : null
+  const metadata =
+    isMobile && !isFolder
+      ? `${formattedUpdatedAt ?? '—'} - ${formattedSize ?? '—'}`
+      : null
 
   return (
     <div
@@ -26,7 +43,12 @@ const FilePickerNameCell = ({ row }) => {
         <FileThumbnail file={row} />
       </div>
       <div className="u-flex-grow-1 u-ellipsis">
-        <Filename filename={filename} extension={extension} midEllipsis />
+        <Filename
+          filename={filename}
+          extension={extension}
+          midEllipsis
+          path={metadata}
+        />
       </div>
     </div>
   )

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -201,7 +201,10 @@ const FilePicker = ({
           />
         </Box>
         <Divider />
-        <footer className="u-mv-1 u-mh-2" data-testid="file-picker-footer">
+        <footer
+          className="u-mv-1 u-mh-2 u-flex-shrink-0-s"
+          data-testid="file-picker-footer"
+        >
           <FilePickerFooter
             onConfirm={handleFooterConfirm}
             publicLinkState={publicLinkState}

--- a/src/modules/services/components/FilePicker/useFilePickerSelection.js
+++ b/src/modules/services/components/FilePicker/useFilePickerSelection.js
@@ -68,7 +68,7 @@ export const useFilePickerSelection = ({
     (item, selectableItemsCount = selectableItems.length) => {
       const nextSelectedItems = multiple ? { ...selectedItemsById } : {}
 
-      if (nextSelectedItems[item._id]) {
+      if (selectedItemsById[item._id]) {
         delete nextSelectedItems[item._id]
       } else {
         nextSelectedItems[item._id] = item

--- a/src/modules/services/components/FilePicker/useFilePickerSelection.js
+++ b/src/modules/services/components/FilePicker/useFilePickerSelection.js
@@ -65,8 +65,8 @@ export const useFilePickerSelection = ({
   }, [selectionContainerRef])
 
   const handleToggleSelect = useCallback(
-    item => {
-      const nextSelectedItems = { ...selectedItemsById }
+    (item, selectableItemsCount = selectableItems.length) => {
+      const nextSelectedItems = multiple ? { ...selectedItemsById } : {}
 
       if (nextSelectedItems[item._id]) {
         delete nextSelectedItems[item._id]
@@ -76,19 +76,25 @@ export const useFilePickerSelection = ({
 
       setSelectedItems(nextSelectedItems)
       setIsSelectAll(
-        Object.keys(nextSelectedItems).length === selectableItems.length
+        Object.keys(nextSelectedItems).length === selectableItemsCount
       )
       setLastInteractedItem(item._id)
       focusSelectionContainer()
     },
     [
       focusSelectionContainer,
+      multiple,
       selectableItems.length,
       selectedItemsById,
       setIsSelectAll,
       setLastInteractedItem,
       setSelectedItems
     ]
+  )
+
+  const handleMobileToggleSelect = useCallback(
+    item => handleToggleSelect(item, items.length),
+    [handleToggleSelect, items.length]
   )
 
   const handleItemClick = useCallback(
@@ -173,5 +179,5 @@ export const useFilePickerSelection = ({
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [handleSelectAll, multiple])
-  return { handleItemClick, selectedItemIds }
+  return { handleItemClick, handleMobileToggleSelect, selectedItemIds }
 }

--- a/src/modules/services/components/IntentHandler.jsx
+++ b/src/modules/services/components/IntentHandler.jsx
@@ -110,7 +110,7 @@ const IntentHandler = ({ intentId }) => {
       ignoreCozySettings
       ignoreItself={false}
     >
-      <BreakpointsProvider>
+      <BreakpointsProvider parentBasedIframe>
         <AlertProvider>{content}</AlertProvider>
       </BreakpointsProvider>
     </CozyTheme>

--- a/src/modules/views/FilePickerDemo/FilePickerDemoView.jsx
+++ b/src/modules/views/FilePickerDemo/FilePickerDemoView.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import Main from '@/modules/layout/Main'
+import FilePickerButton from '@/modules/navigation/components/FilePickerButton'
+
+export const FilePickerDemoView = () => (
+  <Main>
+    <FilePickerButton />
+  </Main>
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11713,7 +11713,7 @@ __metadata:
     cozy-sharing: "npm:^37.2.12"
     cozy-stack-client: "npm:^60.28.0"
     cozy-tsconfig: "npm:^1.8.1"
-    cozy-ui: "npm:^140.5.2"
+    cozy-ui: "npm:^141.0.0"
     cozy-ui-plus: "npm:^12.3.0"
     cozy-viewer: "npm:^30.0.19"
     css-mediaquery: "npm:0.1.2"
@@ -12156,9 +12156,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-ui@npm:^140.5.2":
-  version: 140.5.2
-  resolution: "cozy-ui@npm:140.5.2"
+"cozy-ui@npm:^141.0.0":
+  version: 141.0.0
+  resolution: "cozy-ui@npm:141.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.3.4"
     "@date-io/date-fns": "npm:1"
@@ -12194,7 +12194,7 @@ __metadata:
     twake-i18n: ">=0.3.0"
   bin:
     rsg-screenshots: scripts/screenshots.js
-  checksum: 10/788e2c907c5141f175e8e4f6338e57bef6a967c3239b1faa586de166e985cbc45647dbbea8aa3bba660c22ccdf95b7b9161102c2b250bc33853c9fc67d4b4cad
+  checksum: 10/2a584b8cc17378a99122025d3092ac8c4b54e7afc112004c9225bab5c0d60610d1cf7854786c3655820de159f52eea4985349035572cec37559a80b8d6151bfc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Add mobile support for the file picker intent, including responsive layout, touch interactions, and full-screen mobile dialogs.
There are still some fixes to do on layout and small ui problems which will be fixed in next PR

## Why

Make file picking usable on mobile devices while preserving the existing desktop behavior.

## How

- Derive responsive breakpoints from the parent iframe.
- Add compact mobile file rows, breadcrumbs, and back navigation.
- Support tap navigation and long-press selection.
- Adapt footer actions and dialog behavior for mobile.
- Add a feature-flagged demo route.
- Add unit and Playwright coverage for mobile flows.

## Testing

- Added Jest tests for mobile layout, navigation, selection, and touch cancellation.
- Added Playwright coverage for the full-screen mobile intent flow.
- Ran targeted Jest, ESLint, and Stylint checks.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] No breaking changes (or documented)


[Capture vidéo du 2026-07-30 12-59-52.webm](https://github.com/user-attachments/assets/daa66a12-d828-41f9-98f1-2ef85589e5e0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile-optimized file picker with fullscreen display, touch navigation, long-press selection, checkboxes, mobile breadcrumbs, and responsive actions.
  * Added an optional file picker demo route controlled by a feature flag.
  * Improved file metadata formatting across file and folder listings.

* **Bug Fixes**
  * Touch-cancel gestures now correctly stop pending long-press actions.

* **Tests**
  * Added comprehensive unit and end-to-end coverage for mobile picker interactions, layouts, selection, navigation, and responsive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->