### PR TITLE
fix(file-picker): Use dedicated thumbnail for folders

### DIFF
--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -258,7 +258,7 @@ For folders, `size` is `0` and `mimeType` is `null`.
 
 ### Thumbnails
 
-The File Picker may provide a thumbnail (an illustration or a preview) that may be used by the caller. The thumbnail link is public and has an unlimited lifetime. It is currently a 80x80 png image.
+The File Picker may provide a thumbnail (an illustration or a preview) that may be used by the caller. The thumbnail link is public and has an unlimited lifetime. It is currently a 60x60 png image. Folders use a dedicated `folder.png` thumbnail.
 
 ## Error handling
 

--- a/src/modules/services/components/FilePicker/thumbnail.js
+++ b/src/modules/services/components/FilePicker/thumbnail.js
@@ -1,3 +1,5 @@
+import { isDirectory } from 'cozy-client/dist/models/file'
+
 import { matchMimePattern } from './helpers'
 
 const MIME_TYPE_TO_THUMBNAIL_TYPE = {
@@ -82,6 +84,7 @@ const MIME_TYPE_TO_THUMBNAIL_TYPE = {
 }
 
 const THUMBNAIL_TYPE_TO_THUMBNAIL_LINK = {
+  folder: 'https://files.twake.app/email-assets/file-picker/folder.png',
   audio: 'https://files.twake.app/email-assets/file-picker/audio.png',
   image: 'https://files.twake.app/email-assets/file-picker/image.png',
   video: 'https://files.twake.app/email-assets/file-picker/video.png',
@@ -125,7 +128,9 @@ export const makeThumbnail = file => {
   try {
     return {
       thumbnail: {
-        link: getThumbnailLinkFromMimeType(file.mime)
+        link: isDirectory(file)
+          ? THUMBNAIL_TYPE_TO_THUMBNAIL_LINK.folder
+          : getThumbnailLinkFromMimeType(file.mime)
       }
     }
   } catch {

--- a/src/modules/services/components/FilePicker/thumbnail.spec.js
+++ b/src/modules/services/components/FilePicker/thumbnail.spec.js
@@ -73,6 +73,16 @@ describe('makeThumbnail', () => {
     })
   })
 
+  it('should return folder thumbnail link for directories', () => {
+    const folder = { type: 'directory' }
+    const result = makeThumbnail(folder)
+    expect(result).toEqual({
+      thumbnail: {
+        link: 'https://files.twake.app/email-assets/file-picker/folder.png'
+      }
+    })
+  })
+
   it('should return default thumbnail link when file has no mime property', () => {
     const file = { name: 'test.txt' }
     const result = makeThumbnail(file)


### PR DESCRIPTION
Folders do not have a MIME type, so they previously fell back to the generic thumbnail. Return the dedicated folder asset instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Folders in File Picker results now display a dedicated folder thumbnail.

* **Documentation**
  * Updated File Picker thumbnail documentation to specify folder thumbnails use `folder.png` and adjusted the described thumbnail size to 60x60.

* **Tests**
  * Added a unit test to verify directory objects use the folder thumbnail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->